### PR TITLE
don't batch logs in serial view

### DIFF
--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -415,25 +415,10 @@ export class Editor extends srceditor.Editor {
             this.consoleRoot.appendChild(newEntry)
         }
         else {
-            let lastEntry = this.consoleRoot.lastChild
             let newEntry = document.createElement("div")
-            if (lastEntry && lastEntry.lastChild.textContent == line) {
-                if (lastEntry.childNodes.length == 2) {
-                    //Matches already-collapsed entry
-                    let count = parseInt(lastEntry.firstChild.textContent)
-                    lastEntry.firstChild.textContent = (count + 1).toString()
-                } else {
-                    //Make a new collapsed entry with count = 2
-                    let newLabel = document.createElement("a")
-                    newLabel.className = "ui horizontal label"
-                    newLabel.textContent = "2"
-                    lastEntry.insertBefore(newLabel, lastEntry.lastChild)
-                }
-            } else {
-                //Make a new non-collapsed entry
-                newEntry.appendChild(document.createTextNode(line))
-                this.consoleRoot.appendChild(newEntry)
-            }
+            //Make a new non-collapsed entry
+            newEntry.appendChild(document.createTextNode(line))
+            this.consoleRoot.appendChild(newEntry)
         }
         this.consoleRoot.scrollTop = this.consoleRoot.scrollHeight
         while (this.consoleRoot.childElementCount > this.maxConsoleEntries) {


### PR DESCRIPTION
re: https://forum.makecode.com/t/how-to-stop-console-from-aggregating-data-being-printed-to-it/13732, this pr would stop logs from getting grouped. This makes it more cli javascript like (node / etc) & matches behavior you would see in any java / python cli, but doesn't match webdev javascript style consoles.

(I have other things I need to finish so just putting this up and letting others decide when / if to merge this :) )