### PR TITLE
Show disclaimer for user-provided-extensions

### DIFF
--- a/react-common/components/extensions/ExtensionCard.tsx
+++ b/react-common/components/extensions/ExtensionCard.tsx
@@ -13,6 +13,7 @@ export interface ExtensionCardProps<U> {
     onClick?: (value: U) => void;
     extension?: U;
     loading?: boolean;
+    showDisclaimer?: boolean
 }
 
 export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
@@ -24,7 +25,8 @@ export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
         label,
         onClick,
         extension,
-        loading
+        loading,
+        showDisclaimer
     } = props;
 
     const onCardClick = () => {
@@ -52,15 +54,18 @@ export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
                             {description}
                         </div>
                     </div>
-                    {learnMoreUrl &&
-                        <Button
-                            className="link-button"
-                            label={lf("Learn More")}
-                            title={lf("Learn More")}
-                            onClick={() => { }}
-                            href={learnMoreUrl}
-                        />
-                    }
+                    <>
+                        {showDisclaimer && lf("User-provided extension, not endorsed by Microsoft.")}
+                        {learnMoreUrl &&
+                            <Button
+                                className="link-button"
+                                label={lf("Learn More")}
+                                title={lf("Learn More")}
+                                onClick={() => { }}
+                                href={learnMoreUrl}
+                            />
+                        }
+                    </>
                 </>
                 }
             </div>

--- a/react-common/components/extensions/ExtensionCard.tsx
+++ b/react-common/components/extensions/ExtensionCard.tsx
@@ -54,7 +54,7 @@ export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
                             {description}
                         </div>
                     </div>
-                    <>
+                    <div className="common-extension-card-extra-content">
                         {showDisclaimer && lf("User-provided extension, not endorsed by Microsoft.")}
                         {learnMoreUrl &&
                             <Button
@@ -65,7 +65,7 @@ export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
                                 href={learnMoreUrl}
                             />
                         }
-                    </>
+                    </div>
                 </>
                 }
             </div>

--- a/react-common/components/extensions/ExtensionCard.tsx
+++ b/react-common/components/extensions/ExtensionCard.tsx
@@ -54,18 +54,20 @@ export const ExtensionCard = <U,>(props: ExtensionCardProps<U>) => {
                             {description}
                         </div>
                     </div>
-                    <div className="common-extension-card-extra-content">
-                        {showDisclaimer && lf("User-provided extension, not endorsed by Microsoft.")}
-                        {learnMoreUrl &&
-                            <Button
-                                className="link-button"
-                                label={lf("Learn More")}
-                                title={lf("Learn More")}
-                                onClick={() => { }}
-                                href={learnMoreUrl}
-                            />
-                        }
-                    </div>
+                    {(showDisclaimer || learnMoreUrl) &&
+                        <div className="common-extension-card-extra-content">
+                            {showDisclaimer && lf("User-provided extension, not endorsed by Microsoft.")}
+                            {learnMoreUrl &&
+                                <Button
+                                    className="link-button"
+                                    label={lf("Learn More")}
+                                    title={lf("Learn More")}
+                                    onClick={() => { }}
+                                    href={learnMoreUrl}
+                                />
+                            }
+                        </div>
+                    }
                 </>
                 }
             </div>

--- a/react-common/styles/extensions/ExtensionCard.less
+++ b/react-common/styles/extensions/ExtensionCard.less
@@ -41,18 +41,23 @@
         flex-shrink: 0;
     }
 
-    .common-button.link-button {
-        text-align: right;
+    .common-extension-card-extra-content {
         padding: 0.5rem 1rem;
         background: @white;
         margin: 0;
         border-radius: 0;
         border-top: solid 1px @inputBorderColor;
         flex-shrink: 0;
+        font-size: 16px;
+        color: @lightTextColor;
 
         overflow: hidden;
         border-bottom-left-radius: 0.5rem;
         border-bottom-right-radius: 0.5rem;
+    }
+    
+    .common-button.link-button {
+        float: right;
     }
 
     .common-extension-card-contents {

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -489,6 +489,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                         learnMoreUrl={scr.fullName ? `/pkg/${scr.fullName}` : undefined}
                                         loading={scr.loading}
                                         label={pxt.isPkgBeta(scr) ? lf("Beta") : undefined}
+                                        showDisclaimer={scr?.repo?.status != pxt.github.GitRepoStatus.Approved}
                                     />)}
                             </div>
                             {searchComplete && extensionsToShow.length == 0 &&

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -489,7 +489,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                         learnMoreUrl={scr.fullName ? `/pkg/${scr.fullName}` : undefined}
                                         loading={scr.loading}
                                         label={pxt.isPkgBeta(scr) ? lf("Beta") : undefined}
-                                        showDisclaimer={scr?.repo?.status != pxt.github.GitRepoStatus.Approved}
+                                        showDisclaimer={scr.type != pxtc.service.ExtensionType.Bundled && scr.repo?.status != pxt.github.GitRepoStatus.Approved}
                                     />)}
                             </div>
                             {searchComplete && extensionsToShow.length == 0 &&


### PR DESCRIPTION
#### Problem
The user-created-extension disclaimer is not being shown for unofficial extensions.

#### Solution
Bring back the disclaimer for non-bundled user-created extensions.

#### Validation
Build: https://microbit.staging.pxt.io/app/df47ae067c7d3d76e790488fd9f9c95489693025-767f2bc083
- See that the disclaimer is not present for approved extensions
- Search `blue` in the search bar and notice the bundled `bluetooth` extension does not have a disclaimer
- Search for a user extension such as `https://github.com/aznhassan/test-extension-three` and notice the disclaimer
![image](https://user-images.githubusercontent.com/6496798/173469950-2cc7d7e4-46dd-4568-abd1-6143f22ead3d.png)

#### Notes
Fixes microsoft/pxt-microbit/issues/4747