### PR TITLE
hook to leverage the cache system

### DIFF
--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -163,6 +163,17 @@ export function getCached(component: DataSubscriber, path: string): DataFetchRes
     return getDataWithStatus(path);
 }
 
+export function useVirtualCache() {
+    const [state, setState] = React.useState(0)
+    const componentRef = React.useRef<DataSubscriber>({
+        subscriptions: [],
+        onDataChanged: (path: string) => setState(v => v+1)
+    })
+    React.useEffect(() => () => unsubscribe(componentRef.current), [])
+    unsubscribe(componentRef.current)
+    return (path: string) => getCached(componentRef.current, path)
+}
+
 //
 // Public interface
 //


### PR DESCRIPTION
This hook should mimic the virtual api support in the old react/class system. One should be able to replace the `data.getAsync` calls with sync caching calls from this hook.