### PR TITLE
clear snippet cache when user leaves tutorial

### DIFF
--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -83,6 +83,10 @@ export function TutorialContainer(props: TutorialContainerProps) {
         if (showNext) setHideModal(false);
     }, [currentStep])
 
+    React.useEffect(() => {
+        return () => MarkedContent.clearBlockSnippetCache();
+    }, [hideModal])
+
     const currentStepInfo = steps[currentStep];
     if (!steps[currentStep]) return <div />;
 


### PR DESCRIPTION
closes #8830

Added useEffect to clear the cache of snippets when the tutorial component unmounts.