### PR TITLE
Remove Custom Width for Invisible Scrollbar

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -204,7 +204,6 @@ pre {
 
 .invisibleScrollbar::-webkit-scrollbar {
     background: transparent !important;
-    width: @customScrollbarWidth; // TODO: remove this when the sim breakpoint is fixed
 }
 .invisibleScrollbar::-webkit-scrollbar-thumb {
     display: none !important;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/4816

The custom width being applied when the scrollbar turns invisible differs from the visible scrollbar's width. As a result, when we show/hide the scrollbar, the size of the simulator changes. This opens an edge case where the change in size from adding/removing the scrollbar triggers a change in whether or not the scrollbar is needed, so we end up looping, adding and removing the scrollbar continuously.

By removing this line from the invisible scrollbar CSS, the width should remain unchanged whether the scrollbar is visible or invisible, so there's no size change when the bar is shown or hidden.

The comment on this line indicates that it was used to fix a "sim breakpoint" issue. We aren't certain what this issue was, but I've toyed around with breakpoints and resizing the sim, and I haven't seen any unexpected behavior so far...