### PR TITLE
allow extension to hide parts

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -790,6 +790,7 @@ declare namespace ts.pxtc {
         imageLiteralScale?: number; // button sizing between 0.6 and 2, default is 1
         weight?: number;
         parts?: string;
+        hiddenParts?: string; // allows an extesion to declaratively hide a part
         trackArgs?: number[];
         advanced?: boolean;
         deprecated?: boolean;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -343,20 +343,19 @@ namespace ts.pxtc {
         if (!resp.usedSymbols || !pxt.appTarget.simulator || !pxt.appTarget.simulator.parts)
             return [];
 
+        const parseParts = (partsRaw: string, ps: string[]) => {
+            if (partsRaw) {
+                const partsSplit = partsRaw.split(/[ ,]+/g);
+                ps.push(...partsSplit.filter(p => !!p && ps.indexOf(p) < 0))
+             }
+        }
+
         let parts: string[] = [];
+        let hiddenParts: string[] = [];
         Object.keys(resp.usedSymbols).forEach(symbol => {
-            let info = resp.usedSymbols[symbol]
-            if (info && info.attributes.parts) {
-                let partsRaw = info.attributes.parts;
-                if (partsRaw) {
-                    let partsSplit = partsRaw.split(/[ ,]+/);
-                    partsSplit.forEach(p => {
-                        if (0 < p.length && parts.indexOf(p) < 0) {
-                            parts.push(p);
-                        }
-                    });
-                }
-            }
+            const info = resp.usedSymbols[symbol]
+            parseParts(info?.attributes.parts, parts)
+            parseParts(info?.attributes.hiddenParts, hiddenParts)
         });
 
         if (filter) {
@@ -369,6 +368,9 @@ namespace ts.pxtc {
                 }
             }
         }
+
+        // apply hidden parts filter
+        parts = parts.filter(p => hiddenParts.indexOf(p) < 0)
 
         //sort parts (so breadboarding layout is stable w.r.t. code ordering)
         parts.sort();


### PR DESCRIPTION
Adding a new block attribute, `hiddenParts` that allows to filter out specific parts in the parts computation phase.

```
//% hideParts=servo <-- don't collect 'servo' parts
function someHighLevelfunctionUsingServo() {
    ...
    // this triggers part 'servo'
    pins.setServoValue(...)
}
```

In Jacdac, we use API that enable specific part but eventually the rendering is disabled. Downside of this flag is that it is pretty blunt and does not discriminate where the original part was used.