### PR TITLE
don't disconnect when deploying

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1,5 +1,9 @@
 namespace pxt.BrowserUtils {
 
+    export function isDocumentVisible() {
+        return typeof window !== "undefined" && document.visibilityState === 'visible'
+    }
+
     export function isIFrame(): boolean {
         try {
             return window && window.self !== window.top;


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-microbit/issues/4694

While a deployment is on-going, do not automatically disconnect when page visibilty changes.

- [x] don't disconnect while deploying on page visibilty change
- [x] check page visibility upon deploy completed

Testing:

Keep 2 makecode tab open, with two different program (using different C++ to trigger full flash). Start download, switch tab, wait until download is completed, tab releases USB
 