### PR TITLE
Add a couple more options for expandable arg blocks

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -834,7 +834,9 @@ declare namespace ts.pxtc {
         mutateDefaults?: string;
         mutatePropertyEnum?: string;
         inlineInputMode?: string; // can be inline (horizontal), external (vertical), auto (default), or variable (based off currently expanded number of params)
+        inlineInputModeLimit?: number; // the number of expanded arguments at which to switch from inline to external. only applies when inlineInputMode=variable and expandableArgumentsMode=enabled
         expandableArgumentMode?: string; // can be disabled, enabled, or toggle
+        expandableArgumentBreaks?: string; // a comma separated list of how many arguments to reveal/hide each time + or - is pressed on a block. only applies when expandableArgumentsMode=enabled
         compileHiddenArguments?: boolean; // if true, compiles the values in expandable arguments even when collapsed
         draggableParameters?: string; // can be reporter or variable; defaults to variable
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -818,7 +818,7 @@ namespace ts.pxtc {
         return r;
     }
 
-    const numberAttributes = ["weight", "imageLiteral", "topblockWeight"]
+    const numberAttributes = ["weight", "imageLiteral", "topblockWeight", "inlineInputModeLimit"]
     const booleanAttributes = [
         "advanced",
         "handlerStatement",


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4674

This adds two new comment attributes for use with expandable arg blocks:

1. **inlineInputModeLimit** - sets the number of expanded args at which the block switches from horizontal to vertical. The default is 4
2. **expandableArgumentBreaks** - sets the breakpoints for expandable args

![expandable](https://user-images.githubusercontent.com/13754588/170338175-2132e550-fb61-44b3-a76d-ef4720b41b82.gif)