### PR TITLE
Support for github "main" branch

### DIFF
--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1043,7 +1043,7 @@ namespace pxt.cpp {
                 "libraries": U.values(codalLibraries).map(r => ({
                     "name": r.project,
                     "url": "https://github.com/" + r.fullName,
-                    "branch": r.tag || "master",
+                    "branch": r.tag || "master", // Keep as "master" (no need to support "main" branch here)
                     "type": "git"
                 }))
             }

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -552,7 +552,7 @@ namespace pxt.docs {
         if (opts.repo)
             markdown += `
 \`\`\`package
-${opts.repo.name.replace(/^pxt-/, '')}=github:${opts.repo.fullName}#${opts.repo.tag || "master"}
+${opts.repo.name.replace(/^pxt-/, '')}=github:${opts.repo.fullName}${opts.repo.tag ? `#${opts.repo.tag}` : ""}
 \`\`\`
 `;
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5004,9 +5004,15 @@ async function importGithubProject(repoid: string, requireSignin?: boolean) {
 
     core.showLoading("loadingheader", lf("importing GitHub project..."));
     try {
+        const config = await pxt.packagesConfigAsync();
+        pxt.debug(`importing github project ${repoid}`);
+        const parsedRepoId = pxt.github.parseRepoId(repoid);
+        pxt.debug(`parsed repo id ${JSON.stringify(parsedRepoId)}`);
+        const repo = await pxt.github.repoAsync(parsedRepoId.slug, config);
+        pxt.debug(`repo ${JSON.stringify(repo)}`);
         // normalize for precise matching
-        // if the branch is not specified, assume "master"
-        repoid = pxt.github.normalizeRepoId(repoid, "master");
+        repoid = pxt.github.normalizeRepoId(repoid, repo?.defaultBranch);
+        pxt.debug(`normalized repo id ${repoid}`);
         // try to find project with same id
         let hd = workspace.getHeaders().find(h => h.githubId &&
             pxt.github.normalizeRepoId(h.githubId) == repoid

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -101,7 +101,7 @@ class GithubDb implements pxt.github.IGithubDb {
 
     loadConfigAsync(repopath: string, tag: string): Promise<pxt.PackageConfig> {
         // don't cache master
-        if (tag == "master")
+        if (pxt.github.looksLikeDefaultBranch(tag))
             return this.mem.loadConfigAsync(repopath, tag);
 
         const id = `config-${repopath}-${tag}`;
@@ -124,11 +124,11 @@ class GithubDb implements pxt.github.IGithubDb {
     }
     loadPackageAsync(repopath: string, tag: string): Promise<pxt.github.CachedPackage> {
         if (!tag) {
-          pxt.debug(`dep: default to master`)
-          tag = "master"
+          pxt.debug(`dep: default to main`)
+          tag = "main"
         }
         // don't cache master
-        if (tag == "master")
+        if (pxt.github.looksLikeDefaultBranch(tag))
             return this.mem.loadPackageAsync(repopath, tag);
 
         const id = `pkg-${repopath}-${tag}`;

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -100,8 +100,13 @@ class GithubDb implements pxt.github.IGithubDb {
     }
 
     loadConfigAsync(repopath: string, tag: string): Promise<pxt.PackageConfig> {
+        if (!tag) {
+            pxt.debug(`dep: default to main`)
+            tag = "main"
+          }
+
         // don't cache master
-        if (pxt.github.looksLikeDefaultBranch(tag))
+        if (pxt.github.isDefaultBranch(tag))
             return this.mem.loadConfigAsync(repopath, tag);
 
         const id = `config-${repopath}-${tag}`;
@@ -124,11 +129,12 @@ class GithubDb implements pxt.github.IGithubDb {
     }
     loadPackageAsync(repopath: string, tag: string): Promise<pxt.github.CachedPackage> {
         if (!tag) {
-          pxt.debug(`dep: default to main`)
-          tag = "main"
-        }
-        // don't cache master
-        if (pxt.github.looksLikeDefaultBranch(tag))
+            pxt.debug(`dep: default to main`)
+            tag = "main"
+          }
+
+          // don't cache master
+        if (pxt.github.isDefaultBranch(tag))
             return this.mem.loadPackageAsync(repopath, tag);
 
         const id = `pkg-${repopath}-${tag}`;

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -84,7 +84,7 @@ function renderCompileLink(variantName: string, cs: pxt.TargetCompileService) {
 
     if (typeof cs.codalTarget === "object" && typeof cs.codalTarget.url === "string") {
         url = cs.codalTarget.branch ? pxt.BrowserUtils.joinURLs(cs.codalTarget.url, "releases/tag", cs.codalTarget.branch) : cs.codalTarget.url;
-        version = cs.codalTarget.branch || "master";
+        version = cs.codalTarget.branch || "master"; // Keep as "master" (no need to support "main" branch here)
         name = cs.codalTarget.name || cs.serviceId;
     }
     else {

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -507,7 +507,7 @@ export function showCreateGithubRepoDialogAsync(name?: string) {
                     .finally(() => core.hideLoading("creategithub"))
                     .then(r => {
                         pxt.tickEvent("github.create.ok");
-                        return pxt.github.normalizeRepoId("https://github.com/" + r.fullName, "master");
+                        return pxt.github.normalizeRepoId("https://github.com/" + r.fullName, "main");
                     }, err => {
                         if (!showGithubTokenError(err)) {
                             if (err.statusCode == 422)
@@ -545,7 +545,7 @@ export function showImportGithubDialogAsync() {
                 description: r.description,
                 updatedAt: r.updatedAt,
                 onClick: () => {
-                    res = pxt.github.normalizeRepoId("https://github.com/" + r.fullName, "master")
+                    res = pxt.github.normalizeRepoId("https://github.com/" + r.fullName)
                     core.hideDialog()
                 },
             }));

--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -64,10 +64,10 @@ export class GithubButton extends sui.UIElement<GithubButtonProps, GithubButtonS
         const hasissue = pullStatus == workspace.PullStatus.BranchNotFound;
         const haspull = pullStatus == workspace.PullStatus.GotChanges;
         const modified = meta && !!meta.modified;
-        const repoName = ghid.project && ghid.tag ? `${ghid.project}${pxt.github.looksLikeDefaultBranch(ghid.tag) ? "" : `#${ghid.tag}`}` : ghid.fullName;
+        const repoName = ghid.project && ghid.tag ? `${ghid.project}${pxt.github.isDefaultBranch(ghid.tag) ? "" : `#${ghid.tag}`}` : ghid.fullName;
         // shrink name...
         const maxLength = 20;
-        let displayName = ghid.tag && (pxt.github.looksLikeDefaultBranch(ghid.tag)) ? "" : `#${ghid.tag}`;
+        let displayName = ghid.tag && (pxt.github.isDefaultBranch(ghid.tag)) ? "" : `#${ghid.tag}`;
         if (displayName.length > maxLength)
             displayName = displayName.slice(0, maxLength - 2) + '..';
 

--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -64,10 +64,10 @@ export class GithubButton extends sui.UIElement<GithubButtonProps, GithubButtonS
         const hasissue = pullStatus == workspace.PullStatus.BranchNotFound;
         const haspull = pullStatus == workspace.PullStatus.GotChanges;
         const modified = meta && !!meta.modified;
-        const repoName = ghid.project && ghid.tag ? `${ghid.project}${ghid.tag == "master" ? "" : `#${ghid.tag}`}` : ghid.fullName;
+        const repoName = ghid.project && ghid.tag ? `${ghid.project}${pxt.github.looksLikeDefaultBranch(ghid.tag) ? "" : `#${ghid.tag}`}` : ghid.fullName;
         // shrink name...
         const maxLength = 20;
-        let displayName = ghid.tag && ghid.tag != "master" ? `#${ghid.tag}` : "";
+        let displayName = ghid.tag && (pxt.github.looksLikeDefaultBranch(ghid.tag)) ? "" : `#${ghid.tag}`;
         if (displayName.length > maxLength)
             displayName = displayName.slice(0, maxLength - 2) + '..';
 

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -240,7 +240,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         }))
 
         // only branch from default branch...
-        if (pxt.github.looksLikeDefaultBranch(gid.tag)) {
+        if (pxt.github.isDefaultBranch(gid.tag)) {
             branchList.unshift({
                 name: lf("Create new branch"),
                 description: lf("Based on {0}", gid.tag),
@@ -757,15 +757,15 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         const hasissue = pullStatus == workspace.PullStatus.BranchNotFound || pullStatus == workspace.PullStatus.NoSourceControl;
         const haspull = pullStatus == workspace.PullStatus.GotChanges;
         const githubId = this.parsedRepoId()
-        const defaultBranch = pxt.github.looksLikeDefaultBranch(githubId.tag);
+        const isDefaultBranch = pxt.github.isDefaultBranch(githubId.tag);
         const user = this.getData("github:user") as pxt.editor.UserInfo;
 
         // don't use gs.prUrl, as it gets cleared often
-        const url = `https://github.com/${githubId.slug}/${defaultBranch && !githubId.fileName ? "" : pxt.github.join("tree", githubId.tag || "main", githubId.fileName)}`;
+        const url = `https://github.com/${githubId.slug}/${isDefaultBranch && !githubId.fileName ? "" : pxt.github.join("tree", githubId.tag || "main", githubId.fileName)}`;
         const needsToken = !pxt.github.token;
         // this will show existing PR if any
         const pr: pxt.github.PullRequest = this.getData("pkg-git-pr:" + header.id)
-        const showPr = pr !== null && (gs.isFork || !defaultBranch);
+        const showPr = pr !== null && (gs.isFork || !isDefaultBranch);
         const showPrResolved = showPr && pr && pr.number > 0;
         const showPrCreate = showPr && pr && pr.number <= 0;
         const isOwner = user && user.id === githubId.owner;
@@ -786,7 +786,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                         <sui.Link className="ui button" icon="external alternate" href={url} title={lf("Open repository in GitHub.")} target="_blank" onKeyDown={fireClickOnEnter} />
                     </div>
                 </div>
-                <MessageComponent parent={this} needsToken={needsToken} githubId={githubId} defaultBranch={defaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />
+                <MessageComponent parent={this} needsToken={needsToken} githubId={githubId} isDefaultBranch={isDefaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />
                 <div className="ui form">
                     {showPrResolved &&
                         <sui.Link href={pr.url} role="button" className="ui tiny basic button create-pr"
@@ -799,12 +799,12 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                         <span className="repo-name">{githubId.fullName}</span>
                         <span onClick={this.handleBranchClick} onKeyDown={fireClickOnEnter} tabIndex={0} role="button" className="repo-branch">{"#" + githubId.tag}<i className="dropdown icon" /></span>
                     </h3>
-                    {needsCommit && <CommmitComponent parent={this} needsToken={needsToken} githubId={githubId} defaultBranch={defaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
-                    {showPrResolved && !needsCommit && <PullRequestZone parent={this} needsToken={needsToken} githubId={githubId} defaultBranch={defaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
+                    {needsCommit && <CommmitComponent parent={this} needsToken={needsToken} githubId={githubId} isDefaultBranch={isDefaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
+                    {showPrResolved && !needsCommit && <PullRequestZone parent={this} needsToken={needsToken} githubId={githubId} isDefaultBranch={isDefaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
                     {diffFiles && <DiffView parent={this} diffFiles={diffFiles} cacheKey={gs.commit.sha} allowRevert={true} showWhitespaceDiff={true} blocksMode={isBlocksMode} showConflicts={true} />}
-                    <HistoryZone parent={this} needsToken={needsToken} githubId={githubId} defaultBranch={defaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />
-                    {defaultBranch && <ReleaseZone parent={this} needsToken={needsToken} githubId={githubId} defaultBranch={defaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
-                    {!isBlocksMode && <ExtensionZone parent={this} needsToken={needsToken} githubId={githubId} defaultBranch={defaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
+                    <HistoryZone parent={this} needsToken={needsToken} githubId={githubId} isDefaultBranch={isDefaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />
+                    {isDefaultBranch && <ReleaseZone parent={this} needsToken={needsToken} githubId={githubId} isDefaultBranch={isDefaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
+                    {!isBlocksMode && <ExtensionZone parent={this} needsToken={needsToken} githubId={githubId} isDefaultBranch={isDefaultBranch} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
                     <div></div>
                 </div>
             </div>
@@ -1215,7 +1215,7 @@ class MessageComponent extends sui.StatelessUIElement<GitHubViewProps> {
 interface GitHubViewProps {
     githubId: pxt.github.ParsedRepo;
     needsToken: boolean;
-    defaultBranch: boolean;
+    isDefaultBranch: boolean;
     parent: GithubComponent;
     gs: pxt.github.GitJson;
     isBlocks: boolean;
@@ -1365,7 +1365,7 @@ class ReleaseZone extends sui.StatelessUIElement<GitHubViewProps> {
     private handleBumpClick(e: React.MouseEvent<HTMLElement>) {
         pxt.tickEvent("github.releasezone.bump", undefined, { interactiveConsent: true });
         e.stopPropagation();
-        const { needsCommit, defaultBranch } = this.props;
+        const { needsCommit, isDefaultBranch } = this.props;
         const header = this.props.parent.props.parent.state.header;
         if (needsCommit)
             core.confirmAsync({
@@ -1374,7 +1374,7 @@ class ReleaseZone extends sui.StatelessUIElement<GitHubViewProps> {
                 agreeLbl: lf("Ok"),
                 hideAgree: true
             });
-        else if (!defaultBranch)
+        else if (!isDefaultBranch)
             core.confirmAsync({
                 header: lf("Checkout the default branch..."),
                 body: lf("You need to checkout the default branch to create a release."),

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -936,7 +936,7 @@ data.mountVirtualApi("pkg-git-pr", {
         const ghid = f.getPkgId() == "this" && header && header.githubId;
         if (!ghid) return Promise.resolve(missing);
         const parsed = pxt.github.parseRepoId(ghid);
-        if (!parsed || !parsed.tag || parsed.tag == "master") return Promise.resolve(missing);
+        if (!parsed || !parsed.tag || pxt.github.looksLikeDefaultBranch(parsed.tag)) return Promise.resolve(missing);
         return pxt.github.findPRNumberforBranchAsync(parsed.fullName, parsed.tag)
             .catch(e => missing);
     },

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -936,7 +936,7 @@ data.mountVirtualApi("pkg-git-pr", {
         const ghid = f.getPkgId() == "this" && header && header.githubId;
         if (!ghid) return Promise.resolve(missing);
         const parsed = pxt.github.parseRepoId(ghid);
-        if (!parsed || !parsed.tag || pxt.github.looksLikeDefaultBranch(parsed.tag)) return Promise.resolve(missing);
+        if (!parsed || !parsed.tag || pxt.github.isDefaultBranch(parsed.tag)) return Promise.resolve(missing);
         return pxt.github.findPRNumberforBranchAsync(parsed.fullName, parsed.tag)
             .catch(e => missing);
     },


### PR DESCRIPTION
| **This change needs thorough testing** |
|-|

#### Changes
Adds support for non-"master" default GitHub branches
* Query default branch name when importing a repo
* When creating a new repo, create with "main" branch
* Compatible with old repos using "master" as default
    * (the code can handle any default branch name)

#### Out of scope
The pxt cli has some references to "master" branch. I have not investigated what these are or whether they need to be updated.

