### PR TITLE
[stable7.0] Make sure the package config is up to date before caching extinfo

### DIFF
--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -164,6 +164,10 @@ namespace pxt.cpp {
         let disabledDeps = ""
         let mainDeps: Package[] = []
 
+        if (mainPkg.config) {
+            mainPkg.loadConfig();
+        }
+
         // order shouldn't matter for c++ compilation,
         // so use a stable order to prevent order changes from fetching a new hex file
         const mainPkgDeps = mainPkg.sortedDeps(true)

--- a/tests/common/testHost.ts
+++ b/tests/common/testHost.ts
@@ -88,6 +88,16 @@ export class TestHost implements pxt.Host {
         if (!TestHost.files[module.id]) {
             TestHost.files[module.id] = {}
         }
+
+        if (module.id === "this") {
+            if (filename === "pxt.json") {
+                return;
+            }
+            else if (this.packageFiles[filename]) {
+                this.packageFiles[filename] = contents;
+                return;
+            }
+        }
         TestHost.files[module.id][filename] = contents
     }
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -435,7 +435,7 @@ export async function initAsync() {
     } else if (hidbridge.shouldUse()) {
         log(`deploy: hid`);
         pxt.commands.deployCoreAsync = hidDeployCoreAsync;
-    } else if (pxt.BrowserUtils.isLocalHost() && Cloud.localToken) { // local node.js
+    } else if (pxt.BrowserUtils.isLocalHost() && Cloud.localToken && !/forcehex/i.test(window.location.href)) { // local node.js
         log(`deploy: localhost`);
         pxt.commands.deployCoreAsync = localhostDeployCoreAsync;
     } else { // in browser


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-calliope/issues/161

When we generate compile options for a project, we cache it based on the source of the project and pxt_modules.

The issue here was that we weren't updating the config in the MainPackage when generating the compile options but we were using the updated config in the key of the cache, thus we ended up caching the wrong result.

I also added a forcehex query parameter to make debugging this easier on localhost

@Amerlander FYI (and sorry for the delay! i've been out sick)