### PR TITLE
use github proxy to resolve the latest version available

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -616,9 +616,9 @@ namespace pxt.github {
         return cached
     }
 
-    export async function downloadLatestPackageAsync(repo: ParsedRepo): Promise<{ version: string, config: pxt.PackageConfig }> {
+    export async function downloadLatestPackageAsync(repo: ParsedRepo, useProxy?: boolean, noCache?: boolean): Promise<{ version: string, config: pxt.PackageConfig }> {
         const packageConfig = await pxt.packagesConfigAsync()
-        const tag = await pxt.github.latestVersionAsync(repo.slug, packageConfig)
+        const tag = await pxt.github.latestVersionAsync(repo.slug, packageConfig, useProxy, noCache)
         // download package into cache
         const repoWithTag = `${repo.fullName}#${tag}`;
         await pxt.github.downloadPackageAsync(repoWithTag, packageConfig)

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -323,7 +323,7 @@ export class EditorPackage {
         if (!parsed) return
 
         const packagesConfig = await pxt.packagesConfigAsync()
-        const tag = await pxt.github.latestVersionAsync(parsed.slug, packagesConfig)
+        const tag = await pxt.github.latestVersionAsync(parsed.slug, packagesConfig, true)
         // since all repoes in a mono-repo are tied to the same version number,
         // we'll update them all to this tag at once.
         const ghids = Util.values(this.ksPkg.dependencies())

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -323,7 +323,7 @@ export class EditorPackage {
         if (!parsed) return
 
         const packagesConfig = await pxt.packagesConfigAsync()
-        const tag = await pxt.github.latestVersionAsync(parsed.slug, packagesConfig, true)
+        const tag = await pxt.github.latestVersionAsync(parsed.slug, packagesConfig, true /* use proxy */)
         // since all repoes in a mono-repo are tied to the same version number,
         // we'll update them all to this tag at once.
         const ghids = Util.values(this.ksPkg.dependencies())

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -283,7 +283,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         let r: { version: string, config: pxt.PackageConfig };
         try {
             core.showLoading("downloadingpackage", lf("downloading extension..."));
-            r = await pxt.github.downloadLatestPackageAsync(scr);
+            r = await pxt.github.downloadLatestPackageAsync(scr, true /* use proxy */);
         }
         catch (e) {
             core.handleNetworkError(e);


### PR DESCRIPTION
When adding a new github project reference, resolve latest release using proxy instead of token. The token might not have access to reading this org (which happens for tokens with SAML access).
2 code paths:
- [x] update in explorer
- [x] add github project from add extensions