### PR TITLE
Remove deletion of extension from the toolbox

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -49,7 +49,7 @@ declare namespace pxt {
         // list of trusted custom editor extension urls
         // that can bypass consent and send/receive messages
         approvedEditorExtensionUrls?: string[];
-        extensionsToolboxNoDelete?: string[]; // List of extensions to ignore when allowing for deletion in toolbox
+        extensionsToolboxDisallowDelete?: string[]; // List of extensions to ignore when allowing for deletion in toolbox
     }
 
     interface RepoData {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -49,7 +49,7 @@ declare namespace pxt {
         // list of trusted custom editor extension urls
         // that can bypass consent and send/receive messages
         approvedEditorExtensionUrls?: string[];
-        extensionsToIgnore?: string[]; // List of extensions to ignore when allowing for deletion
+        extensionsToolboxNoDelete?: string[]; // List of extensions to ignore when allowing for deletion in toolbox
         categories?: ExtensionCategory[];
     }
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -50,17 +50,11 @@ declare namespace pxt {
         // that can bypass consent and send/receive messages
         approvedEditorExtensionUrls?: string[];
         extensionsToolboxNoDelete?: string[]; // List of extensions to ignore when allowing for deletion in toolbox
-        categories?: ExtensionCategory[];
     }
 
     interface RepoData {
         slug: string;
         tags?: string[]
-    }
-
-    interface ExtensionCategory {
-        name: string;
-        extensions: string[];
     }
 
     interface ShareConfig {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -344,23 +344,7 @@ export class EditorPackage {
     }
 
     removeDepAsync(pkgid: string) {
-        const blocksEditor = getBlocksEditor();
-        const namespaces = getNsForPkg(pkgid)
-        namespaces?.forEach(ns => {
-            const maybeBlocks = [...blocksEditor.getBlocksForCategory(ns), ...blocksEditor.getBlocksForCategory(ns, "more")]
-
-            maybeBlocks.forEach(b => {
-                if (b.type != "button") {
-                    blocksEditor.editor.getBlocksByType((b as toolbox.BlockDefinition).attributes.blockId, false).forEach(foundBlock =>{
-                        foundBlock.dispose(true);
-                    })
-                }
-            })
-        })
-
-        return blocksEditor.saveToTypeScriptAsync()
-            .then(() => this.updateConfigAsync(cfg => delete cfg.dependencies[pkgid]))
-            .then(() => this.saveFilesAsync());
+        return this.updateConfigAsync(cfg => delete cfg.dependencies[pkgid])
     }
 
     /**
@@ -779,48 +763,6 @@ export function getEditorPkg(p: pxt.Package): EditorPackage {
         newOne.makeTopLevel();
     (p as any)._editorPkg = newOne
     return newOne
-}
-
-
-/**
- * Fetches all packages that have a dependency on the given package
- *
- */
-export function getDependents(pkgid: string) {
-    const deps: string[] = []
-    Object.keys(mainPkg.deps).forEach(id => {
-        const pkg = mainPkg.deps[id]
-        if (pkg.dependencies(false)[pkgid]) {
-            deps.push(id)
-        }
-    })
-    return deps
-}
-
-export function findExtForNs(ns: string): pxt.Package {
-    const pkgId = Object.keys(mainPkg.deps).find( dep => {
-        const associatedNamespaces = getNsForPkg(dep)
-        return associatedNamespaces?.includes(ns)
-    })
-    return mainPkg.deps[pkgId]
-}
-
-export function getNsForPkg(pkgId: string) {
-    const pkg = mainPkg.deps[pkgId]
-    if (!pkg) return undefined
-    const nsRegex = /\s*namespace\s+(\w*)/gm;
-    const ns: string[] = [];
-    pkg.getFiles().filter(f => Util.endsWith(f, ".ts")).forEach(fileName => {
-        const matches = nsRegex.exec(pkg.readFile(fileName))
-        if (matches) {
-            for (let i = 0; i < matches.length; i++) {
-                if (i % 2 != 0) {
-                    ns.push(matches[i])
-                }
-            }
-        }
-    })
-    return ns
 }
 
 export function mainEditorPkg() {

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -380,15 +380,9 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         this.setState({
             tryToDeleteNamespace: undefined
         })
-        const extensionsToDelete = [];
-        const extension = pkg.findExtForNs(ns);
-        extensionsToDelete.push(extension.id)
-        while (extensionsToDelete.length > 0) {
-            const id = extensionsToDelete.pop()
-            await pkg.mainEditorPkg().removeDepAsync(id)
-            extensionsToDelete.push(...pkg.getDependents(id))
-        }
-        await Util.delay(1000) // TODO VVN: Without a delay the reload still tries to load the extension
+        // TODO: Not implemented yet.
+        // Remove the top level extension, only if there are no blocks in the workspace
+        // Associated with that extension.
         await this.props.parent.parent.reloadHeaderAsync()
     }
 
@@ -505,7 +499,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                     {hasSearch ? <CategoryItem key={"search"} toolbox={this} index={index++} selected={selectedItem == "search"} treeRow={searchTreeRow} onCategoryClick={this.setSelection} /> : undefined}
                     {hasTopBlocks ? <CategoryItem key={"topblocks"} toolbox={this} selected={selectedItem == "topblocks"} treeRow={topBlocksTreeRow} onCategoryClick={this.setSelection} /> : undefined}
                     {nonAdvancedCategories.map((treeRow) => (
-                        <CategoryItem key={treeRow.nameid} toolbox={this} index={index++} selected={selectedItem == treeRow.nameid} childrenVisible={expandedItem == treeRow.nameid} treeRow={treeRow} onCategoryClick={this.setSelection} topRowIndex={topRowIndex++} shouldAnimate={this.state.shouldAnimate} hasDeleteButton={treeRow.isExtension} onDeleteClick={this.handleRemoveExtension}>
+                        <CategoryItem key={treeRow.nameid} toolbox={this} index={index++} selected={selectedItem == treeRow.nameid} childrenVisible={expandedItem == treeRow.nameid} treeRow={treeRow} onCategoryClick={this.setSelection} topRowIndex={topRowIndex++} shouldAnimate={this.state.shouldAnimate} hasDeleteButton={treeRow.delete} onDeleteClick={this.handleRemoveExtension}>
                             {treeRow.subcategories ? treeRow.subcategories.map((subTreeRow) => (
                                 <CategoryItem key={subTreeRow.nameid + subTreeRow.subns} index={index++} toolbox={this} selected={selectedItem == (subTreeRow.nameid + subTreeRow.subns)} treeRow={subTreeRow} onCategoryClick={this.setSelection} />
                             )) : undefined}
@@ -685,7 +679,7 @@ export interface ToolboxCategory {
 
     customClick?: (theEditor: editor.ToolboxEditor) => boolean;
     advanced?: boolean; /*@internal*/
-    isExtension?: boolean;
+    delete?: boolean;
 }
 
 export interface TreeRowProps {

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -499,7 +499,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                     {hasSearch ? <CategoryItem key={"search"} toolbox={this} index={index++} selected={selectedItem == "search"} treeRow={searchTreeRow} onCategoryClick={this.setSelection} /> : undefined}
                     {hasTopBlocks ? <CategoryItem key={"topblocks"} toolbox={this} selected={selectedItem == "topblocks"} treeRow={topBlocksTreeRow} onCategoryClick={this.setSelection} /> : undefined}
                     {nonAdvancedCategories.map((treeRow) => (
-                        <CategoryItem key={treeRow.nameid} toolbox={this} index={index++} selected={selectedItem == treeRow.nameid} childrenVisible={expandedItem == treeRow.nameid} treeRow={treeRow} onCategoryClick={this.setSelection} topRowIndex={topRowIndex++} shouldAnimate={this.state.shouldAnimate} hasDeleteButton={treeRow.delete} onDeleteClick={this.handleRemoveExtension}>
+                        <CategoryItem key={treeRow.nameid} toolbox={this} index={index++} selected={selectedItem == treeRow.nameid} childrenVisible={expandedItem == treeRow.nameid} treeRow={treeRow} onCategoryClick={this.setSelection} topRowIndex={topRowIndex++} shouldAnimate={this.state.shouldAnimate} hasDeleteButton={treeRow.allowDelete} onDeleteClick={this.handleRemoveExtension}>
                             {treeRow.subcategories ? treeRow.subcategories.map((subTreeRow) => (
                                 <CategoryItem key={subTreeRow.nameid + subTreeRow.subns} index={index++} toolbox={this} selected={selectedItem == (subTreeRow.nameid + subTreeRow.subns)} treeRow={subTreeRow} onCategoryClick={this.setSelection} />
                             )) : undefined}
@@ -679,7 +679,7 @@ export interface ToolboxCategory {
 
     customClick?: (theEditor: editor.ToolboxEditor) => boolean;
     advanced?: boolean; /*@internal*/
-    delete?: boolean;
+    allowDelete?: boolean;
 }
 
 export interface TreeRowProps {

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -154,27 +154,11 @@ export abstract class ToolboxEditor extends srceditor.Editor {
             }).filter(subns => !!subns);
         }
 
-        function isExtension(ns: string, md: pxtc.CommentAttrs) {
-            const nsAttr = getBlocksEditor().getNamespaceAttrs(ns);
-
-            const foundExtension = pkg.mainEditorPkg().pkgAndDeps().find(p => {
-                const ext = p.getKsPkg()
-                if (!ext) return false
-                const namespaces = pkg.getNsForPkg(ext.id)
-                if (!namespaces) return false
-                return namespaces.indexOf(ns) >= 0
-            })
-            const extensionPkg = foundExtension?.getKsPkg();
-
-            let trgConfigFetch = data.getDataWithStatus("target-config:");
-            let trgConfig = trgConfigFetch.data as pxt.TargetConfig;
-            let isHidden = false;
-            if (trgConfig && trgConfig.packages && trgConfig.packages.extensionsToIgnore && extensionPkg) {
-                isHidden = trgConfig.packages.extensionsToIgnore.includes(extensionPkg.id)
-            }
-
-            const hasDel = (nsAttr?._def?.parts?.length > 0) || (foundExtension && extensionPkg.id != "core" && !isHidden)
-            return hasDel;
+        function isTopLevelExtension(ns: string, md: pxtc.CommentAttrs) {
+            //TODO check if this extension is top level and allow delete for the same.
+            return false;
+            //const nsAttr = getBlocksEditor().extensionsMap[ns];
+            //return nsAttr.isExtension;
         }
 
         function createCategories(names: [string, pxtc.CommentAttrs][], isAdvanced?: boolean): toolbox.ToolboxCategory[] {
@@ -230,8 +214,8 @@ export abstract class ToolboxEditor extends srceditor.Editor {
                             || md.icon : pxt.toolbox.getNamespaceIcon(ns);
                         category.groups = builtInCategory.groups || md.groups;
                         category.customClick = builtInCategory.customClick;
-                    } else if (isExtension(ns, md)) {
-                        category.isExtension = true;
+                    } else if (isTopLevelExtension(ns, md)) {
+                        category.delete = true;
                     }
                     return category;
                 }).filter(cat => !!cat);

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -215,7 +215,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
                         category.groups = builtInCategory.groups || md.groups;
                         category.customClick = builtInCategory.customClick;
                     } else if (isTopLevelExtension(ns, md)) {
-                        category.delete = true;
+                        category.allowDelete = true;
                     }
                     return category;
                 }).filter(cat => !!cat);


### PR DESCRIPTION
This removes the code logic to remove the extension from the toolbox. Basically, isTopLevelExtension returns false, so user doesn't see any option to delete the extension. 

I will do a separate check-in adding the logic to enable this feature later. Idea is to allow only top-level extension to be deleted and if there is any block is used, we won't allow for deletion. 
