### PR TITLE
Remove step 2 of github teacher signup

### DIFF
--- a/docs/github-teacher-verification.md
+++ b/docs/github-teacher-verification.md
@@ -10,12 +10,6 @@ If you don’t already have one, create a GitHub Account. Go to https://github.c
 
 ![GitHub signup](/static/github-teacher/github-signup.png)
 
-### 2. Select 'Teacher'
-
-In the sign-up process, select **Teacher**.
-
-![Teacher signup](/static/github-teacher/teacher-signup.png)
-
 ## Get Verified as a Teacher
 
 ### 1. Verify your account


### PR DESCRIPTION
I'm assuming that this is the "Step 2" in question. There's another "Step 2" in the account verification section. I'd have to try and make another GitHub account to test this.

Closes #8974 