### PR TITLE
resolve and upgrade github versions as they are loaded

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -701,6 +701,30 @@ namespace pxt {
                     pxt.debug(`dep: load ${from.id}.${id}${isCpp ? "++" : ""}: ${ver}`)
                     if (id == "hw" && pxt.hwVariant)
                         id = "hw---" + pxt.hwVariant
+
+                    // for github references, make sure the version is compatible with previously
+                    // loaded references, regardless of the id
+                    const ghver = github.parseRepoId(ver)
+                    if (ghver?.slug) {
+                        // let's start by resolving the maximum version
+                        // number of the parent repo already loaded
+                        const repoVersions = Object.values(from.parent.deps)
+                            .map(p =>  github.parseRepoId(p._verspec))
+                            .filter(v => v?.slug === ghver.slug)
+                            .map(v => v.tag)
+                        const repoVersion = repoVersions
+                            .reduce((v1, v2) => semver.strcmp(v1,v2) > 0 ? v1 : v2, "0.0.0")
+                        pxt.debug(`dep: common repo ${ghver.slug} version found ${repoVersion}`)
+                        if (semver.strcmp(repoVersion, "0.0.0") > 0) {
+                            // now let's check if we have a higher version to use
+                            if (!ghver.tag || semver.strcmp(repoVersion, ghver.tag) > 0) {
+                                pxt.debug(`dep: upgrade from ${ghver.tag} to ${repoVersion}`)
+                                ghver.tag = repoVersion
+                                ver = github.stringifyRepo(ghver)
+                            }
+                        }
+                    }
+
                     let mod = from.resolveDep(id)
                     if (mod) {
                         // check if the current dependecy matches the ones

--- a/pxtlib/semver.ts
+++ b/pxtlib/semver.ts
@@ -101,6 +101,10 @@ namespace pxt.semver {
         return aa.major - bb.major;
     }
 
+    /**
+     * Compares two semver version strings and returns -1 if a < b, 1 if a > b and 0
+     * if versions are equivalent
+     */
     export function strcmp(a: string, b: string) {
         let aa = tryParse(a)
         let bb = tryParse(b)

--- a/pxtlib/semver.ts
+++ b/pxtlib/semver.ts
@@ -103,7 +103,8 @@ namespace pxt.semver {
 
     /**
      * Compares two semver version strings and returns -1 if a < b, 1 if a > b and 0
-     * if versions are equivalent
+     * if versions are equivalent. If a and b are invalid versions, classic strcmp is called.
+     * If a (or b) is an invalid version, it is considered greater than any version (strmp(undefined, "0.0.0") = 1)
      */
     export function strcmp(a: string, b: string) {
         let aa = tryParse(a)


### PR DESCRIPTION
As we load packages and resolve github references, always try to upgrade the referenced version to avoid version clashes. This codepath only happens on github project references

For example, we can have a project with a dependency A, B, A/C where

    A is a repo, version v2
    A/C is a subproject in repo A
    B references A/C#v1

With this program, A gets loaded first and locks to v2; then we need to make sure to all future loaded references of A or A/C are upgraded on v2.

To test this:

- create new project
- add jacdac, which should be something like v1.8.xx
- add https://github.com/pelikhan/pxt-kitronik-stopbit/tree/master/jacdac
- verify that jacdac-traffic-light is now v1.8.xx instead of v0.10.40