### PR TITLE
Fixes the broken link to Math.abs reference page

### DIFF
--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -535,7 +535,8 @@ namespace Math {
       * For example, the absolute value of -5 is the same as the absolute value of 5.
       * @param x A numeric expression for which the absolute value is needed.
       */
-    //% help=./reference/math/abs
+    //% blockId=math_op3
+    //% help=math/abs
     export function abs(x: number): number {
         return x < 0 ? -x : x;
     }

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -554,6 +554,7 @@ namespace Math {
     /**
       * Returns the larger of two supplied numeric expressions.
       */
+    //% blockId=math_op2
     //% help=math/max
     export function max(a: number, b: number): number {
         if (a >= b) return a;
@@ -563,6 +564,7 @@ namespace Math {
     /**
       * Returns the smaller of two supplied numeric expressions.
       */
+    //% blockId=math_op2
     //% help=math/min
     export function min(a: number, b: number): number {
         if (a <= b) return a;

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -535,7 +535,7 @@ namespace Math {
       * For example, the absolute value of -5 is the same as the absolute value of 5.
       * @param x A numeric expression for which the absolute value is needed.
       */
-    //% help=math/abs
+    //% help=./reference/math/abs
     export function abs(x: number): number {
         return x < 0 ? -x : x;
     }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -957,10 +957,10 @@ namespace pxt.blocks {
         initMath(blockInfo);
         initVariables();
         initFunctions();
-        initLists();
+        initLists(blockInfo);
         initLoops();
         initLogic();
-        initText();
+        initText(blockInfo);
         initDrag();
         initDebugger();
         initComments();

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -957,10 +957,10 @@ namespace pxt.blocks {
         initMath(blockInfo);
         initVariables();
         initFunctions();
-        initLists(blockInfo);
+        initLists();
         initLoops();
         initLogic();
-        initText(blockInfo);
+        initText();
         initDrag();
         initDebugger();
         initComments();
@@ -1102,7 +1102,7 @@ namespace pxt.blocks {
 
     export let openHelpUrl: (url: string) => void;
 
-    function initLists(blockInfo : pxtc.BlocksInfo) {
+    function initLists() {
         const msg = Blockly.Msg;
 
         // lists_create_with
@@ -1116,32 +1116,27 @@ namespace pxt.blocks {
 
         // lists_length
         const listsLengthId = "lists_length";
-        const listsLengthqName = "Array.Length"
         const listsLengthDef = pxt.blocks.getBlockDefinition(listsLengthId);
         msg.LISTS_LENGTH_TITLE = listsLengthDef.block["LISTS_LENGTH_TITLE"];
 
         // We have to override this block definition because the builtin block
         // allows both Strings and Arrays in its input check and that confuses
         // our Blockly compiler
-        Blockly.Blocks[listsLengthId] = {
-            init: function () {
-                this.jsonInit({
-                    "message0": msg.LISTS_LENGTH_TITLE,
-                    "args0": [
-                        {
-                            "type": "input_value",
-                            "name": "VALUE",
-                            "check": ['Array']
-                        }
-                    ],
-                    "output": 'Number',
-                    "outputShape": Blockly.OUTPUT_SHAPE_ROUND
-                });
-            },
-
-            codeCard: attachCardInfo(blockInfo, listsLengthqName)
+        let block = Blockly.Blocks[listsLengthId];
+        block.init = function () {
+            this.jsonInit({
+                "message0": msg.LISTS_LENGTH_TITLE,
+                "args0": [
+                    {
+                        "type": "input_value",
+                        "name": "VALUE",
+                        "check": ['Array']
+                    }
+                ],
+                "output": 'Number',
+                "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+            });
         }
-
 
         installBuiltinHelpInfo(listsLengthId);
     }
@@ -2781,7 +2776,7 @@ namespace pxt.blocks {
         installBuiltinHelpInfo(logicBooleanId);
     }
 
-    function initText(blockInfo: pxtc.BlocksInfo) {
+    function initText() {
         // builtin text
         const textInfo = pxt.blocks.getBlockDefinition('text');
         installHelpResources('text', textInfo.name, textInfo.tooltip, textInfo.url,
@@ -2792,30 +2787,26 @@ namespace pxt.blocks {
         // builtin text_length
         const msg = Blockly.Msg;
         const textLengthId = "text_length";
-        const textLengthqName = "String.Length"
         const textLengthDef = pxt.blocks.getBlockDefinition(textLengthId);
         msg.TEXT_LENGTH_TITLE = textLengthDef.block["TEXT_LENGTH_TITLE"];
 
         // We have to override this block definition because the builtin block
         // allows both Strings and Arrays in its input check and that confuses
         // our Blockly compiler
-        Blockly.Blocks[textLengthId] = {
-            init: function () {
-                this.jsonInit({
-                    "message0": msg.TEXT_LENGTH_TITLE,
-                    "args0": [
-                        {
-                            "type": "input_value",
-                            "name": "VALUE",
-                            "check": ['String']
-                        }
-                    ],
-                    "output": 'Number',
-                    "outputShape": Blockly.OUTPUT_SHAPE_ROUND
-                });
-            },
-
-            codeCard: attachCardInfo(blockInfo, textLengthqName)
+        let block = Blockly.Blocks[textLengthId];
+        block.init = function () {
+            this.jsonInit({
+                "message0": msg.TEXT_LENGTH_TITLE,
+                "args0": [
+                    {
+                        "type": "input_value",
+                        "name": "VALUE",
+                        "check": ['String']
+                    }
+                ],
+                "output": 'Number',
+                "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+            });
         }
         installBuiltinHelpInfo(textLengthId);
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1974,6 +1974,7 @@ namespace pxt.blocks {
     function initMath(blockInfo: pxtc.BlocksInfo) {
         // math_op2
         const mathOp2Id = "math_op2";
+        const mathOp2qName = "Math.min"; // TODO: implement logic so that this changes based on which is used (min or max)
         const mathOp2Def = pxt.blocks.getBlockDefinition(mathOp2Id);
         const mathOp2Tooltips = <Map<string>>mathOp2Def.tooltip;
         Blockly.Blocks[mathOp2Id] = {
@@ -2016,7 +2017,9 @@ namespace pxt.blocks {
                     mathOp2Def.url,
                     pxt.toolbox.getNamespaceColor(mathOp2Def.category)
                 );
-            }
+
+            },
+            codeCard: attachCardInfo(blockInfo, mathOp2qName)
         };
 
         // math_op3

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -2,6 +2,7 @@
 /// <reference path="../built/pxtlib.d.ts" />
 
 namespace pxt.blocks {
+
     export let promptTranslateBlock: (blockId: string, blockTranslationIds: string[]) => void;
 
     export interface GrayBlock extends Blockly.Block {
@@ -546,6 +547,15 @@ namespace pxt.blocks {
         }
     }
 
+    function attachCardInfo(blockInfo: pxtc.BlocksInfo, qName: string): pxt.CodeCard | void {
+        const toModify: pxtc.SymbolInfo = blockInfo.apis.byQName[qName];
+        if (toModify) {
+            const comp = compileInfo(toModify);
+            const xml = createToolboxBlock(blockInfo, toModify, comp);
+            return mkCard(toModify, xml);
+        }
+    }
+
     function isSubtype(apis: pxtc.ApisInfo, specific: string, general: string) {
         if (specific == general) return true
         let inf = apis.byQName[specific]
@@ -916,7 +926,7 @@ namespace pxt.blocks {
      * Used by pxtrunner to initialize blocks in the docs
      */
     export function initializeAndInject(blockInfo: pxtc.BlocksInfo) {
-        init();
+        init(blockInfo);
         injectBlocks(blockInfo);
     }
 
@@ -925,12 +935,12 @@ namespace pxt.blocks {
      * Blocks are injected separately by called injectBlocks
      */
     export function initialize(blockInfo: pxtc.BlocksInfo) {
-        init();
+        init(blockInfo);
         initJresIcons(blockInfo);
     }
 
     let blocklyInitialized = false;
-    function init() {
+    function init(blockInfo: pxtc.BlocksInfo) {
         if (blocklyInitialized) return;
         blocklyInitialized = true;
 
@@ -944,7 +954,7 @@ namespace pxt.blocks {
         initFieldEditors();
         initContextMenu();
         initOnStart();
-        initMath();
+        initMath(blockInfo);
         initVariables();
         initFunctions();
         initLists(blockInfo);
@@ -1966,7 +1976,7 @@ namespace pxt.blocks {
         };
     }
 
-    function initMath() {
+    function initMath(blockInfo: pxtc.BlocksInfo) {
         // math_op2
         const mathOp2Id = "math_op2";
         const mathOp2Def = pxt.blocks.getBlockDefinition(mathOp2Id);
@@ -2017,6 +2027,7 @@ namespace pxt.blocks {
         // math_op3
         const mathOp3Id = "math_op3";
         const mathOp3Def = pxt.blocks.getBlockDefinition(mathOp3Id);
+        const mathOp3qName = "Math.abs";
         Blockly.Blocks[mathOp3Id] = {
             init: function () {
                 this.jsonInit({
@@ -2035,7 +2046,8 @@ namespace pxt.blocks {
                 });
 
                 setBuiltinHelpInfo(this, mathOp3Id);
-            }
+            },
+            codeCard: attachCardInfo(blockInfo, mathOp3qName)
         };
 
         // builtin math_number, math_integer, math_whole_number, math_number_minmax

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -2,6 +2,7 @@
 /// <reference path="../built/pxtlib.d.ts" />
 
 namespace pxt.blocks {
+
     export let promptTranslateBlock: (blockId: string, blockTranslationIds: string[]) => void;
 
     export interface GrayBlock extends Blockly.Block {
@@ -546,6 +547,15 @@ namespace pxt.blocks {
         }
     }
 
+    function attachCardInfo(blockInfo: pxtc.BlocksInfo, qName: string): pxt.CodeCard | void {
+        const toModify: pxtc.SymbolInfo = blockInfo.apis.byQName[qName];
+        if (toModify) {
+            const comp = compileInfo(toModify);
+            const xml = createToolboxBlock(blockInfo, toModify, comp);
+            return mkCard(toModify, xml);
+        }
+    }
+
     function isSubtype(apis: pxtc.ApisInfo, specific: string, general: string) {
         if (specific == general) return true
         let inf = apis.byQName[specific]
@@ -916,7 +926,7 @@ namespace pxt.blocks {
      * Used by pxtrunner to initialize blocks in the docs
      */
     export function initializeAndInject(blockInfo: pxtc.BlocksInfo) {
-        init();
+        init(blockInfo);
         injectBlocks(blockInfo);
     }
 
@@ -925,12 +935,12 @@ namespace pxt.blocks {
      * Blocks are injected separately by called injectBlocks
      */
     export function initialize(blockInfo: pxtc.BlocksInfo) {
-        init();
+        init(blockInfo);
         initJresIcons(blockInfo);
     }
 
     let blocklyInitialized = false;
-    function init() {
+    function init(blockInfo: pxtc.BlocksInfo) {
         if (blocklyInitialized) return;
         blocklyInitialized = true;
 
@@ -944,7 +954,7 @@ namespace pxt.blocks {
         initFieldEditors();
         initContextMenu();
         initOnStart();
-        initMath();
+        initMath(blockInfo);
         initVariables();
         initFunctions();
         initLists();
@@ -1961,7 +1971,7 @@ namespace pxt.blocks {
         };
     }
 
-    function initMath() {
+    function initMath(blockInfo: pxtc.BlocksInfo) {
         // math_op2
         const mathOp2Id = "math_op2";
         const mathOp2Def = pxt.blocks.getBlockDefinition(mathOp2Id);
@@ -2012,6 +2022,7 @@ namespace pxt.blocks {
         // math_op3
         const mathOp3Id = "math_op3";
         const mathOp3Def = pxt.blocks.getBlockDefinition(mathOp3Id);
+        const mathOp3qName = "Math.abs";
         Blockly.Blocks[mathOp3Id] = {
             init: function () {
                 this.jsonInit({
@@ -2030,7 +2041,8 @@ namespace pxt.blocks {
                 });
 
                 setBuiltinHelpInfo(this, mathOp3Id);
-            }
+            },
+            codeCard: attachCardInfo(blockInfo, mathOp3qName)
         };
 
         // builtin math_number, math_integer, math_whole_number, math_number_minmax

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1102,7 +1102,7 @@ namespace pxt.blocks {
 
     export let openHelpUrl: (url: string) => void;
 
-    function initLists() {
+    function initLists(blockInfo : pxtc.BlocksInfo) {
         const msg = Blockly.Msg;
 
         // lists_create_with
@@ -1116,27 +1116,32 @@ namespace pxt.blocks {
 
         // lists_length
         const listsLengthId = "lists_length";
+        const listsLenghtqName = "Array.Length"
         const listsLengthDef = pxt.blocks.getBlockDefinition(listsLengthId);
         msg.LISTS_LENGTH_TITLE = listsLengthDef.block["LISTS_LENGTH_TITLE"];
 
         // We have to override this block definition because the builtin block
         // allows both Strings and Arrays in its input check and that confuses
         // our Blockly compiler
-        let block = Blockly.Blocks[listsLengthId];
-        block.init = function () {
-            this.jsonInit({
-                "message0": msg.LISTS_LENGTH_TITLE,
-                "args0": [
-                    {
-                        "type": "input_value",
-                        "name": "VALUE",
-                        "check": ['Array']
-                    }
-                ],
-                "output": 'Number',
-                "outputShape": Blockly.OUTPUT_SHAPE_ROUND
-            });
+        Blockly.Blocks[listsLengthId] = {
+            init: function () {
+                this.jsonInit({
+                    "message0": msg.LISTS_LENGTH_TITLE,
+                    "args0": [
+                        {
+                            "type": "input_value",
+                            "name": "VALUE",
+                            "check": ['Array']
+                        }
+                    ],
+                    "output": 'Number',
+                    "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+                });
+            },
+
+            codeCard: attachCardInfo(blockInfo, listsLenghtqName)
         }
+
 
         installBuiltinHelpInfo(listsLengthId);
     }
@@ -2776,7 +2781,7 @@ namespace pxt.blocks {
         installBuiltinHelpInfo(logicBooleanId);
     }
 
-    function initText() {
+    function initText(blockInfo: pxtc.BlocksInfo) {
         // builtin text
         const textInfo = pxt.blocks.getBlockDefinition('text');
         installHelpResources('text', textInfo.name, textInfo.tooltip, textInfo.url,
@@ -2787,26 +2792,30 @@ namespace pxt.blocks {
         // builtin text_length
         const msg = Blockly.Msg;
         const textLengthId = "text_length";
+        const textLengthqName = "String.Length"
         const textLengthDef = pxt.blocks.getBlockDefinition(textLengthId);
         msg.TEXT_LENGTH_TITLE = textLengthDef.block["TEXT_LENGTH_TITLE"];
 
         // We have to override this block definition because the builtin block
         // allows both Strings and Arrays in its input check and that confuses
         // our Blockly compiler
-        let block = Blockly.Blocks[textLengthId];
-        block.init = function () {
-            this.jsonInit({
-                "message0": msg.TEXT_LENGTH_TITLE,
-                "args0": [
-                    {
-                        "type": "input_value",
-                        "name": "VALUE",
-                        "check": ['String']
-                    }
-                ],
-                "output": 'Number',
-                "outputShape": Blockly.OUTPUT_SHAPE_ROUND
-            });
+        Blockly.Blocks[textLengthId] = {
+            init: function () {
+                this.jsonInit({
+                    "message0": msg.TEXT_LENGTH_TITLE,
+                    "args0": [
+                        {
+                            "type": "input_value",
+                            "name": "VALUE",
+                            "check": ['String']
+                        }
+                    ],
+                    "output": 'Number',
+                    "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+                });
+            },
+
+            codeCard: attachCardInfo(blockInfo, textLengthqName)
         }
         installBuiltinHelpInfo(textLengthId);
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1116,7 +1116,7 @@ namespace pxt.blocks {
 
         // lists_length
         const listsLengthId = "lists_length";
-        const listsLenghtqName = "Array.Length"
+        const listsLengthqName = "Array.Length"
         const listsLengthDef = pxt.blocks.getBlockDefinition(listsLengthId);
         msg.LISTS_LENGTH_TITLE = listsLengthDef.block["LISTS_LENGTH_TITLE"];
 
@@ -1139,7 +1139,7 @@ namespace pxt.blocks {
                 });
             },
 
-            codeCard: attachCardInfo(blockInfo, listsLenghtqName)
+            codeCard: attachCardInfo(blockInfo, listsLengthqName)
         }
 
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -2,7 +2,6 @@
 /// <reference path="../built/pxtlib.d.ts" />
 
 namespace pxt.blocks {
-
     export let promptTranslateBlock: (blockId: string, blockTranslationIds: string[]) => void;
 
     export interface GrayBlock extends Blockly.Block {
@@ -547,15 +546,6 @@ namespace pxt.blocks {
         }
     }
 
-    function attachCardInfo(blockInfo: pxtc.BlocksInfo, qName: string): pxt.CodeCard | void {
-        const toModify: pxtc.SymbolInfo = blockInfo.apis.byQName[qName];
-        if (toModify) {
-            const comp = compileInfo(toModify);
-            const xml = createToolboxBlock(blockInfo, toModify, comp);
-            return mkCard(toModify, xml);
-        }
-    }
-
     function isSubtype(apis: pxtc.ApisInfo, specific: string, general: string) {
         if (specific == general) return true
         let inf = apis.byQName[specific]
@@ -926,7 +916,7 @@ namespace pxt.blocks {
      * Used by pxtrunner to initialize blocks in the docs
      */
     export function initializeAndInject(blockInfo: pxtc.BlocksInfo) {
-        init(blockInfo);
+        init();
         injectBlocks(blockInfo);
     }
 
@@ -935,12 +925,12 @@ namespace pxt.blocks {
      * Blocks are injected separately by called injectBlocks
      */
     export function initialize(blockInfo: pxtc.BlocksInfo) {
-        init(blockInfo);
+        init();
         initJresIcons(blockInfo);
     }
 
     let blocklyInitialized = false;
-    function init(blockInfo: pxtc.BlocksInfo) {
+    function init() {
         if (blocklyInitialized) return;
         blocklyInitialized = true;
 
@@ -954,7 +944,7 @@ namespace pxt.blocks {
         initFieldEditors();
         initContextMenu();
         initOnStart();
-        initMath(blockInfo);
+        initMath();
         initVariables();
         initFunctions();
         initLists(blockInfo);
@@ -1976,7 +1966,7 @@ namespace pxt.blocks {
         };
     }
 
-    function initMath(blockInfo: pxtc.BlocksInfo) {
+    function initMath() {
         // math_op2
         const mathOp2Id = "math_op2";
         const mathOp2Def = pxt.blocks.getBlockDefinition(mathOp2Id);
@@ -2027,7 +2017,6 @@ namespace pxt.blocks {
         // math_op3
         const mathOp3Id = "math_op3";
         const mathOp3Def = pxt.blocks.getBlockDefinition(mathOp3Id);
-        const mathOp3qName = "Math.abs";
         Blockly.Blocks[mathOp3Id] = {
             init: function () {
                 this.jsonInit({
@@ -2046,8 +2035,7 @@ namespace pxt.blocks {
                 });
 
                 setBuiltinHelpInfo(this, mathOp3Id);
-            },
-            codeCard: attachCardInfo(blockInfo, mathOp3qName)
+            }
         };
 
         // builtin math_number, math_integer, math_whole_number, math_number_minmax


### PR DESCRIPTION
In the Guitar Project for micro:bit, a link to the docs page for Math.abs was broken. Thanks to the edits suggested in the attached issue, the link is no longer broken.

Quick video demonstrating the fix: https://user-images.githubusercontent.com/49178322/186541056-5f59059c-70b3-4094-90e6-64ca0f4368f1.mp4

Closes: https://github.com/microsoft/pxt/issues/8142

**Updates:**
>A block now displays on the `abs` card because, as @jwunderl suggested, the real fix lied within code. When blocks are initialized, the function `mkCard()` is run for those that have the `codeCard` field in their object definition. `mkCard()` pre-pends a block's defined 'help' URL with `/reference` so the redirect takes the user to the specified block's docs page. 

<img width="281" alt="block-card" src="https://user-images.githubusercontent.com/49178322/188245269-83932248-e01b-4688-b6d2-a551f5235cc3.png">


This fix adds the `codeCard` field to the special case blocks `Math.abs`, `Math.min`, and `Math.max`.

_**Important note**_ 
The solution for `Math.min` and `Math.max` is not ideal. These blocks have the same special-cased **blockId** `math_op2` but have different **qNames**. A `qName` is needed with this solution as it is the entry point to retrieve the block's `SymbolInfo` which is needed for `mkCard()`. Currently, the hardcoded qName used is 'Math.min'. The hardcoded qName makes it so that, in markdown that uses `Math.min(x,y)` or `Math.max(x,y)` cards, the card displays the min block, description, and, when clicked, directs to the min doc page. The bottom of the min doc page has a link to the max doc page since they are related to each other. This is, with this fix, the only way to reach the max block and doc page through cards.  
Ideally, we would be able to grab which function is being called in markdown (min or max). However, since `codeCard` is being set on block initialization, it is a bit tricky and out of scope for this PR/issue.