### PR TITLE
Fix for null file entry in pxt.json

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2785,7 +2785,7 @@ export class ProjectView
         src = src || "\n";
         const mainPkg = pkg.mainEditorPkg();
         const fileName = this.editorFile.getVirtualFileName(prj);
-        Util.assert(fileName != this.editorFile.name);
+        Util.assert(fileName && fileName != this.editorFile.name);
         return mainPkg.setContentAsync(fileName, src).then(() => {
             if (open) {
                 let f = mainPkg.files[fileName];
@@ -2847,7 +2847,9 @@ export class ProjectView
                 if (src === undefined
                     || (this.editorFile && this.editorFile.name == this.editorFile.getVirtualFileName(pxt.JAVASCRIPT_PROJECT_NAME)))
                     return Promise.resolve();
-                return this.saveVirtualFileAsync(pxt.JAVASCRIPT_PROJECT_NAME, src, open);
+                if (this.editorFile.getVirtualFileName(pxt.JAVASCRIPT_PROJECT_NAME))
+                    return this.saveVirtualFileAsync(pxt.JAVASCRIPT_PROJECT_NAME, src, open);
+                return Promise.resolve();
             });
 
         if (open) {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -370,6 +370,7 @@ export class EditorPackage {
     }
 
     setFile(n: string, v: string, virtual?: boolean): File {
+        Util.assert(!!n, "missing file name");
         let f = new File(this, n, v)
         if (virtual) f.virtual = true;
         this.files[n] = f
@@ -388,6 +389,7 @@ export class EditorPackage {
     }
 
     setContentAsync(n: string, v: string): Promise<void> {
+        Util.assert(!!n, "missing file name");
         let f = this.files[n];
         let p = Promise.resolve();
         if (!f) {


### PR DESCRIPTION
A null file entry can be added to pxt.json when a perfect storm of timing events occurs. I don't have a precise repro, but it tends to happen when code changes pending save start to get saved while assets.json is the current editor file.

This is a conservative change, adding guards to:
- ensure we don't try to write to an undefined file
- only save a "virtual file" if we can generate a filename for it
