### PR TITLE
Ensure github token is present before creating subproject

### DIFF
--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1516,7 +1516,9 @@ export async function importGithubAsync(id: string): Promise<Header> {
                 hasCloseIcon: true,
                 helpUrl: "/github/import"
             })
-            if (!r) return Promise.resolve(undefined);
+            if (!r)
+                return cloudsync.ensureGitHubTokenAsync()
+                    .then(() => undefined)
         }
     } catch (e) {
         if (e.statusCode == 409) {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1517,8 +1517,9 @@ export async function importGithubAsync(id: string): Promise<Header> {
                 helpUrl: "/github/import"
             })
             if (!r)
-                return cloudsync.ensureGitHubTokenAsync()
-                    .then(() => undefined)
+                return Promise.resolve(undefined);
+            // make sure early that we can write to the repo
+            await cloudsync.ensureGitHubTokenAsync()
         }
     } catch (e) {
         if (e.statusCode == 409) {


### PR DESCRIPTION
Before starting the process of populating a sub-folder in a repo, make sure we have a github token.