### PR TITLE
Add ability to import zip files of projects

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2063,6 +2063,7 @@ export class ProjectView
 
    async importZipFileAsync(file: File, options?: pxt.editor.ImportFileOptions) {
         if (!file) return;
+        pxt.tickEvent("import.zip");
 
         await scriptmanager.loadZipAsync();
         const reader = new zip.ZipReader(new zip.BlobReader(file));
@@ -2076,7 +2077,6 @@ export class ProjectView
             core.warningNotification(lf("No projects available to import found inside zip file."));
             return;
         }
-
 
         const confirmed = await core.confirmAsync({
             header: lf("Import zip file?"),

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -67,6 +67,8 @@ type FileHistoryEntry = pxt.editor.FileHistoryEntry;
 type EditorSettings = pxt.editor.EditorSettings;
 type ProjectCreationOptions = pxt.editor.ProjectCreationOptions;
 
+declare const zip: any;
+
 import Cloud = pxt.Cloud;
 import Util = pxt.Util;
 import { HintManager } from "./hinttooltip";
@@ -1987,6 +1989,10 @@ export class ProjectView
         return false
     }
 
+    isZipFile(filename: string): boolean {
+        return /\.zip$/i.test(filename)
+    }
+
     importProjectCoreAsync(buf: Uint8Array, options?: pxt.editor.ImportFileOptions) {
         return (buf[0] == '{'.charCodeAt(0) ?
             Promise.resolve(pxt.U.uint8ArrayToString(buf)) :
@@ -2053,6 +2059,71 @@ export class ProjectView
             .then(buf => pxt.Util.decodeBlobAsync("data:image/png;base64," +
                 btoa(pxt.Util.uint8ArrayToString(buf))))
             .then(buf => this.importProjectCoreAsync(buf, options))
+    }
+
+   async importZipFileAsync(file: File, options?: pxt.editor.ImportFileOptions) {
+        if (!file) return;
+
+        await scriptmanager.loadZipAsync();
+        const reader = new zip.ZipReader(new zip.BlobReader(file));
+
+        const zippedFiles = (await reader.getEntries()).filter((zipped: any) => this.isProjectFile(zipped.filename));
+        let progress = {
+            done: 0
+        }
+
+        if (zippedFiles.length === 0) {
+            core.warningNotification(lf("No projects available to import found inside zip file."));
+            return;
+        }
+
+
+        const confirmed = await core.confirmAsync({
+            header: lf("Import zip file?"),
+            body: lf("Do you want to import all projects in this zip file? This will import {0} projects.", zippedFiles.length),
+            agreeLbl: lf("Okay"),
+            hasCloseIcon: true,
+        });
+
+        if (!confirmed) return;
+
+        let cancelled = false;
+
+        core.dialogAsync({
+            header: lf("Extracting files..."),
+            jsxd: () => <dialogs.ProgressBar percentage={100 * (progress.done / zippedFiles.length)} />,
+            onClose: () => cancelled = true
+        })
+
+        for (const zipped of zippedFiles) {
+            try {
+                const buf: Uint8Array = await zipped.getData(new zip.Uint8ArrayWriter());
+
+                const data = JSON.parse(await pxt.lzmaDecompressAsync(buf)) as pxt.cpp.HexFile;
+
+                let h: pxt.workspace.InstallHeader = {
+                    target: pxt.appTarget.id,
+                    targetVersion: data.meta.targetVersions ? data.meta.targetVersions.target : undefined,
+                    editor: data.meta.editor,
+                    name: data.meta.name,
+                    meta: {},
+                    pubId: "",
+                    pubCurrent: false
+                }
+
+                const files = JSON.parse(data.source) as pxt.Map<string>;
+                await workspace.installAsync(h, files);
+            }
+            catch (e) {
+
+            }
+
+            if (cancelled) break;
+            progress.done ++;
+            core.forceUpdate();
+        }
+
+        core.hideDialog();
     }
 
     importPNGBuffer(buf: ArrayBuffer) {
@@ -2224,7 +2295,7 @@ export class ProjectView
 
     initDragAndDrop() {
         draganddrop.setupDragAndDrop(document.body,
-            file => file.size < 1000000 && this.isHexFile(file.name) || this.isBlocksFile(file.name),
+            file => file.size < 1000000 && this.isHexFile(file.name) || this.isBlocksFile(file.name) || this.isZipFile(file.name),
             files => {
                 if (files) {
                     pxt.tickEvent("dragandrop.open")
@@ -2267,6 +2338,8 @@ export class ProjectView
             this.importAssetFile(file)
         } else if (this.isPNGFile(file.name)) {
             this.importPNGFile(file, options);
+        } else if (this.isZipFile(file.name)) {
+            this.importZipFileAsync(file, options);
         } else {
             const importer = this.resourceImporters.filter(fi => fi.canImport(file))[0];
             if (importer) {

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -15,7 +15,7 @@ import { ProgressBar } from "./dialogs";
 declare const zip: any;
 
 let loadZipJsPromise: Promise<boolean>;
-function loadZipAsync(): Promise<boolean> {
+export function loadZipAsync(): Promise<boolean> {
     if (!loadZipJsPromise)
         loadZipJsPromise = pxt.BrowserUtils.loadScriptAsync("zip.js/zip.min.js")
             .then(() => typeof zip !== "undefined")


### PR DESCRIPTION
The mirror side of https://github.com/microsoft/pxt/pull/8936

Extract and import a zip file full of projects! There are two dialogs: an initial confirm dialog and a progress dialog once the import starts. See the full experience in the gif below

![extract zip](https://user-images.githubusercontent.com/13754588/175167377-5dfadb81-0693-46cb-8c4a-1f077756b60c.gif)


My test zip had 31 arcade projects
