### PR TITLE
collapse blocks with hidden arguments when decompiling

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -2269,7 +2269,14 @@ ${output}</xml>`;
 
             if (optionalCount) {
                 if (!r.mutation) r.mutation = {};
-                r.mutation["_expanded"] = optionalCount.toString();
+
+                if (attributes.compileHiddenArguments) {
+                    r.mutation["_expanded"] =  "0";
+                }
+                else {
+                    r.mutation["_expanded"] = optionalCount.toString();
+                }
+
             }
 
             return r;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4562

Instead of always decompiling with the block expanded, decompile with it collapsed. We can't know the exact number of arguments to show because we don't have any way of storing that information, unfortunately