### PR TITLE
Fix Asset Create Button Formatting

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -231,7 +231,6 @@
 
     .common-button-flex {
         display: flex;
-        flex-wrap: wrap;
         flex-direction: column;
         justify-content: center;
     }

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -229,6 +229,12 @@
         margin: 1rem;
     }
 
+    .common-button-flex {
+        display: flex;
+        flex-wrap: wrap;
+        flex-direction: column;
+        justify-content: center;
+    }
 }
 
 .image-editor-open #tutorialcard {


### PR DESCRIPTION
Specify flex properties for the common-button-flex contained within asset-editor-create-button, ensuring the content of the button (image & text) will wrap as needed to fit within the shape of the button.

Fixes https://github.com/microsoft/pxt-arcade/issues/4839

Previously, these buttons relied on white-space wrapping to get this behavior, but that has since been disabled and the flex approach is hopefully more robust.

Before fix:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/69657545/183981550-30c6692f-f484-4093-8996-243fb6bc44c0.png">

After fix:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/69657545/183981922-69c8f2e4-9e78-4c35-ba41-2632d609b1a9.png">
