### PR TITLE
Hide search only and already installed extensions

### DIFF
--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -281,6 +281,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
             .map(k => JSON.parse(bundled[k]["pxt.json"]) as pxt.PackageConfig)
             .filter(pk => !pk.hidden)
             .filter(pk => !/---/.test(pk.name))
+            .filter(pk => !pk.searchOnly || searchFor?.length != 0)
             .filter(pk => pk.name != "core")
             .filter(pk => false == !!pk.core) // show core in "boards" mode
             .forEach(e => extensionsMap.set(e.name, packageConfigToExtensionMeta(e)))
@@ -366,7 +367,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                         ariaMessage={searchComplete && lf("{0} results matching '{1}'", extensionsToShow.length, searchFor)}
                         placeholder={lf("Search or enter project URL...")}
                         aria-label={lf("Search or enter project URL...")}
-                        searchHandler={setSearchFor}/>
+                        searchHandler={setSearchFor} />
                     <div className="extension-tags">
                         {categoryNames.map(c =>
                             <Button title={pxt.Util.rlf(c)}
@@ -501,5 +502,5 @@ const ExtensionCard = (props: ExtensionCardProps) => {
         props.onCardClick(props.scr);
     }
 
-    return <codecard.CodeCardView {...props} onClick={handleClick} key={props.name}/>
+    return <codecard.CodeCardView {...props} onClick={handleClick} key={props.name} />
 }

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -284,6 +284,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
             .filter(pk => !pk.searchOnly || searchFor?.length != 0)
             .filter(pk => pk.name != "core")
             .filter(pk => false == !!pk.core) // show core in "boards" mode
+            .filter(pk => !pkg.mainPkg.deps[pk.name] || pkg.mainPkg.deps[pk.name].cppOnly) // don't show package already referenced in extensions
             .forEach(e => extensionsMap.set(e.name, packageConfigToExtensionMeta(e)))
         return extensionsMap
     }

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -285,6 +285,26 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
             .filter(pk => pk.name != "core")
             .filter(pk => false == !!pk.core) // show core in "boards" mode
             .filter(pk => !pkg.mainPkg.deps[pk.name] || pkg.mainPkg.deps[pk.name].cppOnly) // don't show package already referenced in extensions
+            .sort((a, b) => {
+                // core first
+                if (a.core != b.core)
+                    return a.core ? -1 : 1;
+
+                // non-beta first
+                const abeta = pxt.isPkgBeta(a);
+                const bbeta = pxt.isPkgBeta(b);
+                if (abeta != bbeta)
+                    return abeta ? 1 : -1;
+
+                // use weight if core packages
+                const aweight = a.weight === undefined ? 50 : a.weight;
+                const bweight = b.weight === undefined ? 50 : b.weight;
+                if (aweight != bweight)
+                    return -aweight + bweight;
+
+                // alphabetical sort
+                return pxt.Util.strcmp(a.name, b.name)
+            })
             .forEach(e => extensionsMap.set(e.name, packageConfigToExtensionMeta(e)))
         return extensionsMap
     }


### PR DESCRIPTION
#### Problem
The _Recommended_ extension tab shows extensions that are either already installed, or that should only be shown when the user searches for them.

#### Solution
* Only show `searchOnly` extensions when the user is searching for them
* Do not show extensions if they're already present in the current program
* Bring back bundled extension sorting so the servo and radio-broadcast have less precedence

#### Validation
https://microbit.staging.pxt.io/app/cd636c66f377800676b92dbea35b41e13c548206-1507b2a4d4#editor
![image](https://user-images.githubusercontent.com/6496798/168174845-f1ebdd78-70cf-422a-a572-e14656e8b199.png)
![image](https://user-images.githubusercontent.com/6496798/168175254-a8f12d39-358a-4ba7-9761-bb7173991c2d.png)

#### Notes
Fixes microsoft/pxt-microbit/issues/4604
