### PR TITLE
add root dependency, better naming when creating nested project

### DIFF
--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1180,6 +1180,9 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
             U.userError(lf("Invalid pxt.json file."));
         pxt.debug(`github: reconstructing pxt.json`)
         cfg = pxt.diff.reconstructConfig(parsed, files, commit, pxt.appTarget.blocksprj || pxt.appTarget.tsprj);
+        if (parsed.fileName && parsed.project)
+            // add root folder as reference
+            cfg.dependencies[parsed.project] = `github:${parsed.slug}`
         files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
     }
     // patch the github references back to local workspaces
@@ -1204,7 +1207,15 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
         await downloadAsync(fn)
 
     if (!cfg.name) {
-        cfg.name = (parsed.fileName || parsed.project || parsed.fullName).replace(/[^\w\-]/g, "");
+        // pxt-xyz/jacdac -> jacdac-xyz
+        if (parsed.fileName && /pxt-/.test(parsed.project))
+            cfg.name = `${parsed.fileName.toLowerCase()}-${parsed.project.slice("pxt-".length)}`
+        else
+            cfg.name = parsed.fileName ? `${parsed.project}-${parsed.fileName}` : (parsed.project || parsed.fullName)
+        cfg.name = cfg.name.replace(/pxt-/ig, '')
+            .replace(/\//g, '-')
+            .replace(/-+/, "-")
+            .replace(/[^\w\-]/g, "")
         if (!justJSON)
             files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
     }

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1207,11 +1207,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
         await downloadAsync(fn)
 
     if (!cfg.name) {
-        // pxt-xyz/jacdac -> jacdac-xyz
-        if (parsed.fileName && /pxt-/.test(parsed.project))
-            cfg.name = `${parsed.fileName.toLowerCase()}-${parsed.project.slice("pxt-".length)}`
-        else
-            cfg.name = parsed.fileName && parsed.project ? `${parsed.project}-${parsed.fileName}` : (parsed.project || parsed.fullName)
+        cfg.name = parsed.fileName && parsed.project ? `${parsed.project}-${parsed.fileName}` : (parsed.project || parsed.fullName)
         cfg.name = cfg.name.replace(/pxt-/ig, '')
             .replace(/\//g, '-')
             .replace(/-+/, "-")

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1181,7 +1181,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
         pxt.debug(`github: reconstructing pxt.json`)
         cfg = pxt.diff.reconstructConfig(parsed, files, commit, pxt.appTarget.blocksprj || pxt.appTarget.tsprj);
         if (parsed.fileName && parsed.project)
-            // add root folder as reference
+            // add root folder as reference when creating nested project
             cfg.dependencies[parsed.project] = `github:${parsed.slug}`
         files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
     }
@@ -1207,7 +1207,10 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
         await downloadAsync(fn)
 
     if (!cfg.name) {
-        cfg.name = parsed.fileName && parsed.project ? `${parsed.project}-${parsed.fileName}` : (parsed.project || parsed.fullName)
+        cfg.name = parsed.fileName && parsed.project
+            // when creating nested project, mangle name
+            ? `${parsed.project}-${parsed.fileName}`
+            : (parsed.project || parsed.fullName)
         cfg.name = cfg.name.replace(/pxt-/ig, '')
             .replace(/\//g, '-')
             .replace(/-+/, "-")

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1211,7 +1211,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
         if (parsed.fileName && /pxt-/.test(parsed.project))
             cfg.name = `${parsed.fileName.toLowerCase()}-${parsed.project.slice("pxt-".length)}`
         else
-            cfg.name = parsed.fileName ? `${parsed.project}-${parsed.fileName}` : (parsed.project || parsed.fullName)
+            cfg.name = parsed.fileName && parsed.project ? `${parsed.project}-${parsed.fileName}` : (parsed.project || parsed.fullName)
         cfg.name = cfg.name.replace(/pxt-/ig, '')
             .replace(/\//g, '-')
             .replace(/-+/, "-")


### PR DESCRIPTION
When creating a new project nested in a github repository (i.e. import url -> https://github.com/owner/project/jacdac), add the following features to the generated project

- dependency to root folder project (https://github.com/owner/repo/)
- better mangling of folder name and existing project name to generate nested project name