### PR TITLE
Fix for cloud sync issue posted to forum

### DIFF
--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -101,6 +101,9 @@ function getAsync(h: Header): Promise<File> {
                 pxt.tickEvent(`identity.cloudApi.getProject.failed`);
                 reject(result.err);
             }
+        } catch (e) {
+            pxt.tickEvent(`identity.cloudApi.getProject.failed`);
+            reject(e);
         } finally {
             cloudMeta.syncFinished();
         }


### PR DESCRIPTION
Debugging this issue: https://forum.makecode.com/t/arcade-makecode-cloud-freezing/14205, I found a saved project missing its "text" field (where we store project code). Trying to sync this project was causing Arcade to hang. While this change doesn't address the underlying cause as to how the project was saved this way, it makes it non-fatal if one is encountered.

I queried the db to see how many other projects are missing their text field and found about **100**.