### PR TITLE
[stable7.4] Cherry picking fixes for arcade patch release

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -821,7 +821,9 @@ declare namespace ts.pxtc {
         mutateDefaults?: string;
         mutatePropertyEnum?: string;
         inlineInputMode?: string; // can be inline, external, or auto
+        inlineInputModeLimit?: number; // the number of expanded arguments at which to switch from inline to external. only applies when inlineInputMode=variable and expandableArgumentsMode=enabled
         expandableArgumentMode?: string; // can be disabled, enabled, or toggle
+        expandableArgumentBreaks?: string; // a comma separated list of how many arguments to reveal/hide each time + or - is pressed on a block. only applies when expandableArgumentsMode=enabled
         draggableParameters?: string; // can be reporter or variable; defaults to variable
 
 

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "monaco-editor": "0.24.0",
     "pouchdb": "7.2.1",
     "pouchdb-adapter-memory": "7.2.1",
-    "pxt-blockly": "4.0.9",
+    "pxt-blockly": "4.0.13",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -348,11 +348,10 @@ namespace pxt.blocks {
             block.appendChild(createShadowValue(info, t, t.shadowBlockId || "variables_get", t.defaultValue || t.definitionName));
         }
         if (fn.parameters) {
-            comp.parameters.filter(pr => !pr.isOptional &&
-                (primitiveTypeRegex.test(pr.type)
+            comp.parameters.filter(pr => primitiveTypeRegex.test(pr.type)
                     || primitiveTypeRegex.test(isArrayType(pr.type))
                     || pr.shadowBlockId
-                    || pr.defaultValue))
+                    || pr.defaultValue)
                 .forEach(pr => {
                     block.appendChild(createShadowValue(info, pr));
                 })

--- a/pxtblocks/fields/field_autocomplete.ts
+++ b/pxtblocks/fields/field_autocomplete.ts
@@ -179,5 +179,16 @@ namespace pxtblockly {
             // This creates the little arrow for dropdown fields. Intentionally
             // do nothing
         }
+
+        showPromptEditor_() {
+            Blockly.prompt(
+                Blockly.Msg['CHANGE_VALUE_TITLE'],
+                this.parsedValue,
+                (newValue) => {
+                    this.setValue(this.getValueFromEditorText_(newValue));
+                    this.forceRerender();
+                }
+            );
+        }
     }
 }

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -250,6 +250,7 @@ namespace ts.pxtc.service {
         let snippet: SnippetNode[];
         if (preDefinedSnippet) {
             snippet = [preDefinedSnippet];
+            snippetPrefix = undefined;
         } else {
             snippet = [fnName];
             if (args?.length || element.kind == pxtc.SymbolKind.Method || element.kind == pxtc.SymbolKind.Function || element.kind == pxtc.SymbolKind.Class) {

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -46,8 +46,8 @@ namespace pxt.editor {
             let id: string;
 
             if (name) {
-                let id = ts.pxtc.escapeIdentifier(name)
-                proj = project.getTilemap(id);
+                id = ts.pxtc.escapeIdentifier(name)
+                proj = project.getTilemap(id) || project.lookupAssetByName(AssetType.Tilemap, name);
             }
 
             if (!proj) {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -816,7 +816,7 @@ namespace ts.pxtc {
         return r;
     }
 
-    const numberAttributes = ["weight", "imageLiteral", "topblockWeight"]
+    const numberAttributes = ["weight", "imageLiteral", "topblockWeight", "inlineInputModeLimit"]
     const booleanAttributes = [
         "advanced",
         "handlerStatement",

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -607,7 +607,7 @@ namespace pxt {
                 id,
                 type: AssetType.Tilemap,
                 meta: {
-                    displayName: id
+                    displayName: name || id
                 },
                 data: data
             });

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -281,25 +281,10 @@ export class Editor extends srceditor.Editor {
             this.consoleRoot.appendChild(newEntry)
         }
         else {
-            let lastEntry = this.consoleRoot.lastChild
             let newEntry = document.createElement("div")
-            if (lastEntry && lastEntry.lastChild.textContent == line) {
-                if (lastEntry.childNodes.length == 2) {
-                    //Matches already-collapsed entry
-                    let count = parseInt(lastEntry.firstChild.textContent)
-                    lastEntry.firstChild.textContent = (count + 1).toString()
-                } else {
-                    //Make a new collapsed entry with count = 2
-                    let newLabel = document.createElement("a")
-                    newLabel.className = "ui horizontal label"
-                    newLabel.textContent = "2"
-                    lastEntry.insertBefore(newLabel, lastEntry.lastChild)
-                }
-            } else {
-                //Make a new non-collapsed entry
-                newEntry.appendChild(document.createTextNode(line))
-                this.consoleRoot.appendChild(newEntry)
-            }
+            //Make a new non-collapsed entry
+            newEntry.appendChild(document.createTextNode(line))
+            this.consoleRoot.appendChild(newEntry)
         }
         this.consoleRoot.scrollTop = this.consoleRoot.scrollHeight
         while (this.consoleRoot.childElementCount > this.maxConsoleEntries) {


### PR DESCRIPTION
Porting a number of fixes to arcade stable:

#8842 
#8904 
#8933 
The field_autocomplete fix in #8891 
All of the improvements from expandable blocks in prs #8767, #8774, and #8868

For those last three, I made those improvements as part of the sound effect editor but really they should have been separate prs. These changes fix several longstanding issues with expandable blocks in pxt-arcade, including problems with filling default arguments and the annoying flickering that happens whenever a collapsed block is loaded. I only took the changes to the expandable blocks for this patch, none of the sound effect changes.

This pr also updates to the latest pxt-blockly to take the minor fixes we've been making there:

https://github.com/microsoft/pxt-blockly/pull/394
https://github.com/microsoft/pxt-blockly/pull/396
https://github.com/microsoft/pxt-blockly/pull/397
https://github.com/microsoft/pxt-blockly/pull/398
https://github.com/microsoft/pxt-blockly/pull/399
https://github.com/microsoft/pxt-blockly/pull/401

I would have just cherry picked the change I wanted (https://github.com/microsoft/pxt-blockly/pull/401) but it looks like we never took a stable branch for pxt-arcade. In any case, I looked over the changes and they're all very safe and useful to port.