### PR TITLE
Update Extension Docs to Clarify Naming Requirements

### DIFF
--- a/docs/extensions/approval.md
+++ b/docs/extensions/approval.md
@@ -15,6 +15,6 @@ Whenever you are submitting an extension for approval, please check that you hav
 - [ ] A GitHub repo description added that's descriptive enough to help with extension search.
 - [ ] A test file, called ``test.ts``, is present and compiles when running **pxt deploy**.
 - [ ] The ``README.md`` file contains API documentation for the extension blocks.
-- [ ] Your public functions and types follow the [MakeCode naming conventions](https://makecode.com/extensions/naming-conventions).
+- [ ] Your public name, functions, and types follow the [MakeCode naming conventions](https://makecode.com/extensions/naming-conventions).
 
 ## #approval

--- a/docs/extensions/getting-started/simple-extension.md
+++ b/docs/extensions/getting-started/simple-extension.md
@@ -77,7 +77,7 @@ We need to make an extension description file next. This is called `pxt.json`. T
 
 This is what the basic entries in the `pxt.json` do:
 
-* **name**: The extension name. This is used to search and select the extension when you go to add an extension in the editor.
+* **name**: The extension name. This is used to search and select the extension when you go to add an extension in the editor. Ensure it follows our [naming conventions](../naming-conventions.md#extension-name).
 * **description**: The description of the extension shown in the extension gallery.
 * **icon**: An icon shown along with the description in the extension gallery.
 * **files**: The list of sources for the code and blocks of the extension.

--- a/docs/extensions/naming-conventions.md
+++ b/docs/extensions/naming-conventions.md
@@ -5,6 +5,19 @@ Naming conventions provide a consistant and expected style of usage across all n
 Although not enforced, these naming conventions help keep the blocks and functions in the MakeCode editor consistent. 
 As much as possible, please try to follow these conventions and consider exceptions only when absolutely necessary. Thank you for creating MakeCode extensions!
 
+## Extension name
+
+Your extension name (defined in [pxt.json](./pxt-json.md)) must adhere to the following rules. Failure to do so may result in issues while loading your extension.
+
+* Start with a letter (lower-case).
+* Contain only the following allowed characters:
+  * Lower-case letters
+  * Numbers
+  * Dash (-)
+  * Underscore (_)
+
+In other words, it should match the following regex: `^[a-z][a-z0-9\-_]+`.
+
 ## TypeScript conventions
 
 MakeCode follows the usual TypeScript naming conventions.


### PR DESCRIPTION
There was already a comment in the pxt-json docs with regex-based requirements for an extension name ([pxt-json.md line 16](https://github.com/microsoft/pxt/blob/thsparks/document_extentsion_name_requirements/docs/extensions/pxt-json.md?plain=1#L16)).

This change takes those requirements and makes them explicit in our naming conventions page. I've also linked to them in the sample extension, where we describe the name field.