### PR TITLE
More sound effect editor polish

### DIFF
--- a/pxtsim/sound/soundEmojiSynthesizer.ts
+++ b/pxtsim/sound/soundEmojiSynthesizer.ts
@@ -162,7 +162,7 @@ namespace pxsim.codal.music {
                         }
 
                         // Synthesize a sample
-                        let s = this.effect.tone.tonePrint(this.effect.tone.parameter, this.position);
+                        let s = this.effect.tone.tonePrint(this.effect.tone.parameter, Math.max(this.position, 0));
 
                         // Apply volume scaling and OR mask (if specified).
                         this.buffer[sample] = (((s * gain) + offset)) // | this.orMask;

--- a/react-common/components/controls/DraggableGraph.tsx
+++ b/react-common/components/controls/DraggableGraph.tsx
@@ -130,6 +130,19 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
         aria-describedby={ariaDescribedBy}
         role={role}>
         <svg viewBox={`0 0 ${width} ${height}`} xmlns="http://www.w3.org/2000/svg">
+            <defs>
+                <filter id="dropshadow">
+                    <feGaussianBlur in="SourceAlpha" stdDeviation="3" />
+                    <feOffset dx="0" dy="0" />
+                    <feComponentTransfer>
+                        <feFuncA type="linear" slope="0.5"/>
+                    </feComponentTransfer>
+                    <feMerge>
+                        <feMergeNode />
+                        <feMergeNode in="SourceGraphic" />
+                    </feMerge>
+                </filter>
+            </defs>
             {points.map((val, index) => {
                 const isNotLast = index < points.length - 1;
                 const x = Math.max(xSlice * index - halfUnit, unit);
@@ -139,14 +152,7 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
                 // flip the label to the other side if it would overlap path
                 const shouldFlipLabel = isNotLast && interpolation === "logarithmic" && getValue(index + 1) > getValue(index);
 
-                return <g key={index}>
-                        <rect
-                            className="draggable-graph-point"
-                            x={x}
-                            y={y}
-                            width={unit}
-                            height={unit}
-                            />
+                return <g key={index} className="draggable-graph-column">
                         {isNotLast &&
                             <path
                                 className="draggable-graph-path"
@@ -154,16 +160,30 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
                                 fill="none"
                                 strokeWidth="2px"
                                 d={getInterpolationPath(
-                                    x + halfUnit,
-                                    y + halfUnit,
+                                    x,
+                                    y,
                                     Math.max(xSlice * (index + 1), 0),
-                                    yOffset + Math.max(yScale * (max - getValue(index + 1)) - halfUnit, halfUnit) + halfUnit,
+                                    yOffset + Math.max(yScale * (max - getValue(index + 1)) - halfUnit, halfUnit),
                                     interpolation,
                                     squiggly
                                 )}
                             />
                         }
-                        <text x={x + halfUnit} y={shouldFlipLabel ? y + unit * 2 : y - halfUnit} fontSize={unit} className="common-draggable-graph-text">
+
+                        <circle
+                            className="draggable-graph-point"
+                            cx={x + halfUnit}
+                            cy={y}
+                            r={unit}
+                            fill="white"
+                            filter="url(#dropshadow)"
+                        />
+                        <text
+                            className="common-draggable-graph-text"
+                            x={isNotLast ? x + unit * 2 : x - unit}
+                            y={shouldFlipLabel ? y + unit * 2 : Math.max(y - unit, unit)}
+                            textAnchor={isNotLast ? "start" : "end"}
+                            fontSize={unit}>
                             {Math.round(getValue(index))}
                         </text>
                         <rect
@@ -175,6 +195,7 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
                             height={height}
                             fill="white"
                             opacity={0}
+
                             />
                     </g>
             })}

--- a/react-common/styles/controls/DraggableGraph.less
+++ b/react-common/styles/controls/DraggableGraph.less
@@ -1,13 +1,16 @@
 .common-draggable-graph-text {
     user-select: none;
     color: @commonTextColor;
-    text-anchor: middle;
 }
 
 .draggable-graph-point {
-    fill: @draggableGraphPointColor;
+    fill: @draggableGraphHandleColor;
 }
 
 .draggable-graph-path {
-    stroke: @draggableGraphPointColor;
+    stroke: @draggableGraphPathColor;
+}
+
+.draggable-graph-surface {
+    cursor: pointer;
 }

--- a/react-common/styles/react-common-variables.less
+++ b/react-common/styles/react-common-variables.less
@@ -47,7 +47,7 @@
  *                DraggableGraph                     *
  ****************************************************/
 
- @draggableGraphPathColor: #E63022;
+ @draggableGraphHandleColor: #ffffff;
  @draggableGraphPointColor: #E63022;
 
 

--- a/webapp/src/components/soundEffectEditor/SoundEffectEditor.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundEffectEditor.tsx
@@ -28,6 +28,22 @@ export const SoundEffectEditor = (props: SoundEffectEditorProps) => {
     let cancelSound: () => void;
     let previewSynthListener: (freq: number, vol: number, sound: pxt.assets.Sound) => void;
 
+    React.useEffect(() => {
+        const keyListener = (ev: KeyboardEvent) => {
+            // Ignore all keys that could be used for accessibility navigation
+            if (ev.key.length !== 1 || ev.metaKey || ev.ctrlKey || /[0-9]/.test(ev.key)) return;
+
+            // Ignore when a text input is focused
+            if (document.activeElement && document.activeElement.tagName === "INPUT" && (document.activeElement as HTMLInputElement).type === "text") return;
+
+            play();
+        };
+
+        document.addEventListener("keydown", keyListener);
+
+        return () => document.removeEventListener("keydown", keyListener);
+    })
+
     const play = (toPlay = sound) => {
         const codalSound = soundToCodalSound(toPlay);
 


### PR DESCRIPTION
Includes the following changes:

1. Redraws the preview when sibling blocks change their values
2. Fixes some speaker-exploding clips that happen with the logarithmic interpolation
3. Adds the ability to trigger the sound by pressing a key on the keyboard. Any key works except those that are important to accessibility navigation
4. Redesigns the handles on the draggable graph to be circles:

![2022-04-12 16 17 34](https://user-images.githubusercontent.com/13754588/163275366-01d212f7-0c70-4ef2-84a2-14c358fdf2dd.gif)
