### PR TITLE
Use an image icon when extension card image fails to load

### DIFF
--- a/react-common/components/controls/LazyImage.tsx
+++ b/react-common/components/controls/LazyImage.tsx
@@ -50,6 +50,7 @@ export const LazyImage = (props: LazyImageProps) => {
             aria-describedby={ariaDescribedBy}
         />
         <div className="common-spinner" />
+        <i className="fas fa-image" aria-hidden={true} />
     </div>
 }
 
@@ -74,6 +75,11 @@ function initObserver() {
                 image.src = url;
                 image.onload = () => {
                     image.parentElement.classList.add("loaded");
+                    image.parentElement.classList.remove("error");
+                }
+                image.onerror = () => {
+                    image.parentElement.classList.add("error")
+                    image.parentElement.classList.remove("loaded")
                 }
             }
         })

--- a/react-common/styles/controls/LazyImage.less
+++ b/react-common/styles/controls/LazyImage.less
@@ -12,6 +12,15 @@
         transition: opacity 0.3s ease;
     }
 
+    i.fa-image {
+        position: absolute;
+        width: auto;
+        height: auto;
+        font-size: 5rem;
+
+        opacity: 0;
+    }
+
     img {
         opacity: 0;
         transition: opacity 0.3s ease;
@@ -23,7 +32,25 @@
         opacity: 0;
     }
 
+    i.fa-image {
+        opacity: 0;
+    }
+
     img {
         opacity: 1;
+    }
+}
+
+.common-lazy-image-wrapper.error {
+    .common-spinner {
+        opacity: 0;
+    }
+
+    i.fa-image {
+        opacity: 1;
+    }
+
+    img {
+        opacity: 0;
     }
 }


### PR DESCRIPTION
#### Problem
The icons for extensions can fail to load, this results in an infinite spinner a cards image.

#### Solution
Remove the spinner if the image fails to load and set the card's image as icon so the user knows the image didn't load

#### Validation
Build: https://microbit.staging.pxt.io/app/35e2f8faee7160c6a48f9bb5c3a1ce2a9b19ee3f-bbe5f6948a#editor

- Search for "blue" in the search bar and note how the `bluetooth-temperature-sensor` extension has an image icon instead of an image

#### Notes
 Fixes microsoft/pxt-microbit/issues/4570

If there is a more common way that we indicate that a resource has failed to load, please let me know.