### PR TITLE
Quick tutorial updates from testing

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -559,7 +559,7 @@
     .tutorial-step-label {
         font-size: 1rem;
         justify-content: space-between;
-        margin-bottom: .5rem;
+        margin-bottom: 1rem;
     }
 
     /* Short Deskstop Only */

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -95,6 +95,11 @@
     }
 }
 
+.tutorial-controls {
+    border-top: 2px solid @tutorialGrayOffset;
+    margin-top: 1rem;
+}
+
 /*******************************
         Exit Tutorial
 *******************************/
@@ -554,6 +559,7 @@
     .tutorial-step-label {
         font-size: 1rem;
         justify-content: space-between;
+        margin-bottom: .5rem;
     }
 
     /* Short Deskstop Only */

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -805,6 +805,11 @@
             .ui.button:not(:hover) {
                 background-color: @tutorialTabletSimulatorButtonColor;
             }
+
+            > .ui.button:last-child {
+                margin-top: 0.75rem;
+                margin-bottom: 0.75rem;
+            }
         }
     }
 

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -559,7 +559,7 @@
     .tutorial-step-label {
         font-size: 1rem;
         justify-content: space-between;
-        margin-bottom: 1rem;
+        margin-bottom: 1.5rem;
     }
 
     /* Short Deskstop Only */

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -693,6 +693,7 @@
         display: flex;
         align-items: center;
         margin: 0;
+        margin-top: 0.5rem;
 
         > .ui.button {
             width: unset;

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -152,7 +152,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         <div className={classList("tutorial-content", hasHint && "has-hint")} ref={contentRef} onScroll={tutorialContentScroll}>
             {isHorizontal ? stepCounter : <div className="tutorial-step-label">
                 {name && <span className="tutorial-step-title">{name}</span>}
-                <span className="tutorial-step-number">{lf("Step {0} of {1}", currentStep + 1, steps.length)}</span>
+                <span className="tutorial-step-number">{lf("Step {0} of {1}", visibleStep + 1, steps.length)}</span>
             </div>}
             {showImmersiveReader && <ImmersiveReaderButton ref={immReaderRef} content={markdown} tutorialOptions={tutorialOptions} />}
             {title && <div className="tutorial-title">{title}</div>}

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -85,6 +85,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
     React.useEffect(() => {
         const contentDiv = contentRef?.current;
         contentDiv.scrollTo(0, 0);
+        contentDiv.querySelector(".tutorial-step-content")?.focus();
         setShowScrollGradient(contentDiv.scrollHeight > contentDiv.offsetHeight);
 
         onTutorialStepChange(currentStep);

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -139,8 +139,8 @@ export function TutorialContainer(props: TutorialContainerProps) {
         })
     }
     const nextButton = showDone
-        ? <Button icon="check circle" className="primary" text={lf("Done")} onClick={onTutorialComplete} />
-        : <Button icon="arrow circle right" className="primary" disabled={!showNext} text={lf("Next")} onClick={tutorialStepNext} />;
+        ? <Button icon="check circle" text={lf("Done")} onClick={onTutorialComplete} />
+        : <Button icon="arrow circle right" disabled={!showNext} text={lf("Next")} onClick={tutorialStepNext} />;
 
     const stepCounter = <TutorialStepCounter tutorialId={tutorialId} currentStep={visibleStep} totalSteps={steps.length} title={name} setTutorialStep={setCurrentStep} />;
     const hasHint = !!hintMarkdown;


### PR DESCRIPTION
* fixes https://github.com/microsoft/pxt-arcade/issues/4968
* margin on step label
* top border on the controls (next button) section so it's visually separated from the text content
* make next button 'tutorial color' instead of orange, so it doesn't clash with download button

<img width="287" alt="image" src="https://user-images.githubusercontent.com/5615930/190713082-327415e7-6e60-41e2-8114-91846dbaa7ac.png">
<img width="291" alt="image" src="https://user-images.githubusercontent.com/5615930/190713112-7d31a8ed-c051-4527-86d3-7a6cc84aaf34.png">



<img width="732" alt="image" src="https://user-images.githubusercontent.com/5615930/190712642-25b813ba-c135-4601-ad88-135859ae71d2.png">
<img width="743" alt="image" src="https://user-images.githubusercontent.com/5615930/190712697-b460e89e-baad-4640-9be4-fa9d2d1a0fbc.png">
