### PR TITLE
Fix crash when runoptions is not defined

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -426,7 +426,7 @@ namespace pxsim {
             frame.frameBorder = "0";
             frame.dataset['runid'] = this.runId;
             frame.dataset['origin'] = new URL(furl).origin || "*";
-            frame.dataset['hidesimbuttons'] = this._runOptions.hideSimButtons ? "true" : "false";
+            frame.dataset['hidesimbuttons'] = this._runOptions?.hideSimButtons ? "true" : "false";
 
             wrapper.appendChild(frame);
 


### PR DESCRIPTION
micro:bit beta currently can't open any projects because of https://github.com/microsoft/pxt/pull/8844/files

Turns out, runOptions can be undefined, which is news to me!