### PR TITLE
update font family for serial icon to brand-icons

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -115,6 +115,10 @@ body.blocklyMinimalBody {
     visibility: visible;
 }
 
+.blocklyTreeIcon.blocklyTreeIconserial {
+    font-family: 'brand-icons';
+}
+
 i.icon.blocklyTreeButton {
     float: right;
     line-height: 40px;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4499

This icon is now under a new font family, 'brand-icons' instead of 'Icons' so we override the font family for this element.