### PR TITLE
[stable8.0] csv view cherry picks

### DIFF
--- a/theme/serial.less
+++ b/theme/serial.less
@@ -17,7 +17,8 @@
     height: 90%;
     padding: 1rem;
 
-    #serialCsv {
+    #serialCsv,
+    #serialCsvViewLatest {
         display: none;
     }
 
@@ -41,6 +42,24 @@
         #serialConsole,
         .csv-hide {
             display: none;
+        }
+
+        #serialCsvViewLatest {
+            display: block;
+            position: absolute;
+            margin-left: auto;
+            margin-right: auto;
+            text-align: center;
+            left: 0;
+            right: 0;
+            max-width: 15rem;
+            margin-top: -3em;
+        }
+
+        &.hide-view-latest {
+            #serialCsvViewLatest {
+                display: none;
+            }
         }
     }
 
@@ -136,7 +155,7 @@
     }
 }
 #serialConsole.nochart {
-    height: calc(100% - 2.5rem);
+    height: calc(100% - 12.5rem);
 }
 
 #serialConsole span {

--- a/theme/serial.less
+++ b/theme/serial.less
@@ -28,6 +28,12 @@
     &.csv-view {
         #serialCsv {
             display: block;
+
+            table:last-child thead {
+                position: sticky;
+                top: -0.75rem;
+                box-shadow: inset 0 2px 0 #ddd, inset 0 -2px 0 #ddd;
+            }
         }
 
         #serialCharts,

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -23,7 +23,7 @@ export class Editor extends srceditor.Editor {
     maxSerialInputDataLength: number = 255;
     isSim: boolean = true;
     isCsvView: boolean = undefined;
-    maxConsoleEntries: number = 1000;
+    maxConsoleEntries: number = 500;
     active: boolean = true
     rawDataBuffer: string = ""
     maxBufferLength: number = 100000;
@@ -278,12 +278,23 @@ export class Editor extends srceditor.Editor {
         this.addCsvRow(tr, csvTable.lastChild as HTMLTableSectionElement);
     }
 
+    goToLatest = () => {
+        const latestTable = this.csvRoot?.lastChild;
+        if (!latestTable) return;
+        //             last body row                   || last header row
+        const lastEl = latestTable.lastChild.lastChild || latestTable.firstChild.lastChild;
+        (lastEl as HTMLTableRowElement).scrollIntoView?.();
+        pxt.BrowserUtils.addClass(this.serialRoot, "hide-view-latest");
+    }
+
     addCsvRow(row: HTMLTableRowElement, target: HTMLTableSectionElement) {
         const currentlyAtBottom = target.getBoundingClientRect().bottom <= window.innerHeight;
         target.appendChild(row);
         this.checkCsvLineCount();
         if (currentlyAtBottom)
             row.scrollIntoView();
+        else
+            pxt.BrowserUtils.removeClass(this.serialRoot, "hide-view-latest");
     }
 
     checkCsvLineCount() {
@@ -489,6 +500,7 @@ export class Editor extends srceditor.Editor {
             this.clearNode(this.csvRoot);
         }
         this.csvLineCount = 0;
+        pxt.BrowserUtils.addClass(this.serialRoot, "hide-view-latest");
 
         // If the editor is currently visible, leave these as is to leave toggle state.
         if (!this.isVisible) {
@@ -655,7 +667,8 @@ export class Editor extends srceditor.Editor {
     display() {
         const rootClasses = classList(
             !this.shouldShowToggle() && "no-toggle",
-            this.isCsvView && "csv-view"
+            this.isCsvView && "csv-view",
+            "hide-view-latest"
         );
 
         return (
@@ -687,6 +700,7 @@ export class Editor extends srceditor.Editor {
                 <div id="serialCharts" ref={this.handleChartRootRef}></div>
                 <div id="serialConsole" ref={this.handleConsoleRootRef}></div>
                 <div id="serialCsv" ref={this.handleCsvRootRef}></div>
+                <sui.Button id="serialCsvViewLatest" onClick={this.goToLatest}>{lf("View latest row...")}</sui.Button>
             </div>
         )
     }

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -288,23 +288,24 @@ export class Editor extends srceditor.Editor {
 
     checkCsvLineCount() {
         this.csvLineCount++;
-        if (this.csvLineCount > this.maxConsoleEntries) {
+        while (this.csvLineCount > this.maxConsoleEntries) {
             const firstTable = this.csvRoot.firstChild;
             const thead = firstTable.firstChild;
             const tbody = firstTable.lastChild;
-            if (thead.hasChildNodes()) {
-                // remove header
-                thead.firstChild.remove();
-            } else {
-                // else remove first data row in table
+            if (tbody.hasChildNodes()) {
+                // remove first data row in table
                 tbody.firstChild.remove();
+                this.csvLineCount--;
+            } else if (tbody.hasChildNodes()) {
+                // if no other data in body, clear header
+                thead.firstChild.remove();
+                this.csvLineCount--;
             }
 
-            if (!tbody.hasChildNodes()) {
+            if (!tbody.hasChildNodes() && !thead.hasChildNodes()) {
                 // table is now empty, clear it.
                 firstTable.remove();
             }
-            this.csvLineCount--;
         }
     }
 


### PR DESCRIPTION
Cherry pick two csv view fixes over:

* Have last header stick to the top to avoid losing context on rows https://github.com/microsoft/pxt/pull/8924
* View latest button when you stop tracking the latest data & new data comes in https://github.com/microsoft/pxt/pull/8929