### PR TITLE
Fix skillmap npm install for local devs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -580,7 +580,19 @@ const replaceWebpackBase = () => gulp.src([`${reactScriptsConfigRoot}/webpack.co
     .pipe(concat("webpack.config.js"))
     .pipe(gulp.dest(`${reactScriptsConfigRoot}`));
 
-const npmInstallSkillmap = () => exec(!fs.existsSync(`${skillmapRoot}/node_modules`) ? "npm ci --prefer-offline" : "echo \"Skip install\"", false, { cwd: skillmapRoot });
+const npmInstallSkillmap = async () => {
+    if (fs.existsSync(`${skillmapRoot}/node_modules`)) {
+        await exec("echo \"Skip install\"", true, { cwd: skillmapRoot });
+        return;
+    }
+    if (process.env.PXT_ENV == "production") {
+        await exec("npm ci --prefer-offline", false, { cwd: skillmapRoot })
+    }
+    else {
+        await exec("npm install", true, { cwd: skillmapRoot });
+    }
+}
+
 const npmBuildSkillmap = () => exec("npm run build", true, { cwd: skillmapRoot });
 
 const buildSkillmap = async () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/4806

Run `npm install` instead of `npm ci --prefer-offline` for local development builds. The CI behavior should be unchanged