### PR TITLE
Fix commenting for specific auto-declared variables.

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1301,13 +1301,27 @@ ${output}</xml>`;
                         break;
                     case SK.VariableDeclaration:
                         const decl = node as ts.VariableDeclaration;
-                        if (isAutoDeclaration(decl)) {
-                            // Don't emit null or automatic initializers;
-                            // They are implicit within the blocks. But do track them in case they
-                            // never get used in the blocks (and thus won't be emitted again)
-
-                            trackAutoDeclaration(decl);
-                            return getNext();
+                        // Logic in isAutoDeclaration() returns true if text === "0".
+                        // If a variable declaration sets the inital value to "0", it is considered
+                        // an auto declaration. However, getComments() will no longer be called.
+                        // This is a problem if there is a comment (e.g. //@highligh) prior to the
+                        // variable declaration. The result being the comment is incorrectly
+                        // inserted into the XML. 
+                        let skipAutoDeclarationCheck = false;
+                        if (ts.isStringOrNumericLiteral(decl.initializer)) {
+                            const text = decl.initializer.getText();
+                            if (text === "0") {
+                                skipAutoDeclarationCheck = true;
+                            }
+                        }
+                        if(!skipAutoDeclarationCheck) {
+                            if (isAutoDeclaration(decl)) {
+                                // Don't emit null or automatic initializers;
+                                // They are implicit within the blocks. But do track them in case they
+                                // never get used in the blocks (and thus won't be emitted again)
+                                trackAutoDeclaration(decl);
+                                return getNext();
+                            }
                         }
                         stmt = getVariableDeclarationStatement(node as ts.VariableDeclaration);
                         break;

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1410,7 +1410,7 @@ ${output}</xml>`;
                             // Don't emit null or automatic initializers;
                             // They are implicit within the blocks. But do track them in case they
                             // never get used in the blocks (and thus won't be emitted again)
-                            
+
                             trackAutoDeclaration(decl);
                             return getNext();
                         }

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1304,7 +1304,7 @@ ${output}</xml>`;
                         // Logic in isAutoDeclaration() returns true if text === "0".
                         // If a variable declaration sets the inital value to "0", it is considered
                         // an auto declaration. However, getComments() will no longer be called.
-                        // This is a problem if there is a comment (e.g. //@highligh) prior to the
+                        // This is a problem if there is a comment (e.g. //@highlight) prior to the
                         // variable declaration. The result being the comment is incorrectly
                         // inserted into the XML. 
                         let skipAutoDeclarationCheck = false;

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1301,12 +1301,15 @@ ${output}</xml>`;
                         break;
                     case SK.VariableDeclaration:
                         const decl = node as ts.VariableDeclaration;
-                        // Logic in isAutoDeclaration() returns true if text === "0".
-                        // If a variable declaration sets the inital value to "0", it is considered
-                        // an auto declaration. However, getComments() will no longer be called.
-                        // This is a problem if there is a comment (e.g. //@highlight) prior to the
-                        // variable declaration. The result being the comment is incorrectly
-                        // inserted into the XML. 
+                        if (isAutoDeclaration(decl)) {
+                        // BUG: A comment (e.g. //@highlight) prior to a variable declaration of "0"
+                        // in markdown results in mis-rendered XML.
+                        //
+                        // Logic in isAutoDeclaration() returns true if `text === "0"`. As a reuslt,
+                        // existing code will not call `getComments()` and not return `stmt`. This
+                        // results in incorrect XML.
+                        //
+                        // FIX: Skip the AutoDeclarationCheck when the variable's text is "0".
                         let skipAutoDeclarationCheck = false;
                         if (ts.isStringOrNumericLiteral(decl.initializer)) {
                             const text = decl.initializer.getText();

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1410,6 +1410,7 @@ ${output}</xml>`;
                             // Don't emit null or automatic initializers;
                             // They are implicit within the blocks. But do track them in case they
                             // never get used in the blocks (and thus won't be emitted again)
+                            
                             trackAutoDeclaration(decl);
                             return getNext();
                         }

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1266,6 +1266,111 @@ ${output}</xml>`;
             return undefined;
         }
 
+        /**
+         * We split up comments according to the following rules:
+         *      1. If the comment is not top-level:
+         *          a. Combine it with all comments for the following statement
+         *          b. If there is no following statement in the current block, group it with the previous statement
+         *          c. If there are no statements inside the block, group it with the parent block
+         *          d. If trailing the same line as the statement, group it with the comments for that statement
+         *      2. If the comment is top-level:
+         *          b. If the comment is followed by an empty line, it becomes a workspace comment
+         *          c. If the comment is followed by a multi-line comment, it becomes a workspace comment
+         *          a. If the comment is a single-line comment, combine it with the next single-line comment
+         *          d. If the comment is not followed with an empty line, group it with the next statement or event
+         *          e. All other comments are workspace comments
+         *
+         * The below function gathers any comments associated to the Node, and attaches them
+         * to the StatementNode.
+         */
+        function getNodeComments(commented: Node, stmt: StatementNode) {
+            let comments: Comment[] = [];
+            let current: Comment;
+            for (let i = 0; i < commentMap.length; i++) {
+                current = commentMap[i];
+                if (!current.owner && current.start >= commented.pos && current.end <= commented.end) {
+                    current.owner = commented;
+                    current.ownerStatement = stmt;
+                    comments.push(current);
+                }
+
+                if (current.start > commented.end) break;
+            }
+
+            if (current && current.isTrailingComment) {
+                const endLine = ts.getLineAndCharacterOfPosition(file, commented.end);
+                const commentLine = ts.getLineAndCharacterOfPosition(file, current.start);
+
+                if (endLine.line === commentLine.line) {
+                    // If the comment is trailing and on the same line as the statement, it probably belongs
+                    // to this statement. Remove it from any statement it's already assigned to and any workspace
+                    // comments
+                    if (current.ownerStatement) {
+                        current.ownerStatement.comment.splice(current.ownerStatement.comment.indexOf(current), 1);
+
+                        for (const wsComment of workspaceComments) {
+                            wsComment.comment.splice(wsComment.comment.indexOf(current), 1)
+                        }
+                    }
+                    current.owner = commented;
+                    current.ownerStatement = stmt;
+                    comments.push(current);
+                }
+            }
+
+            if (comments.length) {
+                const wsCommentRefs: string[] = [];
+
+                if (isTopLevelComment(commented)) {
+                    let currentWorkspaceComment: Comment[] = [];
+
+                    const localWorkspaceComments: Comment[][] = [];
+
+                    comments.forEach((comment, index) => {
+                        let beforeStatement = comment.owner && comment.start < comment.owner.getStart();
+                        if (comment.kind === CommentKind.MultiLine && beforeStatement) {
+                            if (currentWorkspaceComment.length) {
+                                localWorkspaceComments.push(currentWorkspaceComment);
+                                currentWorkspaceComment = [];
+                            }
+                            if (index != comments.length - 1) {
+                                localWorkspaceComments.push([comment]);
+                                return;
+                            }
+                        }
+
+                        currentWorkspaceComment.push(comment);
+
+                        if (comment.followedByEmptyLine && beforeStatement) {
+                            localWorkspaceComments.push(currentWorkspaceComment);
+                            currentWorkspaceComment = [];
+                        }
+                    });
+
+                    comments = currentWorkspaceComment;
+
+                    localWorkspaceComments.forEach(comment => {
+                        const refId = getCommentRef();
+
+                        wsCommentRefs.push(refId);
+                        workspaceComments.push({ comment, refId });
+                    });
+                }
+
+                // Attach comments to StatementNode
+                if (stmt) {
+                    if (wsCommentRefs.length) {
+                        if (stmt.data) stmt.data += ";" + wsCommentRefs.join(";")
+                        else stmt.data = wsCommentRefs.join(";")
+                    }
+                    if (comments && comments.length) {
+                        if (stmt.comment) stmt.comment = stmt.comment.concat(comments);
+                        else stmt.comment = comments;
+                    }
+                }
+            }
+        }
+
         function getStatementBlock(n: ts.Node, next?: ts.Node[], parent?: ts.Node, asExpression = false, topLevel = false): StatementNode {
             const node = n as ts.Node;
             let stmt: StatementNode;
@@ -1371,7 +1476,7 @@ ${output}</xml>`;
             }
 
             if (!skipComments) {
-                getComments(parent || node);
+                getNodeComments(parent || node, stmt);
             }
 
             return stmt;
@@ -1381,108 +1486,6 @@ ${output}</xml>`;
                     return getStatementBlock(next.shift(), next, undefined, false, topLevel);
                 }
                 return undefined;
-            }
-
-            /**
-             * We split up comments according to the following rules:
-             *      1. If the comment is not top-level:
-             *          a. Combine it with all comments for the following statement
-             *          b. If there is no following statement in the current block, group it with the previous statement
-             *          c. If there are no statements inside the block, group it with the parent block
-             *          d. If trailing the same line as the statement, group it with the comments for that statement
-             *      2. If the comment is top-level:
-             *          b. If the comment is followed by an empty line, it becomes a workspace comment
-             *          c. If the comment is followed by a multi-line comment, it becomes a workspace comment
-             *          a. If the comment is a single-line comment, combine it with the next single-line comment
-             *          d. If the comment is not followed with an empty line, group it with the next statement or event
-             *          e. All other comments are workspace comments
-             */
-
-            function getComments(commented: Node) {
-                let comments: Comment[] = [];
-                let current: Comment;
-                for (let i = 0; i < commentMap.length; i++) {
-                    current = commentMap[i];
-                    if (!current.owner && current.start >= commented.pos && current.end <= commented.end) {
-                        current.owner = commented;
-                        current.ownerStatement = stmt;
-                        comments.push(current);
-                    }
-
-                    if (current.start > commented.end) break;
-                }
-
-                if (current && current.isTrailingComment) {
-                    const endLine = ts.getLineAndCharacterOfPosition(file, commented.end);
-                    const commentLine = ts.getLineAndCharacterOfPosition(file, current.start);
-
-                    if (endLine.line === commentLine.line) {
-                        // If the comment is trailing and on the same line as the statement, it probably belongs
-                        // to this statement. Remove it from any statement it's already assigned to and any workspace
-                        // comments
-                        if (current.ownerStatement) {
-                            current.ownerStatement.comment.splice(current.ownerStatement.comment.indexOf(current), 1);
-
-                            for (const wsComment of workspaceComments) {
-                                wsComment.comment.splice(wsComment.comment.indexOf(current), 1)
-                            }
-                        }
-                        current.owner = commented;
-                        current.ownerStatement = stmt;
-                        comments.push(current);
-                    }
-                }
-
-                if (comments.length) {
-                    const wsCommentRefs: string[] = [];
-
-                    if (isTopLevelComment(commented)) {
-                        let currentWorkspaceComment: Comment[] = [];
-
-                        const localWorkspaceComments: Comment[][] = [];
-
-                        comments.forEach((comment, index) => {
-                            let beforeStatement = comment.owner && comment.start < comment.owner.getStart();
-                            if (comment.kind === CommentKind.MultiLine && beforeStatement) {
-                                if (currentWorkspaceComment.length) {
-                                    localWorkspaceComments.push(currentWorkspaceComment);
-                                    currentWorkspaceComment = [];
-                                }
-                                if (index != comments.length - 1) {
-                                    localWorkspaceComments.push([comment]);
-                                    return;
-                                }
-                            }
-
-                            currentWorkspaceComment.push(comment);
-
-                            if (comment.followedByEmptyLine && beforeStatement) {
-                                localWorkspaceComments.push(currentWorkspaceComment);
-                                currentWorkspaceComment = [];
-                            }
-                        });
-
-                        comments = currentWorkspaceComment;
-
-                        localWorkspaceComments.forEach(comment => {
-                            const refId = getCommentRef();
-
-                            wsCommentRefs.push(refId);
-                            workspaceComments.push({ comment, refId });
-                        });
-                    }
-
-                    if (stmt) {
-                        if (wsCommentRefs.length) {
-                            if (stmt.data) stmt.data += ";" + wsCommentRefs.join(";")
-                            else stmt.data = wsCommentRefs.join(";")
-                        }
-                        if (comments && comments.length) {
-                            if (stmt.comment) stmt.comment = stmt.comment.concat(comments);
-                            else stmt.comment = comments;
-                        }
-                    }
-                }
             }
         }
 
@@ -2369,12 +2372,13 @@ ${output}</xml>`;
 
             if (blockStatements.length) {
                 // wrap statement in "on start" if top level
-                const stmtNode = blockStatements.shift();
-                const stmt = getStatementBlock(stmtNode, blockStatements, parent, false, topLevel);
+                const blockNode = blockStatements.shift();
+                const stmt = getStatementBlock(blockNode, blockStatements, parent, false, topLevel);
                 if (emitOnStart) {
                     // Preserve any variable edeclarations that were never used
-                    let current = stmt;
-                    let currentNode: ts.Node = stmtNode;
+                    // stmt and blockNode will not yet align if there was an auto-declared variable.
+                    let currentStmtNode = stmt;
+                    let currentBlockNode: ts.Node = blockNode;
                     autoDeclarations.forEach(([name, node]) => {
                         if (varUsages[name] === ReferenceType.InBlocksOnly) {
                             return;
@@ -2388,18 +2392,24 @@ ${output}</xml>`;
                             v = getTypeScriptStatementBlock(node, "let ");
                         }
                         else {
-                            v = getVariableSetOrChangeBlock(stmtNode, (node as ts.VariableDeclaration).name as ts.Identifier, (node as ts.VariableDeclaration).initializer, false, true);
+                            v = getVariableSetOrChangeBlock(blockNode, (node as ts.VariableDeclaration).name as ts.Identifier, (node as ts.VariableDeclaration).initializer, false, true);
                         }
-                        v.next = current;
-                        current = v;
-                        currentNode = node;
+
+                        // Auto-declared variables were not previously inserted into the stmt linked-list.
+                        // Insert auto-declared 'v' as the currentStmtNode.
+                        v.next = currentStmtNode;
+                        currentStmtNode = v;
+                        currentBlockNode = node;
+
+                        // Attach to currentStmtNode any associated comments
+                        getNodeComments(currentBlockNode.parent, currentStmtNode);
                     });
 
-                    if (current) {
-                        const r = mkStmt(ts.pxtc.ON_START_TYPE, currentNode);
+                    if (currentStmtNode) {
+                        const r = mkStmt(ts.pxtc.ON_START_TYPE, currentBlockNode);
                         r.handlers = [{
                             name: "HANDLER",
-                            statement: current
+                            statement: currentStmtNode
                         }];
                         return r;
                     }
@@ -3232,16 +3242,8 @@ ${output}</xml>`;
                 return true
             }
             else if (isStringOrNumericLiteral(decl.initializer)) {
-                // BUG: A comment (e.g. //@highlight) prior to a variable declaration of "0"
-                // in markdown results in mis-rendered XML.
-                //
-                // Logic in isAutoDeclaration() returns true if `text === "0"`. As a reuslt,
-                // existing code will not call `getComments()` and not return `stmt`. This
-                // results in incorrect XML.
-                //
-                // FIX: Do not consider "0" to be an autoDeclaration.
                 const text = decl.initializer.getText();
-                return isEmptyString(text);
+                return text === "0" || isEmptyString(text);
             }
             else {
                 const callInfo: pxtc.CallInfo = pxtc.pxtInfo(decl.initializer).callInfo

--- a/tests/decompile-test/baselines/comments.blocks
+++ b/tests/decompile-test/baselines/comments.blocks
@@ -98,7 +98,7 @@
 <field name="NUM">0</field>
 </shadow>
 </value>
-<comment pinned="false">&#64;highlight</comment>
+<comment pinned="false">Comment for variable classified as auto-declared.</comment>
 </block>
 </next>
 <comment pinned="false">Comment</comment>

--- a/tests/decompile-test/baselines/comments.blocks
+++ b/tests/decompile-test/baselines/comments.blocks
@@ -2,6 +2,15 @@
 <block type="pxt-on-start">
 <statement name="HANDLER">
 <block type="variables_set">
+<field name="VAR">y</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="logic_boolean">
+<field name="BOOL">FALSE</field>
+</block>
+</value>
+<next>
+<block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
 <shadow type="math_number">
@@ -98,7 +107,7 @@
 <field name="NUM">0</field>
 </shadow>
 </value>
-<comment pinned="false">Comment for variable classified as auto-declared.</comment>
+<comment pinned="false">Comments for variable classified as auto-declared.&#10;0</comment>
 </block>
 </next>
 <comment pinned="false">Comment</comment>
@@ -132,6 +141,9 @@
 </block>
 </next>
 <comment pinned="false">Single-line comment</comment>
+</block>
+</next>
+<comment pinned="false">Comments for variable classified as auto-declared.&#10;FALSE</comment>
 </block>
 </statement>
 </block>

--- a/tests/decompile-test/baselines/comments.blocks
+++ b/tests/decompile-test/baselines/comments.blocks
@@ -90,6 +90,17 @@
 </shadow>
 </value>
 <data>0&#59;1</data>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+</value>
+<comment pinned="false">&#64;highlight</comment>
+</block>
+</next>
 <comment pinned="false">Comment</comment>
 </block>
 </next>

--- a/tests/decompile-test/cases/comments.ts
+++ b/tests/decompile-test/cases/comments.ts
@@ -61,5 +61,5 @@ x += 9;
  */
 x += 10;
 
-//@highlight
+//Comment for variable classified as auto-declared.
 x = 0;

--- a/tests/decompile-test/cases/comments.ts
+++ b/tests/decompile-test/cases/comments.ts
@@ -60,3 +60,6 @@ x += 9;
  * Comment
  */
 x += 10;
+
+//@highlight
+x = 0;

--- a/tests/decompile-test/cases/comments.ts
+++ b/tests/decompile-test/cases/comments.ts
@@ -61,5 +61,5 @@ x += 9;
  */
 x += 10;
 
-//Comment for variable classified as auto-declared.
+// Comment for variable classified as auto-declared.
 x = 0;

--- a/tests/decompile-test/cases/comments.ts
+++ b/tests/decompile-test/cases/comments.ts
@@ -61,5 +61,10 @@ x += 9;
  */
 x += 10;
 
-// Comment for variable classified as auto-declared.
+// Comments for variable classified as auto-declared.
+// 0
 x = 0;
+
+// Comments for variable classified as auto-declared.
+// FALSE
+let y = false;


### PR DESCRIPTION
This fix addresses GitHub issue # 3169 in pxt-arcade:
https://github.com/microsoft/pxt-arcade/issues/3169

- Moves `getComments()` from `getStatementBlock()` private scope, updates signature.
- Renames `getComments()` to `getNodeComments()`, so to not be confused with `getComments()` in `emitter.ts`, which will also show up in `pxtworker.js`.
- Attaches comment to statement node for auto-declared variable.
- Update variable naming and commenting.
- Add test for comments associated with 'false' and "0" auto-declared variables