### PR TITLE
Fix memory leaks in compile webworker

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4295,12 +4295,6 @@ async function testSnippetsAsync(snippets: CodeSnippet[], re?: string, pyStrictS
             return;
         }
 
-        if (++codeSnippetCount % 40 == 0) {
-            // clean up cache every once in a while to speed up / clear up mem
-            // TODO probably this should be handled in the service host as it does become a perf concern
-            cleanService();
-        }
-
         const isPy = snippet.ext === "py";
         const inFiles: pxt.Map<string> = {
             [pxt.MAIN_TS]: isPy ? "" : snippet.code,

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -40,7 +40,7 @@ namespace ts.pxtc {
     // Assumptions:
     // - registers can hold a pointer (data or code)
     // - special registers include: sp
-    // - fixed registers are r0, r1, r2, r3, r5, r6 
+    // - fixed registers are r0, r1, r2, r3, r5, r6
     //   - r0 is the current value (from expression evaluation)
     //   - registers for runtime calls (r0, r1,r2,r3)
     //   - r5 is for captured locals in lambda
@@ -54,7 +54,7 @@ namespace ts.pxtc {
     export abstract class AssemblerSnippets {
         nop() { return "TBD(nop)" }
         reg_gets_imm(reg: string, imm: number) { return "TBD(reg_gets_imm)" }
-        // Registers are stored on the stack in numerical order 
+        // Registers are stored on the stack in numerical order
         proc_setup(numlocals: number, main?: boolean) { return "TBD(proc_setup)" }
         push_fixed(reg: string[]) { return "TBD(push_fixed)" }
         push_local(reg: string) { return "TBD(push_local)" }
@@ -291,7 +291,7 @@ ${baseLabel}_nochk:
                 }
             }
 
-            if (this.bin.options.breakpoints) {
+            if (this.bin.breakpoints) {
                 this.write(this.t.debugger_proc(bkptLabel))
             }
             this.baseStackSize = 1 // push {lr}
@@ -338,7 +338,7 @@ ${baseLabel}_nochk:
                         this.write(`; ${s.expr.data}`)
                         break
                     case ir.SK.Breakpoint:
-                        if (this.bin.options.breakpoints) {
+                        if (this.bin.breakpoints) {
                             let lbl = `__brkp_${s.breakpointInfo.id}`
                             if (s.breakpointInfo.isDebuggerStmt) {
                                 this.write(this.t.debugger_stmt(lbl))

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -138,7 +138,7 @@ namespace ts.pxtc {
         "leaveAccessor"
     ]
 
-    export function jsEmit(bin: Binary) {
+    export function jsEmit(bin: Binary, cres: CompileResult) {
         let jssource = "(function (ectx) {\n'use strict';\n"
 
         for (let n of evalIfaceFields) {
@@ -154,7 +154,7 @@ namespace ts.pxtc {
         jssource += "pxsim.setTitle(" + JSON.stringify(bin.getTitle()) + ");\n"
         let cfg: pxt.Map<number> = {}
         let cfgKey: pxt.Map<number> = {}
-        for (let ce of bin.res.configData || []) {
+        for (let ce of cres.configData || []) {
             cfg[ce.key + ""] = ce.value
             cfgKey[ce.name] = ce.key
         }
@@ -187,8 +187,8 @@ namespace ts.pxtc {
         bin.usedClassInfos.forEach(info => {
             jssource += vtableToJs(info)
         })
-        if (bin.res.breakpoints)
-            jssource += `\nconst breakpoints = setupDebugger(${bin.res.breakpoints.length}, [${bin.globals.filter(c => c.isUserVariable).map(c => `"${c.uniqueName()}"`).join(",")}])\n`
+        if (cres.breakpoints)
+            jssource += `\nconst breakpoints = setupDebugger(${cres.breakpoints.length}, [${bin.globals.filter(c => c.isUserVariable).map(c => `"${c.uniqueName()}"`).join(",")}])\n`
 
         jssource += `\nreturn ${bin.procs[0] ? bin.procs[0].label() : "null"}\n})\n`
 

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -341,7 +341,7 @@ function ${id}(s) {
             let lbl: number;
             write(`s.lastBrkId = ${id};`)
 
-            if (bin.options.breakpoints) {
+            if (bin.breakpoints) {
                 lbl = ++lblIdx
                 let brkCall = `return breakpoint(s, ${lbl}, ${id}, r0);`
                 if (s.breakpointInfo.isDebuggerStmt) {
@@ -349,12 +349,12 @@ function ${id}(s) {
                 }
                 else {
                     write(`if ((breakpoints[0] && isBreakFrame(s)) || breakpoints[${id}]) ${brkCall}`)
-                    if (bin.options.trace) {
+                    if (bin.trace) {
                         write(`else return trace(${id}, s, ${lbl}, ${proc.label()}.info);`)
                     }
                 }
             }
-            else if (bin.options.trace) {
+            else if (bin.trace) {
                 lbl = ++lblIdx
                 write(`return trace(${id}, s, ${lbl}, ${proc.label()}.info);`)
             }

--- a/pxtcompiler/emitter/backvm.ts
+++ b/pxtcompiler/emitter/backvm.ts
@@ -195,7 +195,7 @@ ${info.id}_IfaceVT:
     }
 
     /* eslint-disable no-trailing-spaces */
-    export function vmEmit(bin: Binary, opts: CompileOptions) {
+    export function vmEmit(bin: Binary, opts: CompileOptions, cres: CompileResult) {
         let vmsource = `; VM start
 _img_start:
 ${hexfile.hexPrelude()}
@@ -319,7 +319,7 @@ _start_${name}:
         section("numberLiterals", SectionType.NumberLiterals, () => ctx.dblText.join("\n")
             + "\n.word 0, 0 ; dummy entry to make sure not empty")
 
-        const cfg = bin.res.configData || []
+        const cfg = cres.configData || []
         section("configData", SectionType.ConfigData, () => cfg.map(d =>
             `    .word ${d.key}, ${d.value}  ; ${d.name}=${d.value}`).join("\n")
             + "\n    .word 0, 0")

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -998,7 +998,9 @@ namespace ts.pxtc {
 
         let bin = new Binary()
         let proc: ir.Procedure;
-        bin.options = opts;
+        bin.trace = opts.trace;
+        bin.breakpoints = opts.breakpoints;
+        bin.name = opts.name;
         bin.target = opts.target;
 
         function reset() {
@@ -4970,7 +4972,11 @@ ${lbl}: .short 0xffff
         finalPass = false;
         target: CompileTarget;
         writeFile = (fn: string, cont: string) => { };
-        options: CompileOptions;
+
+        trace: boolean;
+        breakpoints: boolean;
+        name: string;
+
         usedClassInfos: ClassInfo[] = [];
         checksumBlock: number[];
         numStmts = 1;
@@ -5002,7 +5008,7 @@ ${lbl}: .short 0xffff
         }
 
         getTitle() {
-            const title = this.options.name || U.lf("Untitled")
+            const title = this.name || U.lf("Untitled")
             if (title.length >= 90)
                 return title.slice(0, 87) + "..."
             else

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1300,6 +1300,8 @@ namespace ts.pxtc {
                 jsEmit(bin, res)
             }
 
+            // Clear writeFile so that we don't leak the reference to res, which
+            // includes the entire source of the program
             bin.writeFile = undefined;
         }
 

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -765,7 +765,7 @@ ${lbl}: ${snippets.obj_header("pxt::number_vt")}
     }
 
 
-    export function vtableToAsm(info: ClassInfo, opts: CompileOptions, bin: Binary) {
+    export function vtableToAsm(info: ClassInfo, opts: CompileOptions, bin: Binary, res: CompileResult) {
         /*
         uint16_t numbytes;
         ValType objectType;
@@ -868,7 +868,7 @@ ${hexfile.hexPrelude()}
     }
 
 
-    function serialize(bin: Binary, opts: CompileOptions) {
+    function serialize(bin: Binary, opts: CompileOptions, res: CompileResult) {
         let asmsource = `
     .short ${bin.globalsWords}   ; num. globals
     .short 0 ; patched with number of 64 bit words resulting from assembly
@@ -910,7 +910,7 @@ ${hexfile.hexPrelude()}
         asmsource += "_helpers_end:\n\n"
 
         bin.usedClassInfos.forEach(info => {
-            asmsource += vtableToAsm(info, opts, bin)
+            asmsource += vtableToAsm(info, opts, bin, res)
         })
 
         asmsource += `\n.balign 4\n.object _pxt_iface_member_names\n_pxt_iface_member_names:\n`
@@ -924,7 +924,7 @@ ${hexfile.hexPrelude()}
         asmsource += "_vtables_end:\n\n"
 
         asmsource += `\n.balign 4\n.object _pxt_config_data\n_pxt_config_data:\n`
-        const cfg = bin.res.configData || []
+        const cfg = res.configData || []
         // asmsource += `    .word ${cfg.length}, 0 ; num. entries`
         for (let d of cfg) {
             asmsource += `    .word ${d.key}, ${d.value}  ; ${d.name}=${d.value}\n`
@@ -1229,7 +1229,7 @@ __flash_checksums:
     }
 
     export function processorEmit(bin: Binary, opts: CompileOptions, cres: CompileResult) {
-        const src = serialize(bin, opts)
+        const src = serialize(bin, opts, cres)
 
         const opts0 = U.flatClone(opts)
         // normally, this would already have been done, but if the main variant

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -508,7 +508,7 @@ namespace ts.pxtc {
                 for (let i = 0; i < hd.length; ++i)
                     pxt.HF2.write16(resbuf, i * 2 + ctx.jmpStartAddr, hd[i])
                 if (uf2 && !bin.target.switches.rawELF) {
-                    let bn = bin.options.name || "pxt"
+                    let bn = bin.name || "pxt"
                     bn = bn.replace(/[^a-zA-Z0-9\-\.]+/g, "_")
                     uf2.filename = "Projects/" + bn + ".elf"
                     UF2.writeBytes(uf2, 0, resbuf);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3931

This fixes the memory leak in pxtworker that was causing us to crash the tab (and sometimes all of chrome) by running out of memory.

During a compile we annotate the TS ast with a bunch of information for our compiler. To support incremental compilation, we also store references to functions that we can call again when re-emitting the nodes. The closures for these functions were causing a reference to the Binary object to stick around, which in turn was referencing CompileOptions (which contains the entire source of the program) and CompileResult (which includes the text of the emitted `binary.js`). All together this amounted to many mbs of strings being allocated every time the compiler was invoked.

This PR removes the binary's references to CompileResult and CompileOptions.

I also ended up hoisting some of the recordAction functions because they were causing references to the binary and compile result to stick around. I'm not sure why that is, because they don't appear to be referenced inside the function bodies, but this fixes that issue regardless.