### PR TITLE
Add Card and LazyImage to react-common and use in extension dialog

### DIFF
--- a/react-common/components/controls/Card.tsx
+++ b/react-common/components/controls/Card.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { classList, ContainerProps } from "../util";
+import { classList, ContainerProps, fireClickOnEnter } from "../util";
 
 export interface CardProps extends ContainerProps {
     onClick?: () => void;
@@ -34,7 +34,8 @@ export const Card = (props: CardProps) => {
         aria-hidden={ariaHidden}
         aria-label={ariaLabel}
         onClick={onClick}
-        tabIndex={tabIndex}>
+        tabIndex={tabIndex}
+        onKeyDown={fireClickOnEnter}>
             <div className="common-card-body">
                 {children}
             </div>

--- a/react-common/components/controls/Card.tsx
+++ b/react-common/components/controls/Card.tsx
@@ -5,6 +5,8 @@ export interface CardProps extends ContainerProps {
     onClick?: () => void;
     tabIndex?: number;
     ariaLabelledBy?: string;
+    label?: string;
+    labelClass?: string;
 }
 
 export const Card = (props: CardProps) => {
@@ -18,6 +20,8 @@ export const Card = (props: CardProps) => {
         ariaHidden,
         ariaLabel,
         onClick,
+        label,
+        labelClass,
         tabIndex
     } = props;
 
@@ -34,5 +38,10 @@ export const Card = (props: CardProps) => {
             <div className="common-card-body">
                 {children}
             </div>
+            {label &&
+                <label className={classList("common-card-label", labelClass)}>
+                    {label}
+                </label>
+            }
     </div>
 }

--- a/react-common/components/controls/Card.tsx
+++ b/react-common/components/controls/Card.tsx
@@ -3,6 +3,8 @@ import { classList, ContainerProps } from "../util";
 
 export interface CardProps extends ContainerProps {
     onClick?: () => void;
+    tabIndex?: number;
+    ariaLabelledBy?: string;
 }
 
 export const Card = (props: CardProps) => {
@@ -12,9 +14,11 @@ export const Card = (props: CardProps) => {
         role,
         children,
         ariaDescribedBy,
+        ariaLabelledBy,
         ariaHidden,
         ariaLabel,
-        onClick
+        onClick,
+        tabIndex
     } = props;
 
     return <div
@@ -22,9 +26,11 @@ export const Card = (props: CardProps) => {
         className={classList("common-card", className)}
         role={role || (onClick ? "button" : undefined)}
         aria-describedby={ariaDescribedBy}
+        aria-labelledby={ariaLabelledBy}
         aria-hidden={ariaHidden}
         aria-label={ariaLabel}
-        onClick={onClick}>
+        onClick={onClick}
+        tabIndex={tabIndex}>
             <div className="common-card-body">
                 {children}
             </div>

--- a/react-common/components/controls/Card.tsx
+++ b/react-common/components/controls/Card.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { classList, ContainerProps } from "../util";
+
+export interface CardProps extends ContainerProps {
+    onClick?: () => void;
+}
+
+export const Card = (props: CardProps) => {
+    const {
+        id,
+        className,
+        role,
+        children,
+        ariaDescribedBy,
+        ariaHidden,
+        ariaLabel,
+        onClick
+    } = props;
+
+    return <div
+        id={id}
+        className={classList("common-card", className)}
+        role={role || (onClick ? "button" : undefined)}
+        aria-describedby={ariaDescribedBy}
+        aria-hidden={ariaHidden}
+        aria-label={ariaLabel}
+        onClick={onClick}>
+            <div className="common-card-body">
+                {children}
+            </div>
+    </div>
+}

--- a/react-common/components/controls/LazyImage.tsx
+++ b/react-common/components/controls/LazyImage.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { ControlProps } from "../util";
+
+export interface LazyImageProps extends ControlProps {
+    src: string;
+    alt: string;
+    title?: string;
+}
+
+let observer: IntersectionObserver;
+
+export const LazyImage = (props: LazyImageProps) => {
+    const {
+        id,
+        className,
+        role,
+        src,
+        alt,
+        title,
+        ariaLabel,
+        ariaHidden,
+        ariaDescribedBy,
+    } = props;
+
+    initObserver();
+
+    let imageRef: HTMLImageElement;
+
+    const handleImageRef = (ref: HTMLImageElement) => {
+        if (!ref) return;
+
+        if (imageRef) observer.unobserve(imageRef);
+        imageRef = ref;
+        observer.observe(ref);
+    }
+
+    return <img
+        id={id}
+        ref={handleImageRef}
+        className={className}
+        data-src={src}
+        alt={alt}
+        title={title}
+        role={role}
+        aria-label={ariaLabel}
+        aria-hidden={ariaHidden}
+        aria-describedby={ariaDescribedBy}
+        />
+}
+
+function initObserver() {
+    if (observer) return;
+
+    const config = {
+        // If the image gets within 50px in the Y axis, start the download.
+        rootMargin: '50px 0px',
+        threshold: 0.01
+    };
+    const onIntersection: IntersectionObserverCallback = (entries) => {
+        entries.forEach(entry => {
+            // Are we in viewport?
+            if (entry.intersectionRatio > 0) {
+                // Stop watching and load the image
+                observer.unobserve(entry.target);
+                const url = entry.target.getAttribute("data-src");
+                (entry.target as HTMLImageElement).src = url;
+                
+            }
+        })
+    }
+    observer = new IntersectionObserver(onIntersection, config);
+}

--- a/react-common/components/controls/LazyImage.tsx
+++ b/react-common/components/controls/LazyImage.tsx
@@ -34,18 +34,23 @@ export const LazyImage = (props: LazyImageProps) => {
         observer.observe(ref);
     }
 
-    return <img
-        id={id}
-        ref={handleImageRef}
-        className={className}
-        data-src={src}
-        alt={alt}
-        title={title}
-        role={role}
-        aria-label={ariaLabel}
-        aria-hidden={ariaHidden}
-        aria-describedby={ariaDescribedBy}
+
+
+    return <div className="common-lazy-image-wrapper">
+        <img
+            id={id}
+            ref={handleImageRef}
+            className={className}
+            data-src={src}
+            alt={alt}
+            title={title}
+            role={role}
+            aria-label={ariaLabel}
+            aria-hidden={ariaHidden}
+            aria-describedby={ariaDescribedBy}
         />
+        <div className="common-spinner" />
+        </div>
 }
 
 function initObserver() {
@@ -64,7 +69,12 @@ function initObserver() {
                 observer.unobserve(entry.target);
                 const url = entry.target.getAttribute("data-src");
                 (entry.target as HTMLImageElement).src = url;
-                
+
+                const image = entry.target as HTMLImageElement;
+                image.src = url;
+                image.onload = () => {
+                    image.parentElement.classList.add("loaded");
+                }
             }
         })
     }

--- a/react-common/components/controls/LazyImage.tsx
+++ b/react-common/components/controls/LazyImage.tsx
@@ -50,7 +50,7 @@ export const LazyImage = (props: LazyImageProps) => {
             aria-describedby={ariaDescribedBy}
         />
         <div className="common-spinner" />
-        </div>
+    </div>
 }
 
 function initObserver() {

--- a/react-common/components/extensions/ExtensionCard.tsx
+++ b/react-common/components/extensions/ExtensionCard.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Button } from "../controls/Button";
 import { Card } from "../controls/Card";
 import { LazyImage } from "../controls/LazyImage";
+import { classList } from "../util";
 
 export interface ExtensionCardProps<U> {
     title: string;
@@ -22,35 +23,44 @@ export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
         learnMoreUrl,
         label,
         onClick,
-        extension
+        extension,
+        loading
     } = props;
 
     const onCardClick = () => {
         if (onClick) onClick(extension);
     }
 
+    const id = pxt.Util.guidGen();
+
     return <>
         <Card
-            className="common-extension-card"
-            onClick={onCardClick}>
-            <LazyImage src={imageUrl} alt={title} />
-            <div className="common-extension-card-title">
-                {title}
-            </div>
-            <div className="common-extension-card-description">
-                <div>
-                    {description}
+            className={classList("common-extension-card", loading && "loading")}
+            onClick={onCardClick}
+            ariaLabelledBy={id + "-title"}
+            ariaDescribedBy={id + "-description"}
+            tabIndex={onClick && 0}>
+            <div className="common-extension-card-contents">
+                <LazyImage src={imageUrl} alt={title} />
+                <div className="common-extension-card-title" id={id + "-title"}>
+                    {title}
                 </div>
+                <div className="common-extension-card-description">
+                    <div id={id + "-description"}>
+                        {description}
+                    </div>
+                </div>
+                {learnMoreUrl &&
+                    <Button
+                        className="link-button"
+                        label={lf("Learn More")}
+                        title={lf("Learn More")}
+                        onClick={() => {}}
+                        href={learnMoreUrl}
+                    />
+                }
             </div>
-            {learnMoreUrl &&
-                <Button
-                    className="link-button"
-                    label={lf("Learn More")}
-                    title={lf("Learn More")}
-                    onClick={() => {}}
-                    href={learnMoreUrl}
-                />
-            }
+            <div className="common-spinner"/>
         </Card>
     </>
 }

--- a/react-common/components/extensions/ExtensionCard.tsx
+++ b/react-common/components/extensions/ExtensionCard.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { Button } from "../controls/Button";
+import { Card } from "../controls/Card";
+import { LazyImage } from "../controls/LazyImage";
+
+export interface ExtensionCardProps<U> {
+    title: string;
+    description: string;
+    imageUrl?: string;
+    learnMoreUrl?: string;
+    label?: string;
+    onClick?: (value: U) => void;
+    extension?: U;
+    loading?: boolean;
+}
+
+export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
+    const {
+        title,
+        description,
+        imageUrl,
+        learnMoreUrl,
+        label,
+        onClick,
+        extension
+    } = props;
+
+    const onCardClick = () => {
+        if (onClick) onClick(extension);
+    }
+
+    return <>
+        <Card
+            className="common-extension-card"
+            onClick={onCardClick}>
+            <LazyImage src={imageUrl} alt={title} />
+            <div className="common-extension-card-title">
+                {title}
+            </div>
+            <div className="common-extension-card-description">
+                <div>
+                    {description}
+                </div>
+            </div>
+            {learnMoreUrl &&
+                <Button
+                    className="link-button"
+                    label={lf("Learn More")}
+                    title={lf("Learn More")}
+                    onClick={() => {}}
+                    href={learnMoreUrl}
+                />
+            }
+        </Card>
+    </>
+}

--- a/react-common/components/extensions/ExtensionCard.tsx
+++ b/react-common/components/extensions/ExtensionCard.tsx
@@ -39,7 +39,8 @@ export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
             onClick={onCardClick}
             ariaLabelledBy={id + "-title"}
             ariaDescribedBy={id + "-description"}
-            tabIndex={onClick && 0}>
+            tabIndex={onClick && 0}
+            label={label}>
             <div className="common-extension-card-contents">
                 <LazyImage src={imageUrl} alt={title} />
                 <div className="common-extension-card-title" id={id + "-title"}>

--- a/react-common/components/extensions/ExtensionCard.tsx
+++ b/react-common/components/extensions/ExtensionCard.tsx
@@ -42,23 +42,26 @@ export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
             tabIndex={onClick && 0}
             label={label}>
             <div className="common-extension-card-contents">
-                <LazyImage src={imageUrl} alt={title} />
-                <div className="common-extension-card-title" id={id + "-title"}>
-                    {title}
-                </div>
-                <div className="common-extension-card-description">
-                    <div id={id + "-description"}>
-                        {description}
+                {!loading && <>                
+                    <LazyImage src={imageUrl} alt={title} />
+                    <div className="common-extension-card-title" id={id + "-title"}>
+                        {title}
                     </div>
-                </div>
-                {learnMoreUrl &&
-                    <Button
-                        className="link-button"
-                        label={lf("Learn More")}
-                        title={lf("Learn More")}
-                        onClick={() => {}}
-                        href={learnMoreUrl}
-                    />
+                    <div className="common-extension-card-description">
+                        <div id={id + "-description"}>
+                            {description}
+                        </div>
+                    </div>
+                    {learnMoreUrl &&
+                        <Button
+                            className="link-button"
+                            label={lf("Learn More")}
+                            title={lf("Learn More")}
+                            onClick={() => {}}
+                            href={learnMoreUrl}
+                        />
+                    }
+                </>
                 }
             </div>
             <div className="common-spinner"/>

--- a/react-common/styles/controls/Button.less
+++ b/react-common/styles/controls/Button.less
@@ -223,6 +223,12 @@
     text-decoration: underline;
 }
 
+.common-button.link-button:focus {
+    outline: none;
+    border: none;
+    text-decoration: underline;
+}
+
 /****************************************************
  *                   Circle Buttons                 *
  ****************************************************/

--- a/react-common/styles/controls/Card.less
+++ b/react-common/styles/controls/Card.less
@@ -1,0 +1,16 @@
+.common-card {
+    width: 18rem;
+    height: 20rem;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    border: 1px solid @inputBorderColor;
+    transition: border 0.1s ease;
+}
+
+.common-card[role="button"] {
+    cursor: pointer;
+
+    &:hover {
+        border: 1px solid @inputBorderColorFocus;
+    }
+}

--- a/react-common/styles/controls/Card.less
+++ b/react-common/styles/controls/Card.less
@@ -2,10 +2,14 @@
     width: 18rem;
     height: 20rem;
     border-radius: 0.5rem;
-    overflow: hidden;
     border: 1px solid @inputBorderColor;
     transition: border 0.1s ease;
     position: relative;
+
+    .common-card-body {
+        overflow: hidden;
+        border-radius: 0.5rem;
+    }
 }
 
 .common-card[role="button"] {
@@ -14,4 +18,36 @@
     &:hover {
         border: 1px solid @inputBorderColorFocus;
     }
+}
+
+.common-card-label {
+    color: @white;
+    background-color: @orange;
+    
+    border-top-left-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
+    
+    position: absolute;
+    top: 1rem;
+    right: -1rem;
+    
+    padding: 0.5rem 0.5rem 0.25rem 0.5rem;
+    min-width: 5rem;
+    font-size: 16px;
+    border-color: darken(@orange, 10%);
+}
+
+.common-card-label::after {
+    position: absolute;
+    content: "";
+    top: 100%;
+    left: auto;
+    right: 0;
+    background-color: transparent;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 1.2em 1.2em 0 0;
+    border-top-color: inherit;
+    width: 0;
+    height: 0;
 }

--- a/react-common/styles/controls/Card.less
+++ b/react-common/styles/controls/Card.less
@@ -5,6 +5,7 @@
     overflow: hidden;
     border: 1px solid @inputBorderColor;
     transition: border 0.1s ease;
+    position: relative;
 }
 
 .common-card[role="button"] {

--- a/react-common/styles/controls/LazyImage.less
+++ b/react-common/styles/controls/LazyImage.less
@@ -1,0 +1,29 @@
+.common-lazy-image-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    .common-spinner {
+        position: absolute;
+        width: 60px;
+        height: 60px;
+
+        opacity: 1;
+        transition: opacity 0.3s ease;
+    }
+
+    img {
+        opacity: 0;
+        transition: opacity 0.3s ease;
+    }
+}
+
+.common-lazy-image-wrapper.loaded {
+    .common-spinner {
+        opacity: 0;
+    }
+
+    img {
+        opacity: 1;
+    }
+}

--- a/react-common/styles/extensions/ExtensionCard.less
+++ b/react-common/styles/extensions/ExtensionCard.less
@@ -55,6 +55,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
+        width: 100%;
 
         opacity: 1;
         transition: opacity 0.3s ease;

--- a/react-common/styles/extensions/ExtensionCard.less
+++ b/react-common/styles/extensions/ExtensionCard.less
@@ -1,0 +1,51 @@
+.common-extension-card {
+    background-color: @white;
+    
+    .common-card-body {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+
+    .common-extension-card-title {
+        font-weight: 600;
+        font-size: 18px;
+        padding: 0.5rem 1rem 0.25rem 1rem;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        flex-shrink: 0;
+    }
+
+    .common-extension-card-description {
+        flex-grow: 1;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        font-size: 16px;
+        overflow: hidden;
+
+        div {
+            text-overflow: ellipsis;
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 3;
+            overflow: hidden;
+        }
+    }
+
+    img {
+        width: 100%;
+        height: 11rem;
+        object-fit: cover;
+        flex-shrink: 0;
+    }
+
+    .common-button.link-button {
+        text-align: right;
+        padding: 0.5rem 1rem;
+        background: @white;
+        margin: 0;
+        border-radius: 0;
+        border-top: solid 1px @inputBorderColor;
+        flex-shrink: 0;
+    }
+}

--- a/react-common/styles/extensions/ExtensionCard.less
+++ b/react-common/styles/extensions/ExtensionCard.less
@@ -5,6 +5,8 @@
         display: flex;
         flex-direction: column;
         height: 100%;
+        align-items: center;
+        justify-content: center;
     }
 
     .common-extension-card-title {
@@ -47,5 +49,33 @@
         border-radius: 0;
         border-top: solid 1px @inputBorderColor;
         flex-shrink: 0;
+    }
+
+    .common-extension-card-contents {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+
+        opacity: 1;
+        transition: opacity 0.3s ease;
+    }
+
+    .common-spinner {
+        opacity: 0;
+        transition: opacity 0.3s ease;
+
+        position: absolute;
+        width: 60px;
+        height: 60px;
+    }
+}
+
+.common-extension-card.loading {
+    .common-extension-card-contents {
+        opacity: 0;
+    }
+
+    .common-spinner {
+        opacity: 1;
     }
 }

--- a/react-common/styles/react-common.less
+++ b/react-common/styles/react-common.less
@@ -1,6 +1,8 @@
 @import "profile/profile.less";
 @import "share/share.less";
+@import "extensions/ExtensionCard.less";
 @import "controls/Button.less";
+@import "controls/Card.less";
 @import "controls/Checkbox.less";
 @import "controls/DraggableGraph.less";
 @import "controls/Dropdown.less";

--- a/react-common/styles/react-common.less
+++ b/react-common/styles/react-common.less
@@ -9,6 +9,7 @@
 @import "controls/EditorToggle.less";
 @import "controls/Icon.less";
 @import "controls/Input.less";
+@import "controls/LazyImage.less";
 @import "controls/MenuDropdown.less";
 @import "controls/Modal.less";
 @import "controls/RadioButtonGroup.less";

--- a/theme/common.less
+++ b/theme/common.less
@@ -1144,11 +1144,10 @@ Field editors
 }
 
 .extension-cards {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, 18rem);
     gap: 1rem;
-    padding: 1rem;
+    width: 100%;
 }
 
 .import-extension-modal {

--- a/theme/common.less
+++ b/theme/common.less
@@ -1142,6 +1142,15 @@ Field editors
         }
     }
 }
+
+.extension-cards {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding: 1rem;
+}
+
 .import-extension-modal {
     .common-modal-body {
         display: flex;

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -490,24 +490,17 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                     loading={scr.loading}
                                     label={pxt.isPkgBeta(scr) ? lf("Beta") : undefined}
                                 />
-                            )
-                            }
-                            {/* {currentTab == TabState.InDevelopment && local.forEach((p, index) =>
+                            )}
+                            {currentTab == TabState.InDevelopment && local.forEach((p, index) =>
                                 <ExtensionCard
                                     key={`local:${index}`}
                                     title={p.name}
                                     description={lf("Local copy of {0} hosted on github.com", p.githubId)}
-                                    url={"https://github.com/" + p.githubId}
                                     imageUrl={p.icon}
-                                    scr={p}
-                                    onCardClick={addLocal}
-                                    label={lf("Local")}
-                                    title={lf("Local GitHub extension")}
-                                    labelClass="blue right ribbon"
-                                    role="button"
+                                    extension={p}
+                                    onClick={addLocal}
                                 />
-                            )
-                            } */}
+                            )}
                         </div>
                     </div>
                 }

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -3,12 +3,12 @@ import * as React from "react";
 import * as core from "./core";
 import * as workspace from "./workspace";
 import * as pkg from "./package";
-import * as codecard from "./codecard";
 
 import { Button } from "../../react-common/components/controls/Button";
 import { Input } from "../../react-common/components/controls/Input";
 import { useState, useEffect } from "react";
 import { ImportModal } from "../../react-common/components/extensions/ImportModal";
+import { ExtensionCard } from "../../react-common/components/extensions/ExtensionCard";
 import { Modal } from "../../react-common/components/controls/Modal";
 
 type ExtensionMeta = pxtc.service.ExtensionMeta;
@@ -416,19 +416,18 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                         <div className="breadcrumbs">
                             <span className="link" onClick={handleHomeButtonClick}>{lf("Home")}</span>
                         </div>
-                        <div className="ui cards left">
+                        <div className="extension-cards">
                             {extensionsToShow?.map((scr, index) =>
                                 <ExtensionCard
                                     key={`searched:${index}`}
-                                    name={scr.name ?? `${index}`}
+                                    title={scr.name ?? `${index}`}
                                     description={scr.description}
                                     imageUrl={scr.imageUrl}
-                                    scr={scr}
-                                    onCardClick={installExtension}
+                                    extension={scr}
+                                    onClick={installExtension}
                                     learnMoreUrl={scr.fullName ? `/pkg/${scr.fullName}` : undefined}
                                     loading={scr.loading}
                                     label={pxt.isPkgBeta(scr) ? lf("Beta") : undefined}
-                                    role="button"
                                 />)}
                         </div>
                         {searchComplete && extensionsToShow.length == 0 &&
@@ -444,19 +443,18 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                             <span>/</span>
                             <span>{selectedTag}</span>
                         </div>
-                        <div className="ui cards left">
+                        <div className="extension-cards">
                             {extensionsToShow?.map((scr, index) =>
                                 <ExtensionCard
                                     key={`tagged:${index}`}
-                                    name={scr.name ?? `${index}`}
+                                    title={scr.name ?? `${index}`}
                                     description={scr.description}
                                     imageUrl={scr.imageUrl}
-                                    scr={scr}
-                                    onCardClick={installExtension}
+                                    extension={scr}
+                                    onClick={installExtension}
                                     learnMoreUrl={scr.fullName ? `/pkg/${scr.fullName}` : undefined}
                                     loading={scr.loading}
                                     label={pxt.isPkgBeta(scr) ? lf("Beta") : undefined}
-                                    role="button"
                                 />)}
                         </div>
                     </div>}
@@ -478,26 +476,25 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                 className={currentTab == TabState.InDevelopment ? "selected" : ""}
                             />
                         </div>
-                        <div className="ui cards left">
+                        <div className="extension-cards">
                             {currentTab == TabState.Recommended && preferredExts.map((e, index) =>
                                 <ExtensionCard
                                     key={`preferred:${index}`}
-                                    scr={e}
-                                    name={e.name ?? `${index}`}
-                                    onCardClick={installExtension}
+                                    extension={e}
+                                    title={e.name ?? `${index}`}
+                                    onClick={installExtension}
                                     imageUrl={e.imageUrl}
                                     description={e.description}
                                     learnMoreUrl={e.fullName ? `/pkg/${e.fullName}` : undefined}
                                     loading={e.loading}
                                     label={pxt.isPkgBeta(e) ? lf("Beta") : undefined}
-                                    role="button"
                                 />
                             )
                             }
-                            {currentTab == TabState.InDevelopment && local.forEach((p, index) =>
+                            {/* {currentTab == TabState.InDevelopment && local.forEach((p, index) =>
                                 <ExtensionCard
                                     key={`local:${index}`}
-                                    name={p.name}
+                                    title={p.name}
                                     description={lf("Local copy of {0} hosted on github.com", p.githubId)}
                                     url={"https://github.com/" + p.githubId}
                                     imageUrl={p.icon}
@@ -509,25 +506,11 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                     role="button"
                                 />
                             )
-                            }
+                            } */}
                         </div>
                     </div>
                 }
             </div>
         </Modal>
     )
-}
-
-interface ExtensionCardProps extends pxt.CodeCard {
-    scr: pxtc.service.ExtensionMeta;
-    onCardClick: (scr: any) => void;
-    loading?: boolean;
-}
-
-const ExtensionCard = (props: ExtensionCardProps) => {
-    const handleClick = () => {
-        props.onCardClick(props.scr);
-    }
-
-    return <codecard.CodeCardView {...props} onClick={handleClick} key={props.name} />
 }

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect } from "react";
 import { ImportModal } from "../../react-common/components/extensions/ImportModal";
 import { ExtensionCard } from "../../react-common/components/extensions/ExtensionCard";
 import { Modal } from "../../react-common/components/controls/Modal";
+import { classList } from "../../react-common/components/util";
 
 type ExtensionMeta = pxtc.service.ExtensionMeta;
 type EmptyCard = { name: string, loading?: boolean }
@@ -419,7 +420,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                         <div className="extension-cards">
                             {extensionsToShow?.map((scr, index) =>
                                 <ExtensionCard
-                                    key={`searched:${index}`}
+                                    key={classList("searched", index + "", scr.loading && "loading")}
                                     title={scr.name ?? `${index}`}
                                     description={scr.description}
                                     imageUrl={scr.imageUrl}
@@ -446,7 +447,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                         <div className="extension-cards">
                             {extensionsToShow?.map((scr, index) =>
                                 <ExtensionCard
-                                    key={`tagged:${index}`}
+                                    key={classList("tagged", index + "", scr.loading && "loading")}
                                     title={scr.name ?? `${index}`}
                                     description={scr.description}
                                     imageUrl={scr.imageUrl}
@@ -477,17 +478,17 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                             />
                         </div>
                         <div className="extension-cards">
-                            {currentTab == TabState.Recommended && preferredExts.map((e, index) =>
+                            {currentTab == TabState.Recommended && preferredExts.map((scr, index) =>
                                 <ExtensionCard
-                                    key={`preferred:${index}`}
-                                    extension={e}
-                                    title={e.name ?? `${index}`}
+                                    key={classList("preferred", index + "", scr.loading && "loading")}
+                                    extension={scr}
+                                    title={scr.name ?? `${index}`}
                                     onClick={installExtension}
-                                    imageUrl={e.imageUrl}
-                                    description={e.description}
-                                    learnMoreUrl={e.fullName ? `/pkg/${e.fullName}` : undefined}
-                                    loading={e.loading}
-                                    label={pxt.isPkgBeta(e) ? lf("Beta") : undefined}
+                                    imageUrl={scr.imageUrl}
+                                    description={scr.description}
+                                    learnMoreUrl={scr.fullName ? `/pkg/${scr.fullName}` : undefined}
+                                    loading={scr.loading}
+                                    label={pxt.isPkgBeta(scr) ? lf("Beta") : undefined}
                                 />
                             )
                             }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4635
Fixes https://github.com/microsoft/pxt-microbit/issues/4626

Adds two new generic components to react-common:

1. Card - A container for other components that acts like a button. Also includes support for those ribbon labels (most the css I just copied from semantic for those)
2. LazyImage - An image that is lazy loaded when it appears on screen. Also shows a spinner while it is loading.

This also uses those components in the extension browser to make things look much nicer. Changes include:

1. Text is no longer huge. Now follows the conventions for the rest of the webapp
2. Descriptions now get ellipsized after three lines
3. Extension cards and images now show loading spinners when they are loading and fade in when they finish

Here's an upload target:

https://makecode.microbit.org/app/2592776d32dddb4e0d913b66caafcf8f15b8c992-1ca81c68e3