### PR TITLE
.blocklyNonEditableText>text.semanticIcon now has correct styling for…

### DIFF
--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -136,7 +136,6 @@ namespace pxtblockly {
 
             const icon = new svg.Text("\uf008")
                 .at(X_PADDING, 5 + (TOTAL_HEIGHT >> 1))
-                .fill((this.sourceBlock_ as Blockly.BlockSvg).getColourSecondary())
                 .setClass("semanticIcon");
 
             this.fieldGroup_.appendChild(icon.el);

--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -90,7 +90,7 @@ body.blocklyMinimalBody {
         font-style: italic;
     }
 
-    .blocklyEditableText>text.semanticIcon {
+    .blocklyEditableText>text.semanticIcon, .blocklyNonEditableText>text.semanticIcon {
         fill: #fff;
         font-family: "Icons";
         font-size: 19px;


### PR DESCRIPTION
… font-family and fill

In the third level, **Get Animated**, of the Whackem tutorial in beta (the sixth step), there is a preview of an animation block that does not show the preview icon for the field animator. This is because the `semanticIcons` class needs to have `font-family: "Icons";` in CSS. This was not happening for the preview block in the tutorial panel, but now it is.

**Before:**
<img width="250" alt="before-anim-preview-icon" src="https://user-images.githubusercontent.com/49178322/186490886-1b36d58d-b9a9-4e65-9f79-1636399a769b.png">

**After:**
<img width="251" alt="after-anim-preview-icon" src="https://user-images.githubusercontent.com/49178322/186490958-5907b631-992a-45c9-8d0c-961acde64f37.png">


Closes  https://github.com/microsoft/pxt-arcade/issues/4921 

Note: https://github.com/microsoft/pxt/blob/dd7494242ef28baf69d93d67e50e35ca2c3597e6/pxtblocks/fields/field_animation.ts#L139 this line was removed from `field_animation.ts` as, with playing, it did not seem to change anything on the blocks.