### PR TITLE
Various monaco tilemap fixes

### DIFF
--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -250,6 +250,7 @@ namespace ts.pxtc.service {
         let snippet: SnippetNode[];
         if (preDefinedSnippet) {
             snippet = [preDefinedSnippet];
+            snippetPrefix = undefined;
         } else {
             snippet = [fnName];
             if (args?.length || element.kind == pxtc.SymbolKind.Method || element.kind == pxtc.SymbolKind.Function || element.kind == pxtc.SymbolKind.Class) {

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -46,8 +46,8 @@ namespace pxt.editor {
             let id: string;
 
             if (name) {
-                let id = ts.pxtc.escapeIdentifier(name)
-                proj = project.getTilemap(id);
+                id = ts.pxtc.escapeIdentifier(name)
+                proj = project.getTilemap(id) || project.lookupAssetByName(AssetType.Tilemap, name);
             }
 
             if (!proj) {

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -607,7 +607,7 @@ namespace pxt {
                 id,
                 type: AssetType.Tilemap,
                 meta: {
-                    displayName: id
+                    displayName: name || id
                 },
                 data: data
             });


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/4719
Fixes https://github.com/microsoft/pxt-arcade/issues/4722

In addition to those two bugs, this also fixes two more bugs I discovered while testing:

1. When creating a tilemap from the asset editor, we were always adding "1" to the end of the asset name
2. When creating a tilemap from within the monaco editor, we were ignoring the name the user typed and instead always using the name "level#"

That's right, it's one of those classic "one bug fixed for every line changed" prs.

Sorry for the delay @bmarslandCN!