### PR TITLE
Fix Recommended Extensions Returning All Extensions

### DIFF
--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -205,7 +205,7 @@ export function invalidate(path: string) {
     })
 }
 
-export function getAsync<T = any>(path: string) {
+export function getAsync<T = any>(path: string): Promise<T> {
     let ce = lookup(path)
 
     if (ce.api.isSync)

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -109,11 +109,10 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
     }
 
 
-    function updateExtensionTags() {
+    async function updateExtensionTags() {
         if (extensionTags.size > 0)
             return
-        let trgConfigFetch = data.getDataWithStatus("target-config:");
-        let trgConfig = trgConfigFetch.data as pxt.TargetConfig;
+        let trgConfig = await data.getAsync<pxt.TargetConfig>("target-config:")
         if (!trgConfig || !trgConfig.packages || !trgConfig.packages.preferredRepoLib)
             return;
         const allRepos = [...trgConfig.packages.preferredRepoLib, ...trgConfig.packages.approvedRepoLib]
@@ -315,8 +314,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         bundled.forEach(e => {
             repos.push(e)
         })
-        let trgConfigFetch = data.getDataWithStatus("target-config:");
-        let trgConfig = trgConfigFetch.data as pxt.TargetConfig;
+        let trgConfig = await data.getAsync<pxt.TargetConfig>("target-config:")
 
         const toBeFetched: string[] = [];
         if (trgConfig && trgConfig.packages && trgConfig.packages.preferredRepoLib) {

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -158,7 +158,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
     async function fetchGithubDataAsync(preferredRepos: string[]): Promise<pxt.github.GitRepo[]> {
         // When searching multiple repos at the same time, use 'extension-search' which caches results
         // for much longer than 'gh-search'
-        const virtualApi = preferredRepos.length == 1 ? 'gh-search' : 'extension-search';
+        const virtualApi = preferredRepos.length <= 1 ? 'gh-search' : 'extension-search';
         return data.getAsync<pxt.github.GitRepo[]>(`${virtualApi}:${preferredRepos.join("|")}`);
     }
 


### PR DESCRIPTION
#### Problem
When the extensions modal is first loaded it will show all extensions instead of just those that are recommended. Going back to the editor and then back to the extension modal will resolve the issue. We call `data.getDataWithStatus("target-config:");` when updating the preferred extensions. When the extensions deletion feature was in place, the toolbox would actually call `data.getDataWithStatus("target-config:");` first before the extension modal is loaded. The result of this call would eventually be cached by the virtual API system that we use well before the user can open the extension modal. By the time the extension modal was loaded, `getDataWithStatus` for the "target-config" would simply return the cached value. Though the getDataWithStatus is not marked as such it is an asynchronous function when the data is not cached. Since we no longer call `data.getDataWithStatus("target-config:");` within the toolbox, the extension modal becomes the first time we try to retrieve the target config, meaning nothing is cached. Unfortunately, both `updateExtensionTags` and `updatePreferredExts` expect `data.getDataWithStatus` to be synchronous and do not correctly handle the target config being null. This results in no extension tags being loaded, and all extensions being loaded instead of just the approved ones.

#### Solution
Instead of treating `data.getDataWithStatus` as synchronous when it's not, use `data.getAsync` and await the result. Now the target config will be correctly returned and future calls to retrieve it will be served from cache.

#### Validation
See https://microbit.staging.pxt.io/app/63ce6effea7e7522569a17bb7d73ce71457f7b42-09103530da#editor

#### Notes
Fixes microsoft/pxt-microbit/issues/4663