### PR TITLE
Add slug to packages.github message to make queries easier

### DIFF
--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -272,9 +272,12 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
     }
 
     async installGh(scr: pxt.github.GitRepo) {
+        const parsed = pxt.github.parseRepoId(scr.fullName);
         pxt.tickEvent("packages.github", {
             name: scr.fullName,
-            slug: scr.slug.toLowerCase()
+            slug: scr.slug.toLowerCase(),
+            tag: scr.tag,
+            fileName: parsed.fileName
         });
         this.hide(null, this.backOnHide());
         let r: { version: string, config: pxt.PackageConfig };

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -272,7 +272,10 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
     }
 
     async installGh(scr: pxt.github.GitRepo) {
-        pxt.tickEvent("packages.github", { name: scr.fullName });
+        pxt.tickEvent("packages.github", {
+            name: scr.fullName,
+            slug: scr.slug.toLowerCase()
+        });
         this.hide(null, this.backOnHide());
         let r: { version: string, config: pxt.PackageConfig };
         try {


### PR DESCRIPTION
The name parameter just includes whatever the user typed, which can have a number of inconsistencies:

1. trailing slash
2. random uppercase/lowercase letters
3. may not include the repo owner if the extension is approved (e.g. pxt-color instead of jwunderl/pxt-color)

The slug is much more consistently formatted and should always be in the format owner/repo