### PR TITLE
center extension cards instead of left align

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1024,6 +1024,7 @@ Field editors
     .extension-display {
         display: flex;
         flex-wrap: wrap;
+        justify-content: center;
         padding: 2rem;
         gap: .8rem;
 
@@ -1172,6 +1173,7 @@ Field editors
 .extension-cards {
     display: grid;
     grid-template-columns: repeat(auto-fit, 18rem);
+    justify-content: center;
     gap: 1rem;
     width: 100%;
 }

--- a/theme/common.less
+++ b/theme/common.less
@@ -1175,7 +1175,7 @@ Field editors
     grid-template-columns: repeat(auto-fit, 18rem);
     justify-content: center;
     gap: 1rem;
-    width: 100%;
+    max-width: 95%;
 }
 
 .import-extension-modal {


### PR DESCRIPTION
The spacing on the cards / tab buttons in the extension page feels pretty off to me -- it's left aligned with some padding that ends up being ~~ 1/4 left 3/4 right or something like that, with the cards left aligned within that

current beta: 
![image](https://user-images.githubusercontent.com/5615930/170139856-0ff7fc9b-5763-4bbd-b4b5-f197504b1f3c.png)

having the cards be left aligned feels off, so just a quick centering of it

this change:

![image](https://user-images.githubusercontent.com/5615930/170139907-97988df8-b047-4723-840c-09930951b4aa.png)

Changes spacing on the header bar with 'recommended' / 'in development' / 'import file' and the cards themselves so they're centered matching the rest of the elements in the view.

I put it up at https://makecode.microbit.org/app/ab3000df6e13e737ebefe89f0f8f1721610147d0-97a6a8050b#editor for a quick visual comparison in case anyone wants