### PR TITLE
Width added to .image-editor-change-name so that .image-editor-input …

### DIFF
--- a/theme/image-editor/bottomBar.less
+++ b/theme/image-editor/bottomBar.less
@@ -53,6 +53,7 @@
 
 .image-editor-change-name {
     position: relative;
+    width: 20rem;
 }
 
 .image-editor-change-name .image-editor-input {
@@ -67,7 +68,6 @@
     max-width: 100%;
     width: 100%;
     height: 100%;
-    min-width: 20rem;
 
     transition: border-bottom 0.2s;
 }


### PR DESCRIPTION
…will fill the parent container instead of overflow with it's min-width

When adjusting the screen size to smaller ratios during tutorials, the image editor's name changing input field would cover the undo and redo buttons in the bottom bar; this is now fixed. 

Closes https://github.com/microsoft/pxt-arcade/issues/4587 

Note: The ticket does not mention whether or not this just happened in tutorial or regular editor mode. The covering of the buttons was found out to be only in tutorials currently after some digging. If this was a problem in regular editor mode as well, it was likely fixed/helped with this PR: https://github.com/microsoft/pxt/pull/7781/files 