### PR TITLE
Don't crash if a sound expression gets cancelled

### DIFF
--- a/pxtsim/sound/soundexpression.ts
+++ b/pxtsim/sound/soundexpression.ts
@@ -227,7 +227,7 @@ namespace pxsim.codal.music {
             soundQueue.push({
                 notes,
                 onFinished: resolve,
-                onCancelled: reject
+                onCancelled: resolve
             });
         })
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4660

There's no reason to ever reject this promise, so instead we just always resolve.