### PR TITLE
Various extension browser styling fixes and use common input

### DIFF
--- a/react-common/components/controls/Input.tsx
+++ b/react-common/components/controls/Input.tsx
@@ -101,7 +101,7 @@ export const Input = (props: InputProps) => {
                     aria-hidden={ariaHidden}
                     type={type || "text"}
                     placeholder={placeholder}
-                    value={value || initialValue || ""}
+                    value={value !== undefined ? value : (initialValue || "")}
                     readOnly={!!readOnly}
                     onClick={clickHandler}
                     onChange={changeHandler}

--- a/react-common/components/controls/Modal.tsx
+++ b/react-common/components/controls/Modal.tsx
@@ -81,10 +81,11 @@ export const Modal = (props: ModalProps) => {
                 {fullscreen && helpUrl &&
                     <div className="common-modal-help">
                         <Button
-                            className={"menu-button"}
+                            className="menu-button"
                             title={lf("Help on {0} dialog", title)}
-                            onClick={() => { window.open(props.helpUrl, "_blank") }}
-                            rightIcon={"icon help"}
+                            href={props.helpUrl}
+                            onClick={() => {}}
+                            rightIcon="fas fa-question"
                         />
                     </div>
                 }

--- a/react-common/styles/controls/Button.less
+++ b/react-common/styles/controls/Button.less
@@ -16,6 +16,7 @@
     font-weight: 400;
     line-height: 1em;
     font-style: normal;
+    font-size: 16px;
     text-align: center;
     text-decoration: none;
     border-radius: 0.2em;

--- a/react-common/styles/controls/Input.less
+++ b/react-common/styles/controls/Input.less
@@ -10,6 +10,7 @@
     border-radius: 2px;
     border: 1px solid @inputBorderColor;
     background: @inputBackgroundColor;
+    font-size: 16px;
 }
 
 .common-input-group:focus::after,

--- a/theme/common.less
+++ b/theme/common.less
@@ -908,7 +908,7 @@ Field editors
 .fullscreen.extensions-browser > {
     .common-modal > {
         .common-modal-header {
-            height: 3rem;
+            height: @mainMenuHeight;
             background-color: @blue;
             z-index: 202;
             display: flex;
@@ -937,6 +937,13 @@ Field editors
         }
     }
 }
+
+@media @tabletAndBelow {
+    .fullscreen.extensions-browser > .common-modal > .common-modal-header {
+        height: @mobileMenuHeight;
+    }
+}
+
 @media @mobileAndBelow {
     .extensions-browser {
         .common-modal > .common-modal-header > .common-modal-back {
@@ -959,9 +966,10 @@ Field editors
         display: flex;
         justify-content: center;
         flex-wrap: wrap;
-        gap: 1.5rem;
+        gap: 1rem;
+        padding-top: 2rem;
+        padding-bottom: 2rem;
         background-color: #E5E5E5;
-        padding-top: 1rem;
 
         .search {
             width: 100%;
@@ -1025,9 +1033,7 @@ Field editors
 
     .extension-tags {
         display: flex;
-        padding: 2rem;
-        column-gap: 2rem;
-        row-gap: 1rem;
+        gap: 1rem;
         width: 80%;
         justify-content: center;
         flex-wrap: wrap;

--- a/theme/common.less
+++ b/theme/common.less
@@ -971,13 +971,27 @@ Field editors
         padding-bottom: 2rem;
         background-color: #E5E5E5;
 
-        .search {
-            width: 100%;
-            display: flex;
-            justify-content: center;
+        .common-input-wrapper {
+            width: 70%;
 
-            .input {
-                width: 70%;
+            .common-input-group {
+                height: 3rem;
+                border-radius: 500rem;
+                padding: 0.7rem 1rem;
+
+                & > i.fas.fa-search {
+                    position: relative;
+                    margin-top: 0.1rem;
+                    right: 0;
+                    bottom: 0;
+
+                    opacity: .5;
+                    transition: opacity 0.3s ease;
+                }
+            }
+
+            &:focus-within .common-input-group > i.fas.fa-search {
+                opacity: 1;
             }
         }
     }

--- a/theme/common.less
+++ b/theme/common.less
@@ -1081,9 +1081,13 @@ Field editors
     .tab-header {
         width: 100%;
 
+        .common-button {
+            border: 2px solid @white;
+        }
+
         .common-button.selected {
-            font-weight: bold;
-            border-bottom: 0.3rem solid @blue;
+            border-bottom: 2px solid @blue;
+            font-weight: 600;
         }
     }
 

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -397,11 +397,6 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                         onBlur={onSearchBarChange}
                         icon="fas fa-search"
                     />
-                    {/* <SearchInput
-                        ariaMessage={searchComplete && lf("{0} results matching '{1}'", extensionsToShow.length, searchFor)}
-                        placeholder={lf("Search or enter project URL...")}
-                        aria-label={lf("Search or enter project URL...")}
-                        searchHandler={setSearchFor} /> */}
                     <div className="extension-tags">
                         {categoryNames.map(c =>
                             <Button title={pxt.Util.rlf(c)}

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -6,7 +6,7 @@ import * as pkg from "./package";
 import * as codecard from "./codecard";
 
 import { Button } from "../../react-common/components/controls/Button";
-import { SearchInput } from "./components/searchInput";
+import { Input } from "../../react-common/components/controls/Input";
 import { useState, useEffect } from "react";
 import { ImportModal } from "../../react-common/components/extensions/ImportModal";
 import { Modal } from "../../react-common/components/controls/Modal";
@@ -368,6 +368,11 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
 
     const categoryNames = getCategoryNames();
     const local = currentTab == TabState.InDevelopment ? fetchLocalRepositories() : undefined
+
+    const onSearchBarChange = (newValue: string) => {
+        setSearchFor(newValue || "");
+    }
+
     return (
         <Modal
             title={lf("Extensions")}
@@ -384,11 +389,19 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                     />
                 }
                 <div className="extension-search-header">
-                    <SearchInput
+                    <Input
+                        placeholder={lf("Search or enter project URL...")}
+                        ariaLabel={lf("Search or enter project URL...")}
+                        initialValue={searchFor}
+                        onEnterKey={onSearchBarChange}
+                        onBlur={onSearchBarChange}
+                        icon="fas fa-search"
+                    />
+                    {/* <SearchInput
                         ariaMessage={searchComplete && lf("{0} results matching '{1}'", extensionsToShow.length, searchFor)}
                         placeholder={lf("Search or enter project URL...")}
                         aria-label={lf("Search or enter project URL...")}
-                        searchHandler={setSearchFor} />
+                        searchHandler={setSearchFor} /> */}
                     <div className="extension-tags">
                         {categoryNames.map(c =>
                             <Button title={pxt.Util.rlf(c)}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4646
Fixes https://github.com/microsoft/pxt-microbit/issues/4641
Fixes https://github.com/microsoft/pxt-microbit/issues/4639
Fixes https://github.com/microsoft/pxt-microbit/issues/4643
Fixes https://github.com/microsoft/pxt-microbit/issues/4638
Fixes https://github.com/microsoft/pxt-microbit/issues/4662
Fixes https://github.com/microsoft/pxt-microbit/issues/4647
Fixes https://github.com/microsoft/pxt-microbit/issues/4600

This PR does a few things:

1. Moves away from the search input component and uses the react-common input instead (fixes tabbing, search on blur)
2. Fixes the help icon button in the react-common so that it doesn't use any semantic classes
3. Tweaks CSS to make font size, spacing, borders, etc. more consistent


Before:

![image](https://user-images.githubusercontent.com/13754588/169173911-abd72534-b19c-4575-912d-5fb275c23e96.png)

After:

![image](https://user-images.githubusercontent.com/13754588/169173953-dd8b9b60-46bf-4ef7-be72-c853bc3f365c.png)

