### PR TITLE
add device share option to share modal

### DIFF
--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -89,6 +89,15 @@ export const ShareInfo = (props: ShareInfoProps) => {
         }
     }
 
+    const handleDeviceShareClick = () => {
+        pxt.tickEvent("share.device");
+        return navigator?.share?.({
+            title: document.title,
+            url: shareData.url,
+            text: lf("Check out my new MakeCode project!"),
+        })
+    };
+
     const embedOptions = [{
         name: "code",
         label: lf("Code"),
@@ -209,6 +218,12 @@ export const ShareInfo = (props: ShareInfoProps) => {
                                 url={shareData?.url}
                                 type='twitter'
                                 heading={lf("Share on Twitter")} />
+                            {navigator.share && <Button className="circle-button device-share"
+                                title={lf("Show device share options")}
+                                ariaLabel={lf("Show device share options")}
+                                leftIcon={"icon share"}
+                                onClick={handleDeviceShareClick}
+                            />}
                             <Button
                                 className="menu-button project-qrcode"
                                 buttonRef={handleQRCodeButtonRef}

--- a/react-common/styles/controls/Button.less
+++ b/react-common/styles/controls/Button.less
@@ -268,6 +268,11 @@
     color: @buttonTextColorDarkBackground;
 }
 
+.common-button.device-share {
+    background: #333333;
+    color: @buttonTextColorDarkBackground;
+}
+
 /****************************************************
  *                 High Contrast                    *
  ****************************************************/

--- a/react-common/styles/controls/Modal.less
+++ b/react-common/styles/controls/Modal.less
@@ -24,6 +24,12 @@
     overflow: hidden;
 }
 
+@media @mobileAndBelow {
+    .common-modal {
+        width: 95%;
+    }
+}
+
 .common-modal-header {
     background-color: @modalHeaderBackgroundColor;
 


### PR DESCRIPTION
Putting this up as discussed adding text share / etc, this adds a button popping device share dialog. Here's a build with it you can check out on your device (mainly it's for mobile, but it works on windows 11 I suppose):

https://makecode.microbit.org/app/95313fd2676ee0fdc12a097256159fb64538afbc-e2fcfb1ba5

the arrow button here (no design thought put in :) )
![image](https://user-images.githubusercontent.com/5615930/173895409-74342621-6b7a-4434-a247-5e01bf1f705d.png)

![MicrosoftTeams-image (6)](https://user-images.githubusercontent.com/5615930/173895829-69a9e541-3283-4930-ad81-845e6525e3af.png)

