### PR TITLE
allow nested params in optional (hidden) block parameters

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -370,11 +370,10 @@ namespace pxt.blocks {
             block.appendChild(createShadowValue(info, t, t.shadowBlockId || "variables_get", t.defaultValue || t.definitionName));
         }
         if (fn.parameters) {
-            comp.parameters.filter(pr => !pr.isOptional &&
-                (primitiveTypeRegex.test(pr.type)
+            comp.parameters.filter(pr => primitiveTypeRegex.test(pr.type)
                     || primitiveTypeRegex.test(isArrayType(pr.type))
                     || pr.shadowBlockId
-                    || pr.defaultValue))
+                    || pr.defaultValue)
                 .forEach(pr => {
                     block.appendChild(createShadowValue(info, pr));
                 })


### PR DESCRIPTION
I don't have a bug for this one but it came up while implementing data logger block changes; the block def became

```typescript
/**
 * Log data to flash storage
 * @param data Array of data to be logged to flash storage
 */
//% block="log data $dataA||$dataB $dataC $dataD"
//% blockId=dataloggerlogdata
//% dataA.shadow=dataloggercreatecolumnvalue
//% dataB.shadow=dataloggercreatecolumnvalue
//% dataC.shadow=dataloggercreatecolumnvalue
//% dataD.shadow=dataloggercreatecolumnvalue
//% inlineInputMode="inline"
//% group="micro:bit (V2)"
//% weight=100 help=datalogger/log-data
export function logData(
    dataA: datalogger.ColumnValue,
    dataB?: datalogger.ColumnValue,
    dataC?: datalogger.ColumnValue,
    dataD?: datalogger.ColumnValue
): void
```

and currently that makes it so all the parameters for dataB/C/D became empty / null slots.
