### PR TITLE
when decompiling hidden arguments, only hide shadows

### DIFF
--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -27,6 +27,9 @@ namespace pxt.blocks {
         // gets used for the input/field in the Blockly block
         definitionName: string;
 
+        // The index of this parameter in the block string
+        definitionIndex?: number;
+
         // Shadow block ID specified in the block string (if present)
         shadowBlockId?: string;
 
@@ -147,6 +150,7 @@ namespace pxt.blocks {
                 shadowBlockId: def.shadowBlockId,
                 type: fn.namespace,
                 defaultValue: defaultValue,
+                definitionIndex: defParameters.indexOf(def),
 
                 // Normally we pass ths actual parameter name, but the "this" parameter doesn't have one
                 fieldEditor: fieldEditor(defName, THIS_NAME),
@@ -182,6 +186,7 @@ namespace pxt.blocks {
                         type: p.type,
                         defaultValue: isVarOrArray ? (def.varName || p.default) : p.default,
                         definitionName: defName,
+                        definitionIndex: def ? defParameters.indexOf(def) : i,
                         shadowBlockId: def && def.shadowBlockId,
                         isOptional: defParameters ? defParameters.indexOf(def) >= optionalStart : false,
                         fieldEditor: fieldEditor(defName, p.name),

--- a/tests/decompile-test/baselines/compile_hidden_arguments.blocks
+++ b/tests/decompile-test/baselines/compile_hidden_arguments.blocks
@@ -1,0 +1,157 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="soundExpression_playSoundEffect">
+<field name="mode">SoundExpressionPlayMode.UntilDone</field>
+<value name="sound">
+<shadow type="soundExpression_createSoundEffect">
+<mutation _expanded="0" />
+<field name="waveShape">WaveShape.Sine</field>
+<field name="effect">SoundExpressionEffect.None</field>
+<field name="interpolation">InterpolationCurve.Linear</field>
+<value name="startFrequency">
+<shadow type="math_number_minmax">
+<mutation min="0" max="5000" />
+<field name="SLIDER">23</field>
+</shadow>
+</value>
+<value name="endFrequency">
+<shadow type="math_number_minmax">
+<mutation min="0" max="5000" />
+<field name="SLIDER">0</field>
+</shadow>
+</value>
+<value name="startVolume">
+<shadow type="math_number_minmax">
+<mutation min="0" max="255" />
+<field name="SLIDER">25</field>
+</shadow>
+</value>
+<value name="endVolume">
+<shadow type="math_number_minmax">
+<mutation min="0" max="255" />
+<field name="SLIDER">1</field>
+</shadow>
+</value>
+<value name="duration">
+<shadow type="math_number_minmax">
+<mutation min="1" max="9999" />
+<field name="SLIDER">50</field>
+</shadow>
+</value>
+</shadow>
+</value>
+<next>
+<block type="soundExpression_playSoundEffect">
+<field name="mode">SoundExpressionPlayMode.UntilDone</field>
+<value name="sound">
+<shadow type="soundExpression_createSoundEffect">
+<mutation _expanded="5" />
+<field name="waveShape">WaveShape.Sine</field>
+<field name="effect">SoundExpressionEffect.None</field>
+<field name="interpolation">InterpolationCurve.Linear</field>
+<value name="startFrequency">
+<shadow type="math_number_minmax">
+<mutation min="0" max="5000" />
+<field name="SLIDER">23</field>
+</shadow>
+</value>
+<value name="endFrequency">
+<shadow type="math_number_minmax">
+<mutation min="0" max="5000" />
+<field name="SLIDER">0</field>
+</shadow>
+</value>
+<value name="startVolume">
+<shadow type="math_number_minmax">
+<mutation min="0" max="255" />
+<field name="SLIDER">25</field>
+</shadow>
+</value>
+<value name="endVolume">
+<shadow type="math_number_minmax">
+<mutation min="0" max="255" />
+<field name="SLIDER">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<value name="duration">
+<shadow type="math_number_minmax">
+<mutation min="1" max="9999" />
+<field name="SLIDER">50</field>
+</shadow>
+</value>
+</shadow>
+</value>
+<next>
+<block type="soundExpression_playSoundEffect">
+<field name="mode">SoundExpressionPlayMode.UntilDone</field>
+<value name="sound">
+<shadow type="soundExpression_createSoundEffect">
+<mutation _expanded="3" />
+<field name="waveShape">WaveShape.Sine</field>
+<field name="effect">SoundExpressionEffect.None</field>
+<field name="interpolation">InterpolationCurve.Linear</field>
+<value name="startFrequency">
+<shadow type="math_number_minmax">
+<mutation min="0" max="5000" />
+<field name="SLIDER">23</field>
+</shadow>
+</value>
+<value name="endFrequency">
+<shadow type="math_number_minmax">
+<mutation min="0" max="5000" />
+<field name="SLIDER">0</field>
+</shadow>
+</value>
+<value name="startVolume">
+<shadow type="math_number_minmax">
+<mutation min="0" max="255" />
+<field name="SLIDER">25</field>
+</shadow>
+</value>
+<value name="endVolume">
+<shadow type="math_number_minmax">
+<mutation min="0" max="255" />
+<field name="SLIDER">1</field>
+</shadow>
+</value>
+<value name="duration">
+<shadow type="math_number_minmax">
+<mutation min="1" max="9999" />
+<field name="SLIDER">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">50</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+</shadow>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/compile_hidden_arguments.ts
+++ b/tests/decompile-test/cases/compile_hidden_arguments.ts
@@ -1,0 +1,33 @@
+music.playSoundEffect(music.createSoundEffect(
+    WaveShape.Sine,
+    23,
+    0,
+    25,
+    1,
+    50,
+    SoundExpressionEffect.None,
+    InterpolationCurve.Linear
+), SoundExpressionPlayMode.UntilDone)
+
+music.playSoundEffect(music.createSoundEffect(
+    WaveShape.Sine,
+    23,
+    0,
+    25,
+    1 + 1,
+    50,
+    SoundExpressionEffect.None,
+    InterpolationCurve.Linear
+), SoundExpressionPlayMode.UntilDone)
+
+music.playSoundEffect(music.createSoundEffect(
+    WaveShape.Sine,
+    23,
+    0,
+    25,
+    1,
+    50 + 1,
+    SoundExpressionEffect.None,
+    InterpolationCurve.Linear
+), SoundExpressionPlayMode.UntilDone)
+

--- a/tests/decompile-test/cases/testBlocks/mb.ts
+++ b/tests/decompile-test/cases/testBlocks/mb.ts
@@ -193,6 +193,34 @@ enum Melodies {
     Blues,
 }
 
+enum WaveShape {
+    Sine = 0,
+    Sawtooth = 1,
+    Triangle = 2,
+    Square = 3,
+    Noise = 4
+}
+
+enum InterpolationCurve {
+    Linear,
+    Curve,
+    Logarithmic
+}
+
+enum SoundExpressionEffect {
+    None = 0,
+    Vibrato = 1,
+    Tremolo = 2,
+    Warble = 3
+}
+
+enum SoundExpressionPlayMode {
+    //% block="until done"
+    UntilDone,
+    //% block="in background"
+    InBackground
+}
+
  /**
  * Generation of music tones through pin ``P0``.
  */
@@ -206,6 +234,45 @@ namespace music {
     //% blockId=device_builtin_melody block="%melody"
     //% blockHidden=true
     export function builtInMelody(melody: Melodies): number { return 0 };
+
+    //% blockId=soundExpression_playSoundEffect
+    //% block="play sound $sound $mode"
+    //% sound.shadow=soundExpression_createSoundEffect
+    //% weight=100 help=music/play-sound-effect
+    //% blockGap=8
+    //% group="micro:bit (V2)"
+    export function playSoundEffect(sound: string, mode: SoundExpressionPlayMode) {
+
+    }
+
+    //% blockId=soundExpression_createSoundEffect
+    //% help=music/create-sound-effect
+    //% block="$waveShape|| start frequency $startFrequency end frequency $endFrequency duration $duration start volume $startVolume end volume $endVolume effect $effect interpolation $interpolation"
+    //% waveShape.defl=WaveShape.Sine
+    //% waveShape.fieldEditor=soundeffect
+    //% startFrequency.defl=5000
+    //% startFrequency.min=0
+    //% startFrequency.max=5000
+    //% endFrequency.defl=0
+    //% endFrequency.min=0
+    //% endFrequency.max=5000
+    //% startVolume.defl=255
+    //% startVolume.min=0
+    //% startVolume.max=255
+    //% endVolume.defl=0
+    //% endVolume.min=0
+    //% endVolume.max=255
+    //% duration.defl=500
+    //% duration.min=1
+    //% duration.max=9999
+    //% effect.defl=SoundExpressionEffect.None
+    //% interpolation.defl=InterpolationCurve.Linear
+    //% compileHiddenArguments=true
+    //% inlineInputMode="variable"
+    //% group="micro:bit (V2)"
+    export function createSoundEffect(waveShape: WaveShape, startFrequency: number, endFrequency: number, startVolume: number, endVolume: number, duration: number, effect: SoundExpressionEffect, interpolation: InterpolationCurve): string {
+        return "";
+    }
 
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4657

This changes the logic when decompiling blocks with the "compileHiddenArguments" attribute (currently just the createsound block) so that instead of always collapsing the block, it now expands to show any arguments that are not shadows. That means that if you stick a variable or something in, it won't be collapsed. Only number literal arguments will get collapsed in the case of the createsound block.