### PR TITLE
Never word wrap tutorial code snippets

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -62,8 +62,12 @@
         border-top: 2px dashed @tutorialSecondaryColor;
     }
 
-    .lang-blocks .ui.segment.raised {
+    .lang-blocks .ui.segment.raised, .ui.segment.raised.codewidget {
         overflow-x: auto;
+
+        code, code.hljs {
+            white-space: pre;
+        }
     }
 }
 


### PR DESCRIPTION
Instead make them scroll if they are too wide to fit in the tutorial pane
Fixes https://github.com/microsoft/pxt-minecraft/issues/2228