### PR TITLE
Hook logged in share up to persistent API, add dropdown for temporary share

### DIFF
--- a/localtypings/projectheader.d.ts
+++ b/localtypings/projectheader.d.ts
@@ -20,6 +20,7 @@ declare namespace pxt.workspace {
         pubId: string; // for published scripts
         pubCurrent: boolean; // is this exactly pubId, or just based on it
         pubVersions?: PublishVersion[];
+        pubPermalink?: string; // permanent (persistent) share ID
         githubId?: string;
         githubTag?: string; // the release tag if any (commit.tag)
         githubCurrent?: boolean;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -273,6 +273,7 @@ namespace pxt.editor {
 
         anonymousPublishAsync(screenshotUri?: string): Promise<string>;
         anonymousPublishHeaderByIdAsync(headerId: string): Promise<Cloud.JsonScript>;
+        persistentPublishAsync(screenshotUri?: string): Promise<string>;
 
         startStopSimulator(opts?: SimulatorStartOptions): void;
         stopSimulator(unload?: boolean, opts?: SimulatorStartOptions): void;

--- a/react-common/components/share/Share.tsx
+++ b/react-common/components/share/Share.tsx
@@ -18,25 +18,27 @@ export interface ShareData {
 export interface ShareProps {
     projectName: string;
     screenshotUri?: string;
+    showShareDropdown?: boolean;
 
     screenshotAsync: () => Promise<string>;
     gifRecordAsync: () => Promise<void>;
     gifRenderAsync: () => Promise<string | void>;
     gifAddFrame: (dataUri: ImageData, delay?: number) => boolean;
-    publishAsync: (name: string, screenshotUri?: string) => Promise<ShareData>;
+    publishAsync: (name: string, screenshotUri?: string, forceAnonymous?: boolean) => Promise<ShareData>;
     registerSimulatorMsgHandler?: (handler: (msg: any) => void) => void;
     unregisterSimulatorMsgHandler?: () => void;
 }
 
 export const Share = (props: ShareProps) => {
-    const { projectName, screenshotUri, screenshotAsync, gifRecordAsync, gifRenderAsync, gifAddFrame,
-        publishAsync, registerSimulatorMsgHandler, unregisterSimulatorMsgHandler } = props;
+    const { projectName, screenshotUri, showShareDropdown, screenshotAsync, gifRecordAsync, gifRenderAsync,
+        gifAddFrame, publishAsync, registerSimulatorMsgHandler, unregisterSimulatorMsgHandler } = props;
 
 return <div className="project-share">
         {(!!screenshotAsync || !!gifRecordAsync) && <div className="project-share-simulator">
             <div id="shareLoanedSimulator" />
         </div>}
         <ShareInfo projectName={projectName}
+            showShareDropdown={showShareDropdown}
             screenshotUri={screenshotUri}
             screenshotAsync={screenshotAsync}
             gifRecordAsync={gifRecordAsync}

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Button } from "../controls/Button";
 import { EditorToggle } from "../controls/EditorToggle";
 import { Input } from "../controls/Input";
+import { MenuDropdown } from "../controls/MenuDropdown";
 import { Textarea } from "../controls/Textarea";
 
 import { ShareData } from "./Share";
@@ -12,19 +13,20 @@ export interface ShareInfoProps {
     projectName: string;
     description?: string;
     screenshotUri?: string;
+    showShareDropdown?: boolean;
 
     screenshotAsync?: () => Promise<string>;
     gifRecordAsync?: () => Promise<void>;
     gifRenderAsync?: () => Promise<string | void>;
     gifAddFrame?: (dataUri: ImageData, delay?: number) => boolean;
-    publishAsync: (name: string, screenshotUri?: string) => Promise<ShareData>;
+    publishAsync: (name: string, screenshotUri?: string, forceAnonymous?: boolean) => Promise<ShareData>;
     registerSimulatorMsgHandler?: (handler: (msg: any) => void) => void;
     unregisterSimulatorMsgHandler?: () => void;
 }
 
 export const ShareInfo = (props: ShareInfoProps) => {
-    const { projectName, description, screenshotUri, screenshotAsync, gifRecordAsync, gifRenderAsync, gifAddFrame,
-        publishAsync, registerSimulatorMsgHandler, unregisterSimulatorMsgHandler } = props;
+    const { projectName, description, screenshotUri, showShareDropdown, screenshotAsync, gifRecordAsync,
+        gifRenderAsync, gifAddFrame, publishAsync, registerSimulatorMsgHandler, unregisterSimulatorMsgHandler } = props;
     const [ name, setName ] = React.useState(projectName);
     const [ thumbnailUri, setThumbnailUri ] = React.useState(screenshotUri);
     const [ shareState, setShareState ] = React.useState<"share" | "gifrecord" | "publish">("share");
@@ -47,8 +49,8 @@ export const ShareInfo = (props: ShareInfoProps) => {
         exitGifRecord();
     }
 
-    const handlePublishClick = async () => {
-        let publishedShareData = await publishAsync(name, thumbnailUri);
+    const handlePublishClick = async (forceAnonymous?: boolean) => {
+        let publishedShareData = await publishAsync(name, thumbnailUri, forceAnonymous);
         setShareData(publishedShareData);
         if (!publishedShareData?.error) setShareState("publish");
     }
@@ -76,7 +78,6 @@ export const ShareInfo = (props: ShareInfoProps) => {
         }
     }
 
-
     const embedOptions = [{
         name: "code",
         label: lf("Code"),
@@ -99,10 +100,23 @@ export const ShareInfo = (props: ShareInfoProps) => {
         onClick: () => setEmbedState("simulator")
     }];
 
+    const dropdownOptions = [{
+        title: lf("Create snapshot"),
+        label: lf("Create snapshot"),
+        onClick: () => handlePublishClick(true)
+    }]
+
     return <>
         <div className="project-share-info">
             {(shareState === "share" || shareState === "publish") && <>
-                {showSimulator && <h2>{lf("About your project")}</h2>}
+                {showSimulator && <div className="project-share-title">
+                    <h2>{lf("About your project")}</h2>
+                    {showShareDropdown && <MenuDropdown id="project-share-dropdown"
+                        icon="fas fa-ellipsis-h"
+                        title={lf("More share options")}
+                        items={dropdownOptions}
+                        />}
+                </div>}
                 <Input label={lf("Project Name")}
                     initialValue={name}
                     placeholder={lf("Name your project")}

--- a/react-common/styles/share/share.less
+++ b/react-common/styles/share/share.less
@@ -35,6 +35,19 @@
     }
 }
 
+.project-share-title {
+    display: flex;
+
+    h2 {
+        flex: 1;
+        margin: 0;
+    }
+}
+
+#project-share-dropdown {
+    color: @primaryColor;
+}
+
 .project-share-thumbnail {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
plus some cleanup in `share.tsx` ! basically hooks the "Publish" button up to the new persistent share API when the user is logged in and adds a ellipsis menu with a "Create snapshot" option for generating the temporary link. the not-logged-in behavior should be exactly the same as before

requires https://github.com/microsoft/pxt-backend/pull/626 to be deployed