### PR TITLE
Add dependency info when enabling ?compiler=size

### DIFF
--- a/docs/js/profiling.md
+++ b/docs/js/profiling.md
@@ -117,3 +117,6 @@ This can be enabled with `?compiler=size`.
 When compiling for native, this will generate `size.csv` file alongside
 `binary.asm` and `binary.uf2`.
 You can load it into Excel and draw a treemap from the first three columns. 
+
+The switch will also generate a long comment at the head of `binary.asm`
+listing sizes of various objects and which object references which.

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -621,7 +621,7 @@ ${baseLabel}_nochk:
             })
         }
 
-        private helperObject(desc:string) {
+        private helperObject(desc: string) {
             return `.object _pxt_helper_${desc.replace(/[^\w]+/g, "_")} "helper: ${desc}"`
         }
 

--- a/pxtcompiler/emitter/backthumb.ts
+++ b/pxtcompiler/emitter/backthumb.ts
@@ -331,6 +331,7 @@ _numops_fromInt:
                 // this make sure to set the Z flag correctly
                 r += `
 .section code
+.object _pxt_helper_cmp_${op}
 _cmp_${op}:
     lsls r2, r0, #31
     beq .boxed

--- a/pxtcompiler/emitter/thumb.ts
+++ b/pxtcompiler/emitter/thumb.ts
@@ -298,7 +298,8 @@ namespace ts.pxtc.thumb {
                         lbl = "_ldlit_" + ++seq
                         values[v] = lbl
                     }
-                    line.update(`ldr ${reg}, ${lbl}`)
+                    line.ldlitLabel = line.words[3]
+                    line.update(`ldr ${reg}, ${lbl} ; ${line.ldlitLabel}`)
                 }
                 if (line === nextGoodSpot) {
                     nextGoodSpot = null
@@ -306,6 +307,7 @@ namespace ts.pxtc.thumb {
                     let jmplbl = "_jmpwords_" + ++seq
                     if (needsJumpOver)
                         txtLines.push("bb " + jmplbl)
+                    txtLines.push(`.object PUSH`)
                     txtLines.push(".balign 4")
                     for (let v of Object.keys(values)) {
                         let lbl = values[v]
@@ -313,6 +315,7 @@ namespace ts.pxtc.thumb {
                     }
                     if (needsJumpOver)
                         txtLines.push(jmplbl + ":")
+                    txtLines.push(`.object POP`)
                     for (let t of txtLines) {
                         f.buildLine(t, outlines)
                         let ll = outlines[outlines.length - 1]


### PR DESCRIPTION
When you add `?compiler=size` (or `PXT_COMPILE_SWITCHES=size` in command line) this will generate a comment similar to the following in the generated `binary.asm` file:

```
; Code size:
;
;   5280 _hexlit54 [_hexlit54]
;        by main.ts(1,1): <main> [_main___P1]
;   3628 game/physics.ts(349,5): ArcadePhysicsEngine.tilemapCollisions [ArcadePhysicsEngine_tilemapCollisions__P1078]
;        by game/physics.ts(113,5): ArcadePhysicsEngine.move [ArcadePhysicsEngine_move__P1075]
;        by ArcadePhysicsEngine__C1063_VT [ArcadePhysicsEngine__C1063_VT]
;        by game/physics.ts(624,5): ArcadePhysicsEngine.moveSprite [ArcadePhysicsEngine_moveSprite__P1081]
;   3110 mixer---rp2040/melody.ts(349,9): music.MelodyPlayer.play [music_MelodyPlayer_play__P475]
;        by music_MelodyPlayer__C472_VT [music_MelodyPlayer__C472_VT]
;        by mixer---rp2040/melody.ts(247,35): music.Melody.playCore.inline [music_Melody_playCore_inline__P6706]
;   2504 _hexlit55 [_hexlit55]
;        by main.ts(1,1): <main> [_main___P1]
;   2358 game/spritesay.ts(20,9): sprites.SpriteSayRenderer.drawSayFrame [sprites_SpriteSayRenderer_drawSayFrame__P853]
;        by sprites_SpriteSayRenderer__C851_VT [sprites_SpriteSayRenderer__C851_VT]
;        by game/spritesay.ts(240,9): sprites.SpriteSayRenderer.draw [sprites_SpriteSayRenderer_draw__P854]
...
```

it lists what uses what and what size it has. It partially overlaps with `sizes.csv` file also generated by this switch but has more info.
