### PR TITLE
Check to make sure blocks still exist before decompiling

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -315,4 +315,23 @@ namespace pxt.blocks {
             }
         })
     }
+
+    export function validateAllReferencedBlocksExist(xml: string) {
+        pxt.U.assert(!!Blockly?.Blocks, "Called validateAllReferencedBlocksExist before initializing Blockly");
+        const dom = Blockly.Xml.textToDom(xml);
+
+        const blocks = dom.querySelectorAll("block");
+
+        for (let i = 0; i < blocks.length; i++) {
+            if (!Blockly.Blocks[blocks.item(i).getAttribute("type")]) return false;
+        }
+
+        const shadows = dom.querySelectorAll("shadow");
+
+        for (let i = 0; i < shadows.length; i++) {
+            if (!Blockly.Blocks[shadows.item(i).getAttribute("type")]) return false;
+        }
+
+        return true;
+    }
 }

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -17,6 +17,7 @@ namespace pxt.blocks.layout {
         const newDom = Blockly.Xml.workspaceToDom(newWs, true);
         Util.toArray(oldDom.childNodes)
             .filter((n: ChildNode) => n.nodeType == Node.ELEMENT_NODE && (n as Element).localName == "block" && (<Element>n).getAttribute("disabled") == "true")
+            .filter((n: Element) => !!Blockly.Blocks[n.getAttribute("type")])
             .forEach(n => newDom.appendChild(newDom.ownerDocument.importNode(n, true)));
         const updatedXml = Blockly.Xml.domToText(newDom);
         return updatedXml;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -481,7 +481,13 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 .then(() => compiler.getBlocksAsync())
                 .then((bi: pxtc.BlocksInfo) => {
                     blocksInfo = bi;
+                    pxt.blocks.cleanBlocks();
                     pxt.blocks.initializeAndInject(blocksInfo);
+
+                    // It's possible that the extensions changed and some blocks might not exist anymore
+                    if (!pxt.blocks.validateAllReferencedBlocksExist(mainPkg.files[blockFile].content)) {
+                        return [undefined, true];
+                    }
                     const oldWorkspace = pxt.blocks.loadWorkspaceXml(mainPkg.files[blockFile].content);
                     if (oldWorkspace) {
                         return pxt.blocks.compileAsync(oldWorkspace, blocksInfo).then((compilationResult) => {


### PR DESCRIPTION
This fixes a pretty bad bug that i found yesterday while helping some folks on the forum. To repro the bug:

1. Create a new project and make a sprite
2. Add an extension to the project
3. Drag out a block from the extension so that it's disabled (not attached to anything)
4. Switch to JavaScript and remove the extension using the file explorer
5. Switch back to blocks and see that your project is broken and all assets are deleted

The issue had to do with disabled blocks specifically. When we decompile, the process looks something like this:

1. First we check to see if we have an existing workspace lying around from the last time the project was in blocks
2. If we do, we compile that workspace to TypeScript
3. If the compiled TypeScript is the same as the current content of the text editor, then we skip the decompile since nothing changed

This works well for the main program, but it ignores disabled blocks entirely since they don't affect the output of the compile. Even if we did decompile, we actually inject the old disabled blocks into the workspace (we keep them around so that they don't disappear when the user makes changes in TS). If one of those disabled blocks doesn't exist because the extension that defines it was removed, then we get an exception when attempting to load the workspace and it breaks the project.

This PR fixes the problem by explicitly validating that all blocks exist when doing the decompile rigamarole. 