### PR TITLE
Fix new tutorial in headless mode

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -383,6 +383,7 @@ declare namespace pxt {
         hideNewProjectButton?: boolean; // do not show the "new project" button in home page
         saveInMenu?: boolean; // move save icon under gearwheel menu
         lockedEditor?: boolean; // remove default home navigation links from the editor
+        hideReplaceMyCode?: boolean; // hides the "replace my code" button for tutorials with templates in their markdown
         fileNameExclusiveFilter?: string; // anything that does not match this regex is removed from the filename,
         copyrightText?: string; // footer text for any copyright text to be included at the bottom of the home screen and about page
         appFlashingTroubleshoot?: string; // Path to the doc about troubleshooting UWP app flashing failures, e.g. /device/windows-app/troubleshoot

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -418,6 +418,13 @@
     }
 }
 
+#root.headless.tabTutorial.hideMenuBar {
+    #editorSidebar {
+        top: 0;
+        height: 100%;
+    }
+}
+
 /*******************************
         Keymap
 *******************************/

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -147,7 +147,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
             {title && <div className="tutorial-title">{title}</div>}
             <MarkedContent className="no-select" tabIndex={0} markdown={markdown} parent={parent}/>
         </div>
-        {hasTemplate && currentStep == firstNonModalStep && preferredEditor !== "asset" &&
+        {hasTemplate && currentStep == firstNonModalStep && preferredEditor !== "asset" && !pxt.appTarget.appTheme.hideReplaceMyCode &&
             <TutorialResetCode tutorialId={tutorialId} currentStep={visibleStep} resetTemplateCode={parent.resetTutorialTemplateCode} />}
         {showScrollGradient && <div className="tutorial-scroll-gradient" />}
         <div className="tutorial-controls">

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -139,6 +139,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         const nextButton = <Button icon="arrow circle right" text={lf("Next")} onClick={this.showTutorialTab} />;
 
         return <div id="simulator" className="simulator">
+            {!hasSimulator && <div id="boardview" className="headless-sim" role="region" aria-label={lf("Simulator")} tabIndex={-1} />}
             <TabPane id="editorSidebar" activeTabName={activeTab} style={height ? { height: `calc(${height}px + ${marginHeight})` } : undefined}>
                 {hasSimulator && <TabContent name={SIMULATOR_TAB} icon="xicon gamepad" onSelected={this.showSimulatorTab} ariaLabel={lf("Open the simulator tab")}>
                     {isTabTutorial && !isLockedEditor && this.tutorialExitButton()}


### PR DESCRIPTION
The simulator was broken in headless mode even though the UI worked fine.

The fix is just to make sure the div exists. This change puts it in the DOM, but it isn't visible anywhere.