### PR TITLE
don't change casing when upgrading version

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -1037,8 +1037,8 @@ namespace pxt.github {
         return id.slice(0, 7) == "github:"
     }
 
-    export function stringifyRepo(p: ParsedRepo) {
-        return p ? "github:" + p.fullName.toLowerCase() + (p.tag ? `#${p.tag}` : '') : undefined;
+    export function stringifyRepo(p: ParsedRepo, ignoreCase = false) {
+        return p ? "github:" + (ignoreCase ? p.fullName : p.fullName.toLowerCase()) + (p.tag ? `#${p.tag}` : '') : undefined;
     }
 
     export function normalizeRepoId(id: string, defaultTag?: string) {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -720,7 +720,7 @@ namespace pxt {
                             if (!ghver.tag || semver.strcmp(repoVersion, ghver.tag) > 0) {
                                 pxt.debug(`dep: upgrade from ${ghver.tag} to ${repoVersion}`)
                                 ghver.tag = repoVersion
-                                ver = github.stringifyRepo(ghver)
+                                ver = github.stringifyRepo(ghver, true)
                             }
                         }
                     }


### PR DESCRIPTION
stringifyRepo changes the casing of the repo, which then surfaces deeper bug around equality of repo dependencies in the load path. This is a minor fix that makes sure the casing of the slug is not modified.