### PR TITLE
Handle python class instance fields with the same name as static fields

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1402,18 +1402,14 @@ namespace pxt.py {
                     });
                 const staticFieldSymbols = fieldDefs.filter(f => isStatic(f));
 
-                const instanceFields = fieldDefs.filter(f => !isStatic(f))
-                    .map((f) => {
-                        const quotedName = quoteStr(f.pyName!);
-
-                        if (staticFieldSymbols.some(s => quoteStr(s.pyName!) === quotedName)) {
-                            return declareLocalStatic(quoteStr(n.name), quotedName, t2s(f.pyRetType!))
-                        }
-
-                        return B.mkStmt(accessAnnot(f), quote(f.pyName!), typeAnnot(f.pyRetType!));
-                    });
+                const instanceFields = fieldDefs.filter(f => !isStatic(f) && !staticFieldSymbols.some(s => quoteStr(s.pyName!) === quoteStr(f.pyName!)))
+                    .map((f) => B.mkStmt(accessAnnot(f), quote(f.pyName!), typeAnnot(f.pyRetType!)));
                 const staticFields = staticFieldSymbols
-                    .map((f) => B.mkStmt(accessAnnot(f), B.mkText("static "), quote(f.pyName!), typeAnnot(f.pyRetType!)));
+                    .map((f) =>
+                    B.mkGroup([
+                        B.mkStmt(accessAnnot(f), B.mkText("static "), quote(f.pyName!), typeAnnot(f.pyRetType!)),
+                        declareLocalStatic(quoteStr(n.name), quoteStr(f.pyName!), t2s(f.pyRetType!))
+                    ]));
 
                 body.children = staticFields.concat(instanceFields).concat(body.children)
             }

--- a/tests/pyconverter-test/baselines/class_scope.ts
+++ b/tests/pyconverter-test/baselines/class_scope.ts
@@ -1,7 +1,27 @@
 let staticVar = 20
 class Test {
     static staticVar: number
+    private ___staticVar_is_set: boolean
+    private ___staticVar: number
+    get staticVar(): number {
+        return this.___staticVar_is_set ? this.___staticVar : Test.staticVar
+    }
+    set staticVar(value: number) {
+        this.___staticVar_is_set = true
+        this.___staticVar = value
+    }
+
     static x: number
+    private ___x_is_set: boolean
+    private ___x: number
+    get x(): number {
+        return this.___x_is_set ? this.___x : Test.x
+    }
+    set x(value: number) {
+        this.___x_is_set = true
+        this.___x = value
+    }
+
     instanceVar: number
     public static __initTest() {
         Test.staticVar = 9
@@ -10,22 +30,22 @@ class Test {
         }
         console.log(Test.x)
     }
-    
+
     constructor() {
         this.instanceVar = 7
     }
-    
+
     public instanceMethod() {
         let instanceMethodLocalVar = 5
         return this.instanceVar + instanceMethodLocalVar
     }
-    
+
     public static staticMethod() {
-        
+
         let staticMethodLocalVar = 4
         return staticMethodLocalVar + Test.staticVar + staticVar
     }
-    
+
 }
 
 Test.__initTest()

--- a/tests/pyconverter-test/baselines/class_static_local.ts
+++ b/tests/pyconverter-test/baselines/class_static_local.ts
@@ -1,0 +1,35 @@
+class Greeter {
+    static greeting: string
+    private ___greeting_is_set: boolean
+    private ___greeting: string
+    get greeting(): string {
+        return this.___greeting_is_set ? this.___greeting : Greeter.greeting
+    }
+    set greeting(value: string) {
+        this.___greeting_is_set = true
+        this.___greeting = value
+    }
+    
+    local: string
+    public static __initGreeter() {
+        Greeter.greeting = "default"
+    }
+    
+    constructor(message: string) {
+        console.log("constructor: " + this.greeting)
+        this.greeting = message
+        this.local = "local"
+    }
+    
+}
+
+Greeter.__initGreeter()
+
+let greeter = new Greeter("world")
+console.log(greeter.greeting)
+console.log(Greeter.greeting)
+Greeter.greeting = "newdefault"
+greeter = new Greeter("world")
+console.log(Greeter.greeting)
+greeter.greeting = null
+console.log(greeter.greeting)

--- a/tests/pyconverter-test/cases/class_static_local.py
+++ b/tests/pyconverter-test/cases/class_static_local.py
@@ -1,0 +1,22 @@
+class Greeter:
+    greeting = "default"
+    def __init__(self, message):
+
+        print ("constructor: " + self.greeting)
+        self.greeting = message
+        self.local = "local"
+
+
+
+
+greeter = Greeter("world")
+
+
+print (greeter.greeting)
+print (Greeter.greeting)
+
+Greeter.greeting = "newdefault"
+greeter = Greeter("world")
+print (Greeter.greeting)
+greeter.greeting = None
+print (greeter.greeting)


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3456

Python's class semantics for static fields are a bit different than TypeScript's... Basically, if you try to access a field on a class instance and it is defined as a static field, the static field is returned. If that field is then assigned on the instance, then the assigned value is returned. Luckily, it's pretty easy to replicate that behavior using getters and setters in TypeScript!

This PR updates how we emit static fields so that classes like this:

```python
class Greeter:
    greeting = ""
    def __init__(self, message):
        self.greeting = message
    def greet(self):
        return "Hello, " + self.greeting
```

now convert into TypeScript like this:

```typescript
class Greeter {
    static greeting: string
    private ___greeting_is_set: boolean
    private ___greeting: string
    get greeting(): string {
        return this.___greeting_is_set ? this.___greeting : Greeter.greeting
    }
    set greeting(value: string) {
        this.___greeting_is_set = true
        this.___greeting = value
    }
    
    public static __initGreeter() {
        Greeter.greeting = ""
    }
    
    constructor(message: any) {
        this.greeting = message
    }
    
    public greet() {
        return "Hello, " + this.greeting
    }
    
}

Greeter.__initGreeter()
```

...which is not pretty, but hey this doesn't need to go to blocks anyway :)