### PR TITLE
Fix snippet for fixedinstance methods that use variables_get

### DIFF
--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -115,7 +115,6 @@ namespace ts.pxtc.service {
         const fileType = python ? "python" : "typescript";
 
         let snippetPrefix = fn.namespace;
-        let isInstance = false;
         let addNamespace = false;
         let namespaceToUse = "";
         let functionCount = 0;
@@ -177,6 +176,11 @@ namespace ts.pxtc.service {
                 if (python && snippetPrefix)
                     snippetPrefix = U.snakify(snippetPrefix);
             }
+            else if (params.thisParameter?.shadowBlockId === "variables_get") {
+                snippetPrefix = params.thisParameter.defaultValue || params.thisParameter.definitionName;
+                if (python && snippetPrefix)
+                    snippetPrefix = U.snakify(snippetPrefix);
+            }
             else if (element.namespace) { // some blocks don't have a namespace such as parseInt
                 const nsInfo = apis.byQName[element.namespace];
                 if (nsInfo.attributes.fixedInstances) {
@@ -223,8 +227,6 @@ namespace ts.pxtc.service {
                     if (namespaceToUse) {
                         addNamespace = true;
                     }
-
-                    isInstance = true;
                 }
                 else if (element.kind == pxtc.SymbolKind.Method || element.kind == pxtc.SymbolKind.Property) {
                     if (params.thisParameter) {
@@ -238,7 +240,6 @@ namespace ts.pxtc.service {
                         if (python && snippetPrefix)
                             snippetPrefix = U.snakify(snippetPrefix);
                     }
-                    isInstance = true;
                 }
                 else if (nsInfo.kind === pxtc.SymbolKind.Class) {
                     return undefined;

--- a/tests/language-service/snippet_cases/imageThisParam.ts
+++ b/tests/language-service/snippet_cases/imageThisParam.ts
@@ -1,0 +1,2 @@
+// Image.setPixel
+picture.setPixel(0, 0, 0)

--- a/tests/language-service/test-package/basic.ts
+++ b/tests/language-service/test-package/basic.ts
@@ -2,7 +2,7 @@ namespace testNamespace {
     export function someFunction(someParam: string, someNum: number, someBool: boolean) {
         return someParam
     }
-    
+
     //% someNum.defl=5
     //% someBool.defl=true
     export function someFunctionWithDefl(someNum: number, someBool: boolean) {
@@ -40,4 +40,15 @@ namespace testNamespace {
     export function registerSomeEvent(param1: number, handler: () => void, param2: boolean) {
         handler()
     }
+}
+
+//% fixedInstances decompileIndirectFixedInstances
+declare interface Image {
+    /**
+     * Set pixel color
+     */
+    //% shim=ImageMethods::setPixel blockNamespace="images" group="Drawing"
+    //% block="set %picture=variables_get color at x %x y %y to %c=colorindexpicker"
+    //% help=images/image/set-pixel
+    setPixel(x: int32, y: int32, c: int32): void;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/4931

If a fixedinstance type has a variable shadow block set in its block definition, then we don't really want to reference one of the exported fixed instances.