### PR TITLE
Add app theme flag for using legacy tutorial layout

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -410,6 +410,7 @@ declare namespace pxt {
         monacoFieldEditors?: string[]; // A list of field editors to show in monaco. Currently only "image-editor" is supported
         disableAPICache?: boolean; // Disables the api cache in target.js
         sidebarTutorial?: boolean; // Move the tutorial pane to be on the left side of the screen
+        legacyTutorial?: boolean; // Use the legacy tutorial format without tabs
         /**
          * Internal and temporary flags:
          * These flags may be removed without notice, please don't take a dependency on them

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -179,6 +179,7 @@ namespace pxt.BrowserUtils {
     }
 
     export function useOldTutorialLayout(): boolean {
+        if (pxt.appTarget?.appTheme?.legacyTutorial) return true;
         try {
             return (/tutorialview=old/.test(window.location.href));
         } catch (e) { return false; }


### PR DESCRIPTION
Forces the editor to use the old tutorial layout. While the layout is the legacy one, the other new tutorial features like better markdown rendering still work fine. Here's a view of a tutorial in arcade that uses the fancy icon bullets:

<img width="1325" alt="Screen Shot 2022-04-26 at 4 28 27 PM" src="https://user-images.githubusercontent.com/13754588/165409159-59d7434d-4ab3-495c-9a80-ac2e76884485.png">
