### PR TITLE
more explicitly set view state to fix race

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -402,7 +402,6 @@ namespace pxt.editor {
         collapsed?: boolean;
         simSerialActive?: boolean;
         devSerialActive?: boolean;
-        csvSerialActive?: boolean;
     }
 
     export interface IFieldCustomOptions {


### PR DESCRIPTION
fix bug that blocked testing today; I must have been a bit behind master and hit a race condition that wasn't there? It started happening locally as well once I pulled & gulped.

This change makes it *much* more explicit when setting view ~