### PR TITLE
Fix codecard button size on thin screens

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -658,16 +658,11 @@
 
     .projectsdialog {
         .ui.card.buttoncard {
-            width: 9rem;
-            height: 9rem;
             .content {
                 padding: 1rem;
             }
             .header {
                 font-size: 12pt !important;
-            }
-            i.icon.huge {
-                font-size: 3rem;
             }
         }
         .ui.card.example {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2229

This isn't specific to minecraft; also happens in arcade.