### PR TITLE
Add an editor extension for 'program too large' errors

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -247,7 +247,7 @@ namespace ts.pxtc {
         console.log(stringKind(n))
     }
 
-    // next free error 9283
+    // next free error 9284
     function userError(code: number, msg: string, secondary = false): Error {
         let e = new Error(msg);
         (<any>e).ksEmitterUserError = true;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -435,6 +435,7 @@ namespace pxt.editor {
         renderUsbPairDialog?: (firmwareUrl?: string, failedOnce?: boolean) => any /* JSX.Element */;
         renderIncompatibleHardwareDialog?: (unsupportedParts: string[]) => any /* JSX.Element */;
         showUploadInstructionsAsync?: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void>;
+        showProgramTooLargeErrorAsync?: (variants: string[], confirmAsync: (options: any) => Promise<number>) => Promise<pxt.commands.RecompileOptions>;
         toolboxOptions?: IToolboxOptions;
         blocklyPatch?: (pkgTargetVersion: string, dom: Element) => void;
         webUsbPairDialogAsync?: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<number>) => Promise<number>;

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -1,4 +1,10 @@
 namespace pxt.commands {
+    export interface RecompileOptions {
+        recompile: boolean;
+        useVariants: string[];
+    }
+
+
     export interface DeployOptions {
         reportError: (e: string) => void;
         showNotification: (msg: string) => void;
@@ -20,6 +26,7 @@ namespace pxt.commands {
     export let renderIncompatibleHardwareDialog: (unsupportedParts: string[]) => any /* JSX.Element */ = undefined;
     export let renderDisconnectDialog: () => { header: string, jsx: any, helpUrl: string }
     export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>, saveonly?: boolean) => Promise<void> = undefined;
+    export let showProgramTooLargeErrorAsync: (variants: string[], confirmAsync: (options: any) => Promise<number>) => Promise<RecompileOptions>;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts
     export let webUsbPairDialogAsync: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<number>) => Promise<number> = undefined;

--- a/pxtlib/emitter/assembler.ts
+++ b/pxtlib/emitter/assembler.ts
@@ -999,8 +999,12 @@ namespace ts.pxtc.assembler {
             let lenAllCode = lenPrev
             let totalSize = (lenTotal + this.baseOffset) & 0xffffff
 
-            if (flashSize && totalSize > flashSize)
-                U.userError(lf("program too big by {0} bytes!", totalSize - flashSize))
+            if (flashSize && totalSize > flashSize) {
+                const e = new Error(lf("program too big by {0} bytes!", totalSize - flashSize));
+                (e as any).ksErrorCode = 9283;
+                throw e;
+            }
+
             flashSize = flashSize || 128 * 1024
             let totalInfo = lf("; total bytes: {0} ({1}% of {2}k flash with {3} free)",
                 totalSize, (100 * totalSize / flashSize).toFixed(1), (flashSize / 1024).toFixed(1),

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -656,7 +656,7 @@ namespace pxt {
                         const modtag = modid?.tag || mod.config?.version;
                         const vertag = verid.tag
 
-                        // if there is no tag on the current dependency, 
+                        // if there is no tag on the current dependency,
                         // assume same as existing module version if any
                         if (modtag && !vertag) {
                             pxt.debug(`unversioned ${ver}, using ${modtag}`)
@@ -1160,6 +1160,9 @@ namespace pxt {
                 if (ext) {
                     opts.otherMultiVariants.push(etarget)
                 } else {
+                    etarget.target.isNative = opts.target.isNative;
+                    opts.target = etarget.target;
+
                     ext = einfo
                     opts.otherMultiVariants = []
                 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3015,6 +3015,23 @@ export class ProjectView
                     pxt.tickEvent("compile.noemit")
                     const noHexFileDiagnostic = resp.diagnostics.find(diag => diag.code === 9043)
                         || resp.diagnostics.length == 1 ? resp.diagnostics[0] : undefined;
+
+                    if (noHexFileDiagnostic?.code === 9283 /*program too large*/ && pxt.commands.showProgramTooLargeErrorAsync) {
+                        const res = await pxt.commands.showProgramTooLargeErrorAsync(pxt.appTarget.multiVariants, core.confirmAsync);
+                        if (res?.recompile) {
+                            const oldVariants = pxt.appTarget.multiVariants;
+                            this.setState({ compiling: false, isSaving: false });
+                            try {
+                                pxt.appTarget.multiVariants = res.useVariants;
+                                await this.compile(saveOnly);
+                                return;
+                            }
+                            finally {
+                                pxt.appTarget.multiVariants = oldVariants;
+                            }
+                        }
+                    }
+
                     if (noHexFileDiagnostic) {
                         core.warningNotification(noHexFileDiagnostic.messageText as string);
                     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3017,8 +3017,10 @@ export class ProjectView
                         || resp.diagnostics.length == 1 ? resp.diagnostics[0] : undefined;
 
                     if (noHexFileDiagnostic?.code === 9283 /*program too large*/ && pxt.commands.showProgramTooLargeErrorAsync) {
+                        pxt.tickEvent("compile.programTooLargeDialog");
                         const res = await pxt.commands.showProgramTooLargeErrorAsync(pxt.appTarget.multiVariants, core.confirmAsync);
                         if (res?.recompile) {
+                            pxt.tickEvent("compile.programTooLargeDialog.recompile");
                             const oldVariants = pxt.appTarget.multiVariants;
                             this.setState({ compiling: false, isSaving: false });
                             try {
@@ -3029,6 +3031,9 @@ export class ProjectView
                             finally {
                                 pxt.appTarget.multiVariants = oldVariants;
                             }
+                        }
+                        else {
+                            pxt.tickEvent("compile.programTooLargeDialog.cancelled");
                         }
                     }
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -375,6 +375,10 @@ function applyExtensionResult() {
         log(`extension tutorial completed`);
         pxt.commands.onTutorialCompleted = res.onTutorialCompleted;
     }
+    if (res.showProgramTooLargeErrorAsync) {
+        log(`extension showProgramTooLargeErrorAsync`);
+        pxt.commands.showProgramTooLargeErrorAsync = res.showProgramTooLargeErrorAsync;
+    }
 }
 
 export async function initAsync() {


### PR DESCRIPTION
This is a workaround for https://github.com/microsoft/pxt-microbit/issues/4788

It doesn't fix the code size issues, but does allow multivariant editors to show a dialog when this happens and optionally recompile with fewer variants selected.

In other words: it lets us add a "download for V2 only" option to unblock micro:bit v2 users

Here is a gif showing how this works. Please note that the dialog is **very much not final** (that will be a different PR)

![download-for-v2](https://user-images.githubusercontent.com/13754588/182492302-a61a38f3-6b28-457d-a7fd-040af98a5e8e.gif)

