### PR TITLE
when checking repo approved / banned, check slug in addition to fullname

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -915,8 +915,8 @@ namespace pxt.github {
         if (isOrgApproved(repo, config))
             return true;
 
-        const repoFull = repo.fullName?.toLowerCase();
-        const repoSlug = repo.slug?.toLowerCase();
+        const repoFull = repo?.fullName?.toLowerCase();
+        const repoSlug = repo?.slug?.toLowerCase();
         if (!config?.approvedRepoLib || !(repoFull || repoSlug)) return false;
         if (config.approvedRepoLib[repoFull]
             || config.approvedRepoLib[repoSlug])

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -892,9 +892,12 @@ namespace pxt.github {
         if (isOrgBanned(repo, config))
             return true;
         if (!config) return false; // don't know
-        if (!repo || !repo.fullName) return true;
+        if (!repo) return true;
+        const repoFull = repo.fullName?.toLowerCase();
+        const repoSlug = repo.slug?.toLowerCase();
+
         if (config.bannedRepos
-            && config.bannedRepos.some(fn => fn.toLowerCase() == repo.fullName.toLowerCase()))
+            && config.bannedRepos.some(fn => fn && (fn.toLowerCase() == repoFull || fn.toLowerCase() == repoSlug)))
             return true;
         return false;
     }
@@ -912,9 +915,11 @@ namespace pxt.github {
         if (isOrgApproved(repo, config))
             return true;
 
-        if (!repo || !config) return false;
-        if (repo.fullName
-            && config.approvedRepoLib?.[repo.fullName.toLowerCase()])
+        const repoFull = repo.fullName?.toLowerCase();
+        const repoSlug = repo.slug?.toLowerCase();
+        if (!config?.approvedRepoLib || !(repoFull || repoSlug)) return false;
+        if (config.approvedRepoLib[repoFull]
+            || config.approvedRepoLib[repoSlug])
             return true;
         return false;
     }


### PR DESCRIPTION
When checking whether a repo is approved / banned, check both fullname (`microsoft/pxt-jacdac/accelerometer`) and the slug (`microsoft/pxt-jacdac`).

In particular this is re: https://github.com/microsoft/pxt-minecraft/issues/2226, as when we load individual tutorials from repos the fullName is actually up to the full file (e.g. `mojang/educationcontent/CodingWithMinecraft/unit_2/lesson_A`), so they would have to be approved one by one (which also wouldn't really make sense, as we would probably try to fetch the pxt.json under lesson_A directory even though thats a md file [here](https://github.com/Mojang/EducationContent/blob/master/CodingWithMinecraft/unit_2/lesson_A.md)) .

I suppose could also fix specifically in the tutorial load path by changing how we store the filename vs the fullname, but it feels a bit more natural to me that if the root dir of a repo has approved permissions then the whole repo should

In theory I suppose we can also remove https://github.com/microsoft/pxt-microbit/blob/master/targetconfig.json#L644-L710 after this and just leave the one for jacdac? Unless we want the individual sensors to still show up in search results?