### PR TITLE
Add validate range for monaco field editors and some missing css

### DIFF
--- a/pxteditor/monaco-fields/field_soundEffect.ts
+++ b/pxteditor/monaco-fields/field_soundEffect.ts
@@ -151,6 +151,47 @@ namespace pxt.editor {
         }
     }
 
+    function validateRange(range: monaco.Range, model: monaco.editor.ITextModel) {
+        let currentLine = range.startLineNumber;
+        let currentColumn = 0;
+        let foundStart = false;
+        let parenCount = 0;
+
+        const methodName = "createSoundEffect";
+        const totalLines = model.getLineCount();
+
+        while (currentLine < totalLines) {
+            const lineContent = model.getLineContent(currentLine);
+            const startIndex = lineContent.indexOf(methodName)
+            if (startIndex !== -1) {
+                foundStart = true;
+                currentColumn = startIndex + methodName.length;
+            }
+
+            if (foundStart) {
+                while (currentColumn < lineContent.length) {
+                    const currentChar = lineContent.charAt(currentColumn)
+                    if (currentChar === "(") {
+                        parenCount++
+                    }
+                    else if (currentChar === ")") {
+                        parenCount--;
+
+                        if (parenCount === 0) {
+                            return new monaco.Range(range.startLineNumber, range.startColumn, currentLine, currentColumn + model.getLineMinColumn(currentLine) + 1)
+                        }
+                    }
+                    currentColumn ++;
+                }
+            }
+
+            currentColumn = 0;
+            currentLine ++;
+        }
+
+        return undefined;
+    }
+
     function defaultSound(): pxt.assets.Sound {
         return {
             wave: "sine",
@@ -171,10 +212,11 @@ namespace pxt.editor {
         heightInPixels: 510,
         matcher: {
             // match both JS and python
-            searchString: "music\\s*\\.\\s*createSoundEffect\\s*\\([^)]*\\)",
+            searchString: "music\\s*\\.\\s*createSoundEffect\\s*\\(",
             isRegex: true,
             matchCase: true,
-            matchWholeWord: false
+            matchWholeWord: false,
+            validateRange
         },
         proto: MonacoSoundEffectEditor
     };

--- a/pxteditor/monaco-fields/monacoFieldEditor.ts
+++ b/pxteditor/monaco-fields/monacoFieldEditor.ts
@@ -39,6 +39,7 @@ namespace pxt.editor {
         isRegex: boolean;
         matchWholeWord: boolean;
         matchCase: boolean;
+        validateRange?: (range: monaco.Range, model: monaco.editor.ITextModel) => monaco.Range;
     }
 
     const definitions: pxt.Map<MonacoFieldEditorDefinition> = {};

--- a/theme/common.less
+++ b/theme/common.less
@@ -2429,6 +2429,11 @@ div.signin-button:focus {
 #blocks-editor-field-div {
     position: absolute;
     z-index: @blocklyDropdownDivZIndex;
+
+    .sound-effect-editor {
+        max-width: 30rem;
+        margin: auto;
+    }
 }
 
 .blocks-editor-field-overlay {

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -41,7 +41,7 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
     protected hideCallback: () => void;
     protected containerClass: string;
 
-    constructor(protected contentDiv: HTMLDivElement, protected inContainer: boolean) {
+    constructor(protected contentDiv: HTMLDivElement, protected inContainer: boolean, protected useFlex?: boolean) {
     }
 
     injectElement(element: JSX.Element) {
@@ -62,7 +62,7 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
 
         this.visible = true;
         this.resize(this.editorBounds);
-        this.contentDiv.style.display = "block";
+        this.contentDiv.style.display = this.useFlex ? "flex" : "block";
 
         if (!this.inContainer) {
             this.overlayDiv = document.createElement("div");
@@ -232,7 +232,7 @@ export function init() {
             }
         }
 
-        current = new FieldEditorView(container || document.getElementById("blocks-editor-field-div") as HTMLDivElement, !!container);
+        current = new FieldEditorView(container || document.getElementById("blocks-editor-field-div") as HTMLDivElement, !!container, options?.useFlex);
 
         switch (fieldEditorId) {
             case "image-editor":

--- a/webapp/src/monacoFieldEditorHost.ts
+++ b/webapp/src/monacoFieldEditorHost.ts
@@ -345,7 +345,12 @@ export class FieldEditorManager implements monaco.languages.FoldingRangeProvider
 
             const decorations: monaco.editor.IModelDeltaDecoration[] = [];
             matches.forEach(match => {
-                const line = match.range.startLineNumber;
+                let range = match.range;
+                if (matcher.validateRange) {
+                    range = matcher.validateRange(range, model);
+                    if (!range) return;
+                }
+                const line = range.startLineNumber;
 
                 if (this.getInfoForLine(line)) return;
 
@@ -356,7 +361,7 @@ export class FieldEditorManager implements monaco.languages.FoldingRangeProvider
                     }
                 });
 
-                this.trackRange(fe.id, line, match.range);
+                this.trackRange(fe.id, line, range);
 
             });
             this.setDecorations(fe.id, this.editor.deltaDecorations([], decorations));


### PR DESCRIPTION
Re: conversation with @jwunderl in https://github.com/microsoft/pxt/pull/8941

This adds an optional function to validate/adjust monaco field editor ranges so that we don't have to cram more complicated logic into the regex (which becomes a performance concern). The validate range function here just counts parentheses and handles multiline, so a snippet like this:

```ts
music.playSoundEffect(
    music.createSoundEffect(
        WaveShape.Sine,
        1,
        input.acceleration(Dimension.X),
        0,
        0,
        500,
        SoundExpressionEffect.None,
        InterpolationCurve.Linear
    ),
    SoundExpressionPlayMode.UntilDone
);
```

...can now be edited. Note that the acceleration call in this example will be removed when you close the editor (better than the old behavior of breaking your program, though!)

I also accidentally left some css out of the last pr!