### PR TITLE
Specify fill explicitly in svg to fix snapshot

### DIFF
--- a/pxtblocks/fields/field_sound_effect.ts
+++ b/pxtblocks/fields/field_sound_effect.ts
@@ -83,6 +83,7 @@ namespace pxtblockly {
                 .size(TOTAL_WIDTH, TOTAL_HEIGHT)
                 .setClass("blocklySpriteField")
                 .stroke("#fff", 1)
+                .fill("#dedede")
                 .corner(TOTAL_HEIGHT / 2);
 
             const clipPathId = "preview-clip-" + pxt.U.guidGen();


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4602

Not all of the CSS is included when we generate the snapshot. Specify the fill explicitly for this case.