### PR TITLE
fix extensions view in firefox

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1176,6 +1176,7 @@ Field editors
     justify-content: center;
     gap: 1rem;
     max-width: 95%;
+    width: 95%;
 }
 
 .import-extension-modal {


### PR DESCRIPTION
chromium expands to full width but in this specific case firefox does not, so add an extra explicit setting fo rit