### PR TITLE
Always try to resolve the latest release for github dependencies

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -232,6 +232,10 @@ class FileGithubDb implements pxt.github.IGithubDb {
             })
     }
 
+    latestVersionAsync(repopath: string, config: pxt.PackagesConfig): Promise<string> {
+        return this.db.latestVersionAsync(repopath, config)
+    }
+
     loadConfigAsync(repopath: string, tag: string): Promise<pxt.PackageConfig> {
         return this.loadAsync(repopath, tag, "pxt", (r, t) => this.db.loadConfigAsync(r, t));
     }
@@ -3114,7 +3118,7 @@ function installPackageNameAsync(packageName: string): Promise<void> {
         return pxt.packagesConfigAsync()
             .then(config => (parsed.tag ? Promise.resolve(parsed.tag) : pxt.github.latestVersionAsync(parsed.slug, config))
                 .then(tag => { parsed.tag = tag })
-                .then(() => pxt.github.pkgConfigAsync(parsed.fullName, parsed.tag))
+                .then(() => pxt.github.pkgConfigAsync(parsed.fullName, parsed.tag, config))
                 .then(cfg => mainPkg.loadAsync(true)
                     .then(() => {
                         let ver = pxt.github.stringifyRepo(parsed)

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -251,49 +251,6 @@ function searchAsync(...query: string[]) {
         })
 }
 
-function pkginfoAsync(repopath: string) {
-    let parsed = pxt.github.parseRepoId(repopath)
-    if (!parsed) {
-        console.log('Unknown repo');
-        return Promise.resolve();
-    }
-
-    const pkgInfo = (cfg: pxt.PackageConfig, tag?: string) => {
-        pxt.log(`name: ${cfg.name}`)
-        pxt.log(`description: ${cfg.description}`)
-        if (pxt.appTarget.appTheme)
-            pxt.log(`shareable url: ${pxt.appTarget.appTheme.embedUrl}#pub:gh/${parsed.fullName}${tag ? "#" + tag : ""}`)
-    }
-
-    return pxt.packagesConfigAsync()
-        .then(config => {
-            const status = pxt.github.repoStatus(parsed, config);
-            pxt.log(`github org: ${parsed.owner}`);
-            if (parsed.tag) pxt.log(`github tag: ${parsed.tag}`);
-            pxt.log(`package status: ${status == pxt.github.GitRepoStatus.Approved ? "approved" : status == pxt.github.GitRepoStatus.Banned ? "banned" : "neutral"}`)
-            if (parsed.tag)
-                return pxt.github.downloadPackageAsync(repopath, config)
-                    .then(pkg => {
-                        let cfg: pxt.PackageConfig = JSON.parse(pkg.files[pxt.CONFIG_NAME])
-                        pkgInfo(cfg, parsed.tag)
-                        pxt.debug(`size: ${JSON.stringify(pkg.files).length}`)
-                    })
-
-            return pxt.github.pkgConfigAsync(parsed.fullName)
-                .then(cfg => {
-                    pkgInfo(cfg)
-                    return pxt.github.listRefsAsync(repopath)
-                        .then(tags => {
-                            pxt.log("tags: " + tags.join(", "))
-                            return pxt.github.listRefsAsync(repopath, "heads")
-                        })
-                        .then(heads => {
-                            pxt.log("branches: " + heads.join(", "))
-                        })
-                })
-        })
-}
-
 export function pokeRepoAsync(parsed: commandParser.ParsedCommand): Promise<void> {
     const repo = parsed.args[0];
 

--- a/pxtcompiler/simpledriver.ts
+++ b/pxtcompiler/simpledriver.ts
@@ -44,6 +44,10 @@ namespace pxt {
                 })
         }
 
+        latestVersionAsync(repopath: string, config: pxt.PackagesConfig): Promise<string> {
+            return this.db.latestVersionAsync(repopath, config)
+        }
+
         loadConfigAsync(repopath: string, tag: string): Promise<pxt.PackageConfig> {
             return this.loadAsync(repopath, tag, "pxt", (r, t) => this.db.loadConfigAsync(r, t));
         }

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -563,7 +563,7 @@ namespace pxt.github {
                     .then(resolveRefAsync))
     }
 
-    export function pkgConfigAsync(repopath: string, tag = "master") {
+    export function pkgConfigAsync(repopath: string, tag: string) {
         return db.loadConfigAsync(repopath, tag)
     }
 

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -105,6 +105,7 @@ namespace pxt.github {
 
     // caching
     export interface IGithubDb {
+        latestVersionAsync(repopath: string, config: PackagesConfig): Promise<string>;
         loadConfigAsync(repopath: string, tag: string): Promise<pxt.PackageConfig>;
         loadPackageAsync(repopath: string, tag: string): Promise<CachedPackage>;
     }
@@ -163,6 +164,7 @@ namespace pxt.github {
     }
 
     export class MemoryGithubDb implements IGithubDb {
+        private latestVersions: pxt.Map<string> = {};
         private configs: pxt.Map<pxt.PackageConfig> = {};
         private packages: pxt.Map<CachedPackage> = {};
 
@@ -188,7 +190,10 @@ namespace pxt.github {
         }
 
         async loadConfigAsync(repopath: string, tag: string): Promise<pxt.PackageConfig> {
-            if (!tag) tag = "master";
+            if (!tag) {
+                pxt.debug(`dep: default to master branch`)
+                tag = "master";
+            }
 
             // cache lookup
             const key = `${repopath}/${tag}`;
@@ -213,8 +218,20 @@ namespace pxt.github {
             return this.cacheConfig(key, cfg);
         }
 
+        async latestVersionAsync(repopath: string, config: PackagesConfig): Promise<string> {
+            let resolved = this.latestVersions[repopath]
+            if (!resolved) {
+                pxt.debug(`dep: resolve latest version of ${repopath}`)
+                this.latestVersions[repopath] = resolved = await pxt.github.latestVersionAsync(repopath, config, true, false)
+            }
+            return resolved
+        }
+
         async loadPackageAsync(repopath: string, tag: string): Promise<CachedPackage> {
-            if (!tag) tag = "master";
+            if (!tag) {
+                pxt.debug(`load pkg: default to master branch`)
+                tag = "master";
+            }
 
             // try using github proxy first
             if (hasProxy()) {
@@ -563,36 +580,40 @@ namespace pxt.github {
                     .then(resolveRefAsync))
     }
 
-    export function pkgConfigAsync(repopath: string, tag: string) {
-        return db.loadConfigAsync(repopath, tag)
+    export async function pkgConfigAsync(repopath: string, tag: string, config: pxt.PackagesConfig) {
+        if (!tag)
+            tag = await db.latestVersionAsync(repopath, config)
+        return await db.loadConfigAsync(repopath, tag)
     }
 
-    export function downloadPackageAsync(repoWithTag: string, config: pxt.PackagesConfig): Promise<CachedPackage> {
+    export async function downloadPackageAsync(repoWithTag: string, config: pxt.PackagesConfig): Promise<CachedPackage> {
         const p = parseRepoId(repoWithTag)
         if (!p) {
             pxt.log('Unknown GitHub syntax');
-            return Promise.resolve<CachedPackage>(undefined);
+            return undefined
         }
 
         if (isRepoBanned(p, config)) {
             pxt.tickEvent("github.download.banned");
             pxt.log('Github repo is banned');
-            return Promise.resolve<CachedPackage>(undefined);
+            return undefined;
         }
 
-        return db.loadPackageAsync(p.fullName, p.tag)
-            .then(cached => {
-                const dv = upgradedDisablesVariants(config, repoWithTag)
-                if (dv) {
-                    const cfg = Package.parseAndValidConfig(cached.files[pxt.CONFIG_NAME])
-                    if (cfg) {
-                        pxt.log(`auto-disable ${dv.join(",")} due to targetconfig entry for ${repoWithTag}`)
-                        cfg.disablesVariants = dv
-                        cached.files[pxt.CONFIG_NAME] = Package.stringifyConfig(cfg)
-                    }
-                }
-                return cached
-            })
+        // always try to upgrade unbound versions
+        if (!p.tag) {
+            p.tag = await db.latestVersionAsync(p.slug, config)
+        }
+        const cached = await db.loadPackageAsync(p.fullName, p.tag)
+        const dv = upgradedDisablesVariants(config, repoWithTag)
+        if (dv) {
+            const cfg = Package.parseAndValidConfig(cached.files[pxt.CONFIG_NAME])
+            if (cfg) {
+                pxt.log(`auto-disable ${dv.join(",")} due to targetconfig entry for ${repoWithTag}`)
+                cfg.disablesVariants = dv
+                cached.files[pxt.CONFIG_NAME] = Package.stringifyConfig(cfg)
+            }
+        }
+        return cached
     }
 
     export async function downloadLatestPackageAsync(repo: ParsedRepo): Promise<{ version: string, config: pxt.PackageConfig }> {
@@ -603,7 +624,7 @@ namespace pxt.github {
         await pxt.github.downloadPackageAsync(repoWithTag, packageConfig)
 
         // return config
-        const config = await pkgConfigAsync(repo.fullName, tag)
+        const config = await pkgConfigAsync(repo.fullName, tag, packageConfig)
         const version = `github:${repoWithTag}`
 
         return { version, config };
@@ -1012,13 +1033,12 @@ namespace pxt.github {
     }
 
     export function stringifyRepo(p: ParsedRepo) {
-        return p ? "github:" + p.fullName.toLowerCase() + "#" + (p.tag || "master") : undefined;
+        return p ? "github:" + p.fullName.toLowerCase() + (p.tag ? `#${p.tag}` : '') : undefined;
     }
 
     export function normalizeRepoId(id: string) {
         const gid = parseRepoId(id);
         if (!gid) return undefined;
-        gid.tag = gid.tag || "master";
         return stringifyRepo(gid);
     }
 

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -1036,9 +1036,11 @@ namespace pxt.github {
         return p ? "github:" + p.fullName.toLowerCase() + (p.tag ? `#${p.tag}` : '') : undefined;
     }
 
-    export function normalizeRepoId(id: string) {
+    export function normalizeRepoId(id: string, defaultTag?: string) {
         const gid = parseRepoId(id);
         if (!gid) return undefined;
+        if (!gid.tag && defaultTag)
+            gid.tag = defaultTag
         return stringifyRepo(gid);
     }
 

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -52,21 +52,19 @@ namespace pxt {
                 && json;
         }
 
-        static getConfigAsync(pkgTargetVersion: string, id: string, fullVers: string): Promise<pxt.PackageConfig> {
-            return Promise.resolve().then(() => {
-                if (pxt.github.isGithubId(fullVers)) {
-                    const repoInfo = pxt.github.parseRepoId(fullVers);
-                    return pxt.packagesConfigAsync()
-                        .then(config => pxt.github.repoAsync(repoInfo.fullName, config))    // Make sure repo exists and is whitelisted
-                        .then(gitRepo => gitRepo ? pxt.github.pkgConfigAsync(repoInfo.fullName, repoInfo.tag) : null);
-                } else {
-                    // If it's not from GH, assume it's a bundled package
-                    // TODO: Add logic for shared packages if we enable that
-                    const updatedRef = pxt.patching.upgradePackageReference(pkgTargetVersion, id, fullVers);
-                    const bundledPkg = pxt.appTarget.bundledpkgs[updatedRef];
-                    return JSON.parse(bundledPkg[CONFIG_NAME]) as pxt.PackageConfig;
-                }
-            });
+        static async getConfigAsync(pkgTargetVersion: string, id: string, fullVers: string): Promise<pxt.PackageConfig> {
+            if (pxt.github.isGithubId(fullVers)) {
+                const repoInfo = pxt.github.parseRepoId(fullVers);
+                const packagesConfig = await pxt.packagesConfigAsync()
+                const gitRepo = await pxt.github.repoAsync(repoInfo.fullName, packagesConfig)    // Make sure repo exists and is whitelisted
+                return gitRepo ? await pxt.github.pkgConfigAsync(repoInfo.fullName, repoInfo.tag, packagesConfig) : null
+            } else {
+                // If it's not from GH, assume it's a bundled package
+                // TODO: Add logic for shared packages if we enable that
+                const updatedRef = pxt.patching.upgradePackageReference(pkgTargetVersion, id, fullVers);
+                const bundledPkg = pxt.appTarget.bundledpkgs[updatedRef];
+                return JSON.parse(bundledPkg[CONFIG_NAME]) as pxt.PackageConfig;
+            }
         }
 
         static corePackages(): pxt.PackageConfig[] {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2930,7 +2930,7 @@ export class ProjectView
                 if (!resp.outfiles[fn]) {
                     pxt.tickEvent("compile.noemit")
                     const noHexFileDiagnostic = resp.diagnostics.find(diag => diag.code === 9043)
-                                            || resp.diagnostics.length == 1 ?  resp.diagnostics[0] : undefined ;
+                        || resp.diagnostics.length == 1 ? resp.diagnostics[0] : undefined;
                     if (noHexFileDiagnostic) {
                         core.warningNotification(noHexFileDiagnostic.messageText as string);
                     }
@@ -4955,7 +4955,8 @@ async function importGithubProject(repoid: string, requireSignin?: boolean) {
     core.showLoading("loadingheader", lf("importing GitHub project..."));
     try {
         // normalize for precise matching
-        repoid = pxt.github.normalizeRepoId(repoid);
+        // if the branch is not specified, assume "master"
+        repoid = pxt.github.normalizeRepoId(repoid, "master");
         // try to find project with same id
         let hd = workspace.getHeaders().find(h => h.githubId &&
             pxt.github.normalizeRepoId(h.githubId) == repoid

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -284,13 +284,6 @@ mountVirtualApi("gh-search", {
     isOffline: () => !Cloud.isOnline(),
 })
 
-mountVirtualApi("gh-pkgcfg", {
-    getAsync: query =>
-        pxt.github.pkgConfigAsync(stripProtocol(query)).catch(core.handleNetworkError),
-    expirationTime: p => 60 * 1000,
-    isOffline: () => !Cloud.isOnline(),
-})
-
 // gh-commits:repo#sha
 mountVirtualApi("gh-commits", {
     getAsync: query => {
@@ -315,7 +308,6 @@ mountVirtualApi("target-config", {
                         pxt.storage.setLocal("targetconfig", JSON.stringify(js))
                         invalidate("target-config");
                         invalidate("gh-search");
-                        invalidate("gh-pkgcfg");
                     }
                     return js;
                 })

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -95,6 +95,10 @@ class GithubDb implements pxt.github.IGithubDb {
     private mem = new pxt.github.MemoryGithubDb();
     private table = new Table("github");
 
+    latestVersionAsync(repopath: string, config: pxt.PackagesConfig): Promise<string> {
+        return this.mem.latestVersionAsync(repopath, config)
+    }
+
     loadConfigAsync(repopath: string, tag: string): Promise<pxt.PackageConfig> {
         // don't cache master
         if (tag == "master")
@@ -119,7 +123,10 @@ class GithubDb implements pxt.github.IGithubDb {
         );
     }
     loadPackageAsync(repopath: string, tag: string): Promise<pxt.github.CachedPackage> {
-        tag = tag || "master";
+        if (!tag) {
+          pxt.debug(`dep: default to master`)
+          tag = "master"
+        }
         // don't cache master
         if (tag == "master")
             return this.mem.loadPackageAsync(repopath, tag);

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -98,7 +98,7 @@ function renderCompileLink(variantName: string, cs: pxt.TargetCompileService) {
 
 function renderVersionLink(name: string, version: string, url: string) {
     return <p>{lf("{0} version:", name)} &nbsp;
-            <a href={encodeURI(url)}
+        <a href={encodeURI(url)}
             title={`${lf("{0} version: {1}", name, version)}`}
             aria-label={`${lf("{0} version{1}", name, version)}`}
             target="_blank" rel="noopener noreferrer">{version}</a>
@@ -480,13 +480,13 @@ export function showCreateGithubRepoDialogAsync(name?: string) {
                 </p>
                 <div className="ui field">
                     <sui.Input type="url" autoFocus value={repoName} onChange={onNameChanged}
-                    label={lf("Repository name")} id="githubRepoNameInput"
-                    placeholder={`pxt-my-gadget...`} class="fluid" error={nameErr} />
+                        label={lf("Repository name")} id="githubRepoNameInput"
+                        placeholder={`pxt-my-gadget...`} class="fluid" error={nameErr} />
                 </div>
                 <div className="ui field">
                     <sui.Input type="text" value={repoDescription} onChange={onDescriptionChanged}
-                    label={lf("Repository description")} id="githubRepoDescriptionInput"
-                    placeholder={lf("MakeCode extension for my gadget")} class="fluid" />
+                        label={lf("Repository description")} id="githubRepoDescriptionInput"
+                        placeholder={lf("MakeCode extension for my gadget")} class="fluid" />
                 </div>
                 <div className="ui field">
                     <select className={`ui dropdown`} onChange={onPublicChanged} aria-label={lf("Repository visibility setting")}>
@@ -507,7 +507,7 @@ export function showCreateGithubRepoDialogAsync(name?: string) {
                     .finally(() => core.hideLoading("creategithub"))
                     .then(r => {
                         pxt.tickEvent("github.create.ok");
-                        return pxt.github.normalizeRepoId("https://github.com/" + r.fullName);
+                        return pxt.github.normalizeRepoId("https://github.com/" + r.fullName, "master");
                     }, err => {
                         if (!showGithubTokenError(err)) {
                             if (err.statusCode == 422)
@@ -545,7 +545,7 @@ export function showImportGithubDialogAsync() {
                 description: r.description,
                 updatedAt: r.updatedAt,
                 onClick: () => {
-                    res = pxt.github.normalizeRepoId("https://github.com/" + r.fullName)
+                    res = pxt.github.normalizeRepoId("https://github.com/" + r.fullName, "master")
                     core.hideDialog()
                 },
             }));
@@ -573,7 +573,7 @@ export function showImportGithubDialogAsync() {
                                 <i className="large github middle aligned icon"></i>
                                 <div className="content">
                                     <a onClick={r.onClick} role="button" className="header"
-                                        tabIndex={0}  onKeyDown={fireClickOnEnter}
+                                        tabIndex={0} onKeyDown={fireClickOnEnter}
                                     >{r.name}</a>
                                     <div className="description">
                                         {pxt.Util.timeSince(r.updatedAt)}
@@ -716,7 +716,7 @@ export function showWinAppDeprecateAsync() {
         hasCloseIcon: true,
         helpUrl: "/windows-app",
         jsx: <div>
-            <img className="ui medium centered image" src={pxt.appTarget.appTheme.winAppDeprImage} alt={lf("An image of a shrugging board")}/>
+            <img className="ui medium centered image" src={pxt.appTarget.appTheme.winAppDeprImage} alt={lf("An image of a shrugging board")} />
             <div>
                 {lf("This app is being deprecated. Text editing is only available on the MakeCode website ")}
                 {`(https://${pxt.appTarget.name}).`}
@@ -792,12 +792,12 @@ export function renderBrowserDownloadInstructions(saveonly?: boolean) {
                                                 <div className="ui two column grid">
                                                     <div className="icon-align three wide column">
                                                         <div />
-                                                        <i className="icon big usb"/>
+                                                        <i className="icon big usb" />
                                                         <div />
                                                     </div>
                                                     <div className="thirteen wide column">
                                                         {lf("Download your code faster by pairing with web usb!")}
-                                                        <br/>
+                                                        <br />
                                                         <strong><a onClick={onPairClicked}>{lf("Pair now")}</a></strong>
                                                     </div>
                                                 </div>
@@ -840,27 +840,27 @@ export function renderIncompatibleHardwareDialog() {
     const columns = imageURL ? "two" : "one";
 
     return <div className={`ui ${columns} column grid padded download-dialog`}>
-    <div className="column">
-        <div className="ui">
-            <div className="content">
-                <div className="description">
-                {bodyText}
-                <br />
-                {helpURL && <a target="_blank" rel="noopener noreferrer" href={helpURL}>{helpText}</a>}
-                </div>
-            </div>
-        </div>
-    </div>
-    {imageURL &&
         <div className="column">
             <div className="ui">
-                <div className="image download-dialog-image">
-                    <img alt={lf("Image of {0}", boardName)} className="ui medium rounded image" src={imageURL} />
+                <div className="content">
+                    <div className="description">
+                        {bodyText}
+                        <br />
+                        {helpURL && <a target="_blank" rel="noopener noreferrer" href={helpURL}>{helpText}</a>}
+                    </div>
                 </div>
             </div>
         </div>
-    }
-</div>
+        {imageURL &&
+            <div className="column">
+                <div className="ui">
+                    <div className="image download-dialog-image">
+                        <img alt={lf("Image of {0}", boardName)} className="ui medium rounded image" src={imageURL} />
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
 }
 
 export function clearDontShowDownloadDialogFlag() {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1451,7 +1451,8 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
 }
 
 export async function importGithubAsync(id: string): Promise<Header> {
-    const repoid = pxt.github.normalizeRepoId(id).replace(/^github:/, "")
+    // if tag is not specified, asssume master
+    const repoid = pxt.github.normalizeRepoId(id, "master").replace(/^github:/, "")
     const parsed = pxt.github.parseRepoId(repoid)
 
     let sha = ""


### PR DESCRIPTION
Currently unbound github dependencies (no version tag specified) are bound to "master". The desired behavior should be to grab the latest release. There is also some caching involved which leads to some confusing situation where things might not work based on the state of the cache.

## Fixes

- [x] This fix auto-binding of no-tag -> latest tag + bailout to "master" if needed; in the in-memory github database.
- [x] various functions rewritten to async for readability

## Test

This project won't load in the current beta https://github.com/pelikhan/pxt-kitronik-air-quality/blob/master/jacdac/pxt.json if you happen to have an older version of jacdac cached.