### PR TITLE
Improved Python class support

### DIFF
--- a/pxtpy/ast.ts
+++ b/pxtpy/ast.ts
@@ -19,6 +19,7 @@ namespace pxt.py {
         pyAST?: AST;
         isProtected?: boolean;
         moduleTypeMarker?: {};
+        isStatic?: boolean;
 
         declared?: number; // A reference to the current iteration; used for detecting duplicate functions
     }

--- a/pxtpy/ast.ts
+++ b/pxtpy/ast.ts
@@ -199,7 +199,7 @@ namespace pxt.py {
         keywords: Keyword[];
         body: Stmt[];
         decorator_list: Expr[];
-        baseClass?: ClassDef;
+        baseClass?: SymbolInfo;
         isEnum?: boolean;
         isNamespace?: boolean;
     }

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -750,7 +750,7 @@ namespace pxt.py {
         let qid: string;
 
         if (n === "__init__") {
-            qid= ct.pyQName + ".__constructor"
+            qid = ct.pyQName + ".__constructor"
         }
         else {
             qid = ct.pyQName + "." + n;
@@ -1281,7 +1281,7 @@ namespace pxt.py {
                     const superConstructor = ctx.currClass.baseClass.pyQName + ".__constructor"
 
                     if (((firstStatement as ExprStmt).value as Call)?.func?.symbolInfo?.pyQName !== superConstructor) {
-                        error(n, 9575, lf("Sub classes must call 'super().__init__' as the first statment inside an __init__ method"));
+                        error(n, 9575, lf("Sub classes must call 'super().__init__' as the first statement inside an __init__ method"));
                     }
                 }
 
@@ -1386,7 +1386,7 @@ namespace pxt.py {
                     .filter(f => f.kind == SK.Property || isStatic(f))
                     .map(f => {
                         if (!f.pyName || !f.pyRetType)
-                            error(n, 9535, lf("field definition missing py name or ret type", f.qName));
+                            error(n, 9535, lf("field definition missing py name or return type", f.qName));
                         return f
                     });
                 const instanceFields = fieldDefs.filter(f => !isStatic(f))

--- a/tests/pyconverter-test/baselines/class_extend_ts.ts
+++ b/tests/pyconverter-test/baselines/class_extend_ts.ts
@@ -1,0 +1,11 @@
+class MySprite extends sprites.ExtendableSprite {
+    constructor() {
+        super(5)
+    }
+    
+    public draw(drawLeft: number, drawTop: number) {
+        super.draw(drawLeft, drawTop)
+    }
+    
+}
+

--- a/tests/pyconverter-test/baselines/class_namespace.ts
+++ b/tests/pyconverter-test/baselines/class_namespace.ts
@@ -1,0 +1,4 @@
+namespace SpriteKind {
+    export const Whatever = SpriteKind.create()
+}
+

--- a/tests/pyconverter-test/baselines/class_scope.ts
+++ b/tests/pyconverter-test/baselines/class_scope.ts
@@ -1,0 +1,32 @@
+let staticVar = 20
+class Test {
+    static staticVar: number
+    static x: number
+    instanceVar: number
+    public static __initTest() {
+        Test.staticVar = 9
+        for (Test.x = 0; Test.x < 3; Test.x++) {
+            Test.staticVar = Test.staticVar + 1
+        }
+        console.log(Test.x)
+    }
+    
+    constructor() {
+        this.instanceVar = 7
+    }
+    
+    public instanceMethod() {
+        let instanceMethodLocalVar = 5
+        return this.instanceVar + instanceMethodLocalVar
+    }
+    
+    public static staticMethod() {
+        
+        let staticMethodLocalVar = 4
+        return staticMethodLocalVar + Test.staticVar + staticVar
+    }
+    
+}
+
+Test.__initTest()
+

--- a/tests/pyconverter-test/baselines/class_super.ts
+++ b/tests/pyconverter-test/baselines/class_super.ts
@@ -1,0 +1,33 @@
+class Base {
+    constructor(num: number) {
+        
+    }
+    
+    public instanceM() {
+        console.log(1)
+    }
+    
+    public static staticM() {
+        console.log(2)
+    }
+    
+}
+
+class Sub extends Base {
+    constructor() {
+        super(5)
+    }
+    
+    public instanceM() {
+        super.instanceM()
+        console.log(3)
+    }
+    
+    public static staticM() {
+        console.log(4)
+    }
+    
+}
+
+let x = new Base(4)
+let y = new Sub()

--- a/tests/pyconverter-test/cases/class_extend_ts.py
+++ b/tests/pyconverter-test/cases/class_extend_ts.py
@@ -1,0 +1,6 @@
+class MySprite(sprites.ExtendableSprite):
+    def __init__(self):
+        super().__init__(5)
+
+    def draw(self, drawLeft, drawTop):
+        super().draw(drawLeft, drawTop)

--- a/tests/pyconverter-test/cases/class_namespace.py
+++ b/tests/pyconverter-test/cases/class_namespace.py
@@ -1,0 +1,3 @@
+@namespace
+class SpriteKind:
+    Whatever = SpriteKind.create()

--- a/tests/pyconverter-test/cases/class_scope.py
+++ b/tests/pyconverter-test/cases/class_scope.py
@@ -1,0 +1,22 @@
+staticVar = 20
+
+class Test():
+    staticVar = 9
+
+    for x in range(3):
+        staticVar = staticVar + 1
+
+    print(x)
+
+    def __init__(self):
+        self.instanceVar = 7
+
+    def instanceMethod(self):
+        instanceMethodLocalVar = 5
+        return self.instanceVar + instanceMethodLocalVar
+
+    def staticMethod():
+        global staticVar
+        staticMethodLocalVar = 4
+        return staticMethodLocalVar + Test.staticVar + staticVar
+

--- a/tests/pyconverter-test/cases/class_super.py
+++ b/tests/pyconverter-test/cases/class_super.py
@@ -1,0 +1,25 @@
+class Base:
+    def __init__(self, num):
+        pass
+
+    def instanceM(self):
+        print(1)
+    def staticM():
+        print(2)
+
+class Sub(Base):
+    def __init__(self):
+        super().__init__(5)
+
+    def instanceM(self):
+        super().instanceM()
+        print(3)
+    def staticM():
+        print(4)
+
+
+x = Base(4)
+y = Sub()
+
+
+

--- a/tests/pyconverter-test/testlib/classHandlerParameter.ts
+++ b/tests/pyconverter-test/testlib/classHandlerParameter.ts
@@ -1,5 +1,8 @@
 namespace game {
     export class Sprite {
+        constructor(x: number) {
+        }
+
         /**
          * Registers code when the sprite overlaps with another sprite
          * @param spriteType sprite type to match
@@ -9,6 +12,30 @@ namespace game {
         //% blockId=spriteonoverlap block="on %sprite overlaped with"
         //% afterOnStart=true
         onOverlap(handler: (other: Sprite) => void) {
+        }
+    }
+}
+
+namespace sprites {
+    /**
+     * A version of the Sprite class that is easier to extend.
+     *
+     * Unlike the normal Sprite class, this class will automatically add
+     * itself to the physics engine and run all sprite created handlers
+     * in the constructor
+     */
+    export class ExtendableSprite extends game.Sprite {
+        constructor(kind: number) {
+            super(kind)
+        }
+
+        /**
+         * Override to change how the sprite is drawn to the screen
+         *
+         * @param drawLeft The left position to draw the sprite at (already adjusted for camera)
+         * @param drawTop The top position to draw the sprite at (already adjusted for camera)
+         */
+        draw(drawLeft: number, drawTop: number) {
         }
     }
 }


### PR DESCRIPTION
This PR extends our Python class support. I still have a few more bugs to fix, but this adds a lot more functionality and fixes the more egregious bugs. Also this does *not* roundtrip.

Newly supported features include:
* Static methods and properties
* Floating statements in the class scope (i.e. not within a method or a constructor)
* Extending other Python classes
* Extending TypeScript classes

Intentionally unsupported features that we could conceivably support in the future:
* Calling protected properties/methods from a TypeScript class in a python class (right now the pyconverter uses the apiinfo from the language service which does not have access to those symbols; it's nontrivial to fix that)
* `__iter__`, `__str__`, and all the other "special" python methods

Also, for reference, Static Python has some additional restrictions on classes because it maps to classes in static TypeScript. These include:
* No multiple inheritance
* Constructors in subclasses must call `super().__init__` as the first statement
