### PR TITLE
Fix Python Preferred Editor for Tutorials

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1651,7 +1651,7 @@ export class ProjectView
                     file = main.lookupFile(fileName);
 
                     // If the preferred file does not exist, create it.
-                    if(!file) {
+                    if (!file) {
                         file = main.setFile(fileName, '\n');
 
                         pkg.mainPkg.config.files.push(fileName);
@@ -1831,14 +1831,14 @@ export class ProjectView
             if (newText[file] !== undefined) {
                 pkg.mainEditorPkg().setFile(file, newText[file]);
 
-                if(pkg.mainPkg.config.files.indexOf(file) < 0) {
+                if (pkg.mainPkg.config.files.indexOf(file) < 0) {
                     updateConfig = true;
                     pkg.mainPkg.config.files.push(file);
                 }
             }
         }
 
-        if(updateConfig) {
+        if (updateConfig) {
              pkg.mainPkg.saveConfig();
         }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1653,6 +1653,9 @@ export class ProjectView
                     // If the preferred file does not exist, create it.
                     if(!file) {
                         file = main.setFile(fileName, '\n');
+
+                        pkg.mainPkg.config.files.push(fileName);
+                        pkg.mainPkg.saveConfig();
                     }
                 }
 
@@ -1823,10 +1826,20 @@ export class ProjectView
             }
         }
 
+        let updateConfig = false;
         for (const file of Object.keys(newText)) {
             if (newText[file] !== undefined) {
                 pkg.mainEditorPkg().setFile(file, newText[file]);
+
+                if(pkg.mainPkg.config.files.indexOf(file) < 0) {
+                    updateConfig = true;
+                    pkg.mainPkg.config.files.push(file);
+                }
             }
+        }
+
+        if(updateConfig) {
+             pkg.mainPkg.saveConfig();
         }
 
         await workspace.saveAsync(header);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1647,7 +1647,13 @@ export class ProjectView
                 // override inferred editor with tutorial editor if present in markdown
                 const tutorialPreferredEditor = h.tutorial?.metadata?.preferredEditor;
                 if (tutorialPreferredEditor) {
-                    file = main.lookupFile("this/" + filenameForEditor(tutorialPreferredEditor)) || file;
+                    let fileName  = "this/" + filenameForEditor(tutorialPreferredEditor);
+                    file = main.lookupFile(fileName);
+
+                    // If the preferred file does not exist, create it.
+                    if(!file) {
+                        file = main.setFile(fileName, '\n');
+                    }
                 }
 
                 if (file.name === pxt.MAIN_TS) {


### PR DESCRIPTION
When Python is set as the preferred editor for a tutorial, we still end up loading the blocks editor because main.py doesn't exist at the time we try to load it.

To address this issue, if the preferred file does not exist, we can create it rather than falling back on the blocks file. We also have to update config to ensure the python files are included in pxt.json. Without that, the python script won't actually be included when the app runs, so it doesn't do anything. This was also missing inside loadTutorialTemplateCodeAsync, so I've added it there, too.

Fixes https://github.com/microsoft/pxt-arcade/issues/4892