### PR TITLE
Fix gridpicker field editor in rtl languages

### DIFF
--- a/pxtblocks/fields/field_gridpicker.ts
+++ b/pxtblocks/fields/field_gridpicker.ts
@@ -397,10 +397,6 @@ namespace pxtblockly {
 
             containerSize.height += addedHeight;
 
-            if (this.sourceBlock_.RTL) {
-                (Blockly.utils as any).uiMenu.adjustBBoxesForRTL(viewportBBox, anchorBBox, containerSize);
-            }
-
             // Position the menu.
             Blockly.WidgetDiv.positionWithAnchor(viewportBBox, anchorBBox, containerSize,
                 this.sourceBlock_.RTL);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4815

My guess is that this function was removed in one of the Blockly updates. I don't know what it does, but the field editor seems to work fine without it. Its functionality was probably moved somewhere else in Blockly.