### PR TITLE
Embed generated codal.json in compile results

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1043,6 +1043,7 @@ declare namespace ts.pxtc {
         extensionFiles: pxt.Map<string>;
         yotta?: pxt.YottaConfig;
         platformio?: pxt.PlatformIOConfig;
+        codal?: pxt.CodalJson;
         npmDependencies?: pxt.Map<string>;
         sha: string;
         compileData: string;

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -123,6 +123,10 @@ declare namespace pxt {
         libraries?: string[];
     }
 
+    interface CodalJson {
+        
+    }
+
     interface YottaConfig {
         dependencies?: Map<string>;
         config?: any;

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1306,6 +1306,8 @@ namespace ts.pxtc {
             if (opts.target.isNative) {
                 if (opts.extinfo.yotta)
                     bin.writeFile("yotta.json", JSON.stringify(opts.extinfo.yotta, null, 2));
+                if (opts.extinfo.codal)
+                    bin.writeFile("codal.json", JSON.stringify(opts.extinfo.codal, null, 2));
                 if (opts.extinfo.platformio)
                     bin.writeFile("platformio.json", JSON.stringify(opts.extinfo.platformio, null, 2));
                 if (opts.target.nativeType == NATIVE_TYPE_VM)

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1304,12 +1304,15 @@ namespace ts.pxtc {
                 bin.procs = bin.procs.filter(p => p.inlineBody && !p.info.usedAsIface && !p.info.usedAsValue ? false : true)
 
             if (opts.target.isNative) {
-                if (opts.extinfo.yotta)
-                    bin.writeFile("yotta.json", JSON.stringify(opts.extinfo.yotta, null, 2));
-                if (opts.extinfo.codal)
-                    bin.writeFile("codal.json", JSON.stringify(opts.extinfo.codal, null, 2));
-                if (opts.extinfo.platformio)
-                    bin.writeFile("platformio.json", JSON.stringify(opts.extinfo.platformio, null, 2));
+                // collect various output files from all variants
+                [...(opts.otherMultiVariants || []), opts].forEach(({ extinfo }) => {
+                    if (extinfo.yotta)
+                        bin.writeFile("yotta.json", JSON.stringify(extinfo.yotta, null, 2));
+                    if (extinfo.codal)
+                        bin.writeFile("codal.json", JSON.stringify(extinfo.codal, null, 2));
+                    if (extinfo.platformio)
+                        bin.writeFile("platformio.json", JSON.stringify(extinfo.platformio, null, 2));
+                })
                 if (opts.target.nativeType == NATIVE_TYPE_VM)
                     vmEmit(bin, opts)
                 else

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1055,6 +1055,7 @@ namespace pxt.cpp {
             })
             res.generatedFiles["/codal.json"] = JSON.stringify(codalJson, null, 4) + "\n"
             pxt.debug(`codal.json: ${res.generatedFiles["/codal.json"]}`);
+            res.codal = codalJson
         } else if (isPlatformio) {
             const iniLines = compileService.platformioIni.slice()
             // TODO merge configjson


### PR DESCRIPTION
When compiling for multiple hardware targets, we forget to collect the output files of other build platforms, like codal. So for micro:bit, we only see yotta.json and not codal.json.

This change walks the list of compile results and collects those values. (also yotta is set in codal for no good reason). The information in codal.json is used by pxt-microbit to determine if the compiled .hex file has Jacdac in the firmware.