### PR TITLE
Option to ignore checkdocs in folder

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -270,7 +270,7 @@ export function buildHexAsync(buildEngine: BuildEngine, mainPkg: pxt.MainPackage
     U.jsonCopyFrom(allFiles, extInfo.extensionFiles)
 
     let writeFiles = () => {
-        for (let f of nodeutil.allFiles(buildEngine.buildPath + "/" + buildEngine.appPath, 8, true)) {
+        for (let f of nodeutil.allFiles(buildEngine.buildPath + "/" + buildEngine.appPath, { maxDepth: 8, allowMissing: true })) {
             let bn = f.slice(buildEngine.buildPath.length)
             bn = bn.replace(/\\/g, "/").replace(/^\//, "/")
             if (U.startsWith(bn, "/" + buildEngine.appPath + "/") && !allFiles[bn]) {
@@ -545,7 +545,7 @@ export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage
                         dn = buildEngine.buildPath + "/" + dn
                         if (U.endsWith(dn, ".h")) files.push(dn)
                         else {
-                            let here = nodeutil.allFiles(dn, 20).filter(fn => U.endsWith(fn, ".h"))
+                            let here = nodeutil.allFiles(dn, { maxDepth: 20 }).filter(fn => U.endsWith(fn, ".h"))
                             U.pushRange(files, here)
                         }
                     }
@@ -562,7 +562,7 @@ export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage
                 incPath = buildEngine.buildPath
             if (!fs.existsSync(incPath))
                 U.userError("cannot find " + incPath);
-            files = nodeutil.allFiles(incPath, 20)
+            files = nodeutil.allFiles(incPath, { maxDepth: 20 })
                 .filter(fn => U.endsWith(fn, ".h"))
                 .filter(fn => fn.indexOf("/mbed-classic/") < 0)
                 .filter(fn => fn.indexOf("/mbed-os/") < 0)

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -366,11 +366,19 @@ export function cp(srcFile: string, destDirectory: string, destName?: string) {
     fs.writeFileSync(dest, buf);
 }
 
-export function allFiles(top: string, maxDepth = 8, allowMissing = false, includeDirs = false, ignoredFileMarker: string = undefined): string[] {
+interface AllFilesOpts {
+    maxDepth?: number;
+    allowMissing?: boolean;
+    includeDirs?: boolean;
+    ignoredFileMarker?: string;
+    includeHidden?: boolean;
+}
+
+export function allFiles(top: string, maxDepth = 8, allowMissing = false, includeDirs = false, ignoredFileMarker: string = undefined, includeHiddenFiles = false): string[] {
     let res: string[] = []
     if (allowMissing && !existsDirSync(top)) return res
     for (const p of fs.readdirSync(top)) {
-        if (p[0] == ".") continue;
+        if (p[0] == "." && !includeHiddenFiles) continue;
         const inner = path.join(top, p)
         const st = fs.statSync(inner)
         if (st.isDirectory()) {
@@ -378,7 +386,7 @@ export function allFiles(top: string, maxDepth = 8, allowMissing = false, includ
             if (ignoredFileMarker && fs.existsSync(path.join(inner, ignoredFileMarker)))
                 continue;
             if (maxDepth > 1)
-                Util.pushRange(res, allFiles(inner, maxDepth - 1))
+                Util.pushRange(res, allFiles(inner, maxDepth - 1, allowMissing, includeDirs, ignoredFileMarker, includeHiddenFiles))
             if (includeDirs)
                 res.push(inner);
         } else {

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -344,7 +344,7 @@ export function mkdirP(thePath: string) {
 
 export function cpR(src: string, dst: string, maxDepth = 8) {
     src = path.resolve(src)
-    let files = allFiles(src, maxDepth)
+    let files = allFiles(src, { maxDepth })
     let dirs: pxt.Map<boolean> = {}
     for (let f of files) {
         let bn = f.slice(src.length)
@@ -371,10 +371,20 @@ interface AllFilesOpts {
     allowMissing?: boolean;
     includeDirs?: boolean;
     ignoredFileMarker?: string;
-    includeHidden?: boolean;
+    includeHiddenFiles?: boolean;
 }
+export function allFiles(top: string, opts: AllFilesOpts = {}) {
+    const {
+        maxDepth,
+        allowMissing,
+        includeDirs,
+        ignoredFileMarker,
+        includeHiddenFiles
+    } = {
+        maxDepth: 8,
+        ...opts
+    };
 
-export function allFiles(top: string, maxDepth = 8, allowMissing = false, includeDirs = false, ignoredFileMarker: string = undefined, includeHiddenFiles = false): string[] {
     let res: string[] = []
     if (allowMissing && !existsDirSync(top)) return res
     for (const p of fs.readdirSync(top)) {
@@ -386,7 +396,7 @@ export function allFiles(top: string, maxDepth = 8, allowMissing = false, includ
             if (ignoredFileMarker && fs.existsSync(path.join(inner, ignoredFileMarker)))
                 continue;
             if (maxDepth > 1)
-                Util.pushRange(res, allFiles(inner, maxDepth - 1, allowMissing, includeDirs, ignoredFileMarker, includeHiddenFiles))
+                Util.pushRange(res, allFiles(inner, { ...opts, maxDepth: maxDepth - 1 }))
             if (includeDirs)
                 res.push(inner);
         } else {

--- a/docs/cli/checkdocs.md
+++ b/docs/cli/checkdocs.md
@@ -25,7 +25,8 @@ Regex filter to select files to be scanned for snippets
 
 ## Other
 
-Add a ``.ignorelargefiles`` file in a folder to disable large file checks under this folder.
+* Add a ``.ignorelargefiles`` file in a folder to disable large file checks under this folder.
+* Add a ``.checkdocs-ignore`` file in a folder to disable snippet / link checks under this folder.
 
 ## See Also
 


### PR DESCRIPTION
Add option to throw in a `.checkdocs-ignore` file to suppress checkdocs for the folder; we can ignore checkdocs in pxtarget but that's pretty aggressive. We have a few other cases where we do this anyways (`.ignorelargefiles`, `.crowdin-ignore`)

Also did a minor refactor on `nodeutil.allFiles` parameters because the parameter list was getting too long and we only ever end up passing one or two (and if you're not careful you can e.g. pass null for maxDepth when you intend to pass a file marker or something)

This would be used for https://github.com/microsoft/pxt-arcade/pull/4820 as that has a minor typescript api change that would need a docs fix post release (follow -> cameraFollow)