### PR TITLE
don't crash on home screen when runOptions is nullish

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -426,7 +426,7 @@ namespace pxsim {
             frame.frameBorder = "0";
             frame.dataset['runid'] = this.runId;
             frame.dataset['origin'] = new URL(furl).origin || "*";
-            if (this._runOptions.autofocus) frame.setAttribute("autofocus", "true");
+            if (this._runOptions?.autofocus) frame.setAttribute("autofocus", "true");
 
             wrapper.appendChild(frame);
 


### PR DESCRIPTION
https://github.com/microsoft/pxt/pull/8943/files#diff-38049390bd51d827d9db5eb6f97a982b29b6a8448ae2937f765530c5bc389ba3R429 makes when loading a project from homescreen because for some reason we spin up simulator with no runOptions at that point. We should probably... just not do that and make sure that _runOptions exists to avoid this sort of thing in the future (I recall us hitting it at least 2 or 3 times before), but for now just guard the check here~

(note that the commit this came from was made pretty much solely the kiosk app only with the embedded sim, which is why we didn't catch it right away; if you go to arcade.makecode.com/v1.9 you can see the crash)