### PR TITLE
Add support for hiding sim buttons

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -11,6 +11,7 @@ namespace pxt.runner {
         id?: string;
         code?: string;
         assets?: string;
+        hideSimButtons?: boolean;
         highContrast?: boolean;
         light?: boolean;
         fullScreen?: boolean;
@@ -405,6 +406,7 @@ namespace pxt.runner {
             storedState: storedState,
             light: simOptions.light,
             single: simOptions.single,
+            hideSimButtons: simOptions.hideSimButtons
         };
         if (pxt.appTarget.simulator && !simOptions.fullScreen)
             runOptions.aspectRatio = parts.length && pxt.appTarget.simulator.partsAspectRatio

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -70,6 +70,7 @@ namespace pxsim {
         dependencies?: Map<string>;
         // single iframe, no message simulators
         single?: boolean;
+        hideSimButtons?: boolean;
     }
 
     export interface HwDebugger {
@@ -425,6 +426,7 @@ namespace pxsim {
             frame.frameBorder = "0";
             frame.dataset['runid'] = this.runId;
             frame.dataset['origin'] = new URL(furl).origin || "*";
+            frame.dataset['hidesimbuttons'] = this._runOptions.hideSimButtons ? "true" : "false";
 
             wrapper.appendChild(frame);
 

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -106,6 +106,7 @@
         var localToken = /local_token(?:[:=])([^&?]+)/i.exec(window.location.href);
         var hex = !!/hex(?:[:=])1/i.exec(window.location.href);
         var footer = !/nofooter(?:[:=])1/i.exec(window.location.href);
+        var hideSimButtons = !!/hidesimbuttons(?:[:=])1/i.exec(window.location.href);
         var debugSim = !!/debugSim(?:[:=])1/i.exec(window.location.href);
         var sims = document.getElementById('simulators');
         var highContrast = !!/hc(?:[:=])1/i.exec(window.location.href);
@@ -180,6 +181,7 @@
                                 code: files["main.ts"],
                                 assets: JSON.stringify(files),
                                 dependencies: Object.keys(deps).map(v => v + "=" + deps[v]),
+                                hideSimButtons: hideSimButtons,
                                 highContrast: highContrast,
                                 light: light,
                                 fullScreen: fullScreen,
@@ -239,7 +241,8 @@
                         fullScreen: fullScreen,
                         dependencies: deps ? decodeURIComponent(deps[1]).split(",") : undefined,
                         builtJsInfo: builtSimJs,
-                        single: single
+                        single: single,
+                        hideSimButtons: hideSimButtons
                     };
                     console.log('simulating script')
                     pxt.runner.simulateAsync(sims, options).then(function() {


### PR DESCRIPTION
Adds support for relaying a request to display the sim without buttons by pulling it in from the request query string and configuring the sim iframe via its dataset.