### PR TITLE
Changed division symbol to '/' for math blocks.

### DIFF
--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -455,7 +455,7 @@ namespace pxt.blocks {
                     MATH_ADDITION_SYMBOL: Util.lf("{id:op}+"),
                     MATH_SUBTRACTION_SYMBOL: Util.lf("{id:op}-"),
                     MATH_MULTIPLICATION_SYMBOL: Util.lf("{id:op}×"),
-                    MATH_DIVISION_SYMBOL: Util.lf("{id:op}÷"),
+                    MATH_DIVISION_SYMBOL: Util.lf("{id:op}/"),
                     MATH_POWER_SYMBOL: Util.lf("{id:op}**")
                 }
             },
@@ -465,7 +465,7 @@ namespace pxt.blocks {
                 url: '/blocks/math',
                 category: 'math',
                 block: {
-                    MATH_MODULO_TITLE: Util.lf("remainder of %1 ÷ %2")
+                    MATH_MODULO_TITLE: Util.lf("remainder of %1 / %2")
                 }
             },
             'math_js_op': {
@@ -494,7 +494,7 @@ namespace pxt.blocks {
                     "acos": Util.lf("{id:op}acos"),
                     "tan": Util.lf("{id:op}tan"),
                     "atan2": Util.lf("{id:op}atan2"),
-                    "idiv": Util.lf("{id:op}integer ÷"),
+                    "idiv": Util.lf("{id:op}integer /"),
                     "imul": Util.lf("{id:op}integer ×"),
                 }
             },


### PR DESCRIPTION
Because of how the symbols are rendered, it is hard to tell the difference between a plus sign and the division symbol in the math blocks. This PR changes the classic division symbol to a '/' so there is a noticeable difference between addition and division. 

**Before:**
<img width="173" alt="traditional-division" src="https://user-images.githubusercontent.com/49178322/186998782-bbf26c40-b8d4-42e8-be1a-6b2d6520532a.png">

**After:**
<img width="169" alt="division-forward-slash" src="https://user-images.githubusercontent.com/49178322/186998797-bcd76d0e-1bd7-4dd8-8085-590446e458f6.png">


Closes: https://github.com/microsoft/pxt/issues/7907 