### PR TITLE
fix imm reader on electron

### DIFF
--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -191,7 +191,7 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
     const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
     if (!cachedToken || (Date.now() / 1000 > cachedToken.expiration)) {
-        return pxt.Cloud.privateGetAsync("immreader").then(
+        return pxt.Cloud.privateGetAsync("immreader", true).then(
             res => {
                 pxt.storage.setLocal(IMMERSIVE_READER_ID, JSON.stringify(res));
                 return res;
@@ -273,7 +273,7 @@ export function launchImmersiveReader(content: string, tutorialOptions: pxt.tuto
     });
 
     function testConnectionAsync(token: ImmersiveReaderToken): Promise<ImmersiveReaderToken> {
-        return pxt.Cloud.privateGetAsync("ping").then(() => {return token});
+        return pxt.Cloud.privateGetAsync("ping", true).then(() => {return token});
     }
 }
 


### PR DESCRIPTION
we need to hit a live endpoint to get an imm reader token, not the local serve. these two calls were changed from requestAsync to privateGetAsync a while back (https://github.com/microsoft/pxt/pull/8259/files#diff-1fde1e59e8adfc854cf59f6d572551b0828f3f5a5c9d08a35b8d854006eacf87L194) when adding error messages for offline, but that has a slight change in behavior as this was hitting /immreader insteader of /api/immreader here https://github.com/microsoft/pxt/blob/makeImmReaderHitLiveEndpoint/pxtlib/emitter/cloud.ts#L74 because its static.

This sets 'forceLiveEndpoint' to true for both api requests so they know to go directly to our backend instead of local serve