### PR TITLE
Removing fuzzy search and fix the name

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -715,7 +715,6 @@ namespace ts.pxtc.service {
     // don't export, fuse is internal only
     let lastFuse: Fuse<SearchInfo>;
     let lastProjectFuse: Fuse<ProjectSearchInfo>;
-    let lastExtensionFuse: Fuse<ExtensionMeta>;
     export let builtinItems: SearchInfo[];
     export let blockDefinitions: pxt.Map<pxt.blocks.BlockDefinition>;
     export let tbSubset: pxt.Map<boolean | string>;
@@ -787,7 +786,6 @@ namespace ts.pxtc.service {
         snippet: (v: OpArg) => string;
         blocksInfo: (v: OpArg) => BlocksInfo;
         apiSearch: (v: OpArg) => SearchInfo[];
-        extensionSearch: (v: OpArg) => ExtensionMeta[];
         projectSearch: (v: OpArg) => ProjectSearchInfo[];
         projectSearchClear: () => void;
     };
@@ -1215,28 +1213,6 @@ namespace ts.pxtc.service {
             }
             const fns = lastFuse.search(search.term);
             return fns.slice(0, SEARCH_RESULT_COUNT);
-        },
-        extensionSearch: v => {
-            const extensions = v.extensions.srcs
-            const searchFor = v.search.term;
-
-            const fuseOptions = {
-                shouldSort: true,
-                threshold: 0.6,
-                location: 0,
-                distance: 100,
-                maxPatternLength: 16,
-                minMatchCharLength: 2,
-                findAllMatches: false,
-                caseSensitive: false,
-                keys: [
-                    { name: 'name', weight: 1 }
-                ]
-            };
-
-            lastExtensionFuse = new Fuse(extensions, fuseOptions);
-            const found = lastExtensionFuse.search(searchFor);
-            return found;
         },
         projectSearch: v => {
             const search = v.projectSearch;

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -283,7 +283,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         setExtensionsToShow([...extensionsWeHave, ...loadingCards]);
     }
 
-        function packageConfigToExtensionMeta(p: pxt.PackageConfig): ExtensionMeta {
+    function packageConfigToExtensionMeta(p: pxt.PackageConfig): ExtensionMeta {
         return {
             name: p.name,
             imageUrl: p.icon,

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -62,31 +62,24 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
 
     useEffect(() => {
         if (searchFor && searchFor != "") {
-            if (searchFor.indexOf("/") >= 0) {
-                searchForGithubAsync();
-            } else {
-                workerOpAsync("extensionSearch", {
-                    search: {
-                        term: searchFor
-                    },
-                    extensions: {
-                        srcs: Array.from(allExtensions.values())
-                    }
-                }).then(e => {
-                    setExtensionsToShow(e)
-                    setSelectedTag("")
-                })
-            }
+            searchForBundledAndGithubAsync();
         }
     }, [searchFor])
 
     /**
      * Github search
      */
-    async function searchForGithubAsync() {
+    async function searchForBundledAndGithubAsync() {
         setExtensionsToShow([emptyCard, emptyCard, emptyCard, emptyCard])
         const exts = await fetchGithubDataAsync([searchFor])
         const parsedExt = exts.map(repo => parseGithubRepo(repo))
+        //Search bundled extensions as well
+        fetchBundled().forEach(e => {
+            if (e.name.toLowerCase().indexOf(searchFor.toLowerCase()) > -1) {
+                //Fuzzy search here?
+                parsedExt.unshift(e)
+            }
+        })
         addExtensionsToPool(parsedExt)
         setExtensionsToShow(parsedExt)
     }
@@ -231,9 +224,14 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         updateInstalledExts()
     }
 
+    function ghName(scr: pxt.github.GitRepo) {
+        let n = scr.name.replace(/^pxt-/, "");
+        return n;
+    }
+
     function parseGithubRepo(r: pxt.github.GitRepo): ExtensionMeta {
         return {
-            name: r.name,
+            name: ghName(r),
             type: pxtc.service.ExtensionType.Github,
             imageUrl: pxt.github.repoIconUrl(r),
             repo: r,
@@ -285,7 +283,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         setExtensionsToShow([...extensionsWeHave, ...loadingCards]);
     }
 
-    function packageConfigToExtensionMeta(p: pxt.PackageConfig): ExtensionMeta {
+        function packageConfigToExtensionMeta(p: pxt.PackageConfig): ExtensionMeta {
         return {
             name: p.name,
             imageUrl: p.icon,


### PR DESCRIPTION
This removes the fuzzy search from the client side. We need to do the fuzzy search in the server otherwise we will miss out on lot of packages and inconsistent results. 

This also removes pxt- prefix from names for the extensions to make it nicer as before.

Fixes: 
https://github.com/microsoft/pxt-microbit/issues/4568
https://github.com/microsoft/pxt-microbit/issues/4578
https://github.com/microsoft/pxt-microbit/issues/4596