### PR TITLE
Fix social share minecraft

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1285,7 +1285,10 @@ namespace pxt.BrowserUtils {
             const left = ((width / 2) - (popUpWidth / 2)) + winLeft;
             const top = ((height / 2) - (popUpHeight / 2)) + winTop;
 
-            const popupWindow = window.open(url, title, "width=" + popUpWidth + ", height=" + popUpHeight + ", top=" + top + ", left=" + left);
+            const features = "width=" + popUpWidth + ", height=" + popUpHeight + ", top=" + top + ", left=" + left + ", popup";
+
+            // Current CEF version does not like when features parameter is passed and just immediately rejects.
+            const popupWindow = window.open(url, title, !pxt.BrowserUtils.isIpcRenderer() ? features : undefined);
             if (popupWindow.focus) {
                 popupWindow.focus();
             }

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1285,7 +1285,7 @@ namespace pxt.BrowserUtils {
             const left = ((width / 2) - (popUpWidth / 2)) + winLeft;
             const top = ((height / 2) - (popUpHeight / 2)) + winTop;
 
-            const features = "width=" + popUpWidth + ", height=" + popUpHeight + ", top=" + top + ", left=" + left + ", popup";
+            const features = "width=" + popUpWidth + ", height=" + popUpHeight + ", top=" + top + ", left=" + left;
 
             // Current CEF version does not like when features parameter is passed and just immediately rejects.
             const popupWindow = window.open(url, title, !pxt.BrowserUtils.isIpcRenderer() ? features : undefined);

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1296,7 +1296,7 @@ namespace pxt.BrowserUtils {
             return popupWindow;
         } catch (e) {
             // Error opening popup
-            pxt.tickEvent('pxt.popupError', { url: url, msg: e.message });
+            pxt.tickEvent('pxt.popupError', { msg: e.message });
             return null;
         }
     }


### PR DESCRIPTION
fix fb half of https://github.com/microsoft/pxt-minecraft/issues/2178 -- also have to set socialOptions in minecrafts pxtarget for twitter as that's failing here https://github.com/microsoft/pxt/blob/fixSocialShareMinecraft/react-common/components/share/SocialButton.tsx#L24 due to socialOptions being undefined

I took a look and it appears that there are a few options in window.open features that are allowlisted (e.g. noreferrer / noopener), but as soon as there is anything in there that is not allowlisted the window gets rejected -- in this case none of the parameters listed for pop up window are allowlisted

also remove url from the failure tick event -- it looks like the popupwindow is only used for these social share anyways, and those contain the share link as a query param