### PR TITLE
move extensions button to non-advanced categories

### DIFF
--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -563,7 +563,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 return true;
             },
             attributes: {
-                advanced: true,
+                advanced: false,
                 weight: -1,
                 icon: "addpackage",
                 callingConvention: ts.pxtc.ir.CallingConvention.Plain,


### PR DESCRIPTION
closes microsoft/pxt-microbit#4622