### PR TITLE
Show data and dont show csv on hw

### DIFF
--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -66,11 +66,11 @@ export class Editor extends srceditor.Editor {
         }
         this.isVisible = b;
 
-        if (this.isCsvView === undefined || !this.receivedLog) {
+        if (this.isSim && (this.isCsvView === undefined || !this.receivedLog)) {
             // If only csv received, default to csv.
             this.setCsv(!this.receivedLog);
             this.parent.forceUpdate();
-        } else if (this.isCsvView && !this.receivedCsv) {
+        } else if (this.isCsvView && (!this.receivedCsv || !this.isSim)) {
             this.setCsv(false);
             this.parent.forceUpdate();
         }
@@ -223,7 +223,7 @@ export class Editor extends srceditor.Editor {
 
         const niceSource = this.mapSource(source);
 
-        if (this.receivedCsv && this.receivedLog) {
+        if (this.shouldShowToggle()) {
             pxt.BrowserUtils.removeClass(this.serialRoot, "no-toggle")
         }
         if (isCsv) {
@@ -643,9 +643,13 @@ export class Editor extends srceditor.Editor {
         />
     }
 
+    shouldShowToggle = () => {
+        return this.receivedCsv && this.receivedLog && this.isSim;
+    }
+
     display() {
         const rootClasses = classList(
-            !(this.receivedCsv && this.receivedLog) && "no-toggle",
+            !this.shouldShowToggle() && "no-toggle",
             this.isCsvView && "csv-view"
         );
 

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -470,6 +470,10 @@ export class Editor extends srceditor.Editor {
             pxt.BrowserUtils.addClass(this.consoleRoot, "nochart");
         }
 
+        if (!this.isSim) {
+            this.setCsv(false);
+        }
+
         this.charts = []
         this.serialInputDataBuffer = ""
         this.rawDataBuffer = ""

--- a/webapp/src/serialindicator.tsx
+++ b/webapp/src/serialindicator.tsx
@@ -58,11 +58,11 @@ export class SerialIndicator extends data.Component<SerialIndicatorProps, Serial
         if (!this.active()) return <div />;
         const description = this.props.isSim ? lf("Simulator") : lf("Device");
         return (
-            <div role="button" title={lf("Open {0} console", description)} className="ui label circular" tabIndex={0} onClick={this.props.onClick} onKeyDown={fireClickOnEnter}>
+            <div role="button" title={lf("Open {0} data", description)} className="ui label circular" tabIndex={0} onClick={this.props.onClick} onKeyDown={fireClickOnEnter}>
                 <div className="detail">
                     <img alt={lf("Animated bar chart")} className="barcharticon" src={pxt.Util.pathJoin(pxt.webConfig.commitCdnUrl, `images/Bars_black.gif`)}></img>
                 </div>
-                <span>{lf("Show console")}</span>
+                <span>{lf("Show data")}</span>
                 <div className="detail">
                     {description}
                 </div>


### PR DESCRIPTION
As discussed, use data instead of console for the button:

![image](https://user-images.githubusercontent.com/5615930/174155573-77d905f2-6bed-4849-b0aa-be6a06eb0d2e.png)

and remove toggle / csv view when on hw as we don't currently have that option / it would be misleading to be in hw view but see sim data