### PR TITLE
explicitly give focus to iframe to get past cross domain security focus issues

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -714,7 +714,7 @@ namespace pxsim {
                     const frameid = (msg as pxsim.SimulatorReadyMessage).frameid;
                     const frame = document.getElementById(frameid) as HTMLIFrameElement;
                     if (frame) {
-                        if (this._runOptions.autofocus)
+                        if (this._runOptions?.autofocus)
                             frame.focus();
                         this.startFrame(frame);
                         if (this.options.revealElement)

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -714,6 +714,8 @@ namespace pxsim {
                     const frameid = (msg as pxsim.SimulatorReadyMessage).frameid;
                     const frame = document.getElementById(frameid) as HTMLIFrameElement;
                     if (frame) {
+                        if (this._runOptions.autofocus)
+                            frame.focus();
                         this.startFrame(frame);
                         if (this.options.revealElement)
                             this.options.revealElement(frame);


### PR DESCRIPTION
cross domain autofocus is annoying https://bugs.chromium.org/p/chromium/issues/detail?id=998450&q=autofocus%20iframe&can=2

Explicitly pass focus over after the simulator has loaded to make sure the sim can actually take the focus