### PR TITLE
make /#newproject create a non-empty project

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4774,16 +4774,20 @@ function handleHash(newHash: { cmd: string; arg: string }, loading: boolean): bo
             return true;
         case "newproject": // shortcut to create a new blocks proj
             pxt.tickEvent("hash.newproject")
-            editor.newEmptyProject();
+            editor.newProject();
             pxt.BrowserUtils.changeHash("");
             return true;
         case "newjavascript": // shortcut to create a new JS proj
             pxt.tickEvent("hash.newjavascript");
             editor.newProject({
-                prj: pxt.appTarget.blocksprj,
-                filesOverride: {
-                    [pxt.MAIN_BLOCKS]: ""
-                }
+                preferredEditor: pxt.JAVASCRIPT_PROJECT_NAME
+            });
+            pxt.BrowserUtils.changeHash("");
+            return true;
+        case "newpython": // shortcut to create a new python proj
+            pxt.tickEvent("hash.newpython");
+            editor.newProject({
+                preferredEditor: pxt.PYTHON_PROJECT_NAME
             });
             pxt.BrowserUtils.changeHash("");
             return true;


### PR DESCRIPTION
At BETT Andrew asked for ability to create a new project with a hash so it can be embedded in a minecraft world to allow for a 'free coding' section sort of thing; I remembered we had these but right now it hits a path that creates a completely empty blocks project (i.e. no on start / default blocks: https://minecraft.makecode.com/#newproject); fixes that, and also just use preferred editor for javascript / create a parallel one for python to load up nicely.