### PR TITLE
wait for first type check before completing api search

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -496,7 +496,7 @@ export function refreshLanguageServiceApisInfo() {
     refreshApis = true;
 }
 
-export async function apiSearchAsync(searchFor: pxtc.service.SearchOptions) {
+export async function apiSearchAsync(searchFor: pxtc.service.SearchOptions): Promise<pxtc.service.SearchInfo[]> {
     await waitForFirstTypecheckAsync();
     await ensureApisInfoAsync();
     searchFor.localizedApis = cachedApis;
@@ -507,7 +507,7 @@ export async function apiSearchAsync(searchFor: pxtc.service.SearchOptions) {
     });
 }
 
-export function projectSearchAsync(searchFor: pxtc.service.ProjectSearchOptions) {
+export function projectSearchAsync(searchFor: pxtc.service.ProjectSearchOptions): Promise<pxtc.service.ProjectSearchInfo[]> {
     return ensureApisInfoAsync()
         .then(() => {
             return workerOpAsync("projectSearch", { projectSearch: searchFor });


### PR DESCRIPTION
I was playing in arcade/beta and hit https://github.com/microsoft/pxt-minecraft/issues/2209 (only pxt-core search results when doing block search) again even with the previous fix that made it so it only occurred when first loading a new project -- arcade's initial compile is *just* slow enough that it is pretty feasible to hit there. This should fix that case.

build with it: https://arcade.makecode.com/app/645365a6d33945b4c0d36686efe9d9db77508a67-3da56e082f#editor

strictly speaking the change in `apiSearchAsync` is enough to cover it, but the change in `typecheckAsync` feels like a good thing just to make sure~

closes  https://github.com/microsoft/pxt-minecraft/issues/2209
