### PR TITLE
Fix status icon on github button

### DIFF
--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -85,11 +85,13 @@ export class GithubButton extends sui.UIElement<GithubButtonProps, GithubButtonS
         >
             <i className="github icon" />
             <span className="ui mobile hide">{displayName}</span>
-            <i className={`ui long ${
-                hasissue ? "exclamation circle"
-                    : haspull ? "arrow alternate down"
-                        : modified ? "arrow alternate up"
-                            : "check"} icon mobile hide`} />
+            <span className="ui long mobile hide">
+                <i className={`${
+                    hasissue ? "exclamation circle"
+                        : haspull ? "arrow alternate down"
+                            : modified ? "arrow alternate up"
+                                : "check"} icon`} />
+            </span>
         </div>;
     }
 }


### PR DESCRIPTION
This was buggin' me.

At issue: The `mobile hide` class names were being interpreted as icons.

Fixes https://github.com/microsoft/pxt-arcade/issues/4261
