### PR TITLE
update script page iframe sandbox to allow downloads

### DIFF
--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -43,7 +43,7 @@
 
     <div class="ui main container mainbody script-content">
         <iframe id="embed-frame" class="script-embed" src="/@versionsuff@#sandbox:@id@"
-            sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe>
+            sandbox="allow-popups allow-forms allow-scripts allow-same-origin allow-downloads" frameborder="0"></iframe>
         <div class="script-bookend">
             <div id="abuse-message" class="ui tiny blue message">
                 <div class="ui grid padded">


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4383

Chrome started disallowing downloads in sandboxed iframes. I don't see any issue with explicitly enabling it!