### PR TITLE
chain skillmap npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "uglifyify": "5.0.2"
   },
   "scripts": {
-    "postinstall": "cd skillmaps && npm install && cd ..",
+    "postinstall": "cd skillmap && npm install && cd ..",
     "build": "gulp",
     "test": "gulp travis",
     "clean": "gulp clean",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "uglifyify": "5.0.2"
   },
   "scripts": {
+    "postinstall": "cd skillmaps && npm install && cd ..",
     "build": "gulp",
     "test": "gulp travis",
     "clean": "gulp clean",


### PR DESCRIPTION
The requirement to run npm install in /skillmaps is undocumented and very annoying. This should make it automatic.