### PR TITLE
allow simulator iframe to access microphone

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -413,7 +413,7 @@ namespace pxsim {
             frame.id = 'sim-frame-' + this.nextId()
             frame.title = pxsim.localization.lf("Simulator")
             frame.allowFullscreen = true;
-            frame.setAttribute('allow', 'autoplay');
+            frame.setAttribute('allow', 'autoplay;microphone');
             frame.setAttribute('sandbox', 'allow-same-origin allow-scripts');
             frame.className = 'no-select'
             const furl = (url || this.getSimUrl()) + '#' + frame.id;


### PR DESCRIPTION
the jacdac sound level simulator uses the microphone; but it needs to be allowed on the iframe. The user still needs to give consent through the browser native permission dialog

<img width="397" alt="image" src="https://user-images.githubusercontent.com/4175913/162994612-21ad35b1-1d1c-4bb0-a983-bdf238de82e0.png">
