### PR TITLE
Fixed color theming in extension dialog.

### DIFF
--- a/skillmap/package-lock.json
+++ b/skillmap/package-lock.json
@@ -23,7 +23,8 @@
     },
     "../built/react-common/components": {
       "name": "react-common",
-      "version": "0.0.1"
+      "version": "0.0.0",
+      "devDependencies": {}
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.1.2",
@@ -18546,9 +18547,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "optional": true,
       "peer": true,
       "engines": {
@@ -34999,9 +35000,9 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "optional": true,
       "peer": true
     },

--- a/skillmap/package-lock.json
+++ b/skillmap/package-lock.json
@@ -23,8 +23,7 @@
     },
     "../built/react-common/components": {
       "name": "react-common",
-      "version": "0.0.0",
-      "devDependencies": {}
+      "version": "0.0.1"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.1.2",
@@ -18547,9 +18546,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "optional": true,
       "peer": true,
       "engines": {
@@ -35000,9 +34999,9 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "optional": true,
       "peer": true
     },

--- a/theme/common.less
+++ b/theme/common.less
@@ -909,7 +909,7 @@ Field editors
     .common-modal > {
         .common-modal-header {
             height: @mainMenuHeight;
-            background-color: @blue;
+            background-color: @mainMenuInvertedBackground;
             z-index: 202;
             display: flex;
             padding-left: 0rem;


### PR DESCRIPTION
When clicking on extensions in the development environment of micro:bit, the extensions header was not the correct color. This code change fixed this issue and it was verified that the right color was maintained across pxt.

Closes https://github.com/microsoft/pxt-arcade/issues/4782 