### PR TITLE
Only Show In Development Extension Tab If They Exist

### DIFF
--- a/react-common/components/extensions/ExtensionCard.tsx
+++ b/react-common/components/extensions/ExtensionCard.tsx
@@ -42,8 +42,8 @@ export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
             tabIndex={onClick && 0}
             label={label}>
             <div className="common-extension-card-contents">
-                {!loading && <>                
-                    <LazyImage src={imageUrl} alt={title} />
+                {!loading && <>
+                    {imageUrl && <LazyImage src={imageUrl} alt={title} />}
                     <div className="common-extension-card-title" id={id + "-title"}>
                         {title}
                     </div>
@@ -57,14 +57,14 @@ export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
                             className="link-button"
                             label={lf("Learn More")}
                             title={lf("Learn More")}
-                            onClick={() => {}}
+                            onClick={() => { }}
                             href={learnMoreUrl}
                         />
                     }
                 </>
                 }
             </div>
-            <div className="common-spinner"/>
+            <div className="common-spinner" />
         </Card>
     </>
 }

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -525,7 +525,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                     label={pxt.isPkgBeta(scr) ? lf("Beta") : undefined}
                                 />
                             )}
-                            {currentTab == TabState.InDevelopment && local.forEach((p, index) =>
+                            {currentTab == TabState.InDevelopment && local.map((p, index) =>
                                 <ExtensionCard
                                     key={`local:${index}`}
                                     title={p.name}

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -33,6 +33,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
     const [searchFor, setSearchFor] = useState("");
     const [searchComplete, setSearchComplete] = useState(true)
     const [allExtensions, setAllExtensions] = useState(fetchBundled());
+    const [extensionsInDevelopment, _] = useState(fetchLocalRepositories());
     const [extensionsToShow, setExtensionsToShow] = useState<(ExtensionMeta & EmptyCard)[]>([]);
     const [selectedTag, setSelectedTag] = useState("");
     const [currentTab, setCurrentTab] = useState(TabState.Recommended);
@@ -377,7 +378,6 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
     }
 
     const categoryNames = getCategoryNames();
-    const local = currentTab == TabState.InDevelopment ? fetchLocalRepositories() : undefined
 
     const onSearchBarChange = (newValue: string) => {
         setSearchFor(newValue || "");
@@ -448,18 +448,26 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                         }
                         {displayMode == ExtensionView.Tabbed &&
                             <div className="tab-header">
-                                <Button
-                                    title={lf("Recommended")}
-                                    label={lf("Recommended")}
-                                    onClick={() => { setCurrentTab(TabState.Recommended) }}
-                                    className={currentTab == TabState.Recommended ? "selected" : ""}
-                                />
-                                <Button
-                                    title={lf("In Development")}
-                                    label={lf("In Development")}
-                                    onClick={() => { setCurrentTab(TabState.InDevelopment) }}
-                                    className={currentTab == TabState.InDevelopment ? "selected" : ""}
-                                />
+                                {extensionsInDevelopment.length > 0 &&
+                                    <>
+                                        <Button
+                                            key={"Recommended"}
+                                            title={lf("Recommended")}
+                                            label={lf("Recommended")}
+                                            onClick={() => { setCurrentTab(TabState.Recommended) }}
+                                            className={currentTab == TabState.Recommended ? "selected" : ""}
+                                        />
+                                        <Button
+                                            key={"In Development"}
+                                            title={lf("In Development")}
+                                            label={lf("In Development")}
+                                            onClick={() => { setCurrentTab(TabState.InDevelopment) }}
+                                            className={currentTab == TabState.InDevelopment ? "selected" : ""}
+                                        />
+                                    </>}
+                                {extensionsInDevelopment.length == 0 &&
+                                    <h2>{lf("Recommended")}</h2>
+                                }
                             </div>
                         }
                         <div className="import-button">
@@ -525,7 +533,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                     label={pxt.isPkgBeta(scr) ? lf("Beta") : undefined}
                                 />
                             )}
-                            {currentTab == TabState.InDevelopment && local.map((p, index) =>
+                            {currentTab == TabState.InDevelopment && extensionsInDevelopment.map((p, index) =>
                                 <ExtensionCard
                                     key={`local:${index}`}
                                     title={p.name}


### PR DESCRIPTION
* Use map to return local extensions
* Only show _Recommended_ when there are no extensions in development
* Don't show extension card images if the image URL is none
* Only grab the extensions in development when the component is mounted

### Validation
- Create a micro:bit extension and push it to GitHub: https://github.com/aznhassan/test-extension-three
- Open up a new project
- Go to the extension page and see tabs for recommended and in development
- In a new window delete the test extension
- Back on the old windows, hit go-back, and then hit the extensions button again
- See that there is now just a Recommended header and no tabs

#### No tabs
![image](https://user-images.githubusercontent.com/6496798/170143600-9e4cac88-0d26-4016-b439-7cef43322be1.png)

#### Tabs
![image](https://user-images.githubusercontent.com/6496798/170144014-08fd4095-f044-41e3-9b76-0a97c019ba80.png)
![image](https://user-images.githubusercontent.com/6496798/170144032-ac8521a5-82a1-4e0d-b9fa-f88501f68852.png)

Fixes microsoft/pxt-microbit/issues/4575