### PR TITLE
Blockly snapshot fixes

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -284,7 +284,7 @@ namespace pxt.blocks.layout {
         const xmlString = serializeNode(sg)
             .replace(/^\s*<svg[^>]+>/i, '')
             .replace(/<\/svg>\s*$/i, '') // strip out svg tag
-        const svgXml = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="${XLINK_NAMESPACE}" width="${renderWidth}" height="${renderHeight}" viewBox="${x} ${y} ${width} ${height}" class="pxt-renderer">${xmlString}</svg>`;
+        const svgXml = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="${XLINK_NAMESPACE}" width="${renderWidth}" height="${renderHeight}" viewBox="${x} ${y} ${width} ${height}" class="pxt-renderer classic-theme">${xmlString}</svg>`;
         const xsg = new DOMParser().parseFromString(svgXml, "image/svg+xml");
 
         const cssLink = xsg.createElementNS("http://www.w3.org/1999/xhtml", "style");
@@ -298,7 +298,7 @@ namespace pxt.blocks.layout {
                     .filter((el: HTMLStyleElement) => /\.blocklySvg/.test(el.innerText))[0] as HTMLStyleElement;
                 // Custom CSS injected directly into the DOM by Blockly
                 customCss.unshift((document.getElementById(`blockly-common-style`) as HTMLLinkElement)?.innerText || "");
-                customCss.unshift((document.getElementById(`blockly-renderer-style-pxt`) as HTMLLinkElement)?.innerText || "");
+                customCss.unshift((document.getElementById(`blockly-renderer-style-pxt-classic`) as HTMLLinkElement)?.innerText || "");
                 // CSS may contain <, > which need to be stored in CDATA section
                 const cssString = (blocklySvg ? blocklySvg.innerText : "") + '\n\n' + customCss.map(el => el + '\n\n');
                 cssLink.appendChild(xsg.createCDATASection(cssString));

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -342,6 +342,7 @@ namespace pxtblockly {
                     .at((FieldCustomMelody.COLOR_BLOCK_WIDTH + FieldCustomMelody.COLOR_BLOCK_SPACING) * i + FieldCustomMelody.COLOR_BLOCK_X, FieldCustomMelody.COLOR_BLOCK_Y)
                     .size(FieldCustomMelody.COLOR_BLOCK_WIDTH, FieldCustomMelody.COLOR_BLOCK_HEIGHT)
                     .stroke("#898989", 1)
+                    .fill(getPlaceholderColor(pxtmelody.noteToRow(notes[i])))
                     .corners(3, 2);
 
                 pxt.BrowserUtils.addClass(cb.el, className);
@@ -820,5 +821,24 @@ namespace pxtblockly {
         if (!props.switchColor) props.switchColor = "#ffffff";
 
         return props as ToggleProps;
+    }
+
+    /**
+     * This gets the placeholder color which is embedded in the rendered svg. These are overridden
+     * by the css class we set on each rect from pxtmelody.getColorClass and will only be seen
+     * if the svg is taken without the corresponding css (e.g. in a blockly snapshot)
+     */
+    function getPlaceholderColor(row: number): string {
+        switch (row) {
+            case 0: return "#A80000"; // Middle C
+            case 1: return "#D83B01"; // Middle D
+            case 2: return "#FFB900"; // Middle E
+            case 3: return "#107C10"; // Middle F
+            case 4: return "#008272"; // Middle G
+            case 5: return "#0078D7"; // Middle A
+            case 6: return "#5C2D91"; // Middle B
+            case 7: return "#B4009E"; // Tenor C
+        }
+        return "#DCDCDC";
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4753
Fixes https://github.com/microsoft/pxt-microbit/issues/4739


Fix the css that broke from the blockly update and explicitly set the color of the melody editor fields