### PR TITLE
block config: Fix for variables_set parse issue

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1826,19 +1826,23 @@ export class ProjectView
                 try {
                     const entry: pxt.tutorial.TutorialBlockConfigEntry = {};
                     const blockType = block.getAttribute("type");
-                    if (blockType === "typescript_statement") {
+                    switch (blockType) {
+                        case "typescript_statement": {
                         // Decompiled to gray block
                         throw new Error("Block config decompiled to gray block: " + Blockly.Xml.domToText(block));
                     }
-                    if (blockType === "variables_set") {
-                        // get block id from within variables_set context
-                        const variables_set = block.children[0];
-                        const value = Array.from(variables_set.children).find(child => child.tagName === "value");
-                        const rhs = Array.from(value.children).find(child => child.tagName === "block");
-                        entry.blockId = rhs.getAttribute("type");
-                    } else {
-                        // Set block id from root type
-                        entry.blockId = blockType;
+                        case "variables_set":
+                        case "variables_change": {
+                            // get block id from within variables_set context
+                            const value = Array.from(block.children).find(child => child.tagName === "value");
+                            const rhs = Array.from(value.children).find(child => child.tagName === "block");
+                            entry.blockId = rhs.getAttribute("type");
+                            break;
+                        }
+                        default: {
+                            // Set block id from root type
+                            entry.blockId = blockType;
+                        }
                     }
                     entry.xml =
                         Blockly.Xml.domToText(block)

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1828,9 +1828,9 @@ export class ProjectView
                     const blockType = block.getAttribute("type");
                     switch (blockType) {
                         case "typescript_statement": {
-                        // Decompiled to gray block
-                        throw new Error("Block config decompiled to gray block: " + Blockly.Xml.domToText(block));
-                    }
+                            // Decompiled to gray block
+                            throw new Error("Block config decompiled to gray block: " + Blockly.Xml.domToText(block));
+                        }
                         case "variables_set":
                         case "variables_change": {
                             // get block id from within variables_set context


### PR DESCRIPTION
Conversion to switch statement makes this change look bigger than it is. All I did was remove the line `const variables_set = block.children[0];` (line 1835). I don't recall why I had to navigate into the children like that. Maybe we'll rediscover it in a future edge case. I expect some of these to pop up initially, and we'll have to play whack-a-mole(tm) for a while.

I do wonder if there's a better way to extract the value node from a variables_set/change dom heirarchy. Do we have an xml utility for this?