### PR TITLE
Add scrollbar for when blocks overflow in tutorial sidebar

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -61,6 +61,10 @@
         border: 0;
         border-top: 2px dashed @tutorialSecondaryColor;
     }
+
+    .lang-blocks .ui.segment.raised {
+        overflow-x: auto;
+    }
 }
 
 .tutorial-scroll-gradient {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2169

![embed-overflow](https://user-images.githubusercontent.com/13754588/177611107-64997442-4039-44eb-9837-b0b715f1233c.gif)

Really, it works much better if you just put the blocks in the hint since that isn't constrained by the width of the sidebar