### PR TITLE
add `onStartGroup`

### DIFF
--- a/docs/targets/pxtarget.md
+++ b/docs/targets/pxtarget.md
@@ -251,6 +251,7 @@ This severely misnamed option controls the available blocks in the Blockly edito
         // options specific to the special "on start" block
         onStartNamespace?: string; // default = loops
         onStartColor?: string;
+        onStartGroup?: string;
         onStartWeight?: number;
         onStartUnDeletable?: boolean;
     }

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -137,6 +137,7 @@ declare namespace pxt {
         loopsBlocks?: boolean;
         onStartNamespace?: string; // default = loops
         onStartColor?: string;
+        onStartGroup?: string;
         onStartWeight?: number;
         onStartUnDeletable?: boolean;
         pauseUntilBlock?: BlockOptions;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1421,7 +1421,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 name: ts.pxtc.ON_START_TYPE,
                 attributes: {
                     blockId: ts.pxtc.ON_START_TYPE,
-                    weight: pxt.appTarget.runtime.onStartWeight || 10
+                    weight: pxt.appTarget.runtime.onStartWeight || 10,
+                    group: pxt.appTarget.runtime.onStartGroup || undefined
                 },
                 blockXml: `<block type="pxt-on-start"></block>`
             });

--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -742,7 +742,8 @@ export function allBuiltinBlocks() {
         name: ts.pxtc.ON_START_TYPE,
         attributes: {
             blockId: ts.pxtc.ON_START_TYPE,
-            weight: pxt.appTarget.runtime.onStartWeight || 10
+            weight: pxt.appTarget.runtime.onStartWeight || 10,
+            group: pxt.appTarget.runtime.onStartGroup || undefined
         },
         blockXml: `<block type="pxt-on-start"></block>`
     };


### PR DESCRIPTION
This PR adds the ability to define a group for the `onStart`-Block in the `pxtarget.json`:
```json
"runtime": {
        "onStartGroup": "Control"
}
```

This will help us to close our issue at https://github.com/microsoft/pxt-calliope/issues/165
We are using pxt 7.0.14, so it would be great if this could also get available on the 7.0.x versions.