### PR TITLE
add scrollbar for lang-block snippets as well

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -62,7 +62,7 @@
         border-top: 2px dashed @tutorialSecondaryColor;
     }
 
-    .lang-blocks .ui.segment.raised, .ui.segment.raised.codewidget {
+    .lang-block .ui.segment.raised, .lang-blocks .ui.segment.raised, .ui.segment.raised.codewidget {
         overflow-x: auto;
 
         code, code.hljs {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/4920, we have a ` ```block` snippet that behaves similarly to ` ```blocks` that wasn't included in this rule