### PR TITLE
Sound effect editor fixes

### DIFF
--- a/pxtlib/soundeffect.ts
+++ b/pxtlib/soundeffect.ts
@@ -18,7 +18,7 @@ namespace pxt.assets {
     export const MAX_VOLUME = 255;
 
     export function renderSoundPath(sound: pxt.assets.Sound, width: number, height: number) {
-        const {
+        let {
             startFrequency,
             endFrequency,
             startVolume,
@@ -26,6 +26,12 @@ namespace pxt.assets {
             wave,
             interpolation
         } = sound;
+
+        startFrequency = Math.max(Math.min(startFrequency, MAX_FREQUENCY), 1);
+        endFrequency = Math.max(Math.min(endFrequency, MAX_FREQUENCY), 1);
+
+        startVolume = Math.max(Math.min(startVolume, MAX_VOLUME), 0);
+        endVolume = Math.max(Math.min(endVolume, MAX_VOLUME), 0);
 
         // To make the graph appear consistent with the implementation, use a seeded random for the noise waveform.
         // The numbers are still nonsense but at least this reflects that it's deterministic.
@@ -91,6 +97,7 @@ namespace pxt.assets {
         const random = new SeededRandom(frequency);
         if (wave === "noise") frequency = random.randomRange(500, 5000);
 
+        frequency = Math.max(Math.min(frequency, MAX_FREQUENCY), 1);
 
         const amplitude = (volume / MAX_VOLUME) * (height - 2) / 2;
         const waveHalfWidth =  (width / (frequency * timeBase / 1000)) / 2;

--- a/react-common/components/controls/DraggableGraph.tsx
+++ b/react-common/components/controls/DraggableGraph.tsx
@@ -111,7 +111,7 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
     }, [dragIndex, onPointChange])
 
     const getValue = (index: number) => {
-        return points[index];
+        return Math.min(Math.max(points[index], min), max);
     }
 
     const handleRectAnimateRef = (ref: SVGAnimateElement) => {

--- a/react-common/components/controls/DraggableGraph.tsx
+++ b/react-common/components/controls/DraggableGraph.tsx
@@ -79,6 +79,7 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
         refs.forEach((ref, index) => {
             ref.onpointerdown = ev => {
                 if (dragIndex !== -1) return;
+                ev.preventDefault();
                 const coord = clientCoord(ev);
                 const svg = screenToSVGCoord(ref.ownerSVGElement, coord);
                 setDragIndex(index);
@@ -87,6 +88,7 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
 
             ref.onpointermove = ev => {
                 if (dragIndex !== index) return;
+                ev.preventDefault();
                 const coord = clientCoord(ev);
                 const svg = screenToSVGCoord(ref.ownerSVGElement, coord);
                 throttledSetDragValue(index, svgCoordToValue(svg));
@@ -131,7 +133,7 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
         aria-hidden={ariaHidden}
         aria-describedby={ariaDescribedBy}
         role={role}>
-        <svg viewBox={`0 0 ${width} ${height}`} xmlns="http://www.w3.org/2000/svg">
+        <svg className="draggable-graph-svg" viewBox={`0 0 ${width} ${height}`} xmlns="http://www.w3.org/2000/svg">
             <defs>
                 <filter id="dropshadow">
                     <feGaussianBlur in="SourceAlpha" stdDeviation="3" />

--- a/react-common/styles/controls/DraggableGraph.less
+++ b/react-common/styles/controls/DraggableGraph.less
@@ -14,3 +14,7 @@
 .draggable-graph-surface {
     cursor: pointer;
 }
+
+.draggable-graph-svg {
+    touch-action: none;
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4649
Fixes https://github.com/microsoft/pxt-microbit/issues/4634

The first issue was caused by the renderSoundPath code looping forever when it received out of range values. I just clamped the inputs (and also clamped the values in the draggable graph because it had a similar issue).

The second issue was caused by the browser trying to perform touch gestures when dragging the SVG. Fixed by setting the touch-action to none. 