### PR TITLE
Add support for mixer synth engine to sound effect editor

### DIFF
--- a/pxtblocks/fields/field_sound_effect.ts
+++ b/pxtblocks/fields/field_sound_effect.ts
@@ -13,6 +13,7 @@ namespace pxtblockly {
         waveFieldName: string;
         interpolationFieldName: string;
         effectFieldName: string;
+        useMixerSynthesizer: any;
     }
 
     const MUSIC_ICON_WIDTH = 20;
@@ -38,6 +39,7 @@ namespace pxtblockly {
             if (!this.options.waveFieldName) this.options.waveFieldName = "waveShape";
             if (!this.options.interpolationFieldName) this.options.interpolationFieldName = "interpolation";
             if (!this.options.effectFieldName) this.options.effectFieldName = "effect";
+            if (!this.options.useMixerSynthesizer) this.options.useMixerSynthesizer = false;
 
             this.redrawPreview();
 
@@ -178,7 +180,8 @@ namespace pxtblockly {
                     this.updateSiblingBlocks(newSound);
                     this.redrawPreview();
                 },
-                initialSound: initialSound
+                initialSound: initialSound,
+                useMixerSynthesizer: isTrue(this.options.useMixerSynthesizer)
             }
 
             const fv = pxt.react.getFieldEditorView("soundeffect-editor", initialSound, opts, widgetDiv);
@@ -413,5 +416,24 @@ namespace pxtblockly {
 
     function reverseLookup(map: {[index: string]: string}, value: string) {
         return Object.keys(map).find(k => map[k] === value);
+    }
+
+    function isTrue(value: any) {
+        if (!value) return false;
+
+        if (typeof value === "string") {
+            switch (value.toLowerCase().trim()) {
+                case "1":
+                case "yes":
+                case "y":
+                case "on":
+                case "true":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        return !!value;
     }
 }

--- a/pxteditor/monaco-fields/field_soundEffect.ts
+++ b/pxteditor/monaco-fields/field_soundEffect.ts
@@ -146,7 +146,8 @@ namespace pxt.editor {
                 onClose: () => this.fv.hide(),
                 onSoundChange: (newValue: pxt.assets.Sound) => this.value = newValue,
                 initialSound: this.value,
-                useFlex: true
+                useFlex: true,
+                useMixerSynthesizer: pxt.appTarget.id !== "microbit" // FIXME
             };
         }
     }

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -659,111 +659,117 @@ namespace pxsim {
             return 440 * Math.pow(2, (note - 69) / 12);
         }
 
-        export async function playInstructionsAsync(instructions: Uint8Array, isCancelled?: () => boolean, onPull?: (freq: number, volume: number) => void) {
-            let ctx = context();
-            let channel = new Channel()
+        export function playInstructionsAsync(instructions: Uint8Array, isCancelled?: () => boolean, onPull?: (freq: number, volume: number) => void) {
+            return new Promise<void>(async resolve => {
+                let resolved = false;
+                let ctx = context();
+                let channel = new Channel()
 
-            if (channels.length > 5)
-                channels[0].remove()
-            channels.push(channel);
+                if (channels.length > 5)
+                    channels[0].remove()
+                channels.push(channel);
 
 
-            channel.gain = ctx.createGain();
-            channel.gain.gain.value = 1;
+                channel.gain = ctx.createGain();
+                channel.gain.gain.value = 1;
 
-            channel.gain.connect(destination);
+                channel.gain.connect(destination);
 
-            const oscillators: pxt.Map<OscillatorNode | AudioBufferSourceNode> = {};
-            const gains: pxt.Map<GainNode> = {};
-            let startTime = ctx.currentTime;
-            let currentTime = startTime;
-            let currentWave = 0;
+                const oscillators: pxt.Map<OscillatorNode | AudioBufferSourceNode> = {};
+                const gains: pxt.Map<GainNode> = {};
+                let startTime = ctx.currentTime;
+                let currentTime = startTime;
+                let currentWave = 0;
 
-            let totalDuration = 0;
+                let totalDuration = 0;
 
-            /** Square waves are perceved as much louder than other sounds, so scale it down a bit to make it less jarring **/
-            const scaleVol = (n: number, isSqWave?: boolean) => (n / 1024) / 4 * (isSqWave ? .5 : 1);
+                /** Square waves are perceved as much louder than other sounds, so scale it down a bit to make it less jarring **/
+                const scaleVol = (n: number, isSqWave?: boolean) => (n / 1024) / 4 * (isSqWave ? .5 : 1);
 
-            const disconnectNodes = () => {
-                channel.disconnectNodes();
+                const disconnectNodes = () => {
+                    if (resolved) return;
+                    resolved = true;
+                    channel.disconnectNodes();
 
-                for (const wave of Object.keys(oscillators)) {
-                    oscillators[wave].stop();
-                    oscillators[wave].disconnect();
-                    gains[wave].disconnect();
-                }
-            }
-
-            for (let i = 0; i < instructions.length; i += 12) {
-                const wave = instructions[i];
-                const startFrequency = readUint16(instructions, i + 2);
-                const duration = readUint16(instructions, i + 4) / 1000;
-                const startVolume = readUint16(instructions, i + 6);
-                const endVolume = readUint16(instructions, i + 8);
-                const endFrequency = readUint16(instructions, i + 10);
-                totalDuration += duration
-
-                const isSquareWave = 11 <= wave && wave <= 15;
-
-                if (!oscillators[wave]) {
-                    oscillators[wave] = getGenerator(wave, startFrequency);
-                    gains[wave] = ctx.createGain();
-                    gains[wave].gain.value = 0;
-                    gains[wave].connect(channel.gain);
-                    oscillators[wave].connect(gains[wave]);
-                    oscillators[wave].start();
+                    for (const wave of Object.keys(oscillators)) {
+                        oscillators[wave].stop();
+                        oscillators[wave].disconnect();
+                        gains[wave].disconnect();
+                    }
+                    resolve();
                 }
 
-                if (currentWave && wave !== currentWave) {
-                    gains[currentWave].gain.setTargetAtTime(0, currentTime, 0.015);
-                }
+                for (let i = 0; i < instructions.length; i += 12) {
+                    const wave = instructions[i];
+                    const startFrequency = readUint16(instructions, i + 2);
+                    const duration = readUint16(instructions, i + 4) / 1000;
+                    const startVolume = readUint16(instructions, i + 6);
+                    const endVolume = readUint16(instructions, i + 8);
+                    const endFrequency = readUint16(instructions, i + 10);
+                    totalDuration += duration
 
-                const osc = oscillators[wave];
-                const gain = gains[wave];
+                    const isSquareWave = 11 <= wave && wave <= 15;
 
-                if (osc instanceof OscillatorNode) {
-                    osc.frequency.setValueAtTime(startFrequency, currentTime);
-                    osc.frequency.linearRampToValueAtTime(endFrequency, currentTime + duration);
-                }
-                else {
-                    const isFilteredNoise = wave == 4 || (16 <= wave && wave <= 18);
-
-                    if (isFilteredNoise)
-                        osc.playbackRate.linearRampToValueAtTime(endFrequency / (ctx.sampleRate / 4), currentTime + duration);
-                    else if (wave != 5)
-                        osc.playbackRate.linearRampToValueAtTime(endFrequency / (ctx.sampleRate / 1024), currentTime + duration);
-                }
-                gain.gain.setValueAtTime(scaleVol(startVolume, isSquareWave), currentTime);
-                gain.gain.linearRampToValueAtTime(scaleVol(endVolume, isSquareWave), currentTime + duration);
-
-                currentWave = wave;
-                currentTime += duration;
-            }
-            channel.gain.gain.setTargetAtTime(0, currentTime, 0.015);
-
-            if (isCancelled || onPull) {
-                const handleAnimationFrame = () => {
-                    const time = ctx.currentTime;
-                    if (time > startTime + totalDuration) {
-                        return;
+                    if (!oscillators[wave]) {
+                        oscillators[wave] = getGenerator(wave, startFrequency);
+                        gains[wave] = ctx.createGain();
+                        gains[wave].gain.value = 0;
+                        gains[wave].connect(channel.gain);
+                        oscillators[wave].connect(gains[wave]);
+                        oscillators[wave].start();
                     }
 
-
-                    if (isCancelled && isCancelled()) {
-                        disconnectNodes();
-                        return;
+                    if (currentWave && wave !== currentWave) {
+                        gains[currentWave].gain.setTargetAtTime(0, currentTime, 0.015);
                     }
 
-                    const { frequency, volume } = findFrequencyAndVolumeAtTime((time - startTime) * 1000, instructions);
-                    onPull(frequency, volume / 1024);
+                    const osc = oscillators[wave];
+                    const gain = gains[wave];
 
-                    requestAnimationFrame(handleAnimationFrame)
+                    if (osc instanceof OscillatorNode) {
+                        osc.frequency.setValueAtTime(startFrequency, currentTime);
+                        osc.frequency.linearRampToValueAtTime(endFrequency, currentTime + duration);
+                    }
+                    else {
+                        const isFilteredNoise = wave == 4 || (16 <= wave && wave <= 18);
+
+                        if (isFilteredNoise)
+                            osc.playbackRate.linearRampToValueAtTime(endFrequency / (ctx.sampleRate / 4), currentTime + duration);
+                        else if (wave != 5)
+                            osc.playbackRate.linearRampToValueAtTime(endFrequency / (ctx.sampleRate / 1024), currentTime + duration);
+                    }
+                    gain.gain.setValueAtTime(scaleVol(startVolume, isSquareWave), currentTime);
+                    gain.gain.linearRampToValueAtTime(scaleVol(endVolume, isSquareWave), currentTime + duration);
+
+                    currentWave = wave;
+                    currentTime += duration;
                 }
-                requestAnimationFrame(handleAnimationFrame);
-            }
+                channel.gain.gain.setTargetAtTime(0, currentTime, 0.015);
 
-            await U.delay(totalDuration * 1000)
-            disconnectNodes();
+                if (isCancelled || onPull) {
+                    const handleAnimationFrame = () => {
+                        const time = ctx.currentTime;
+                        if (time > startTime + totalDuration) {
+                            return;
+                        }
+
+
+                        if (isCancelled && isCancelled()) {
+                            disconnectNodes();
+                            return;
+                        }
+
+                        const { frequency, volume } = findFrequencyAndVolumeAtTime((time - startTime) * 1000, instructions);
+                        onPull(frequency, volume / 1024);
+
+                        requestAnimationFrame(handleAnimationFrame)
+                    }
+                    requestAnimationFrame(handleAnimationFrame);
+                }
+
+                await U.delay(totalDuration * 1000)
+                disconnectNodes();
+            })
         }
 
         function readUint16(buf: Uint8Array, offset: number) {

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -246,7 +246,7 @@ export function init() {
                 current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} />);
                 break;
             case "soundeffect-editor":
-                current.injectElement(<SoundEffectEditor onClose={options.onClose} onSoundChange={options.onSoundChange} initialSound={options.initialSound} />)
+                current.injectElement(<SoundEffectEditor onClose={options.onClose} onSoundChange={options.onSoundChange} initialSound={options.initialSound} useMixerSynthesizer={options.useMixerSynthesizer} />)
                 break;
 
         }

--- a/webapp/src/components/soundEffectEditor/SoundEffectEditor.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundEffectEditor.tsx
@@ -77,7 +77,7 @@ export const SoundEffectEditor = (props: SoundEffectEditorProps) => {
         }
 
         if (useMixerSynthesizer) {
-            await pxsim.AudioContextManager.playInstructionsNoLoopAsync(pxt.assets.soundToInstructionBuffer(toPlay, 20, 1), isCancelled, onPull);
+            await pxsim.AudioContextManager.playInstructionsAsync(pxt.assets.soundToInstructionBuffer(toPlay, 20, 1), isCancelled, onPull);
         }
         else {
             await pxsim.codal.music.playSoundExpressionAsync(soundToCodalSound(toPlay).src, isCancelled, onPull);
@@ -164,9 +164,10 @@ export const SoundEffectEditor = (props: SoundEffectEditorProps) => {
                 }}
             />
             <SoundGallery
-                sounds={getGallerySounds()}
+                sounds={getGallerySounds(useMixerSynthesizer)}
                 onSoundSelected={handleGallerySelection}
                 visible={selectedView === "gallery"}
+                useMixerSynthesizer={useMixerSynthesizer}
                 />
         </div>
     </div>

--- a/webapp/src/components/soundEffectEditor/soundUtil.ts
+++ b/webapp/src/components/soundEffectEditor/soundUtil.ts
@@ -47,7 +47,16 @@ export function soundToCodalSound(sound: pxt.assets.Sound): pxsim.codal.music.So
     return codalSound;
 }
 
-export function getGallerySounds(): SoundGalleryItem[] {
+export function getGallerySounds(useMixerSynthesizer: boolean): SoundGalleryItem[] {
+    if (useMixerSynthesizer) {
+        return getMixerGallerySounds();
+    }
+    else {
+        return getCODALGallerySounds();
+    }
+
+}
+export function getCODALGallerySounds(): SoundGalleryItem[] {
     const res: SoundGalleryItem[] = [
         {
             name: pxt.U.lf("Laser"),
@@ -177,6 +186,104 @@ export function getGallerySounds(): SoundGalleryItem[] {
                 startFrequency: 54,
                 endFrequency: 54,
                 duration: 500
+            }
+        }
+    ];
+
+    return res;
+}
+
+export function getMixerGallerySounds(): SoundGalleryItem[] {
+    const res: SoundGalleryItem[] = [
+        {
+            name: pxt.U.lf("Laser"),
+            sound: {
+                interpolation: "curve",
+                effect: "none",
+                wave: "square",
+                startVolume: pxt.assets.MAX_VOLUME,
+                endVolume: 0,
+                startFrequency: 1600,
+                endFrequency: 1,
+                duration: 300
+            }
+        },
+        {
+            name: pxt.U.lf("Jump"),
+            sound: {
+                interpolation: "linear",
+                effect: "none",
+                wave: "square",
+                startVolume: pxt.assets.MAX_VOLUME,
+                endVolume: 0,
+                startFrequency: 400,
+                endFrequency: 600,
+                duration: 100
+            }
+        },
+        {
+            name: pxt.U.lf("Water Drop"),
+            sound: {
+                interpolation: "linear",
+                effect: "none",
+                wave: "sine",
+                startVolume: pxt.assets.MAX_VOLUME,
+                endVolume: 0,
+                startFrequency: 200,
+                endFrequency: 600,
+                duration: 150
+            }
+        },
+        {
+            name: pxt.U.lf("Kick Drum"),
+            sound: {
+                interpolation: "curve",
+                effect: "none",
+                wave: "square",
+                startVolume: pxt.assets.MAX_VOLUME,
+                endVolume: 0,
+                startFrequency: 200,
+                endFrequency: 1,
+                duration: 100
+            }
+        },
+        {
+            name: pxt.U.lf("Tom"),
+            sound: {
+                interpolation: "curve",
+                effect: "none",
+                wave: "triangle",
+                startVolume: pxt.assets.MAX_VOLUME,
+                endVolume: 0,
+                startFrequency: 300,
+                endFrequency: 200,
+                duration: 75
+            }
+        },
+        {
+            name: pxt.U.lf("Snare"),
+            sound: {
+                interpolation: "linear",
+                effect: "warble",
+                wave: "noise",
+                startVolume: pxt.assets.MAX_VOLUME,
+                endVolume: 0,
+                startFrequency: 3300,
+                endFrequency: 1400,
+                duration: 150
+            }
+        },
+        {
+            name: pxt.U.lf("Hi-Hat"),
+            sound: {
+                interpolation: "linear",
+                effect: "none",
+                wave: "noise",
+                startVolume: pxt.assets.MAX_VOLUME,
+                endVolume: 0,
+                startFrequency: 3900,
+                endFrequency: 3500,
+                duration: 10
             }
         }
     ];


### PR DESCRIPTION
This PR adds support for the mixer synth engine that @mmoskal wrote in pxt-common-packages to the sound effect editor.

In order to mimic the interpolation curves and the vibrato/tremolo effects, each sound is compiled to 20 synth instructions. Each instruction is 12 bytes long, so the end result is 240 bytes per sound which is roughly equivalent to a 16 x 32 image in arcade. If that ends up being too much (though I don't think it will) we can tweak the number of instructions.

As part of this I also rewrote the sim implementation of the synth because the old one wasn't so great at playing multiple short instructions in quick succession.

Here's a test build of arcade with the changes:

https://arcade.makecode.com/app/37e2d1ae2e70da5c0e4010586849d9ceca186a0f-895a1917a8

Please note that the test build currently ignores the global volume setting.

Some future work items:

1. Add more things to the gallery. I bet a lot of the builtin sounds would be easy to convert
2. Change the rendering of the noise wave since it's not actually noise
3. Make sounds into assets?



