### PR TITLE
better handling of versioning changes

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -654,13 +654,22 @@ namespace pxt {
                         // this may be an issue if the user does not create releases
                         // and pulls from master
                         const modtag = modid?.tag || mod.config?.version;
+                        const vertag = verid.tag
+
+                        // if there is no tag on the current dependency, 
+                        // assume same as existing module version if any
+                        if (modtag && !vertag) {
+                            pxt.debug(`unversioned ${ver}, using ${modtag}`)
+                            return
+                        }
+
                         const c = pxt.semver.strcmp(modtag, verid.tag);
                         if (c == 0) {
                             // turns out to be the same versions
                             pxt.debug(`resolved version are ${modtag}`)
                             return;
                         }
-                        else if (c < 0) {
+                        else if (c > 0) {
                             // already loaded version of dependencies is greater
                             // than current version, use it instead
                             pxt.debug(`auto-upgraded ${ver} to ${modtag}`)


### PR DESCRIPTION
Fixing a bug in the version resolution algorithm when loading dependencies.

- [ ] when trying to resolve the version of a unversion depency, use already loaded depency version if any
- [ ] semver.strcmp was used background to decide to upgrade assemblies.

Repro: this project https://makecode.microbit.org/_0yu10HJeKRUU contains the following dependencies:

```
{
    "name": "Untitled",
    "description": "",
    "dependencies": {
        "core": "*",
        "radio": "*",
        "microphone": "*",
        "jacdac": "github:microsoft/pxt-jacdac#v1.8.13",
        "kitronik-stopbitv10": "github:pelikhan/pxt-kitronik-stopbit/jacdac"
    },
    "files": [
        "main.blocks",
        "main.ts",
        "README.md",
        "jacdac.json",
        "jacdac.ts"
    ],
    "preferredEditor": "tsprj"
}
```
 and `github:pelikhan/pxt-kitronik-stopbit/jacdac` links to pxt-jacdac#0.10.64. With the new changes, the automatic upgrade happens and resolution is correct.


