### PR TITLE
new shape for allowed repos field in targetconfig

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5834,6 +5834,13 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
     // test targetconfig
     if (nodeutil.fileExistsSync("targetconfig.json")) {
         const targetConfig = nodeutil.readJson("targetconfig.json") as pxt.TargetConfig;
+        if (targetConfig?.packages?.approvedRepoLib) {
+            for (const repoSlug of Object.keys(targetConfig.packages.approvedRepoLib)) {
+                if (repoSlug !== repoSlug.toLocaleLowerCase()) {
+                    U.userError(`targetconfig.json: repo slugs in approvedRepoLib must be lowercased.\n\tError: ${repoSlug}`);
+                }
+            }
+        }
         if (targetConfig && targetConfig.galleries) {
             Object.keys(targetConfig.galleries).forEach(k => {
                 pxt.log(`gallery ${k}`);

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -6402,7 +6402,7 @@ function testGithubPackagesAsync(parsed: commandParser.ParsedCommand): Promise<v
         .then(() => nodeutil.mkdirP(pkgsroot))
         .then(() => pxt.github.searchAsync("", packages))
         .then(ghrepos => ghrepos.filter(ghrepo => ghrepo.status == pxt.github.GitRepoStatus.Approved)
-            .map(ghrepo => ghrepo.fullName).concat(packages.approvedRepos || []))
+            .map(ghrepo => ghrepo.fullName).concat(Object.keys(packages.approvedRepoLib || {})))
         .then(fullnames => {
             // remove dups
             fullnames = U.unique(fullnames, f => f.toLowerCase());

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -34,14 +34,11 @@ declare namespace pxt {
 
     interface PackagesConfig {
         approvedOrgs?: string[];
-        approvedRepos?: string[]; // list of company/project
         releases?: pxt.Map<string[]>;  // per major version list of approved company/project#tag
         bannedOrgs?: string[];
         bannedRepos?: string[];
         allowUnapproved?: boolean;
-        preferredRepos?: string[]; // list of company/project(#tag) of packages to show by default in search
-        preferredRepoLib?: RepoData[];
-        approvedRepoLib?: RepoData[];
+        approvedRepoLib?: pxt.Map<RepoData>;
         // format:
         // "acme-corp/pxt-widget": "min:v0.1.2" - auto-upgrade to that version
         // "acme-corp/pxt-widget": "dv:foo,bar" - add "disablesVariant": ["foo", "bar"] to pxt.json
@@ -53,8 +50,9 @@ declare namespace pxt {
     }
 
     interface RepoData {
-        slug: string;
-        tags?: string[]
+        preferred?: boolean;
+        tags?: string[];
+        upgrades?: string[];
     }
 
     interface ShareConfig {
@@ -835,7 +833,7 @@ declare namespace ts.pxtc {
         mutatePrefix?: string;
         mutateDefaults?: string;
         mutatePropertyEnum?: string;
-        inlineInputMode?: string; // can be inline (horizontal), external (vertical), auto (default), or variable (based off currently expanded number of params)
+        inlineInputMode?: string; // can be inline, external, or auto
         expandableArgumentMode?: string; // can be disabled, enabled, or toggle
         compileHiddenArguments?: boolean; // if true, compiles the values in expandable arguments even when collapsed
         draggableParameters?: string; // can be reporter or variable; defaults to variable

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -833,7 +833,7 @@ declare namespace ts.pxtc {
         mutatePrefix?: string;
         mutateDefaults?: string;
         mutatePropertyEnum?: string;
-        inlineInputMode?: string; // can be inline, external, or auto
+        inlineInputMode?: string; // can be inline (horizontal), external (vertical), auto (default), or variable (based off currently expanded number of params)
         expandableArgumentMode?: string; // can be disabled, enabled, or toggle
         compileHiddenArguments?: boolean; // if true, compiles the values in expandable arguments even when collapsed
         draggableParameters?: string; // can be reporter or variable; defaults to variable

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -908,7 +908,7 @@ namespace pxt.github {
 
         if (!repo || !config) return false;
         if (repo.fullName
-            && config.approvedRepoLib[repo.fullName.toLowerCase()])
+            && config.approvedRepoLib?.[repo.fullName.toLowerCase()])
             return true;
         return false;
     }

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -124,7 +124,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                     newMap.set(tag, [])
                 }
                 const tagRepos = newMap.get(tag)
-                if (!tagRepos.indexOf(repoSlug)) {
+                if (tagRepos.indexOf(repoSlug) === -1) {
                     tagRepos.push(repoSlug);
                 }
             })
@@ -321,14 +321,14 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         const toBeFetched: string[] = [];
         if (trgConfig?.packages?.approvedRepoLib) {
             Object.keys(trgConfig.packages.approvedRepoLib).forEach(repoSlug => {
-                const repoData = trgConfig.packages.approvedRepoLib;
+                const repoData = trgConfig.packages.approvedRepoLib[repoSlug];
                 if (!repoData.preferred)
                     return;
-                const fetched = getExtensionFromFetched(repoSlug)
+                const fetched = getExtensionFromFetched(repoSlug);
                 if (fetched) {
-                    repos.push(fetched)
+                    repos.push(fetched);
                 } else {
-                    toBeFetched.push(repoSlug)
+                    toBeFetched.push(repoSlug);
                 }
             })
         }

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -148,8 +148,11 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             const trgConfigFetch = this.getDataWithStatus("target-config:");
             const trgConfig = trgConfigFetch.data as pxt.TargetConfig;
 
-            if (trgConfigFetch.status === data.FetchStatus.Complete && trgConfig && trgConfig.packages && trgConfig.packages.preferredRepos) {
-                searchFor = trgConfig.packages.preferredRepos.join("|");
+            if (trgConfigFetch.status === data.FetchStatus.Complete && trgConfig?.packages?.approvedRepoLib) {
+                const approvedRepoLib = trgConfig?.packages?.approvedRepoLib;
+                const preferredRepos = approvedRepoLib && Object.keys(approvedRepoLib).filter(el => !!approvedRepoLib[el].preferred);
+                if (preferredRepos)
+                    searchFor = preferredRepos.join("|");
             }
         }
 


### PR DESCRIPTION
the current one expands out to be super big in target config / is a bit tedious to add to; this one you can get by with just adding a single line of `"{reposlug}": {}` most of the time and expanding on that when you want to add tags / upgrade rules / etc. Also collapses preferred extensions into field as an optional parameter.


As an aside, this makes it so in `allowedRepoLib` we require it to be in lowercase for the slug; if we want we can also handle that at runtime, but I think it's reasonable to leave as is (it was semi-inconsistent on casing matters in the past anyways) & at worst add a bit to the json file check part of the ci that throws if casing is off.

closes https://github.com/microsoft/pxt-microbit/issues/4675