### PR TITLE
Kim fix tutorial cache

### DIFF
--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -83,6 +83,10 @@ export function TutorialContainer(props: TutorialContainerProps) {
         if (showNext) setHideModal(false);
     }, [currentStep])
 
+    React.useEffect(() => {
+        return () => MarkedContent.clearBlockSnippetCache();
+    }, [hideModal])
+
     const currentStepInfo = steps[currentStep];
     if (!steps[currentStep]) return <div />;
 

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -76,15 +76,16 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
     private cachedRenderLangSnippetAsync(langBlock: HTMLElement, renderer: (code: string) => Promise<string | HTMLElement>): Promise<void> {
         const code = langBlock.textContent;
+        const lang = langBlock.className;
         const wrapperDiv = this.startRenderLangSnippet(langBlock);
-        if (MarkedContent.blockSnippetCache[code]) {
-            this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[code]);
+        if (MarkedContent.blockSnippetCache[lang+code]) {
+            this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[lang+code]);
             return undefined;
         } else {
             return renderer(code)
                 .then(renderedCode => {
-                    MarkedContent.blockSnippetCache[code] = renderedCode;
-                    this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[code]);
+                    MarkedContent.blockSnippetCache[lang+code] = renderedCode;
+                    this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[lang+code]);
                 }).catch(e => {
                     pxt.reportException(e);
                     this.finishRenderLangSnippet(wrapperDiv, lf("Something changed."))

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -78,14 +78,14 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         const code = langBlock.textContent;
         const lang = langBlock.className;
         const wrapperDiv = this.startRenderLangSnippet(langBlock);
-        if (MarkedContent.blockSnippetCache[lang+code]) {
-            this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[lang+code]);
+        if (MarkedContent.blockSnippetCache[lang + code]) {
+            this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[lang + code]);
             return undefined;
         } else {
             return renderer(code)
                 .then(renderedCode => {
-                    MarkedContent.blockSnippetCache[lang+code] = renderedCode;
-                    this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[lang+code]);
+                    MarkedContent.blockSnippetCache[lang + code] = renderedCode;
+                    this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[lang + code]);
                 }).catch(e => {
                     pxt.reportException(e);
                     this.finishRenderLangSnippet(wrapperDiv, lf("Something changed."))


### PR DESCRIPTION
closes #8830 

Added useEffect to clear the cache of snippets when the tutorial component unmounts.