### PR TITLE
Add cache skip opt for tutorial info, fix tutorial functions in monaco

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1726,7 +1726,7 @@ export class ProjectView
 
         const t = header.tutorial;
 
-        const skipTutorialInfoCache = /notutorialinfocache=1/i.test(window?.location.href);
+        const skipTutorialInfoCache = /notutorialinfocache=1/i.test(window.location.href);
 
         if (typeof t.tutorialCode === "string") {
             t.tutorialCode = [t.tutorialCode];

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1726,12 +1726,14 @@ export class ProjectView
 
         const t = header.tutorial;
 
+        const skipTutorialInfoCache = /notutorialinfocache=1/i.test(window?.location.href);
+
         if (typeof t.tutorialCode === "string") {
             t.tutorialCode = [t.tutorialCode];
         }
 
         return this.loadBlocklyAsync()
-            .then(() => tutorial.getUsedBlocksAsync(t.tutorialCode, t.tutorial, t.language))
+            .then(() => tutorial.getUsedBlocksAsync(t.tutorialCode, t.tutorial, t.language, skipTutorialInfoCache))
             .then((tutorialBlocks) => {
                 let editorState: pxt.editor.EditorState = {
                     searchBar: false

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -281,7 +281,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     pySnippetName: "def do_something",
                     pySnippet: `def do_something():\n    pass`,
                     attributes: {
-                        blockId: 'procedures_defnoreturn',
+                        blockId: 'function_definition',
                         jsDoc: lf("Define a function")
                     }
                 },
@@ -292,7 +292,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     pySnippetName: "do_something",
                     pySnippet: `do_something()`,
                     attributes: {
-                        blockId: 'procedures_callnoreturn',
+                        blockId: 'function_call',
                         jsDoc: lf("Call a function")
                     }
                 },

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -49,6 +49,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
                 return true;
             } else if (ns === "functions" && (!filters.blocks ||
                 filters.blocks["function_definition"] ||
+                filters.blocks["function_call"] ||
                 filters.blocks["procedures_defnoreturn"] ||
                 filters.blocks["procedures_callnoreturn"]) &&
                 (!filters.namespaces || filters.namespaces["functions"] !== pxt.editor.FilterState.Disabled)) {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2160

This ended up requiring a bit more context in the codebase / block definitions that expected so it ended up being that I fixed it while figuring out what wasn't working when the first portion lucas & I were looking at only half fixed it, and then lucas and I chatted about it.

It originally looked like the issue was here: https://github.com/microsoft/pxt/blob/master/webapp/src/toolboxeditor.tsx#L186, since the blocks toolbox has a button but the monaco functions toolbox category only has two fake blocks. However, the issue ended up being over in the monacoSnippets block definition, since those two were using the old blockly style function id for the two function snippets that show up in monaco which doesn't match the blockIds used in the tutorialInfo.

I also ended up having to add a quick flag for skipping the cache for tutorial info, since that was thwarting testing 