### PR TITLE
pass project id when card is clicked from project list view

### DIFF
--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -489,7 +489,7 @@ class ProjectsCodeRow extends sui.StatelessUIElement<ProjectsCodeRowProps> {
     }
 
     handleClick(e: any) {
-        this.props.onRowClicked(e, this.props.scr, this.props.index);
+        this.props.onRowClicked(e, this.props.scr, this.props.index, this.props.id);
     }
 
     handleCheckboxClick(e: any) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4598

Now that we use id instead of index to identify the project, we need to make sure to pass in id.