### PR TITLE
Add palette picker/editor experiment

### DIFF
--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -173,6 +173,11 @@ namespace pxt.editor.experiments {
                 name: lf("Blocks Error List"),
                 description: lf("Show an error list panel for Blocks")
             },
+            {
+                id: "palettePicker",
+                name: lf("Change Color Palette"),
+                description: lf("Change the game palette in project settings")
+            },
         ].filter(experiment => ids.indexOf(experiment.id) > -1 && !(pxt.BrowserUtils.isPxtElectron() && experiment.enableOnline));
     }
 

--- a/react-common/components/palette/ColorPickerField.tsx
+++ b/react-common/components/palette/ColorPickerField.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import { Button } from "../controls/Button";
+import { Input } from "../controls/Input";
+
+
+export interface ColorPickerFieldProps {
+    index: number;
+    color: string;
+    onColorChanged: (color: string) => void;
+    onMoveColor: (up: boolean) => void;
+    disabled?: boolean;
+}
+
+const colorNames = [
+    lf("Transparency"),
+    lf("White"),
+    lf("Red"),
+    lf("Pink"),
+    lf("Orange"),
+    lf("Yellow"),
+    lf("Green"),
+    lf("Teal"),
+    lf("Blue"),
+    lf("Cyan"),
+    lf("Purple"),
+    lf("Light Purple"),
+    lf("Dark Purple"),
+    lf("Tan"),
+    lf("Brown"),
+    lf("Black"),
+]
+
+
+export const ColorPickerField = (props: ColorPickerFieldProps) => {
+    const { index, color, onColorChanged, onMoveColor, disabled } = props;
+
+    const [currentColor, setCurrentColor] = React.useState<string | undefined>(undefined);
+
+    const onBlur = () => {
+        if (currentColor) onColorChanged(currentColor);
+        setCurrentColor(undefined);
+    }
+
+    const onColorPickerChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setCurrentColor(e.target.value);
+    }
+
+    const onTextInputChanged = (newValue: string) => {
+        if (/#[0-9a-fA-F]{6}/.test(newValue)) {
+            onColorChanged(newValue);
+        }
+    }
+
+    return <div className="common-color-picker-field">
+        <div className="common-color-index">
+            {index} ({colorNames[index]})
+        </div>
+        <div className="common-color-inputs">
+            <input type="color" value={currentColor || color} onBlur={onBlur} onChange={onColorPickerChanged} disabled={disabled}  />
+            <Input initialValue={currentColor || color} onChange={onTextInputChanged} disabled={disabled} />
+        </div>
+        <Button className="circle-button" title={lf("Move color up")} leftIcon="fas fa-arrow-up" onClick={() => onMoveColor(true)} disabled={disabled} />
+        <Button className="circle-button" title={lf("Move color down")} leftIcon="fas fa-arrow-down" onClick={() => onMoveColor(false)} disabled={disabled} />
+    </div>
+}

--- a/react-common/components/palette/PaletteEditor.tsx
+++ b/react-common/components/palette/PaletteEditor.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import { Modal } from "../controls/Modal";
+import { ColorPickerField } from "./ColorPickerField";
+import { Palette } from "./Palettes";
+
+export interface PaletteEditorProps {
+    palette: Palette;
+    onPaletteChanged: (newPalette: Palette) => void;
+}
+
+export const PaletteEditor = (props: PaletteEditorProps) => {
+    const { palette, onPaletteChanged } = props;
+
+    const [currentPalette, setCurrentPalette] = React.useState<Palette | undefined>(undefined);
+
+    const updateColor = (index: number, newColor: string) => {
+        const toUpdate = currentPalette || palette;
+        setCurrentPalette({
+            ...toUpdate,
+            colors: toUpdate.colors.map((c, i) =>
+                index === i ? newColor : c
+            )
+        });
+    }
+
+    const moveColor = (index: number, up: boolean) => {
+        const toUpdate = currentPalette || palette;
+        const res = {
+            ...toUpdate,
+            colors: toUpdate.colors.slice()
+        };
+
+        if (up) {
+            if (index > 1) {
+                res.colors[index - 1] = toUpdate.colors[index];
+                res.colors[index] = toUpdate.colors[index - 1];
+            }
+        }
+        else {
+            if (index < res.colors.length - 1) {
+                res.colors[index + 1] = toUpdate.colors[index];
+                res.colors[index] = toUpdate.colors[index + 1];
+            }
+        }
+        setCurrentPalette(res);
+    }
+
+    const onClose = () => {
+        onPaletteChanged(currentPalette || palette);
+    }
+
+    return <Modal title={lf("Edit Palette")} onClose={onClose}>
+        <div className="common-palette-editor">
+            {(currentPalette || palette).colors.map((c, i) =>
+                <ColorPickerField
+                    key={i}
+                    index={i}
+                    color={c}
+                    onColorChanged={newColor => updateColor(i, newColor)}
+                    onMoveColor={up => moveColor(i, up)}
+                    disabled={i === 0}
+                />
+            )}
+        </div>
+    </Modal>
+}

--- a/react-common/components/palette/PalettePicker.tsx
+++ b/react-common/components/palette/PalettePicker.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
+import { Button } from "../controls/Button";
 import { Dropdown } from "../controls/Dropdown";
+import { PaletteEditor } from "./PaletteEditor";
 import { Palette } from "./Palettes";
 import { PaletteSwatch } from "./PaletteSwatch";
 
@@ -12,8 +14,19 @@ export interface PalettePickerProps {
 export const PalettePicker = (props: PalettePickerProps) => {
     const { palettes, selectedId, onPaletteSelected } = props;
 
+    const [editingPalette, setEditingPalette] = React.useState<Palette | undefined>(undefined);
+
     const onItemSelected = (id: string) => {
         onPaletteSelected(palettes.find(p => p.id === id));
+    }
+
+    const openPaletteEditor = () => {
+        setEditingPalette(palettes.find(p => p.id === selectedId));
+    }
+
+    const onPaletteEdit = (newPalette: Palette) => {
+        onPaletteSelected(newPalette);
+        setEditingPalette(undefined);
     }
 
     return <div className="common-palette-picker">
@@ -27,5 +40,13 @@ export const PalettePicker = (props: PalettePickerProps) => {
                 label: <PaletteSwatch palette={p} />
             }))}
         />
+        <Button
+            title={lf("Edit Palette")}
+            leftIcon="fas fa-edit"
+            onClick={openPaletteEditor}
+        />
+        {editingPalette &&
+            <PaletteEditor palette={editingPalette} onPaletteChanged={onPaletteEdit}/>
+        }
     </div>
 }

--- a/react-common/components/palette/PalettePicker.tsx
+++ b/react-common/components/palette/PalettePicker.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { Dropdown } from "../controls/Dropdown";
+import { Palette } from "./Palettes";
+import { PaletteSwatch } from "./PaletteSwatch";
+
+export interface PalettePickerProps {
+    palettes: Palette[];
+    selectedId: string;
+    onPaletteSelected: (selected: Palette) => void;
+}
+
+export const PalettePicker = (props: PalettePickerProps) => {
+    const { palettes, selectedId, onPaletteSelected } = props;
+
+    const onItemSelected = (id: string) => {
+        onPaletteSelected(palettes.find(p => p.id === id));
+    }
+
+    return <div className="common-palette-picker">
+        <Dropdown
+            id="common-palette-picker"
+            selectedId={selectedId}
+            onItemSelected={onItemSelected}
+            items={palettes.map(p => ({
+                id: p.id,
+                title: p.name,
+                label: <PaletteSwatch palette={p} />
+            }))}
+        />
+    </div>
+}

--- a/react-common/components/palette/PaletteSwatch.tsx
+++ b/react-common/components/palette/PaletteSwatch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { Palette } from "./Palettes";
+
+export interface PaletteSwatchProps {
+    palette: Palette;
+}
+
+export const PaletteSwatch = (props: PaletteSwatchProps) => {
+    const { palette } = props;
+
+
+    return <div className="common-palette-swatch">
+        <div className="common-palette-swatch-name">
+            {palette.name}
+        </div>
+        <div className="common-palette-color-list">
+            {palette.colors.map((color, index) => <PaletteColor key={index} color={color} />)}
+        </div>
+    </div>
+}
+
+interface PaletteColorProps {
+    color: string;
+}
+
+const PaletteColor = (props: PaletteColorProps) =>
+    <div className="common-palette-color" style={{backgroundColor: props.color}} />

--- a/react-common/components/palette/Palettes.ts
+++ b/react-common/components/palette/Palettes.ts
@@ -1,0 +1,289 @@
+export interface Palette {
+    name: string;
+    id: string;
+    colors: string[];
+}
+
+export const Adafruit: Palette = {
+    id: "Adafruit",
+    name: lf("Adafruit"),
+    colors: [
+        "#000000",
+        "#FFFFFF",
+        "#FF0000",
+        "#FF007D",
+        "#FF7a00",
+        "#e5FF00",
+        "#2D9F00",
+        "#00FF72",
+        "#0034FF",
+        "#17ABFF",
+        "#C600FF",
+        "#636363",
+        "#7400DB",
+        "#00EFFF",
+        "#DF2929",
+        "#000000",
+    ]
+}
+
+// https://lospec.com/palette-list/vanilla-milkshake missing #e9f59d
+export const Pastel: Palette = {
+    id: "Pastel",
+    name: lf("Pastel"),
+    colors: [
+        "#000000",
+        "#fff7e4",
+        "#f98284",
+        "#feaae4",
+        "#ffc384",
+        "#fff7a0",
+        "#87a889",
+        "#b0eb93",
+        "#b0a9e4",
+        "#accce4",
+        "#b3e3da",
+        "#d9c8bf",
+        "#6c5671",
+        "#ffe6c6",
+        "#dea38b",
+        "#28282e",
+    ]
+}
+
+
+export const Matte: Palette = {
+    id: "Matte",
+    name: lf("Matte"),
+    colors: [
+        "#000000",
+        "#FFF1E8",
+        "#FF004D",
+        "#FF77A8",
+        "#FFA300",
+        "#FFEC27",
+        "#008751",
+        "#00E436",
+        "#29ADFF",
+        "#C2C3C7",
+        "#7E2553",
+        "#83769C",
+        "#5F574F",
+        "#FFCCAA",
+        "#AB5236",
+        "#1D2B53",
+    ]
+}
+
+
+export const Grayscale: Palette = {
+    id: "Grayscale",
+    name: lf("Grayscale"),
+    colors: [
+        "#000000",
+        "#FFFFFF",
+        "#EDEDED",
+        "#DBDBDB",
+        "#C8C8C8",
+        "#B6B6B6",
+        "#A4A4A4",
+        "#929292",
+        "#808080",
+        "#6D6D6D",
+        "#5B5B5B",
+        "#494949",
+        "#373737",
+        "#242424",
+        "#121212",
+        "#000000",
+    ]
+}
+
+
+// https://lospec.com/palette-list/poke14 with #b56edd added for purple
+export const Poke: Palette = {
+    id: "Poke",
+    name: lf("Poke"),
+    colors: [
+        "#000000",
+        "#ffffff",
+        "#d45362",
+        "#e8958b",
+        "#cc8945",
+        "#f5dc8c",
+        "#417d53",
+        "#5dd48f",
+        "#5162c2",
+        "#6cadeb",
+        "#b56edd",
+        "#8f3f29",
+        "#612431",
+        "#c0fac2",
+        "#24325e",
+        "#1b1221",
+    ]
+}
+
+
+// https://lospec.com/palette-list/warioware-diy
+export const DIY: Palette = {
+    id: "DIY",
+    name: lf("DIY"),
+    colors: [
+        "#000000",
+        "#f8f8f8",
+        "#f80000",
+        "#FF93C4",
+        "#f8a830",
+        "#f8f858",
+        "#089050",
+        "#70d038",
+        "#2868c0",
+        "#10c0c8",
+        "#c868e8",
+        "#c0c0c0",
+        "#787878",
+        "#f8d898",
+        "#c04800",
+        "#000000",
+    ]
+}
+
+
+// https://lospec.com/palette-list/still-life
+export const StillLife: Palette = {
+    id: "StillLife",
+    name: lf("Still Life"),
+    colors: [
+        "#000000",
+        "#a8e4d4",
+        "#d13b27",
+        "#e07f8a",
+        "#cc8218",
+        "#b3e868",
+        "#5d853a",
+        "#68c127",
+        "#286fb8",
+        "#9b8bff",
+        "#3f2811",
+        "#513155",
+        "#122615",
+        "#c7b581",
+        "#7a2222",
+        "#000000",
+    ]
+}
+
+
+// https://lospec.com/palette-list/steam-lords, missing 0xa0b9ba
+export const SteamPunk: Palette = {
+    id: "SteamPunk",
+    name: lf("Steam Punk"),
+    colors: [
+        "#000000",
+        "#c0d1cc",
+        "#603b3a",
+        "#170e19",
+        "#775c4f",
+        "#77744f",
+        "#4f7754",
+        "#a19f7c",
+        "#4f5277",
+        "#65738c",
+        "#3a604a",
+        "#213b25",
+        "#433a60",
+        "#7c94a1",
+        "#3b2137",
+        "#2f213b",
+    ]
+}
+
+// https://lospec.com/palette-list/sweetie-16, missing 0x73eff7
+export const Sweet: Palette = {
+    id: "Sweet",
+    name: lf("Sweet"),
+    colors: [
+        "#000000",
+        "#f4f4f4",
+        "#b13e53",
+        "#a7f070",
+        "#ef7d57",
+        "#ffcd75",
+        "#257179",
+        "#38b764",
+        "#29366f",
+        "#3b5dc9",
+        "#41a6f6",
+        "#566c86",
+        "#333c57",
+        "#94b0c2",
+        "#5d275d",
+        "#1a1c2c",
+    ]
+}
+
+
+// https://lospec.com/palette-list/na16, missing 0x70377f
+export const Adventure: Palette = {
+    id: "Adventure",
+    name: lf("Adventure"),
+    colors: [
+        "#000000",
+        "#f5edba",
+        "#9d303b",
+        "#d26471",
+        "#e4943a",
+        "#c0c741",
+        "#647d34",
+        "#34859d",
+        "#17434b",
+        "#7ec4c1",
+        "#584563",
+        "#8c8fae",
+        "#3e2137",
+        "#d79b7d",
+        "#9a6348",
+        "#1f0e1c",
+    ]
+}
+
+
+//% fixedInstance whenUsed block="arcade"
+export const Arcade: Palette = {
+    id: "Arcade",
+    name: lf("Arcade"),
+    colors: [
+        "#000000",
+        "#FFFFFF",
+        "#FF2121",
+        "#FF93C4",
+        "#FF8135",
+        "#FFF609",
+        "#249CA3",
+        "#78DC52",
+        "#003FAD",
+        "#87F2FF",
+        "#8E2EC4",
+        "#A4839F",
+        "#5C406c",
+        "#E5CDC4",
+        "#91463d",
+        "#000000",
+    ]
+}
+
+
+export const AllPalettes = [
+    Arcade,
+    Matte,
+    Pastel,
+    Sweet,
+    Poke,
+    Adventure,
+    DIY,
+    Adafruit,
+    StillLife,
+    SteamPunk,
+    Grayscale,
+]

--- a/react-common/styles/palette/ColorPickerField.less
+++ b/react-common/styles/palette/ColorPickerField.less
@@ -1,0 +1,21 @@
+.common-color-picker-field {
+    display: grid;
+    grid-template-columns: 3fr 6fr 1fr 1fr;
+    align-items: center;
+    padding: 0.1rem 0rem;
+}
+
+.common-color-inputs {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    &>:first-child {
+        margin-right: 0.5rem;
+    }
+
+    &>:last-child {
+        flex-grow: 1;
+        margin-right: 0.5rem;
+    }
+}

--- a/react-common/styles/palette/PalettePicker.less
+++ b/react-common/styles/palette/PalettePicker.less
@@ -3,3 +3,8 @@
     flex-direction: row;
     align-items: center;
 }
+
+.common-palette-editor {
+    max-height: 35rem;
+    overflow-y: auto;
+}

--- a/react-common/styles/palette/PalettePicker.less
+++ b/react-common/styles/palette/PalettePicker.less
@@ -1,0 +1,5 @@
+.common-palette-picker {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}

--- a/react-common/styles/palette/PaletteSwatch.less
+++ b/react-common/styles/palette/PaletteSwatch.less
@@ -1,0 +1,27 @@
+.common-palette-swatch {
+    display: flex;
+    flex-direction: row;
+}
+
+.common-palette-color-list {
+    display: flex;
+    flex-direction: row;
+}
+
+.common-palette-color {
+    width: 1rem;
+    height: 1rem;
+}
+
+.common-palette-swatch-name {
+    flex-grow: 1;
+    padding-right: 0.5rem;
+}
+
+.common-palette-picker > .common-dropdown > .common-button .common-button-label .common-palette-color-list {
+    display: none;
+}
+
+.common-palette-picker > .common-dropdown > .common-button .common-button-flex {
+    display: flex;
+}

--- a/react-common/styles/palette/palette.less
+++ b/react-common/styles/palette/palette.less
@@ -1,0 +1,3 @@
+@import "./PalettePicker.less";
+@import "./PaletteSwatch.less";
+@import "./ColorPickerField.less";

--- a/react-common/styles/react-common.less
+++ b/react-common/styles/react-common.less
@@ -1,6 +1,6 @@
 @import "profile/profile.less";
 @import "share/share.less";
-@import "palette/PaletteSwatch.less";
+@import "palette/palette.less";
 @import "extensions/ExtensionCard.less";
 @import "controls/Button.less";
 @import "controls/Card.less";

--- a/react-common/styles/react-common.less
+++ b/react-common/styles/react-common.less
@@ -1,5 +1,6 @@
 @import "profile/profile.less";
 @import "share/share.less";
+@import "palette/PaletteSwatch.less";
 @import "extensions/ExtensionCard.less";
 @import "controls/Button.less";
 @import "controls/Card.less";

--- a/theme/common.less
+++ b/theme/common.less
@@ -2501,3 +2501,15 @@ select.ui.dropdown {
         background-color: #F5BC5F;
     }
 }
+
+
+/** Project settings */
+
+.palette-picker-field {
+    display: flex;
+    align-items: center;
+}
+
+.palette-picker-label {
+    margin-right: 0.5rem;
+}

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -284,7 +284,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         const showSimCollapse = !readOnly && !isController && !!targetTheme.simCollapseInMenu;
         const showGreenScreen = targetTheme.greenScreen || /greenscreen=1/i.test(window.location.href);
         const showPrint = targetTheme.print && !pxt.BrowserUtils.isIE();
-        const showProjectSettings = targetTheme.showProjectSettings;
+        const showProjectSettings = targetTheme.showProjectSettings || pxt.editor.experiments.isEnabled("palettePicker");
         const docItems = targetTheme.docMenu && targetTheme.docMenu.filter(d => !d.tutorial);
         const usbIcon = pxt.appTarget.appTheme.downloadDialogTheme?.deviceIcon || "usb";
 

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -131,7 +131,7 @@ export class Editor extends srceditor.Editor {
 
     private onPaletteSelected = (selected: Palette) => {
         this.config.palette = selected.colors;
-        this.save();
+        this.save(true);
     }
 
     display(): JSX.Element {


### PR DESCRIPTION
![palette-picker](https://user-images.githubusercontent.com/13754588/183133234-bbfc4957-27a3-415c-b8c7-ae238709a04f.gif)

Adds an experiment for use in pxt-arcade that lets you change your project's color palette! 

Obviously this has gone through zero design iterations, so don't expect it to turn into anything other than an experiment anytime soon. Most of the palettes came from [lospec.com](https://lospec.com/palette-list) via @jwunderl's pxt-color extension.

I went through and reordered the colors so that they are somewhat close to our default palette. This makes it so that the gallery sprites are still somewhat usable.