### PR TITLE
Add support for `blockconfig` tutorial sections

### DIFF
--- a/docs/writing-docs/tutorials/basics.md
+++ b/docs/writing-docs/tutorials/basics.md
@@ -168,27 +168,32 @@ forever(function() {
 ```
 ````
 
-## Reconfiguring blocks in toolbox (`blockconfig`)
+## Reconfiguring blocks in the toolbox (`blockconfig.local` and `blockconfig.global` sections)
 
-If you want to change the default parameters on an existing block, use a `blockconfig` section. A `blockconfig` contains a JavaScript snippet that defines one or more functions or operations. If the function is a handler, e.g. `sprites.onOverlap`, the handler may contain a code snippet.
+If you want to change the default parameters on an existing block as it appears in the toolbox, use a blockconfig section. A blockconfig contains a JavaScript snippet that defines one or more functions or operations along with their default arguments.
+
+There are two kinds of blockconfig sections: `blockconfig.local` and `blockconfig.global`. The global blockconfig can appear anywhere in the tutorial markdown, and the customizations it contains are applied globally, i.e. to all tutorial steps. Local blockconfigs must appear within a tutorial step, and apply to that step only. Local blockconfigs take precedence over global ones.
 
 ### Limitations
 
-* Declaring custom assets is not supported. You cannot set a custom image on a sprite, or declare a tilemap. We are thinking through how to support this, and may come in the future!
+* Declaring custom assets is not supported yet. This means you will not be able to set a custom image on sprite creation, for example. We are thinking through how to support this, and it may come in the future!
+* `blockconfig.local` sections have a performance impact on the toolbox. They aren't able to take advantage of previously cached toolbox contents and must regenerate it each time.
 
 ### Examples
 
-**Set the default background color to green**
+**Set the default background color to green. Apply globally**
 
 ````
-```blockconfig
+```blockconfig.global
 scene.setBackgroundColor(7)
 ```
 ````
 
-**When Player sprite overlaps with Food**
+**When Player sprite overlaps with Food. Apply to the current tutorial step only**
 ````
-```blockconfig
+### {Step 3}
+
+```blockconfig.local
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
 })
 ```
@@ -196,7 +201,7 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSpr
 
 **When Player sprite overlaps with Food, with embedded code snippet**
 ````
-```blockconfig
+```blockconfig.global
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
     info.changeScoreBy(1)
 })
@@ -205,7 +210,7 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSpr
 
 **Creating an Enemy sprite**
 ````
-```blockconfig
+```blockconfig.global
 let myEnemy = sprites.create(img``, SpriteKind.Enemy)
 ```
 ````
@@ -214,7 +219,7 @@ let myEnemy = sprites.create(img``, SpriteKind.Enemy)
 
 **Change default sprite position to the center of the screen**
 ````
-```blockconfig
+```blockconfig.global
 let mySprite: Sprite = null
 mySprite.setPosition(80, 60)
 ```
@@ -224,7 +229,7 @@ mySprite.setPosition(80, 60)
 
 **Place sprite in random location**
 ````
-```blockconfig
+```blockconfig.global
 let mySprite: Sprite = null
 mySprite.setPosition(randint(0, scene.screenWidth()), randint(0, scene.screenHeight()))
 ```
@@ -232,14 +237,14 @@ mySprite.setPosition(randint(0, scene.screenWidth()), randint(0, scene.screenHei
 
 **Change random number range**
 ````
-```blockconfig
+```blockconfig.global
 randint(-10, 10)
 ```
 ````
 
-**Multiple reconfigured blocks in a single blockconfig section**
+**Multiple reconfigured blocks in a single blockconfig**
 ````
-```blockconfig
+```blockconfig.global
 randint(-10, 10)
 let mySprite: Sprite = null
 mySprite = sprites.create(img``, SpriteKind.Enemy)
@@ -251,7 +256,7 @@ mySprite.setPosition(randint(0, scene.screenWidth()), randint(0, scene.screenHei
 
 If your reconfigured block isn't showing up in the toolbox, look for errors like this one in the debug console:
 
-`Failed to resolve block config xml for tutorial`
+`Failed to resolve block config for tutorial`
 
 Followed by a more detailed error message. The most common error you're likely to see is:
 

--- a/docs/writing-docs/tutorials/basics.md
+++ b/docs/writing-docs/tutorials/basics.md
@@ -168,6 +168,100 @@ forever(function() {
 ```
 ````
 
+## Reconfiguring blocks in toolbox (`blockconfig`)
+
+If you want to change the default parameters on an existing block, use a `blockconfig` section. A `blockconfig` contains a JavaScript snippet that defines one or more functions or operations. If the function is a handler, e.g. `sprites.onOverlap`, the handler may contain a code snippet.
+
+### Limitations
+
+* Declaring custom assets is not supported. You cannot set a custom image on a sprite, or declare a tilemap. We are thinking through how to support this, and may come in the future!
+
+### Examples
+
+**Set the default background color to green**
+
+````
+```blockconfig
+scene.setBackgroundColor(7)
+```
+````
+
+**When Player sprite overlaps with Food**
+````
+```blockconfig
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+})
+```
+````
+
+**When Player sprite overlaps with Food, with embedded code snippet**
+````
+```blockconfig
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+    info.changeScoreBy(1)
+})
+```
+````
+
+**Creating an Enemy sprite**
+````
+```blockconfig
+let myEnemy = sprites.create(img``, SpriteKind.Enemy)
+```
+````
+
+> **Note the empty image.** blockconfigs don't yet work with custom assets (images, tilemaps, etc)!
+
+**Change default sprite position to the center of the screen**
+````
+```blockconfig
+let mySprite: Sprite = null
+mySprite.setPosition(80, 60)
+```
+````
+
+> Note here the declaration of `mySprite`. Variables used in the snippet must be declared so the decompiler can resolve the datatypes.
+
+**Place sprite in random location**
+````
+```blockconfig
+let mySprite: Sprite = null
+mySprite.setPosition(randint(0, scene.screenWidth()), randint(0, scene.screenHeight()))
+```
+````
+
+**Change random number range**
+````
+```blockconfig
+randint(-10, 10)
+```
+````
+
+**Multiple reconfigured blocks in a single blockconfig section**
+````
+```blockconfig
+randint(-10, 10)
+let mySprite: Sprite = null
+mySprite = sprites.create(img``, SpriteKind.Enemy)
+mySprite.setPosition(randint(0, scene.screenWidth()), randint(0, scene.screenHeight()))
+```
+````
+
+### Troubleshooting blockconfigs
+
+If your reconfigured block isn't showing up in the toolbox, look for errors like this one in the debug console:
+
+`Failed to resolve block config xml for tutorial`
+
+Followed by a more detailed error message. The most common error you're likely to see is:
+
+`Block config decompiled to gray block`
+
+Gray blocks will be generated when not all datatypes are known (e.g. `mySprite` used, but not declared), or when a function name is misspelled.
+
+If you don't see an error message, try adding the `dbg=1` URL parameter and reload. This will output some information about each blockconfig to the console, and should provide a clue about what is failing.
+
+
 ## Accordion/hidden hints
 If you want to provide extra information without having to divert the coder's attention, you can include content in an "accordion" style hint control. 
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1146,8 +1146,8 @@ declare namespace pxt.tutorial {
         // fullscreen?: boolean; // DEPRECATED, replaced by "showHint"
         // unplugged?: boolean: // DEPRECATED, replaced by "showDialog"
 
-        // `blockconfig` sections
-        blockConfigs?: pxt.tutorial.TutorialBlockConfig[];
+        // concatenated `blockconfig` sections
+        blockConfig?: pxt.tutorial.TutorialBlockConfig;
     }
 
     interface TutorialActivityInfo {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -995,6 +995,7 @@ declare namespace ts.pxtc {
         skipPxtModulesEmit?: boolean; // skip re-emit of pxt_modules/*
         clearIncrBuildAndRetryOnError?: boolean; // on error when compiling in service, try again with a full recompile.
         errorOnGreyBlocks?: boolean;
+        generateSourceMap?: boolean;
 
         otherMultiVariants?: ExtensionTarget[];
 
@@ -1113,6 +1114,16 @@ declare namespace pxt.tutorial {
         blockIds?: string[];
     }
 
+    interface TutorialBlockConfigEntry {
+        blockId?: string;
+        xml?: string;
+    }
+
+    interface TutorialBlockConfig {
+        md?: string;    // `blockconfig` markdown fragment
+        blocks?: TutorialBlockConfigEntry[]; // markdown fragment can contain multiple block definitions
+    }
+
     interface TutorialStepInfo {
         // Step metadata
         showHint?: boolean; // automatically displays hint
@@ -1134,6 +1145,9 @@ declare namespace pxt.tutorial {
         hintContentMd?: string;
         // fullscreen?: boolean; // DEPRECATED, replaced by "showHint"
         // unplugged?: boolean: // DEPRECATED, replaced by "showDialog"
+
+        // `blockconfig` sections
+        blockConfigs?: pxt.tutorial.TutorialBlockConfig[];
     }
 
     interface TutorialActivityInfo {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1089,6 +1089,7 @@ declare namespace pxt.tutorial {
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
         customTs?: string; // custom typescript code loaded in a separate file for the tutorial
         tutorialValidationRules?: pxt.Map<boolean>; //a map of rules used in a tutorial and if the rules are activated
+        globalBlockConfig?: TutorialBlockConfig; // concatenated `blockconfig.global` sections. Contains block configs applicable to all tutorial steps
     }
 
     interface TutorialMetadata {
@@ -1146,8 +1147,8 @@ declare namespace pxt.tutorial {
         // fullscreen?: boolean; // DEPRECATED, replaced by "showHint"
         // unplugged?: boolean: // DEPRECATED, replaced by "showDialog"
 
-        // concatenated `blockconfig` sections
-        blockConfig?: pxt.tutorial.TutorialBlockConfig;
+        // concatenated `blockconfig.local` sections. Contains block configs applicable to the current step only
+        localBlockConfig?: pxt.tutorial.TutorialBlockConfig;
     }
 
     interface TutorialActivityInfo {
@@ -1179,6 +1180,7 @@ declare namespace pxt.tutorial {
         customTs?: string; // custom typescript code loaded in a separate file for the tutorial
         tutorialValidationRules?: pxt.Map<boolean>; //a map of rules used in a tutorial and if the rules are activated
         templateLoaded?: boolean; // if the template code has been loaded once, we skip
+        globalBlockConfig?: TutorialBlockConfig; // concatenated `blockconfig.global` sections. Contains block configs applicable to all tutorial steps
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/pxtblocks/fields/field_kind.ts
+++ b/pxtblocks/fields/field_kind.ts
@@ -54,7 +54,7 @@ namespace pxtblockly {
             const res: string[][] = [];
 
             const that = this as FieldKind;
-            if (that.sourceBlock_ && that.sourceBlock_.workspace) {
+            if (that.sourceBlock_ && that.sourceBlock_.workspace && !that.sourceBlock_.isInFlyout) {
                 const options = that.sourceBlock_.workspace.getVariablesOfType(kindType(opts.name));
                 options.forEach(model => {
                     res.push([model.name, model.name]);

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -2759,7 +2759,7 @@ ${output}</xml>`;
                     if (alias) {
                         info.decompilerBlockAlias = env.aliasBlocks[info.qName];
                     }
-                    else {
+                    else if (!env.opts.snippetMode) {
                         return Util.lf("No output expressions as statements");
                     }
                 }

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -297,7 +297,7 @@ namespace ts.pxtc {
             snippetMode: opts.snippetMode || false,
             alwaysEmitOnStart: opts.alwaysDecompileOnStart,
             includeGreyBlockMessages,
-            generateSourceMap: !!opts.ast,
+            generateSourceMap: opts.generateSourceMap !== undefined ? opts.generateSourceMap : !!opts.ast,
             allowedArgumentTypes: opts.allowedArgumentTypes || ["number", "boolean", "string"],
             errorOnGreyBlocks: !!opts.errorOnGreyBlocks
         };
@@ -316,7 +316,7 @@ namespace ts.pxtc {
             snippetMode: opts.snippetMode || false,
             alwaysEmitOnStart: opts.alwaysDecompileOnStart,
             includeGreyBlockMessages,
-            generateSourceMap: !!opts.ast,
+            generateSourceMap: opts.generateSourceMap !== undefined ? opts.generateSourceMap : !!opts.ast,
             allowedArgumentTypes: opts.allowedArgumentTypes || ["number", "boolean", "string"],
             errorOnGreyBlocks: !!opts.errorOnGreyBlocks
         };

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -31,6 +31,7 @@ namespace pxt.tutorial {
         }
 
         const assetFiles = parseAssetJson(assetJson);
+        const globalBlockConfig = parseTutorialBlockConfig("global", tutorialmd);
 
         // strip hidden snippets
         steps.forEach(step => {
@@ -52,7 +53,8 @@ namespace pxt.tutorial {
             jres,
             assetFiles,
             customTs,
-            tutorialValidationRules
+            tutorialValidationRules,
+            globalBlockConfig
         };
     }
 
@@ -80,7 +82,8 @@ namespace pxt.tutorial {
                 switch (m1) {
                     case "block":
                     case "blocks":
-                    case "blockconfig":
+                    case "blockconfig.local":
+                    case "blockconfig.global":
                     case "requiredTutorialBlock":
                     case "filterblocks":
                         if (!checkTutorialEditor(pxt.BLOCKS_PROJECT_NAME))
@@ -245,7 +248,7 @@ ${code}
         markdown.replace(stepRegex, function (match, flags, step) {
             step = step.trim();
             let { header, hint, requiredBlocks } = parseTutorialHint(step, metadata && metadata.explicitHints, metadata.tutorialCodeValidation);
-            const blockConfig = parseTutorialBlockConfig(step);
+            const blockConfig = parseTutorialBlockConfig("local", step);
 
             // if title is not hidden ("{TITLE HERE}"), strip flags
             const title = !flags.match(/^\{.*\}$/)
@@ -256,7 +259,7 @@ ${code}
                 title,
                 contentMd: step,
                 headerContentMd: header,
-                blockConfig
+                localBlockConfig: blockConfig
             }
             if (/@(fullscreen|unplugged|showdialog|showhint)/i.test(flags))
                 info.showHint = true;
@@ -316,12 +319,13 @@ ${code}
         return { header, hint, requiredBlocks };
     }
 
-    function parseTutorialBlockConfig(step: string): TutorialBlockConfig {
+    function parseTutorialBlockConfig(scope: "local" | "global", content: string): TutorialBlockConfig {
         let blockConfig: pxt.tutorial.TutorialBlockConfig = {
             md: "",
             blocks: [],
         };
-        step.replace(/```\s*blockconfig\s*\n([\s\S]*?)\n```/gmi, function (m0, m1) {
+        const regex = new RegExp(`\`\`\`\\s*blockconfig\\.${scope}\\s*\\n([\\s\\S]*?)\\n\`\`\``, "gmi");
+        content.replace(regex, (m0, m1) => {
             blockConfig.md += `${m1}\n`;
             return "";
         });
@@ -343,7 +347,7 @@ ${code}
     /* Remove hidden snippets from text */
     function stripHiddenSnippets(str: string): string {
         if (!str) return str;
-        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template|jres|assetjson|customts|blockconfig)\s*\n([\s\S]*?)\n```/gmi;
+        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template|jres|assetjson|customts|blockconfig\.local|blockconfig\.global)\s*\n([\s\S]*?)\n```/gmi;
         return str.replace(hiddenSnippetRegex, '').trim();
     }
 
@@ -431,7 +435,8 @@ ${code}
             jres: tutorialInfo.jres,
             assetFiles: tutorialInfo.assetFiles,
             customTs: tutorialInfo.customTs,
-            tutorialValidationRules: tutorialInfo.tutorialValidationRules
+            tutorialValidationRules: tutorialInfo.tutorialValidationRules,
+            globalBlockConfig: tutorialInfo.globalBlockConfig
         };
 
         return { options: tutorialOptions, editor: tutorialInfo.editor };

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -80,6 +80,7 @@ namespace pxt.tutorial {
                 switch (m1) {
                     case "block":
                     case "blocks":
+                    case "blockconfig":
                     case "requiredTutorialBlock":
                     case "filterblocks":
                         if (!checkTutorialEditor(pxt.BLOCKS_PROJECT_NAME))
@@ -244,6 +245,7 @@ ${code}
         markdown.replace(stepRegex, function (match, flags, step) {
             step = step.trim();
             let { header, hint, requiredBlocks } = parseTutorialHint(step, metadata && metadata.explicitHints, metadata.tutorialCodeValidation);
+            const blockConfigs = parseTutorialBlockConfigs(step);
 
             // if title is not hidden ("{TITLE HERE}"), strip flags
             const title = !flags.match(/^\{.*\}$/)
@@ -253,7 +255,8 @@ ${code}
             let info: TutorialStepInfo = {
                 title,
                 contentMd: step,
-                headerContentMd: header
+                headerContentMd: header,
+                blockConfigs
             }
             if (/@(fullscreen|unplugged|showdialog|showhint)/i.test(flags))
                 info.showHint = true;
@@ -313,6 +316,15 @@ ${code}
         return { header, hint, requiredBlocks };
     }
 
+    function parseTutorialBlockConfigs(step: string): TutorialBlockConfig[] {
+        let blockConfigs: pxt.tutorial.TutorialBlockConfig[] = [];
+        step.replace(/```\s*blockconfig\s*\n([\s\S]*?)\n```/gmi, function (m0, m1) {
+            blockConfigs.push({ md: m1 });
+            return "";
+        });
+        return blockConfigs;
+    }
+
     function categorizingValidationRules(listOfRules: pxt.Map<boolean>, title: string) {
         const ruleNames = Object.keys(listOfRules);
         for (let i = 0; i < ruleNames.length; i++) {
@@ -328,7 +340,7 @@ ${code}
     /* Remove hidden snippets from text */
     function stripHiddenSnippets(str: string): string {
         if (!str) return str;
-        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template|jres|assetjson|customts)\s*\n([\s\S]*?)\n```/gmi;
+        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template|jres|assetjson|customts|blockconfig)\s*\n([\s\S]*?)\n```/gmi;
         return str.replace(hiddenSnippetRegex, '').trim();
     }
 

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -245,7 +245,7 @@ ${code}
         markdown.replace(stepRegex, function (match, flags, step) {
             step = step.trim();
             let { header, hint, requiredBlocks } = parseTutorialHint(step, metadata && metadata.explicitHints, metadata.tutorialCodeValidation);
-            const blockConfigs = parseTutorialBlockConfigs(step);
+            const blockConfig = parseTutorialBlockConfig(step);
 
             // if title is not hidden ("{TITLE HERE}"), strip flags
             const title = !flags.match(/^\{.*\}$/)
@@ -256,7 +256,7 @@ ${code}
                 title,
                 contentMd: step,
                 headerContentMd: header,
-                blockConfigs
+                blockConfig
             }
             if (/@(fullscreen|unplugged|showdialog|showhint)/i.test(flags))
                 info.showHint = true;
@@ -316,13 +316,16 @@ ${code}
         return { header, hint, requiredBlocks };
     }
 
-    function parseTutorialBlockConfigs(step: string): TutorialBlockConfig[] {
-        let blockConfigs: pxt.tutorial.TutorialBlockConfig[] = [];
+    function parseTutorialBlockConfig(step: string): TutorialBlockConfig {
+        let blockConfig: pxt.tutorial.TutorialBlockConfig = {
+            md: "",
+            blocks: [],
+        };
         step.replace(/```\s*blockconfig\s*\n([\s\S]*?)\n```/gmi, function (m0, m1) {
-            blockConfigs.push({ md: m1 });
+            blockConfig.md += `${m1}\n`;
             return "";
         });
-        return blockConfigs;
+        return blockConfig;
     }
 
     function categorizingValidationRules(listOfRules: pxt.Map<boolean>, title: string) {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -1252,10 +1252,16 @@ namespace pxt.runner {
     }
 
     function renderBlockConfig(options: ClientRenderOptions) {
-        let c = $('code.lang-blockconfig');
-        if (options.snippetReplaceParent)
-            c = c.parent();
-        c.remove();
+        function render(scope: "local" | "global") {
+            $(`code.lang-blockconfig.${scope}`).each((i, c) => {
+                let $c = $(c);
+                if (options.snippetReplaceParent)
+                    $c = $c.parent();
+                $c.remove();
+            });
+        }
+        render("local");
+        render("global");
     }
 
     function renderSims(options: ClientRenderOptions) {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -1251,6 +1251,13 @@ namespace pxt.runner {
         c.remove();
     }
 
+    function renderBlockConfig(options: ClientRenderOptions) {
+        let c = $('code.lang-blockconfig');
+        if (options.snippetReplaceParent)
+            c = c.parent();
+        c.remove();
+    }
+
     function renderSims(options: ClientRenderOptions) {
         if (!options.simulatorClass) return;
         // simulators
@@ -1289,6 +1296,7 @@ namespace pxt.runner {
 
         renderQueue = [];
         renderGhost(options);
+        renderBlockConfig(options);
         renderSims(options);
         renderTypeScript(options);
         renderDirectPython(options);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1777,7 +1777,7 @@ export class ProjectView
             return;
         const resolveBlockConfigAsync = async (blockConfig: pxt.tutorial.TutorialBlockConfig): Promise<void> => {
             if (blockConfig.blocks?.length) {
-                // `blockConfig.blocks` is already populated. This information is saved in the project header, so this happens when the tutorial project is reloaded.
+                // Already populated? This is a project reload from previous save.
                 return;
             }
             blockConfig.blocks = [];
@@ -1851,10 +1851,10 @@ export class ProjectView
         };
         const tasks: Promise<void>[] = [];
         const stepInfo = header.tutorial.tutorialStepInfo;
-        stepInfo.forEach(step => {
-            const blockConfigs = step.blockConfigs ?? [];
-            blockConfigs.forEach(blockConfig => tasks.push(resolveBlockConfigAsync(blockConfig)));
-        });
+        stepInfo
+            .map(step => step.blockConfig)
+            .filter(blockConfig => blockConfig?.md)
+            .forEach(blockConfig => tasks.push(resolveBlockConfigAsync(blockConfig)));
         await Promise.all(tasks);
     }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1745,16 +1745,13 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 // If we're in a tutorial and the current step defines a custon block config, use that.
                 const currTutorialStep = this.parent.state.tutorialOptions?.tutorialStep;
                 const currTutorialStepInfo = currTutorialStep !== undefined ? this.parent.state.tutorialOptions.tutorialStepInfo[currTutorialStep] : undefined;
-                if (currTutorialStepInfo?.blockConfigs) {
-                    const blockConfigs = currTutorialStepInfo.blockConfigs;
-                    for (const blockConfig of blockConfigs) {
-                        const entry = blockConfig.blocks.find(entry => entry.blockId === block.attributes.blockId);
-                        if (entry) {
-                            blockXml = Blockly.Xml.textToDom(entry.xml);
-                            blockXml.setAttribute("gap", `${pxt.appTarget.appTheme
-                                && pxt.appTarget.appTheme.defaultBlockGap && pxt.appTarget.appTheme.defaultBlockGap.toString() || 8}`);
-                            break;
-                        }
+                if (currTutorialStepInfo?.blockConfig?.blocks) {
+                    const blockConfig = currTutorialStepInfo.blockConfig;
+                    const entry = blockConfig.blocks.find(entry => entry.blockId === block.attributes.blockId);
+                    if (entry) {
+                        blockXml = Blockly.Xml.textToDom(entry.xml);
+                        blockXml.setAttribute("gap", `${pxt.appTarget.appTheme
+                            && pxt.appTarget.appTheme.defaultBlockGap && pxt.appTarget.appTheme.defaultBlockGap.toString() || 8}`);
                     }
                 }
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -292,13 +292,17 @@ export function decompileAsync(fileName: string, blockInfo?: ts.pxtc.BlocksInfo,
 }
 
 // TS -> blocks, load blocs before calling this api
-export function decompileBlocksSnippetAsync(code: string, blockInfo?: ts.pxtc.BlocksInfo, dopts?: { snippetMode?: boolean }): Promise<pxtc.CompileResult> {
+export function decompileBlocksSnippetAsync(code: string, blockInfo?: ts.pxtc.BlocksInfo, dopts?: {
+    snippetMode?: boolean,
+    generateSourceMap?: boolean
+}): Promise<pxtc.CompileResult> {
     const trg = pkg.mainPkg.getTargetOptions()
     return pkg.mainPkg.getCompileOptionsAsync(trg)
         .then(opts => {
             opts.fileSystem[pxt.MAIN_TS] = code;
             opts.fileSystem[pxt.MAIN_BLOCKS] = "";
             opts.snippetMode = (dopts && dopts.snippetMode) || false;
+            opts.generateSourceMap = dopts?.generateSourceMap;
 
             if (opts.sourceFiles.indexOf(pxt.MAIN_TS) === -1) {
                 opts.sourceFiles.push(pxt.MAIN_TS);


### PR DESCRIPTION
`blockconfig` sections give tutorials the ability to reconfigure blocks in the toolbox, giving them different default parameters. Example:

**When player overlaps food**
This is a "local" block config, applies to the tutorial step in which it appears
````
```blockconfig.local
sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
})
```
````
Resulting block in toolbox
![image](https://user-images.githubusercontent.com/12176807/186999971-4505bb1d-b534-4677-977a-e87f5338be97.png)

**Multiple blocks can be configured in one blockconfig**
This is a "global" block config, and applies to the entire tutorial.
````
```blockconfig.global
randint(-10, 10)
let mySprite: Sprite = null
mySprite = sprites.create(img``, SpriteKind.Enemy)
mySprite.setPosition(randint(0, scene.screenWidth()), randint(0, scene.screenHeight()))
```
````

**Handler blocks can contain code snippets**
````
```blockconfig.global
sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
    info.changeScoreBy(1)
})
```
````



### limitations
1. blockconfigs do not support custom assets yet. Passing a custom sprite to sprite.create will not work currently, for example. This is due to the way assets are created and tracked internally. We're thinking about how this could be implemented and hope to support it in the future.
