### PR TITLE
Don't override the compile variant when setting up the app target

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2268,6 +2268,7 @@ async function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
 
     cfg.bundledpkgs = {}
     pxt.setAppTarget(cfg);
+    pxt.reloadAppTargetVariant();
     dirsToWatch = cfg.bundleddirs.slice()
     if (pxt.appTarget.id != "core") {
         if (fs.existsSync("theme")) {


### PR DESCRIPTION
Fixes the local build for codal in pxt-microbit