### PR TITLE
Simulator: fix for cross-domain bidirectional multiplayer messages

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -363,7 +363,7 @@ namespace pxt.runner {
             })
     }
 
-    export async function simulateAsync(container: HTMLElement, simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {
+    export async function simulateAsync(container: HTMLElement, simOptions: SimulateOptions): Promise<pxsim.SimulatorDriver> {
         const builtSimJS = simOptions.builtJsInfo || await buildSimJsInfo(simOptions);
         const {
             js,
@@ -411,7 +411,7 @@ namespace pxt.runner {
                 ? pxt.appTarget.simulator.partsAspectRatio
                 : pxt.appTarget.simulator.aspectRatio;
         driver.run(js, runOptions);
-        return builtSimJS;
+        return driver;
     }
 
     export async function buildSimJsInfo(simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -116,6 +116,7 @@
         var single = !!/single(?:[:=])1/i.test(window.location.href);
         var server = !!/server(?:[:=])1/i.test(window.location.href);
         var mpRole = /[\&\?]mp=(server|client)/i.exec(window.location.href)?.[1]?.toLowerCase();
+        var simdriver = null; /*pxsim.SimulatorDriver;*/
 
         var codeFromSrc = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
         var codeFromData = undefined;
@@ -168,8 +169,14 @@
                     window.parent.postMessage(msg.data, "*");
                 }
                 else if (mpRole && data.type === "multiplayer") {
-                    // propagate message packets to parent frames
-                    window.parent.postMessage(msg.data, "*");
+                    // Multiplayer messages are bi-directional
+                    if (mpRole === msg.data.origin) {
+                        // propagate to parent frame
+                        window.parent.postMessage(msg.data, "*");
+                    } else {
+                        // propagate to child frames
+                        if (simdriver) simdriver.postMessage(msg.data);
+                    }
                 }
                 else if (server && data.type === "simulateproject") {
                     var files = typeof data.project === "string" ? JSON.parse(data.project) : data.project;
@@ -187,8 +194,9 @@
                                 single: single
                             };
                             console.log('simulating project')
-                            pxt.runner.simulateAsync(sims, options).then(function() {
+                            pxt.runner.simulateAsync(sims, options).then(function(driver) {
                                 console.log('simulator started for project...')
+                                simdriver = driver;
                                 $(loading).remove();
                             })
                         });
@@ -242,8 +250,9 @@
                         single: single
                     };
                     console.log('simulating script')
-                    pxt.runner.simulateAsync(sims, options).then(function() {
+                    pxt.runner.simulateAsync(sims, options).then(function(driver) {
                         console.log('simulator started...')
+                        simdriver = driver;
                         $(loading).remove();
                     })
                 });


### PR DESCRIPTION
Hosting the simulator within another app is a multiple nested iframe situation. The middle frame - run.html - has the responsibility of marshaling multiplayer message traffic to/from the simulator component, which is hosted in a child iframe. Because multiplayer messaging is bidirectional, traffic passing through the middle frame's singular event handler must be explicitly routed inbound or outbound.

In development, things were working fine on localhost without this routing, but I'm not certain why. There might be a special case somewhere, or the same-origin nature of localhost resulted in different behavior. In any case, this change makes it work in both scenarios.
