### PR TITLE
make it so beta experiment always opens in place

### DIFF
--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -68,7 +68,6 @@ export class CodeCardView extends data.Component<CodeCardProps, CodeCardState> {
         const renderMd = (md: string) => md.replace(/`/g, '');
         const url = card.url ? /^[^:]+:\/\//.test(card.url) ? card.url : ('/' + card.url.replace(/^\.?\/?/, ''))
             : undefined;
-        const sideUrl = url && /^\//.test(url) ? "#doc:" + url : url;
         const className = card.className;
         const cardType = card.cardType;
         const tutorialDone = card.tutorialLength == card.tutorialStep + 1;
@@ -173,12 +172,7 @@ export class CodeCardView extends data.Component<CodeCardProps, CodeCardState> {
         </div>;
 
         if (!card.onClick && url) {
-            return (
-                <div>
-                    <a href={url} target="docs" className="ui widedesktop hide">{cardDiv}</a>
-                    <a href={sideUrl} className="ui widedesktop only">{cardDiv}</a>
-                </div>
-            )
+            return <a href={url}>{cardDiv}</a>;
         } else {
             return (cardDiv)
         }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/2172

turns out the reason it worked on my machine (at first) & not abhijiths was because it worked in widescreen but not narrow screens :) it looks like at some point there was the idea to make it so we could have a codecard that opens in sidedocs for pcs & a new tab for others, but every other location I saw codecard being used passes the `onClick` so it was just mostly dead code that causes us to open a new tab only for this beta experiment. For what it's worth I don't think we would want that behavior anyways as you'd e.g. end up with mixed results in a classroom with half the class having side docs and half the class having a new tab which feels bad.

For what it's worth testing this is kinda annoying as the beta codecard only shows up on when on the live site (that is, local serve and `/app/asdf` won't show the button) -- to get it to show on my uploadtrg for a quick test I set a breakpoint here https://github.com/microsoft/pxt/blob/fixBetaExp/webapp/src/scriptsearch.tsx#L350, set betaUrl to "https://minecraft.makecode.com/beta?inGame=1&ipc=1", then continued. 