### PR TITLE
Fix Python destructuring for global/nonlocal variables

### DIFF
--- a/pxtpy/ast.ts
+++ b/pxtpy/ast.ts
@@ -172,6 +172,8 @@ namespace pxt.py {
         vars: Map<ScopeSymbolInfo>;
         parent?: ScopeDef;
         blockDepth?: number;
+        /* used to avoid name collisions when generating helper vars (e.g. __tempvar1) */
+        nextHelperVariableId?: number;
     }
 
     export interface FunctionDef extends Symbol, ScopeDef {

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -393,6 +393,16 @@ namespace pxt.py {
         return sym!
     }
 
+    function getHelperVariableName() {
+        const scope = currentScope();
+
+        if (scope.nextHelperVariableId === undefined) {
+            scope.nextHelperVariableId = 0;
+        }
+
+        return "__tempvar" + scope.nextHelperVariableId++
+    }
+
     function defvar(name: string, opts: py.VarDescOptions, modifier?: VarModifier, scope?: ScopeDef): ScopeSymbolInfo {
         if (!scope)
             scope = currentScope()
@@ -1853,74 +1863,9 @@ namespace pxt.py {
             return B.mkStmt(B.mkText(pref), B.mkInfix(expr(target), "=", expr(value)))
         }
         if (!pref && target.kind == "Tuple") {
-            let tup = target as py.Tuple
-            let targs = [B.mkText("let "), B.mkText("[")]
-            let nonNames = tup.elts.filter(e => e.kind !== "Name")
-            if (nonNames.length) {
-                error(n, 9556, U.lf("non-trivial tuple assignment unsupported"));
-                return stmtTODO(n)
-            }
 
-            const symbols = tup.elts
-                .map(e => tryGetName(e))
-                .map(nm => nm ? currentScope().vars[nm] : undefined);
+            return convertDestructuring(n, target as py.Tuple, value);
 
-            if (symbols.some(s => s?.modifier !== undefined)) {
-                const tempVarName = "__tempVar";
-                const valueAssign = B.mkStmt(
-                    B.mkInfix(
-                        B.mkGroup(
-                            [B.mkText("let "), B.mkText(tempVarName)]
-                        ),
-                        "=",
-                        expr(value)
-                    )
-                );
-
-                const assignStatements = [valueAssign];
-
-                for (let i = 0; i < symbols.length; i++) {
-                    if (symbols[i]?.modifier !== undefined) {
-                        assignStatements.push(
-                            B.mkStmt(
-                                B.mkInfix(
-                                    convertName(tup.elts[i] as py.Name),
-                                    "=",
-                                    B.mkGroup(
-                                        [B.mkText(tempVarName), B.mkText(`[${i}]`)]
-                                    )
-                                )
-                            )
-                        )
-                    }
-                    else {
-                        assignStatements.push(
-                            B.mkStmt(
-                                B.mkInfix(
-                                    B.mkGroup(
-                                        [B.mkText("let "), convertName(tup.elts[i] as py.Name)!]
-                                    ),
-                                    "=",
-                                    B.mkGroup(
-                                        [B.mkText(tempVarName), B.mkText(`[${i}]`)]
-                                    )
-                                )
-                            )
-                        )
-                    }
-                }
-
-                return B.mkGroup(assignStatements);
-            }
-            else {
-                let tupNames = tup.elts
-                    .map(e => e as py.Name)
-                    .map(convertName)
-                targs.push(B.mkCommaSep(tupNames))
-                targs.push(B.mkText("]"))
-                let res = B.mkStmt(B.mkInfix(B.mkGroup(targs), "=", expr(value)))
-                return res
-            }
         }
         if (target.kind === "Name") {
             const scopeSym = currentScope().vars[nm];
@@ -1952,13 +1897,68 @@ namespace pxt.py {
             lExp = expr(target)
 
         return B.mkStmt(B.mkText(pref), B.mkInfix(lExp, "=", expr(value)))
+    }
 
-        function convertName(n: py.Name) {
+    function convertDestructuring(parent: py.AnnAssign | py.Assign, targets: py.Tuple, value: py.Expr) {
+        let nonNames = targets.elts.filter(e => e.kind !== "Name")
+        if (nonNames.length) {
+            error(parent, 9556, U.lf("non-trivial tuple assignment unsupported"));
+            return stmtTODO(parent)
+        }
+
+        const names = targets.elts.map(tryGetName);
+
+        const symbols = names
+            .map(nm => nm ? currentScope().vars[nm] : undefined);
+
+        if (symbols.some(s => s?.modifier !== undefined)) {
+            const helperVar = getHelperVariableName();
+            const valueAssign = B.mkStmt(
+                B.mkInfix(
+                    B.mkGroup(
+                        [B.mkText("let "), B.mkText(helperVar)]
+                    ),
+                    "=",
+                    expr(value)
+                )
+            );
+
+            const assignStatements = [valueAssign];
+
+            for (let i = 0; i < symbols.length; i++) {
+                const name = convertName(targets.elts[i] as py.Name);
+
+                assignStatements.push(
+                    B.mkStmt(
+                        B.mkInfix(
+                           name,
+                            "=",
+                            B.mkGroup(
+                                [B.mkText(helperVar), B.mkText(`[${i}]`)]
+                            )
+                        )
+                    )
+                )
+            }
+
+            return B.mkGroup(assignStatements);
+        }
+        else {
+            let targs = [B.mkText("let "), B.mkText("[")]
+            let tupNames = targets.elts
+                .map(e => e as py.Name)
+                .map(e => convertName(e, true))
+            targs.push(B.mkCommaSep(tupNames))
+            targs.push(B.mkText("]"))
+            return B.mkStmt(B.mkInfix(B.mkGroup(targs), "=", expr(value)))
+        }
+
+        function convertName(n: py.Name, excludeLet = false) {
             // TODO resuse with Name expr
             markInfoNode(n, "identifierCompletion")
             typeOf(n)
             let v = lookupName(n)
-            return possibleDef(n, /*excludeLet*/true)
+            return possibleDef(n, excludeLet)
         }
     }
 

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -400,7 +400,7 @@ namespace pxt.py {
             scope.nextHelperVariableId = 0;
         }
 
-        return "__tempvar" + scope.nextHelperVariableId++
+        return "___tempvar" + scope.nextHelperVariableId++
     }
 
     function defvar(name: string, opts: py.VarDescOptions, modifier?: VarModifier, scope?: ScopeDef): ScopeSymbolInfo {

--- a/tests/pyconverter-test/baselines/destructuring.ts
+++ b/tests/pyconverter-test/baselines/destructuring.ts
@@ -1,0 +1,12 @@
+function initValue() {
+
+    let __tempvar2 = [1, 0, 3]
+    g_value = __tempvar2[0]
+    let _ = __tempvar2[1]
+    _ = __tempvar2[2]
+    let [a, b, c] = ["A", "B", "C"]
+    let [d, e, f] = ["D", "E", "F"]
+}
+
+let g_value = 0
+initValue()

--- a/tests/pyconverter-test/baselines/destructuring.ts
+++ b/tests/pyconverter-test/baselines/destructuring.ts
@@ -1,9 +1,9 @@
 function initValue() {
 
-    let __tempvar2 = [1, 0, 3]
-    g_value = __tempvar2[0]
-    let _ = __tempvar2[1]
-    _ = __tempvar2[2]
+    let ___tempvar2 = [1, 0, 3]
+    g_value = ___tempvar2[0]
+    let _ = ___tempvar2[1]
+    _ = ___tempvar2[2]
     let [a, b, c] = ["A", "B", "C"]
     let [d, e, f] = ["D", "E", "F"]
 }

--- a/tests/pyconverter-test/cases/destructuring.py
+++ b/tests/pyconverter-test/cases/destructuring.py
@@ -1,0 +1,9 @@
+def initValue():
+    global g_value
+    g_value, _, _ = 1,0,3
+    a,b,c = "A","B","C"
+    d,e,f = ["D", "E", "F"]
+
+g_value = 0
+initValue()
+


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4826

When a variable is already declared, we can't convert python destructuring into the TS syntax. Instead, fall back to a series of assigments. for example,

```python
g = 0
def initValue():
    global g

    g, _ = 1, 2
```
becomes

```typescript
let g = 0
function initValue() {
    let __tempvar2 = [1, 2]
    g = __tempvar2[0]
    let _ = __tempvar2[1]
}
```
