### PR TITLE
compute recursive dependencies for run info

### DIFF
--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -291,7 +291,9 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
     lastCompileResult = res;
     const { mute, highContrast, light, clickTrigger, storedState, autoRun } = options;
     const isIpcRenderer = pxt.BrowserUtils.isIpcRenderer() || undefined;
-    const dependencies = pkg.dependencies()
+    const dependencies: pxt.Map<string> = {}
+    for(const dep of pkg.sortedDeps())
+        dependencies[dep.id] = dep.version()
 
     const opts: pxsim.SimulatorRunOptions = {
         boardDefinition: boardDefinition,


### PR DESCRIPTION
When starting a run, we compute the complete list of dependencies resolved in the project; and pass it to the simulator.

This information is used by the Jacdac simulator to determine if an additional extension needs to be loaded.