### PR TITLE
sort fixed instances drop down by weight

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -3000,9 +3000,11 @@ namespace pxt.blocks {
     }
 
     export function getFixedInstanceDropdownValues(apis: pxtc.ApisInfo, qName: string) {
-        return pxt.Util.values(apis.byQName).filter(sym => sym.kind === pxtc.SymbolKind.Variable
+        const symbols = pxt.Util.values(apis.byQName).filter(sym => sym.kind === pxtc.SymbolKind.Variable
             && sym.attributes.fixedInstance
-            && isSubtype(apis, sym.retType, qName));
+            && isSubtype(apis, sym.retType, qName))
+            .sort((l,r) => (r.attributes.weight || 50) - (l.attributes.weight || 50))
+        return symbols
     }
 
     export function generateIcons(instanceSymbols: pxtc.SymbolInfo[]) {


### PR DESCRIPTION
Currently fixedInstance symbol are not sorted and based solely on import order. This PR adds basic `//% weight=...` sorting.
```
namespace yo {
    //% fixedInstances
    export class Foo {
        ///% block
        bar() {

        }
    }
    //% fixedInstance
    export const aaa = new Foo()
    //% fixedInstance weight=100
    export const bbb = new Foo()
}
```
<img width="225" alt="image" src="https://user-images.githubusercontent.com/4175913/162473677-553d1faf-6706-4c0e-a193-d66c8887e428.png">
