### PR TITLE
make default modal take up more of screen on mobile

### DIFF
--- a/react-common/styles/controls/Modal.less
+++ b/react-common/styles/controls/Modal.less
@@ -24,6 +24,12 @@
     overflow: hidden;
 }
 
+@media @mobileAndBelow {
+    .common-modal {
+        width: 90%;
+    }
+}
+
 .common-modal-header {
     background-color: @modalHeaderBackgroundColor;
 

--- a/react-common/styles/controls/Modal.less
+++ b/react-common/styles/controls/Modal.less
@@ -26,7 +26,7 @@
 
 @media @mobileAndBelow {
     .common-modal {
-        width: 90%;
+        width: 95%;
     }
 }
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/4756

![image](https://user-images.githubusercontent.com/5615930/173893174-23d2bc3d-31de-4fea-9737-a24504a75645.png)

(ignore the arrow button to the left of the qr code, that was another button I was testing out)

I haven't poked around but there's probably a decent number of modals this will benefit, 50% of mobile phones is way too tiny