### PR TITLE
add Menu, Reset shortcut to keymap view

### DIFF
--- a/theme/keymap.less
+++ b/theme/keymap.less
@@ -70,7 +70,7 @@
 
 .keymap.above,
 .fullscreensim .keymap {
-    top: 5.5rem;
+    top: 4.5rem;
 
     .close {
         color: @teal;

--- a/webapp/src/keymap.tsx
+++ b/webapp/src/keymap.tsx
@@ -65,7 +65,7 @@ export class Keymap extends data.Component<ISettingsProps, KeymapState> {
                             [lf("right")]: ["→", "D"],
                             "a": ["Z", lf("{id:keyboard symbol}space")],
                             "b": ["X", lf("{id:keyboard symbol}enter")],
-                            [lf("Menu")]: ["1"]
+                            [lf("Menu")]: ["`"]
                         }
                     },
                     {
@@ -77,7 +77,7 @@ export class Keymap extends data.Component<ISettingsProps, KeymapState> {
                             [lf("right")]: ["L"],
                             [lf("a")]: ["U"],
                             [lf("b")]: ["O"],
-                            [lf("Reset")]: ["2"]
+                            [lf("Reset")]: ["⌫"]
                         }
                     } ]
                 }

--- a/webapp/src/keymap.tsx
+++ b/webapp/src/keymap.tsx
@@ -64,7 +64,8 @@ export class Keymap extends data.Component<ISettingsProps, KeymapState> {
                             [lf("left")]: ["←", "A"],
                             [lf("right")]: ["→", "D"],
                             "a": ["Z", lf("{id:keyboard symbol}space")],
-                            "b": ["X", lf("{id:keyboard symbol}enter")]
+                            "b": ["X", lf("{id:keyboard symbol}enter")],
+                            [lf("Menu")]: ["1"]
                         }
                     },
                     {
@@ -75,7 +76,8 @@ export class Keymap extends data.Component<ISettingsProps, KeymapState> {
                             [lf("left")]: ["J"],
                             [lf("right")]: ["L"],
                             [lf("a")]: ["U"],
-                            [lf("b")]: ["O"]
+                            [lf("b")]: ["O"],
+                            [lf("Reset")]: ["2"]
                         }
                     } ]
                 }


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-common-packages/pull/1348, add to the keymap view

I just added them to the end of player1/player2, can add a 'system' header above them if we want but that would take up more space and I'm not sure it would look any better:

![image](https://user-images.githubusercontent.com/5615930/170795115-6f41e62b-e1ea-4153-bcf5-8ffdab4e4abd.png)
