### PR TITLE
Add flag to make a block the child of another in the toolbox

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -801,6 +801,9 @@ declare namespace ts.pxtc {
         topblock?: boolean;
         topblockWeight?: number;
         locs?: pxt.Map<string>;
+        toolboxParent?: string; // The ID of a block that will wrap this block in the toolbox. Useful for having multiple instances of the same parent block with different child shadows
+        toolboxParentArgument?: string; // Used with toolboxParent. The name of the arg that this block should be inserted into as a shadow
+
         // On namepspace
         subcategories?: string[];
         groups?: string[];

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -334,10 +334,32 @@ namespace pxt.blocks {
     }
 
     export function createToolboxBlock(info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, comp: pxt.blocks.BlockCompileInfo): HTMLElement {
+        let parent: HTMLElement;
+        let parentInput: HTMLElement;
+
+        if (fn.attributes.toolboxParent) {
+            const parentFn = info.blocksById[fn.attributes.toolboxParent];
+
+            if (parentFn) {
+                parent = createToolboxBlock(info, parentFn, pxt.blocks.compileInfo(parentFn));
+
+                parentInput = fn.attributes.toolboxParentArgument ?
+                    parent.querySelector(`value[name=${fn.attributes.toolboxParentArgument}]`) :
+                    parent.querySelector(`value`);
+
+                if (parentInput) {
+                    while (parentInput.firstChild) parentInput.removeChild(parentInput.firstChild);
+                }
+                else {
+                    parent = undefined;
+                }
+            }
+        }
+
         //
         // toolbox update
         //
-        let block = document.createElement("block");
+        let block = document.createElement(parent ? "shadow" : "block");
         block.setAttribute("type", fn.attributes.blockId);
         if (fn.attributes.blockGap)
             block.setAttribute("gap", fn.attributes.blockGap);
@@ -405,6 +427,12 @@ namespace pxt.blocks {
                 });
             }
         }
+
+        if (parent) {
+            parentInput.appendChild(block);
+            return parent;
+        }
+
         return block;
     }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1826,8 +1826,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 .filter(shadow => !shadow.innerHTML)
                 .forEach((shadow, i) => {
                     let type = shadow.getAttribute('type');
+                    if (type === block.type) return;
                     const builtin = snippets.allBuiltinBlocks()[type];
-                    let b = this.getBlockXml(builtin ? builtin : { name: type, attributes: { blockId: type } }, ignoregap, true);
+                    let b = this.getBlockXml(builtin ? builtin : { name: type, type: type, attributes: { blockId: type } }, ignoregap, true);
                     // Note: we're setting one innerHTML to another
                     // eslint-disable-next-line @microsoft/sdl/no-inner-html
                     if (b && b.length > 0 && b[0]) shadow.innerHTML = b[0].innerHTML;


### PR DESCRIPTION
Let blocks specify that they should be a the child of another block. This can sort of be thought of as a more generalized version of the flag that makes it so a block is within a "variable set" block. This is in support of the requested changes for 

https://github.com/microsoft/pxt-microbit/pull/4545