### PR TITLE
Restore share page tick events

### DIFF
--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -67,6 +67,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
     }
 
     const handleQRCodeClick = () => {
+        pxt.tickEvent('share.qrtoggle');
         if (!showQRCode) {
             setEmbedState("none");
             setShowQRCode(true);

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -155,6 +155,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
     }
 
     screenshotAsync = () => {
+        pxt.tickEvent("share.takescreenshot", { view: 'computer', collapsedTo: '' + !this.props.parent.state.collapseEditorTools }, { interactiveConsent: true });
         return this.props.parent.requestScreenshotAsync()
             .then(img => {
                 if (img) {
@@ -285,6 +286,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
 
         const screenshotAsync = async () => await this.props.parent.requestScreenshotAsync();
         const publishAsync = async (name: string, screenshotUri?: string) => {
+            pxt.tickEvent("menu.embed.publish", undefined, { interactiveConsent: true });
             if (name && parent.state.projectName != name) {
                 await parent.updateHeaderNameAsync(name);
             }
@@ -292,6 +294,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 const id = await parent.anonymousPublishAsync(screenshotUri);
                 return await this.getShareUrl(id);
             } catch (e) {
+                pxt.tickEvent("menu.embed.error", { code: (e as any).statusCode })
                 return { url: "", embed: {}, error: e } as ShareData
             }
         }


### PR DESCRIPTION
I was going to do an all-up telemetry pass after the persistent stuff is merged in but since that is waiting on a backend release I figured I would add back the original share ticks