### PR TITLE
Don't use void type for ts constructors in python

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -236,8 +236,25 @@ namespace pxt.py {
             if (isModule(sym)) {
                 sym.pyRetType = mkType({ moduleType: sym })
             } else {
-                if (sym.retType)
-                    sym.pyRetType = mapTsType(sym.retType)
+                if (sym.retType) {
+                    if (sym.qName?.endsWith(".__constructor") && sym.retType === "void") {
+                        // This must be a TS class. Because python treats constructors as functions,
+                        // set the return type to be the class instead of void
+                        const classSym = lookupGlobalSymbol(sym.qName.substring(0, sym.qName.lastIndexOf(".")));
+
+                        if (classSym) {
+                            sym.pyRetType = mkType({
+                                classType: classSym
+                            });
+                        }
+                        else {
+                            sym.pyRetType = mapTsType(sym.retType)
+                        }
+                    }
+                    else {
+                        sym.pyRetType = mapTsType(sym.retType)
+                    }
+                }
                 else if (sym.pyRetType) {
                     // nothing to do
                 } else {

--- a/tests/pyconverter-test/baselines/class_ts_constructor.ts
+++ b/tests/pyconverter-test/baselines/class_ts_constructor.ts
@@ -1,0 +1,2 @@
+let x = new sprites.ExtendableSprite(4)
+x.setPosition(1, 1)

--- a/tests/pyconverter-test/cases/class_ts_constructor.py
+++ b/tests/pyconverter-test/cases/class_ts_constructor.py
@@ -1,0 +1,2 @@
+x = sprites.ExtendableSprite(4)
+x.set_position(1, 1)

--- a/tests/pyconverter-test/testlib/classHandlerParameter.ts
+++ b/tests/pyconverter-test/testlib/classHandlerParameter.ts
@@ -13,6 +13,10 @@ namespace game {
         //% afterOnStart=true
         onOverlap(handler: (other: Sprite) => void) {
         }
+
+        setPosition(x: number, y: number) {
+
+        }
     }
 }
 


### PR DESCRIPTION
Fixing a bug found by @alex-kulcsar!

When calling a constructor for a class defined in TypeScript, we were setting the python return type to void.