### PR TITLE
Inline snippet click highlight

### DIFF
--- a/docs/writing-docs/snippets.md
+++ b/docs/writing-docs/snippets.md
@@ -36,6 +36,17 @@ the namespace name separated with a ``:``.
 ``||loops:repeat 4 times||``
 ```
 
+If the user clicks on the resulting button, it will toggle the toolbox for the given namespace.
+
+If you have a need for a button to appear one color but open a different category,
+you can add the namespace it should open in parentheses after the normal one
+
+```
+``||variables(sprites):set mySprite to||``
+```
+
+This will appear in tutorials as the `variables` category, but clicking it will toggle the `sprites` category.
+
 ### highlight
 
 Although used in snippets, the renderer will higlight the next line of code or block following a comment containing
@@ -306,7 +317,7 @@ names using the ``package`` macro. Note, the name **package** is still used even
 though these are now called **extensions**.
 
 The package setting listed last in the example below uses a special format to reference
-its location in a separate GitHub repository. You can find this _package specification_ 
+its location in a separate GitHub repository. You can find this _package specification_
 in the ``Project Settings`` / ``pxt.json`` file, listed under ``dependencies``. Notice
 that it lists the exact version to use; this isn't required (that is, you can leave off
 the `#v0.6.12`), but it is highly recommended you include this so that future changes to
@@ -465,7 +476,7 @@ The project is specified by its share URL.
 ### sig
 
 The **sig** snippet displays a signature of the first function call in the snippet,
-rendering it in blocks, JavaScript, and Python. 
+rendering it in blocks, JavaScript, and Python.
 
     ```sig
     basic.showNumber(5)

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -266,6 +266,10 @@ span.docs.inlineblock {
     font-size: 1em !important;
     &.clickable {
         cursor: pointer;
+
+        &:hover, &:focus {
+            opacity: .8;
+        }
     }
 }
 

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -264,6 +264,9 @@ span.docs.inlineblock {
     color: @white;
     font-family: @blocklyFont !important;
     font-size: 1em !important;
+    &.clickable {
+        cursor: pointer;
+    }
 }
 
 code.lang-filterblocks {

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -367,18 +367,18 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                 for (const inlineBlock of inlineBlocks) {
                     let ns = inlineBlock.getAttribute("data-ns");
                     const bi = blocksInfo.apis.byQName[ns];
-                    // TODO special case functions, variables?
                     let color = bi?.attributes?.color;
-                    if (/^functions?$/i.test(ns)) {
-                        ns = "Functions";
-                        // color = pxt.appTarget.appTheme.blockColors["functions"];
-                        color = pxt.toolbox.getNamespaceColor("functions");
+                    if (/^logic$/i.test(ns)) {
+                        ns = "logic";
+                        color = pxt.toolbox.getNamespaceColor(ns);
+                    } else if (/^functions?$/i.test(ns)) {
+                        ns = "functions";
+                        color = pxt.toolbox.getNamespaceColor(ns);
                     } else if (/^variables?$/i.test(ns)) {
-                        ns = "Variables";
-                        // color = pxt.appTarget.appTheme.blockColors["variables"];
-                        color = pxt.toolbox.getNamespaceColor("variables");
+                        ns = "variables";
+                        color = pxt.toolbox.getNamespaceColor(ns);
                     } else if (bi?.kind !== pxtc.SymbolKind.Module){
-                        return;
+                        continue;
                     }
 
                     inlineBlock.classList.add("clickable");
@@ -387,7 +387,8 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                         inlineBlock.style.borderColor = pxt.toolbox.fadeColor(color, 0.1, false);
                     }
                     inlineBlock.addEventListener("click", e => {
-                        alert(inlineBlock.getAttribute("data-ns") + " " + color + " " + pxt.toolbox.fadeColor(color, 0.1, false));
+                        const toolboxRow = document.querySelector<HTMLDivElement>(`.blocklyTreeRow[data-ns="${ns}"]`);
+                        toolboxRow?.focus();
                     });
                 }
             });

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -6,6 +6,7 @@ import * as marked from "marked";
 import * as compiler from "./compiler"
 import { MediaPlayer } from "dashjs"
 import dashjs = require("dashjs");
+import { fireClickOnEnter } from "../../react-common/components/util";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -382,6 +383,9 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     }
 
                     inlineBlock.classList.add("clickable");
+                    inlineBlock.tabIndex = 0;
+                    inlineBlock.ariaLabel = lf("Toggle the {0} category", ns);
+                    inlineBlock.title = inlineBlock.ariaLabel;
                     if (color) {
                         inlineBlock.style.backgroundColor = color;
                         inlineBlock.style.borderColor = pxt.toolbox.fadeColor(color, 0.1, false);
@@ -390,6 +394,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                         const toolboxRow = document.querySelector<HTMLDivElement>(`.blocklyTreeRow[data-ns="${ns}"]`);
                         toolboxRow?.click();
                     });
+                    inlineBlock.addEventListener("keydown", e => fireClickOnEnter(e as any))
                 }
             });
     }

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -388,7 +388,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     }
                     inlineBlock.addEventListener("click", e => {
                         const toolboxRow = document.querySelector<HTMLDivElement>(`.blocklyTreeRow[data-ns="${ns}"]`);
-                        toolboxRow?.focus();
+                        toolboxRow?.click();
                     });
                 }
             });

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -345,20 +345,25 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                 const mbtn = /^(\|+)([^\|]+)\|+$/.exec(text);
                 if (mbtn) {
                     const mtxt = /^(([^\:]*?)[\:])?(.*)$/.exec(mbtn[2]);
-                    const ns = mtxt[2] ? mtxt[2].trim().toLowerCase() : '';
                     const txt = mtxt[3].trim();
                     const isInlineButton = mbtn[1].length == 1;
-                    const escapedNs = pxt.Util.htmlEscape(ns);
+                    const ns = mtxt[2] ? mtxt[2].trim().toLowerCase() : '';
+                    const nsSplit = /^([^()]+)\(([^()]+)\)$/.exec(ns);
+                    const displayNs = pxt.Util.htmlEscape(nsSplit?.[1] || ns);
+                    const behaviorNs = pxt.Util.htmlEscape(nsSplit?.[2] || ns);
                     const lev = isInlineButton ?
                         `docs inlinebutton ui button ${pxt.Util.htmlEscape(txt.toLowerCase())}-button`
-                        : `docs inlineblock ${escapedNs}`;
+                        : `docs inlineblock ${displayNs}`;
 
                     const inlineBlockDiv = document.createElement('span');
                     pxsim.U.clear(inlineBlock);
                     inlineBlock.appendChild(inlineBlockDiv);
                     inlineBlockDiv.className = lev;
                     inlineBlockDiv.textContent = pxt.U.rlf(txt);
-                    inlineBlockDiv.setAttribute("data-ns", escapedNs)
+                    inlineBlockDiv.setAttribute("data-ns", behaviorNs);
+                    if (displayNs !== behaviorNs) {
+                        inlineBlockDiv.setAttribute("data-norecolor", "true")
+                    }
                     return !isInlineButton && inlineBlockDiv;
                 }
                 return undefined;
@@ -386,7 +391,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     inlineBlock.tabIndex = 0;
                     inlineBlock.ariaLabel = lf("Toggle the {0} category", ns);
                     inlineBlock.title = inlineBlock.ariaLabel;
-                    if (color) {
+                    if (color && !inlineBlock.getAttribute("data-norecolor")) {
                         inlineBlock.style.backgroundColor = color;
                         inlineBlock.style.borderColor = pxt.toolbox.fadeColor(color, 0.1, false);
                     }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -829,6 +829,7 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
         const extraIconClass = !subns && Object.keys(this.brandIcons).includes(icon) ? 'brandIcon' : ''
         return <div role="button" ref={this.handleTreeRowRef} className={treeRowClass}
             style={treeRowStyle} tabIndex={0}
+            data-ns={nameid}
             aria-label={lf("Toggle category {0}", rowTitle)} aria-expanded={selected}
             onMouseEnter={this.onmouseenter} onMouseLeave={this.onmouseleave}
             onClick={onClick} onContextMenu={onClick} onKeyDown={onKeyDown ? onKeyDown : fireClickOnEnter}>


### PR DESCRIPTION
add tutorial block discoverability feature -- when user clicks on an inlineblock snippet (the little colored bars), open the associated toolbox category. (Note that the namespace needs to exactly match, so it might need some post release cleanup for existing tutorials, but should be fine for the most part):

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/5615930/190685797-917fcb90-bba5-4653-aa02-dee082bd393d.gif)
