### PR TITLE
Don't allow multiple events with the same arguments to be decompiled

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -609,11 +609,12 @@ ${output}</xml>`;
             if (attributes.blockAllowMultiple) return undefined;
             if (attributes.blockHandlerKey) return attributes.blockHandlerKey;
 
-            // FIXME: this might have some issues with whitespace?
             const args = callInfo.args.filter(arg => !isArrowFunction(arg) && !isFunctionExpression(arg)).map(arg => getArgKeyRecursive(arg)).join("$$");
             return attributes.blockId + "-" + args;
         }
 
+        // custom function to get the key for an argument. we do this instead of simply calling getText() because this
+        // handles whitespace and certain passthrough nodes like parenthesized expressions
         function getArgKeyRecursive(n: ts.Expression): string {
             if (!n) return "";
 

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -3973,20 +3973,4 @@ ${output}</xml>`;
 
         return emitShadowOnly;
     }
-
-    function cleanArgString(arg: string) {
-        const closureStack: string[] = [];
-        let out = "";
-
-        for (let i = 0; i < arg.length; i++) {
-            const current = arg.charAt(i);
-
-            if (current === "\"" || current === "'" || current === "`") {
-                const lastClosure = closureStack[closureStack.length - 1];
-
-                if (lastClosure === current) closureStack.pop();
-                else closureStack.push(current)
-            }
-        }
-    }
 }

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -601,6 +601,57 @@ ${output}</xml>`;
             return undefined;
         }
 
+        function getCallKey(statement: ExpressionStatement) {
+            const call = statement.expression as CallExpression;
+            const callInfo = pxtInfo(call).callInfo;
+            const attributes = attrs(callInfo);
+
+            if (attributes.blockAllowMultiple) return undefined;
+            if (attributes.blockHandlerKey) return attributes.blockHandlerKey;
+
+            // FIXME: this might have some issues with whitespace?
+            const args = callInfo.args.filter(arg => !isArrowFunction(arg) && !isFunctionExpression(arg)).map(arg => getArgKeyRecursive(arg)).join("$$");
+            return attributes.blockId + "-" + args;
+        }
+
+        function getArgKeyRecursive(n: ts.Expression): string {
+            if (!n) return "";
+
+            switch (n.kind) {
+                case SK.ParenthesizedExpression:
+                case SK.AsExpression:
+                    return getArgKeyRecursive((n as ts.ParenthesizedExpression).expression);
+                case SK.Identifier:
+                    return (n as ts.Identifier).text;
+                case SK.StringLiteral:
+                case SK.FirstTemplateToken:
+                case SK.NoSubstitutionTemplateLiteral:
+                    return `"${(n as ts.StringLiteral).text}"`
+                case SK.NumericLiteral:
+                    return (n as ts.LiteralExpression).text;
+                case SK.TrueKeyword:
+                    return "true";
+                case SK.FalseKeyword:
+                    return "false";
+                case SK.BinaryExpression:
+                    return `{${getArgKeyRecursive((n as ts.BinaryExpression).left)}${(n as ts.BinaryExpression).operatorToken.getText()}${getArgKeyRecursive((n as ts.BinaryExpression).right)}}`
+                case SK.PrefixUnaryExpression:
+                    return (n as ts.PrefixUnaryExpression).operator + getArgKeyRecursive((n as ts.PrefixUnaryExpression).operand)
+                case SK.PropertyAccessExpression:
+                    return getArgKeyRecursive((n as ts.PropertyAccessExpression).expression) + "." + getArgKeyRecursive((n as ts.PropertyAccessExpression).name)
+                case SK.ArrayLiteralExpression:
+                    return `[${(n as ts.ArrayLiteralExpression).elements.map(e => getArgKeyRecursive(e))}]`
+                case SK.ElementAccessExpression:
+                    return `${(n as ts.ElementAccessExpression).expression}[${(n as ts.ElementAccessExpression).argumentExpression}]`;
+                case SK.TaggedTemplateExpression:
+                    return `${getArgKeyRecursive((n as ts.TaggedTemplateExpression).tag)}\`${(n as ts.TaggedTemplateExpression).template.getText()}\``;
+                case SK.CallExpression:
+                    return `${getArgKeyRecursive((n as ts.CallExpression).expression)}(${(n as ts.CallExpression).arguments.map(getArgKeyRecursive).join(",")})`
+                default:
+                    return n.getText();
+            }
+        }
+
         function countBlock() {
             emittedBlocks++;
             if (emittedBlocks > MAX_BLOCKS) {
@@ -2369,7 +2420,22 @@ ${output}</xml>`;
                 }
             }
 
-            eventStatements.map(n => getStatementBlock(n, undefined, undefined, false, topLevel)).forEach(emitStatementNode);
+            const compiledEvents: StatementNode[] = [];
+            const keyMap: {[index: string]: boolean} = {};
+            for (const statement of eventStatements) {
+                const key = statement.kind === SK.FunctionDeclaration ? undefined : getCallKey(statement as ExpressionStatement);
+
+                if (key && keyMap[key]) {
+                    // Pass false for topLevel to force a grey block
+                    compiledEvents.push(getStatementBlock(statement, undefined, undefined, false, false))
+                }
+                else {
+                    keyMap[key] = true;
+                    compiledEvents.push(getStatementBlock(statement, undefined, undefined, false, topLevel))
+                }
+            }
+
+            compiledEvents.forEach(emitStatementNode);
 
             if (blockStatements.length) {
                 // wrap statement in "on start" if top level
@@ -3905,5 +3971,21 @@ ${output}</xml>`;
         }
 
         return emitShadowOnly;
+    }
+
+    function cleanArgString(arg: string) {
+        const closureStack: string[] = [];
+        let out = "";
+
+        for (let i = 0; i < arg.length; i++) {
+            const current = arg.charAt(i);
+
+            if (current === "\"" || current === "'" || current === "`") {
+                const lastClosure = closureStack[closureStack.length - 1];
+
+                if (lastClosure === current) closureStack.pop();
+                else closureStack.push(current)
+            }
+        }
     }
 }

--- a/tests/decompile-test/baselines/multiple_events.blocks
+++ b/tests/decompile-test/baselines/multiple_events.blocks
@@ -43,14 +43,14 @@
 <field name="arg1">TestEnum.testValue2</field>
 <value name="arg2">
 <block type="typescript_expression">
-<field name="EXPRESSION">testNamespace.customShadowFieldNoLiterals&#40;2&#41;</field>
+<field name="EXPRESSION">testNamespace.customShadowFieldNoLiterals&#40;&#10;    2&#10;    &#41;</field>
 </block>
 </value>
 <statement name="HANDLER">
 </statement>
 </block>
 <block type="typescript_statement">
-<mutation numlines="3" error="Events must be top level" line0="testNamespace.callbackNoMultiple&#40;TestEnum.testValue2&#44; testNamespace.customShadowFieldNoLiterals&#40;1&#41;&#44; function &#40;&#41; &#123;" line1="" line2="&#125;&#41;" />
+<mutation numlines="4" error="Events must be top level" line0="testNamespace.callbackNoMultiple&#40;TestEnum.testValue2&#44; &#40;&#40;testNamespace.customShadowFieldNoLiterals&#40;1&#41;" line1="&#41;&#41;&#44; function &#40;&#41; &#123;" line2="" line3="&#125;&#41;" />
 </block>
 <block type="typescript_statement">
 <mutation numlines="3" error="Events must be top level" line0="testNamespace.callbackNoMultiple&#40;TestEnum.testValue1&#44; 1&#44; function &#40;&#41; &#123;" line1="" line2="&#125;&#41;" />

--- a/tests/decompile-test/baselines/multiple_events.blocks
+++ b/tests/decompile-test/baselines/multiple_events.blocks
@@ -1,0 +1,58 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="test_callback_with_argument_no_multi">
+<field name="arg1">TestEnum.testValue1</field>
+<value name="arg2">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="test_callback_with_argument_no_multi">
+<field name="arg1">TestEnum.testValue1</field>
+<value name="arg2">
+<shadow type="math_number">
+<field name="NUM">2</field>
+</shadow>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="test_callback_with_argument_no_multi">
+<field name="arg1">TestEnum.testValue2</field>
+<value name="arg2">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="test_callback_with_argument_no_multi">
+<field name="arg1">TestEnum.testValue2</field>
+<value name="arg2">
+<block type="typescript_expression">
+<field name="EXPRESSION">testNamespace.customShadowFieldNoLiterals&#40;1&#41;</field>
+</block>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="test_callback_with_argument_no_multi">
+<field name="arg1">TestEnum.testValue2</field>
+<value name="arg2">
+<block type="typescript_expression">
+<field name="EXPRESSION">testNamespace.customShadowFieldNoLiterals&#40;2&#41;</field>
+</block>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="typescript_statement">
+<mutation numlines="3" error="Events must be top level" line0="testNamespace.callbackNoMultiple&#40;TestEnum.testValue2&#44; testNamespace.customShadowFieldNoLiterals&#40;1&#41;&#44; function &#40;&#41; &#123;" line1="" line2="&#125;&#41;" />
+</block>
+<block type="typescript_statement">
+<mutation numlines="3" error="Events must be top level" line0="testNamespace.callbackNoMultiple&#40;TestEnum.testValue1&#44; 1&#44; function &#40;&#41; &#123;" line1="" line2="&#125;&#41;" />
+</block>
+</xml>

--- a/tests/decompile-test/baselines/multiple_events_block_handler_key.blocks
+++ b/tests/decompile-test/baselines/multiple_events_block_handler_key.blocks
@@ -1,0 +1,18 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="test_callback_with_argument_no_multi_key">
+<field name="arg1">TestEnum.testValue1</field>
+<value name="arg2">
+<shadow type="math_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="typescript_statement">
+<mutation numlines="3" error="Events must be top level" line0="testNamespace.callbackNoMultipleKey&#40;TestEnum.testValue2&#44; 6&#44; function &#40;&#41; &#123;" line1="" line2="&#125;&#41;" />
+</block>
+<block type="typescript_statement">
+<mutation numlines="3" error="Events must be top level" line0="testNamespace.callbackNoMultipleKey&#40;TestEnum.testValue1&#44; 5&#44; function &#40;&#41; &#123;" line1="" line2="&#125;&#41;" />
+</block>
+</xml>

--- a/tests/decompile-test/cases/multiple_events.ts
+++ b/tests/decompile-test/cases/multiple_events.ts
@@ -14,11 +14,15 @@ testNamespace.callbackNoMultiple(TestEnum.testValue2, testNamespace.customShadow
 
 })
 
-testNamespace.callbackNoMultiple(TestEnum.testValue2, testNamespace.customShadowFieldNoLiterals(2), function () {
+testNamespace.callbackNoMultiple(TestEnum.testValue2, (
+    testNamespace.customShadowFieldNoLiterals(
+    2
+    )), function () {
 
 })
 
-testNamespace.callbackNoMultiple(TestEnum.testValue2, testNamespace.customShadowFieldNoLiterals(1), function () {
+testNamespace.callbackNoMultiple(TestEnum.testValue2, ((testNamespace.customShadowFieldNoLiterals(1)
+)), function () {
 
 })
 

--- a/tests/decompile-test/cases/multiple_events.ts
+++ b/tests/decompile-test/cases/multiple_events.ts
@@ -1,0 +1,27 @@
+testNamespace.callbackNoMultiple(TestEnum.testValue1, 1, function () {
+
+})
+
+testNamespace.callbackNoMultiple(TestEnum.testValue1, 2, function () {
+
+})
+
+testNamespace.callbackNoMultiple(TestEnum.testValue2, 1, function () {
+
+})
+
+testNamespace.callbackNoMultiple(TestEnum.testValue2, testNamespace.customShadowFieldNoLiterals(1), function () {
+
+})
+
+testNamespace.callbackNoMultiple(TestEnum.testValue2, testNamespace.customShadowFieldNoLiterals(2), function () {
+
+})
+
+testNamespace.callbackNoMultiple(TestEnum.testValue2, testNamespace.customShadowFieldNoLiterals(1), function () {
+
+})
+
+testNamespace.callbackNoMultiple(TestEnum.testValue1, 1, function () {
+
+})

--- a/tests/decompile-test/cases/multiple_events_block_handler_key.ts
+++ b/tests/decompile-test/cases/multiple_events_block_handler_key.ts
@@ -1,0 +1,11 @@
+testNamespace.callbackNoMultipleKey(TestEnum.testValue1, 5, function () {
+
+})
+
+testNamespace.callbackNoMultipleKey(TestEnum.testValue2, 6, function () {
+
+})
+
+testNamespace.callbackNoMultipleKey(TestEnum.testValue1, 5, function () {
+
+})

--- a/tests/decompile-test/cases/testBlocks/basic.ts
+++ b/tests/decompile-test/cases/testBlocks/basic.ts
@@ -33,10 +33,12 @@ namespace testNamespace {
 
     //% blockId=test_callback
     //% block="Callback"
+    //% blockAllowMultiple
     export function withCallback(body: () => void): void {}
 
     //% blockId=test_callback_with_argument
     //% block="Callback with|enum %arg1|and number %arg2"
+    //% blockAllowMultiple
     export function withCallbackAndArguments(arg1: TestEnum, arg2: number, body: () => void): void {}
 
     //% blockId=test_number_with_enum_shadow
@@ -97,22 +99,27 @@ namespace testNamespace {
 
     //% blockId=test_optional_argument_2
     //% block="Callback with optional arg"
+    //% blockAllowMultiple
     export function optionalArgumentWithCallback(arg1: () => void, arg2?: number) { }
 
     //% blockId=test_handler_arguments
     //% block="Handler arguments"
+    //% blockAllowMultiple
     export function callbackWithArguments(cb: (a: number, b: number) => void) {}
 
     //% blockId=test_handler_arguments2 optionalVariableArgs=true
     //% block="Handler with optioinal arguments"
+    //% blockAllowMultiple
     export function callbackWithIgnoredArguments(cb: (c: number, d: number) => void) {}
 
     //% blockId=test_handler_arguments3 draggableParameters=1
     //% block="Handler with draggable arguments"
+    //% blockAllowMultiple
     export function callbackWithDraggableParams(cb: (c: number, d: number) => void) {}
 
     //% blockId=test_handler_arguments4 draggableParameters="reporter"
     //% block="Handler with draggable reporters"
+    //% blockAllowMultiple
     export function callbackWithDraggableParamsReporters(cb: (c: string, d: number, e: boolean, f: TestClass) => void) {}
 
     /**
@@ -161,6 +168,7 @@ namespace testNamespace {
     //% block="object destructure: "
     //% mutate="objectdestructuring""
     //% mutateText="Visible properties""
+    //% blockAllowMultiple
     export function objectDestructuringTest(cb: (a: SomeBagOfProperties) => void): void { }
 
     export class Anotherclass {
@@ -223,6 +231,15 @@ namespace testNamespace {
     export function toStringArg(msg: string) {
 
     }
+
+    //% blockId=test_callback_with_argument_no_multi
+    //% block="Callback with|enum %arg1|and number %arg2"
+    export function callbackNoMultiple(arg1: TestEnum, arg2: number, body: () => void): void {}
+
+    //% blockId=test_callback_with_argument_no_multi_key
+    //% block="Callback with|enum %arg1|and number %arg2"
+    //% blockHandlerKey=somevalue
+    export function callbackNoMultipleKey(arg1: TestEnum, arg2: number, body: () => void): void {}
 }
 
 //% color=#0078D7 weight=100
@@ -257,7 +274,7 @@ enum EnumWithValueBlock {
 
 enum EnumWithAlias {
     //% alias=FOO
-    Foo    
+    Foo
 }
 
 const FOO = EnumWithAlias.Foo;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/860

I kinda can't believe i never implemented this before...

This makes it so that the decompiler no longer allows for multiple events with the same arguments to be decompiled. Previously we would decompile them and the blockly compiler would then disable them since you can't have multiple events with the same args in blocks. Now one of the offending calls will end up as a grey block