### PR TITLE
add microsoft.github.io to domains

### DIFF
--- a/docfiles/domains-template.html
+++ b/docfiles/domains-template.html
@@ -405,6 +405,7 @@
         addRow("https://immersivereaderprod.cognitiveservices.azure.com");
         addRow("https://github.com");
         addRow("https://raw.githubusercontent.com/")
+        addRow("https://microsoft.github.io/");
 
     </script>
 


### PR DESCRIPTION
Domain used by Jacdac to host simulator.

 - needs to be ported into servicing branch of microbit as well