### PR TITLE
Use new share dialog in skillmap

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -193,6 +193,18 @@ namespace pxt.editor {
         photo?: string;
     }
 
+    export interface ShareData {
+        url: string;
+        embed: {
+            code?: string;
+            editor?: string;
+            simulator?: string;
+            url?: string;
+        }
+        qr?: string;
+        error?: any;
+    }
+
     export type Activity = "tutorial" | "recipe" | "example";
 
     export interface IProjectView {
@@ -272,9 +284,9 @@ namespace pxt.editor {
         setHintSeen(step: number): void;
         setEditorOffset(): void;
 
-        anonymousPublishAsync(screenshotUri?: string): Promise<string>;
-        anonymousPublishHeaderByIdAsync(headerId: string): Promise<Cloud.JsonScript>;
-        persistentPublishAsync(screenshotUri?: string): Promise<string>;
+        anonymousPublishHeaderByIdAsync(headerId: string, projectName?: string): Promise<ShareData>;
+        publishCurrentHeaderAsync(persistent: boolean, screenshotUri?: string): Promise<string>;
+        publishAsync (name: string, screenshotUri?: string, forceAnonymous?: boolean): Promise<pxt.editor.ShareData>;
 
         startStopSimulator(opts?: SimulatorStartOptions): void;
         stopSimulator(unload?: boolean, opts?: SimulatorStartOptions): void;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -369,6 +369,7 @@ namespace pxt.editor {
     export interface EditorShareRequest extends EditorMessageRequest {
         action: "shareproject";
         headerId: string;
+        projectName: string;
     }
 
     export interface EditorShareResponse extends EditorMessageRequest {
@@ -587,7 +588,7 @@ namespace pxt.editor {
                                 }
                                 case "shareproject": {
                                     const msg = data as EditorShareRequest;
-                                    return projectView.anonymousPublishHeaderByIdAsync(msg.headerId)
+                                    return projectView.anonymousPublishHeaderByIdAsync(msg.headerId, msg.projectName)
                                         .then(scriptInfo => {
                                             resp = scriptInfo;
                                         });

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -142,7 +142,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
 
     const prePublish = shareState === "share" || shareState === "publishing";
 
-    const inputTitle = showSimulator && prePublish ? lf("Project Title") : lf("Project Link")
+    const inputTitle = prePublish ? lf("Project Title") : lf("Project Link")
 
     return <>
         <div className="project-share-info">

--- a/skillmap/src/actions/dispatch.ts
+++ b/skillmap/src/actions/dispatch.ts
@@ -1,3 +1,4 @@
+import { ShareData } from 'react-common/share/Share';
 import { ReadyResources } from '../lib/readyResources';
 import { ModalState, PageSourceStatus } from '../store/reducer';
 import * as actions from './types'
@@ -35,7 +36,7 @@ export const dispatchLogout = () => ({ type: actions.USER_LOG_OUT });
 export const dispatchShowUserProfile = () => ({ type: actions.SHOW_USER_PROFILE });
 export const dispatchCloseUserProfile = () => ({ type: actions.HIDE_USER_PROFILE });
 
-export const dispatchSetShareStatus = (headerId?: string, url?: string) =>  ({ type: actions.SET_SHARE_STATUS, headerId, url });
+export const dispatchSetShareStatus = (headerId?: string, projectName?: string, data?: ShareData) =>  ({ type: actions.SET_SHARE_STATUS, headerId, projectName, data });
 export const dispatchSetCloudStatus = (headerId: string, status: string) => ({ type: actions.SET_CLOUD_STATUS, headerId, status });
 export const dispatchSetReadyResources = (resources: ReadyResources) => ({ type: actions.SET_READY_RESOURCES, resources });
 export const dispatchGrantSkillmapBadge = (mapId: string) => ({ type: actions.GRANT_SKILLMAP_BADGE, mapId });

--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -9,6 +9,7 @@ import  { dispatchSetHeaderIdForActivity, dispatchCloseActivity, dispatchSaveAnd
 
 /* eslint-disable import/no-unassigned-import, import/no-internal-modules */
 import '../styles/makecode-editor.css'
+import { ShareData } from "react-common/share/Share";
 /* eslint-enable import/no-unassigned-import, import/no-internal-modules */
 
 interface MakeCodeFrameProps {
@@ -23,6 +24,7 @@ interface MakeCodeFrameProps {
     previousHeaderId?: string;
     progress?: ActivityState;
     shareHeaderId?: string;
+    shareProjectName?: string;
     signedIn?: boolean;
     highContrast?: boolean;
     pageSourceUrl: string;
@@ -30,7 +32,7 @@ interface MakeCodeFrameProps {
     dispatchCloseActivity: (finished?: boolean) => void;
     dispatchSaveAndCloseActivity: () => void;
     dispatchUpdateUserCompletedTags: () => void;
-    dispatchSetShareStatus: (headerId?: string, url?: string) => void;
+    dispatchSetShareStatus: (headerId?: string, projectName?: string, data?: ShareData) => void;
     dispatchShowLoginPrompt: () => void;
     dispatchSetCloudStatus: (headerId: string, status: string) => void;
     onWorkspaceReady: (sendMessageAsync: (message: any) => Promise<any>) => void;
@@ -263,15 +265,16 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
     }
 
     protected async shareProjectAsync() {
-        const { shareHeaderId, dispatchSetShareStatus } = this.props;
+        const { shareHeaderId, shareProjectName, dispatchSetShareStatus } = this.props;
 
         const resp = (await this.sendMessageAsync({
             type: "pxteditor",
             action: "shareproject",
-            headerId: shareHeaderId
+            headerId: shareHeaderId,
+            projectName: shareProjectName
         })) as any;
 
-        dispatchSetShareStatus(shareHeaderId, resp.resp.shortid);
+        dispatchSetShareStatus(shareHeaderId, shareProjectName, resp.resp);
         this.setState({
             pendingShare: false
         });
@@ -334,10 +337,12 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
 }
 
 function mapStateToProps(state: SkillMapState, ownProps: any) {
-    const shareHeaderId = !state.shareState?.url ? state.shareState?.headerId : undefined;
+    const shareHeaderId = !state.shareState?.data ? state.shareState?.headerId : undefined;
+    const shareProjectName = state.shareState?.projectName;
 
     if (!state || !state.editorView) return {
-        shareHeaderId
+        shareHeaderId,
+        shareProjectName
     };
 
     const { currentActivityId, currentMapId, currentHeaderId, state: saveState, allowCodeCarryover, previousHeaderId } = state.editorView;
@@ -362,6 +367,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
         progress,
         save: saveState === "saving",
         shareHeaderId,
+        shareProjectName,
         signedIn: state.auth.signedIn,
         highContrast: state.auth.preferences?.highContrast,
         pageSourceUrl: state.pageSourceUrl

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -1,3 +1,4 @@
+import { ShareData } from 'react-common/share/Share';
 import * as actions from '../actions/types'
 import { guidGen, cloudLocalStoreKey } from '../lib/browserUtils';
 import { ReadyResources } from '../lib/readyResources';
@@ -48,7 +49,8 @@ export interface ModalState {
 
 export interface ShareState {
     headerId: string;
-    url?: string;
+    projectName: string;
+    data?: ShareData;
     rewardsShare?: boolean;
 }
 
@@ -289,7 +291,8 @@ const topReducer = (state: SkillMapState = initialState, action: any): SkillMapS
                 ...state,
                 shareState: action.headerId || action.url ? {
                     headerId: action.headerId,
-                    url: action.url,
+                    projectName: action.projectName,
+                    data: action.data,
                     rewardsShare: state.shareState?.rewardsShare
                 } : undefined
             }
@@ -347,7 +350,8 @@ const topReducer = (state: SkillMapState = initialState, action: any): SkillMapS
                 ...state,
                 shareState: action.rewardsShare !== undefined ? {
                     headerId: state.shareState?.headerId || "",
-                    url: state.shareState?.url,
+                    projectName: state.shareState?.projectName || "",
+                    data: state.shareState?.data,
                     rewardsShare: action.rewardsShare
                 } : state.shareState,
                 modalQueue: [action.modal]


### PR DESCRIPTION
Currently, recording a thumbnail is not supported in the skillmap. Other than that, this makes the share dialog the same in the editor and skillmap.

Also refactored the share/publish code in the webapp a little bit to clean things up.