### PR TITLE
Fix python snippet for enums with emitAsConstant set to true

### DIFF
--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -319,7 +319,7 @@ namespace ts.pxtc.service {
                 }
                 const type = checker?.getTypeAtLocation(param);
                 const typeSymbol = getPxtSymbolFromTsSymbol(type?.symbol, apis, checker);
-                if (typeSymbol?.attributes.fixedInstances && python) {
+                if ((typeSymbol?.attributes.fixedInstances || typeSymbol?.attributes.emitAsConstant) && python) {
                     return pxt.Util.snakify(paramDefl);
                 }
                 if (python) {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -658,7 +658,13 @@ namespace ts.pxtc {
             const left = param.substr(0, dotIdx)
             let right = param.substr(dotIdx + 1)
             right = U.snakify(right).toUpperCase();
-            return `${left}.${right}`
+
+            if (left) {
+                return `${left}.${right}`
+            }
+            else {
+                return right;
+            }
         }
         return param;
     }

--- a/tests/language-service/snippet_cases/emitAsConstant.py
+++ b/tests/language-service/snippet_cases/emitAsConstant.py
@@ -1,0 +1,2 @@
+# gameplay.setGameMode
+gameplay.set_game_mode(SURVIVAL, mobs.target(NEAREST_PLAYER))

--- a/tests/language-service/snippet_cases/emitAsConstant.ts
+++ b/tests/language-service/snippet_cases/emitAsConstant.ts
@@ -1,0 +1,2 @@
+// gameplay.setGameMode
+gameplay.setGameMode(SURVIVAL, mobs.target(NEAREST_PLAYER))

--- a/tests/language-service/test-package/minecraft.ts
+++ b/tests/language-service/test-package/minecraft.ts
@@ -1,0 +1,40 @@
+declare namespace gameplay {
+    /**
+     * Change the game mode for the selected players
+     * @param mode the desired game mode
+     * @param player a selector to determine which players to change the game mode for
+     */
+    //% help=gameplay/set-game-mode
+    //% promise
+    //% weight=210 blockGap=60
+    //% blockId=minecraftGamemode block="change game mode to %mode|for %player=minecraftTarget"
+    //% blockExternalInputs=1
+    //% mode.defl=SURVIVAL
+    //% shim=gameplay::setGameModeAsync promise
+    function setGameMode(mode: GameMode, player: TargetSelector): void;
+}
+
+//% emitAsConstant
+declare const enum GameMode {
+    //% block=survival alias=SURVIVAL
+    Survival,
+    //% block=creative alias=CREATIVE
+    Creative,
+    //% block=adventure alias=ADVENTURE
+    Adventure
+}
+
+/**
+ * A target selector
+ */
+//% snippet=mobs.target(NEAREST_PLAYER)
+//% pySnippet=mobs.target(NEAREST_PLAYER)
+declare class TargetSelector {
+}
+
+//% enumIdentity="GameMode.Survival"
+const SURVIVAL = GameMode.Survival;
+//% enumIdentity="GameMode.Creative"
+const CREATIVE = GameMode.Creative;
+//% enumIdentity="GameMode.Adventure"
+const ADVENTURE = GameMode.Adventure;

--- a/tests/language-service/test-package/pxt.json
+++ b/tests/language-service/test-package/pxt.json
@@ -2,7 +2,8 @@
     "name": "test-package",
     "description": "Project that defines a variety of APIs for testing the TypeScript and Python language service",
     "files": [
-        "basic.ts"
+        "basic.ts",
+        "minecraft.ts"
     ],
     "public": true,
     "dependencies": {},


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2170

Does what the title says!

As a fun aside: when I finished fixing this I implemented an entire test runner for testing snippets from the language service only to realize that I had already done that two years ago