### PR TITLE
make learn more for builtin point to /reference/{pkg}

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -1679,6 +1679,7 @@ namespace ts.pxtc.service {
 
         pkgConfig?: pxt.PackageConfig; // Added if the type is Bundled
         repo?: pxt.github.GitRepo; //Added if the type is Github VVN TODO ADD THIS
+        learnMoreUrl?: string;
     }
 
 

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -274,6 +274,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
             name: p.name,
             imageUrl: p.icon,
             type: pxtc.service.ExtensionType.Bundled,
+            learnMoreUrl: `/reference/${p.name}`,
             pkgConfig: p,
             description: p.description
         }
@@ -486,7 +487,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                         imageUrl={scr.imageUrl}
                                         extension={scr}
                                         onClick={installExtension}
-                                        learnMoreUrl={scr.fullName ? `/pkg/${scr.fullName}` : undefined}
+                                        learnMoreUrl={scr.learnMoreUrl || (scr.fullName ? `/pkg/${scr.fullName}` : undefined)}
                                         loading={scr.loading}
                                         label={pxt.isPkgBeta(scr) ? lf("Beta") : undefined}
                                         showDisclaimer={scr.type != pxtc.service.ExtensionType.Bundled && scr.repo?.status != pxt.github.GitRepoStatus.Approved}
@@ -508,7 +509,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                     imageUrl={scr.imageUrl}
                                     extension={scr}
                                     onClick={installExtension}
-                                    learnMoreUrl={scr.fullName ? `/pkg/${scr.fullName}` : undefined}
+                                    learnMoreUrl={scr.learnMoreUrl || (scr.fullName ? `/pkg/${scr.fullName}` : undefined)}
                                     loading={scr.loading}
                                     label={pxt.isPkgBeta(scr) ? lf("Beta") : undefined}
                                 />)}
@@ -523,7 +524,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                     onClick={installExtension}
                                     imageUrl={scr.imageUrl}
                                     description={scr.description}
-                                    learnMoreUrl={scr.fullName ? `/pkg/${scr.fullName}` : undefined}
+                                    learnMoreUrl={scr.learnMoreUrl || (scr.fullName ? `/pkg/${scr.fullName}` : undefined)}
                                     loading={scr.loading}
                                     label={pxt.isPkgBeta(scr) ? lf("Beta") : undefined}
                                 />


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/4752#issuecomment-1157016629
fix https://github.com/microsoft/pxt-microbit/issues/4587


funny enough this fails locally since our cli seems to miss the `/libs/pkg/docs/` path, but the live site verison of that page should be fine

![image](https://user-images.githubusercontent.com/5615930/173955543-0607c522-75f4-4cf9-8010-4f7e5574b598.png)
