### PR TITLE
Fix conversion of python classes with no constructor

### DIFF
--- a/tests/pyconverter-test/baselines/class_no_constructor.ts
+++ b/tests/pyconverter-test/baselines/class_no_constructor.ts
@@ -1,0 +1,9 @@
+class Test {
+    public hello() {
+        
+    }
+    
+}
+
+let x = new Test()
+x.hello()

--- a/tests/pyconverter-test/baselines/class_no_constructor_inherit_global.ts
+++ b/tests/pyconverter-test/baselines/class_no_constructor_inherit_global.ts
@@ -1,0 +1,9 @@
+class MySprite extends sprites.ExtendableSprite {
+    public hello() {
+        
+    }
+    
+}
+
+let x = new MySprite(5)
+x.hello()

--- a/tests/pyconverter-test/baselines/class_no_constructor_inherit_local.ts
+++ b/tests/pyconverter-test/baselines/class_no_constructor_inherit_local.ts
@@ -1,0 +1,21 @@
+class Foo {
+    constructor(value: number) {
+        
+    }
+    
+    public hello() {
+        
+    }
+    
+}
+
+class Bar extends Foo {
+    public goodbye() {
+        
+    }
+    
+}
+
+let y = new Bar(5)
+y.hello()
+y.goodbye()

--- a/tests/pyconverter-test/cases/class_no_constructor.py
+++ b/tests/pyconverter-test/cases/class_no_constructor.py
@@ -1,0 +1,8 @@
+class Test:
+    pass
+
+    def hello(self):
+        pass
+
+x = Test()
+x.hello()

--- a/tests/pyconverter-test/cases/class_no_constructor_inherit_global.py
+++ b/tests/pyconverter-test/cases/class_no_constructor_inherit_global.py
@@ -1,0 +1,6 @@
+class MySprite(sprites.ExtendableSprite):
+    def hello(self):
+        pass
+
+x = MySprite(5)
+x.hello()

--- a/tests/pyconverter-test/cases/class_no_constructor_inherit_local.py
+++ b/tests/pyconverter-test/cases/class_no_constructor_inherit_local.py
@@ -1,0 +1,14 @@
+class Foo:
+    def __init__(self, value):
+        pass
+
+    def hello(self):
+        pass
+
+class Bar(Foo):
+    def goodbye(self):
+        pass
+
+y = Bar(5)
+y.hello()
+y.goodbye()


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4416

This PR fixes the conversion of python classes with no defined constructor by creating a dummy symbol with the correct parameters, type definitions, etc.