### PR TITLE
Clean Deletable Flags Before Loading a Workspace

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -320,7 +320,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private cleanXmlForWorkspace(dom: Element) {
         // Clear out any deletable flags. There are currently no scenarios where we rely on this flag,
         // and it can be persisted erroneously (with value "false") if the app closes unexpectedly while in debug mode.
-        dom.querySelectorAll("block[deletable]").forEach(b => { b.removeAttribute("deletable") });
+        dom.querySelectorAll("block[deletable], shadow[deletable]").forEach(b => { b.removeAttribute("deletable") });
     }
 
     private initLayout() {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -293,6 +293,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         try {
             const text = s || `<block type="${ts.pxtc.ON_START_TYPE}"></block>`;
             const xml = Blockly.Xml.textToDom(text);
+            this.cleanXmlForWorkspace(xml);
             pxt.blocks.domToWorkspaceNoEvents(xml, this.editor);
 
             pxtblockly.upgradeTilemapsInWorkspace(this.editor, pxt.react.getTilemapProject());
@@ -314,6 +315,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.changeCallback();
 
         return true;
+    }
+
+    private cleanXmlForWorkspace(dom: Element) {
+        // Clear out any deletable flags. There are currently no scenarios where we rely on this flag,
+        // and it can be persisted erroneously (with value "false") if the app closes unexpectedly while in debug mode.
+        dom.querySelectorAll("block[deletable]").forEach(b => { b.removeAttribute("deletable") });
     }
 
     private initLayout() {


### PR DESCRIPTION
Before we load a workspace from xml, clean out any deletable flags that exist in the XML. There are currently no scenarios where we rely on this deletable flag, and it can be persisted erroneously with value "false" if the app closes unexpectedly while in debug mode, which then prevents users from being able to delete/duplicate blocks in their workspace.

This approach should also fix any existing projects that have gotten into that non-deletable state.

Fixes https://github.com/microsoft/pxt-arcade/issues/4906