### PR TITLE
Don't treat space as enter by default on an input field

### DIFF
--- a/react-common/components/controls/Input.tsx
+++ b/react-common/components/controls/Input.tsx
@@ -15,6 +15,7 @@ export interface InputProps extends ControlProps {
     readOnly?: boolean;
     autoComplete?: boolean;
     selectOnClick?: boolean;
+    treatSpaceAsEnter?: boolean
 
     onChange?: (newValue: string) => void;
     onEnterKey?: (value: string) => void;
@@ -66,7 +67,7 @@ export const Input = (props: InputProps) => {
 
     const enterKeyHandler = (e: React.KeyboardEvent) => {
         const charCode = (typeof e.which == "number") ? e.which : e.keyCode;
-        if (charCode === /*enter*/13 || charCode === /*space*/32) {
+        if (charCode === /*enter*/13 || props.treatSpaceAsEnter && charCode === /*space*/32) {
             if (onEnterKey) {
                 e.preventDefault();
                 onEnterKey(value);
@@ -120,7 +121,7 @@ export const Input = (props: InputProps) => {
                         onClick={iconClickHandler} />
                     : <i
                         className={icon}
-                        aria-hidden={true} />) }
+                        aria-hidden={true} />)}
             </div>
         </div>
     );

--- a/webapp/src/components/soundEffectEditor/SoundControls.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundControls.tsx
@@ -197,6 +197,7 @@ export const SoundControls = (props: SoundControlsProps) => {
                         initialValue={sound.duration + ""}
                         className="sound-duration-input"
                         onEnterKey={onDurationChange}
+                        treatSpaceAsEnter={true}
                         onBlur={onDurationChange}
                     />
                 </div>
@@ -269,7 +270,7 @@ export const SoundControls = (props: SoundControlsProps) => {
 
 
 function getWaveformLabel(waveform: pxt.assets.SoundWaveForm) {
-    switch(waveform) {
+    switch (waveform) {
         case "sine": return pxt.U.lf("Sine");
         case "square": return pxt.U.lf("Square");
         case "triangle": return pxt.U.lf("Triangle");


### PR DESCRIPTION
#### Problem
When searching for extensions you can no longer press the space bar to search multiple terms at the same time.

#### Solution
Change react-common Input to no longer treat the space button as an enter button by default. Now you have to specify if you want that behavior by setting the `treatSpaceAsEnter` property.

#### Validation
Build: https://microbit.staging.pxt.io/app/d6f9b2143795af11f5046326f410a0f5a9dc4598-667bbfa881#editor
- Press space in the extension search bar and see that the search doesn't begin until you click away or press enter
- Press space in the duration field of sound editor, see that it is not allowed

#### Notes
Fixes microsoft/pxt-microbit/issues/4717