### PR TITLE
Fix share copy in chrome

### DIFF
--- a/react-common/components/controls/Input.tsx
+++ b/react-common/components/controls/Input.tsx
@@ -15,7 +15,8 @@ export interface InputProps extends ControlProps {
     readOnly?: boolean;
     autoComplete?: boolean;
     selectOnClick?: boolean;
-    treatSpaceAsEnter?: boolean
+    treatSpaceAsEnter?: boolean;
+    handleInputRef?: (ref: HTMLInputElement) => void;
 
     onChange?: (newValue: string) => void;
     onEnterKey?: (value: string) => void;
@@ -44,7 +45,8 @@ export const Input = (props: InputProps) => {
         onChange,
         onEnterKey,
         onIconClick,
-        onBlur
+        onBlur,
+        handleInputRef
     } = props;
 
     const [value, setValue] = React.useState(undefined);
@@ -112,7 +114,8 @@ export const Input = (props: InputProps) => {
                     autoCorrect={autoComplete ? "" : "off"}
                     autoCapitalize={autoComplete ? "" : "off"}
                     spellCheck={autoComplete}
-                    disabled={disabled} />
+                    disabled={disabled}
+                    ref={handleInputRef} />
                 {icon && (onIconClick
                     ? <Button
                         leftIcon={icon}

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -39,6 +39,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
     const showSimulator = !!screenshotAsync || !!gifRecordAsync;
     const showDescription = shareState !== "publish";
     let qrCodeButtonRef: HTMLButtonElement;
+    let inputRef: HTMLInputElement;
 
     React.useEffect(() => {
         setThumbnailUri(screenshotUri)
@@ -62,8 +63,19 @@ export const ShareInfo = (props: ShareInfoProps) => {
     }
 
     const handleCopyClick = () => {
-        navigator.clipboard.writeText(shareData.url);
-        setCopySuccessful(true);
+        if (pxt.BrowserUtils.isIpcRenderer()) {
+            // Not suppported in older chrome
+            const selection = document.createRange();
+            selection.selectNode(inputRef);
+            window.getSelection().addRange(selection);
+            const success = document.execCommand("copy");
+
+            setCopySuccessful(success);
+        }
+        else {
+            navigator.clipboard.writeText(shareData.url);
+            setCopySuccessful(true);
+        }
     }
 
     const handleCopyBlur = () => {
@@ -141,6 +153,10 @@ export const ShareInfo = (props: ShareInfoProps) => {
         if (qrCodeButtonRef) qrCodeButtonRef.focus();
     }
 
+    const handleInputRef = (ref: HTMLInputElement) => {
+        if (ref) inputRef = ref;
+    }
+
     const prePublish = shareState === "share" || shareState === "publishing";
 
     return <>
@@ -201,6 +217,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
                         </div>
                         <div className="common-input-attached-button">
                             <Input
+                                handleInputRef={handleInputRef}
                                 initialValue={shareData.url}
                                 readOnly={true}
                                 onChange={setName} />


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2184

The new clipboard API isn't supported in all older versions of chrome. Luckily, the old deprecated copy api does work.