### PR TITLE
Unselect tags when a search is begun

### DIFF
--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -426,16 +426,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                 </div>
                 <div className="extension-display">
                     <div className="extension-header">
-                        {displayMode == ExtensionView.Search &&
-                            <Button
-                                title={lf("Home")}
-                                label={lf("Home")}
-                                onClick={handleHomeButtonClick}
-                                className="link-button"
-                            />
-                        }
-                        {displayMode == ExtensionView.Tags &&
-
+                        {(displayMode == ExtensionView.Search || displayMode == ExtensionView.Tags) &&
                             <div className="breadcrumbs">
                                 <Button
                                     title={lf("Home")}
@@ -443,8 +434,12 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                     onClick={handleHomeButtonClick}
                                     className="link-button"
                                 />
-                                <span>/</span>
-                                <span>{selectedTag}</span>
+                                {displayMode == ExtensionView.Tags &&
+                                    <>
+                                        <span>/</span>
+                                        <span>{selectedTag}</span>
+                                    </>
+                                }
                             </div>
                         }
                         {displayMode == ExtensionView.Tabbed &&

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -56,6 +56,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
      * Github search
      */
     async function searchForBundledAndGithubAsync() {
+        setSelectedTag("")
         setSearchComplete(false)
         setExtensionsToShow([emptyCard, emptyCard, emptyCard, emptyCard])
         const exts = await fetchGithubDataAsync([searchFor])


### PR DESCRIPTION
* Unselect tags when a search is begun so that it's clear we are not searching within the tags

https://user-images.githubusercontent.com/6496798/170350750-0ac771af-3896-4e55-87a9-3151acb5e720.mp4

Fixes microsoft/pxt-microbit/issues/4624
Fixes microsoft/pxt-microbit/issues/4595

build: https://microbit.staging.pxt.io/app/72d3350df53901d342c82efe3bd268d8085682f3-bde050c4f3#editor
