### PR TITLE
ios and safari microbit fixes

### DIFF
--- a/pxtblocks/fields/field_autocomplete.ts
+++ b/pxtblocks/fields/field_autocomplete.ts
@@ -179,5 +179,16 @@ namespace pxtblockly {
             // This creates the little arrow for dropdown fields. Intentionally
             // do nothing
         }
+
+        showPromptEditor_() {
+            Blockly.prompt(
+                Blockly.Msg['CHANGE_VALUE_TITLE'],
+                this.parsedValue,
+                (newValue) => {
+                    this.setValue(this.getValueFromEditorText_(newValue));
+                    this.forceRerender();
+                }
+            );
+        }
     }
 }

--- a/react-common/styles/extensions/ExtensionCard.less
+++ b/react-common/styles/extensions/ExtensionCard.less
@@ -1,6 +1,6 @@
 .common-extension-card {
     background-color: @white;
-    
+
     .common-card-body {
         display: flex;
         flex-direction: column;
@@ -49,6 +49,10 @@
         border-radius: 0;
         border-top: solid 1px @inputBorderColor;
         flex-shrink: 0;
+
+        overflow: hidden;
+        border-bottom-left-radius: 0.5rem;
+        border-bottom-right-radius: 0.5rem;
     }
 
     .common-extension-card-contents {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4718
Fixes https://github.com/microsoft/pxt-microbit/issues/4719

Fixes two bugs:
1. A CSS bug where the border radius was being ignored in safari for extension cards
2. An iOS bug where the mobile prompt editor wasn't triggering a rerender for some reason

For bug number 2, I have no idea why the other mobile prompt editors are working. Doesn't seem like they should be! But in any case, this fixes it for autocomplete.

As a side note, the iOS autocomplete field does not provide autocomplete. I figured it was too much trouble to reimplement Blockly's prompt input. In any case, I think it's a separate issue from this one if we want to add it.