### PR TITLE
Fix snippets cache to include language info

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -76,15 +76,16 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
     private cachedRenderLangSnippetAsync(langBlock: HTMLElement, renderer: (code: string) => Promise<string | HTMLElement>): Promise<void> {
         const code = langBlock.textContent;
+        const lang = langBlock.className;
         const wrapperDiv = this.startRenderLangSnippet(langBlock);
-        if (MarkedContent.blockSnippetCache[code]) {
-            this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[code]);
+        if (MarkedContent.blockSnippetCache[lang+code]) {
+            this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[lang+code]);
             return undefined;
         } else {
             return renderer(code)
                 .then(renderedCode => {
-                    MarkedContent.blockSnippetCache[code] = renderedCode;
-                    this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[code]);
+                    MarkedContent.blockSnippetCache[lang+code] = renderedCode;
+                    this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[lang+code]);
                 }).catch(e => {
                     pxt.reportException(e);
                     this.finishRenderLangSnippet(wrapperDiv, lf("Something changed."))


### PR DESCRIPTION
Closes [microsoft/pxt-microbit#4508](https://github.com/microsoft/pxt-microbit/issues/4508) 

Before, we were caching the snippet regardless of the language so if someone opened a tutorial in Python and then later tried the tutorial in JS, the cached Python snippet would be shown. I added a string with the language info to the key for caching the snippet renderings. 

Note: that bug only repros when using the new tutorial layout (set "legacyTutorial": false in pxtarget.json). Currently, using the legacy tutorial doesn't hit the cache of snippets. I'll file another issue for that.