### PR TITLE
hide embed opt in share dialog on mobile devices

### DIFF
--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -212,7 +212,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
                                 onBlur={handleCopyBlur} />
                         </div>
                         <div className="project-share-actions">
-                            <Button className="circle-button gray"
+                            <Button className="circle-button gray embed mobile-portrait-hidden"
                                 title={lf("Show embed code")}
                                 leftIcon="fas fa-code"
                                 onClick={handleEmbedClick} />

--- a/react-common/styles/react-common-breakpoints.less
+++ b/react-common/styles/react-common-breakpoints.less
@@ -4,16 +4,33 @@
 @largeMonitorBreakpoint: 1200px;
 @widescreenMonitorBreakpoint: 1920px;
 
+@largestMobilePortraitScreen: (@mobileBreakpoint + 100px);
 @largestMobileScreen: (@tabletBreakpoint - 1px);
 @largestTabletScreen: (@computerBreakpoint - 1px);
 @largestSmallMonitor: (@largeMonitorBreakpoint - 1px);
 @largestLargeMonitor: (@widescreenMonitorBreakpoint - 1px);
 
+@portraitMobileAndBelow: ~"only screen and (max-width: @{largestMobilePortraitScreen})";
 @mobileAndBelow: ~"only screen and (max-width: @{largestMobileScreen})";
 @tabletAndBelow: ~"only screen and (max-width: @{largestTabletScreen})";
 @computerAndBelow: ~"only screen and (max-width: @{largestSmallMonitor})";
 @largeMonitorAndBelow: ~"only screen and (max-width: @{largestLargeMonitor})";
 
+/****************************************************
+ *                Mobile Portrait                   *
+ ****************************************************/
+
+@media only screen and (min-width: @portraitMobileAndBelow) {
+    .mobile-portrait-only {
+        display: none !important;
+    }
+}
+
+@media @mobileAndBelow {
+    .mobile-portrait-hidden {
+        display: none !important;
+    }
+}
 
 /****************************************************
  *                    Mobile                        *

--- a/react-common/styles/share/share.less
+++ b/react-common/styles/share/share.less
@@ -93,12 +93,6 @@
     .common-button {
         margin-right: 1rem;
     }
-
-    @media @mobileAndBelow {
-        .common-button.embed {
-            display: none;
-        }
-    }
 }
 
 .project-share-text {

--- a/react-common/styles/share/share.less
+++ b/react-common/styles/share/share.less
@@ -93,6 +93,12 @@
     .common-button {
         margin-right: 1rem;
     }
+
+    @media @mobileAndBelow {
+        .common-button.embed {
+            display: none;
+        }
+    }
 }
 
 .project-share-text {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/4760


@riknoll I added a new size to react-common-breakpoints for this; largestMobileScreen is actually pretty big to the point that it hits lots of tablets / not full screen monitors. 420 px is just above the biggest normal portrait screens (e.g. my samsung big phone is 412px) and I feel like the portrait size is probably what we intend most of the time we add 'phone size screen optimizations' since landscape can be pretty wide / fit most things

![image](https://user-images.githubusercontent.com/5615930/174161118-0b587dee-67d1-4d63-bd90-ed6172c71341.png)