### PR TITLE
when log is full and you scroll up, don't change bkgd color of cells

### DIFF
--- a/theme/serial.less
+++ b/theme/serial.less
@@ -142,11 +142,12 @@
         font-weight: 700;
     }
 
-    tbody tr:nth-child(odd) {
-        background: #f2f2f2;
-    }
-    tr:nth-child(even), thead tr {
+    tbody tr, thead tr {
         background: @white;
+    }
+
+    tbody tr.odd {
+        background: #f2f2f2;
     }
     td, th {
         border: 1px solid #ddd;

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -273,7 +273,7 @@ export class Editor extends srceditor.Editor {
         const tr = document.createElement("tr");
         tr.title = lf("Received: {0}", new Date(receivedTime).toTimeString());
         if (this.nextEntryIsOdd) {
-            tr.classList.add("odd")
+            tr.classList.add("odd");
         }
         this.nextEntryIsOdd = !this.nextEntryIsOdd;
         for (const data of line.trim().split(",")) {

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -39,6 +39,7 @@ export class Editor extends srceditor.Editor {
     rawCsvBuf = "";
     receivedCsv: boolean;
     receivedLog: boolean;
+    nextEntryIsOdd: boolean = true;
 
     //refs
     startPauseButton: StartPauseButton;
@@ -250,6 +251,7 @@ export class Editor extends srceditor.Editor {
         table.appendChild(document.createElement("thead"));
         table.appendChild(document.createElement("tbody"));
         this.csvRoot.appendChild(table);
+        this.nextEntryIsOdd = true;
         return table;
     }
 
@@ -270,6 +272,10 @@ export class Editor extends srceditor.Editor {
 
         const tr = document.createElement("tr");
         tr.title = lf("Received: {0}", new Date(receivedTime).toTimeString());
+        if (this.nextEntryIsOdd) {
+            tr.classList.add("odd")
+        }
+        this.nextEntryIsOdd = !this.nextEntryIsOdd;
         for (const data of line.trim().split(",")) {
             const dataElement = document.createElement("td");
             dataElement.appendChild(document.createTextNode(data));


### PR DESCRIPTION
Fix bug richard noticed, when you scroll up and the log is full so it starts throwing away rows it was changing the 'even-ness' of the rows -- so as you read old data it would flash gray/white. Instead just use a class