### PR TITLE
Fix Image Editor Top Bar Button Sizing

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -104,7 +104,7 @@
 }
 
 .image-editor-header-center {
-    flex: 1.5;
+    flex: 3;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -693,8 +693,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     protected resizeFieldEditorView() {
         if (!window) return;
         const blocklyDiv = this.getBlocksEditorDiv();
-        if (blocklyDiv && this.parent.isTutorial() && !pxt.BrowserUtils.isTabletSize()) {
-            const containerRect = blocklyDiv.getBoundingClientRect();
+        const containerRect = blocklyDiv.getBoundingClientRect();
+        if (blocklyDiv && this.parent.isTutorial() && containerRect.width > pxt.BREAKPOINT_TABLET) {
             blocklyFieldView.setEditorBounds({
                 top: containerRect.top,
                 left: containerRect.left,

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -693,8 +693,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     protected resizeFieldEditorView() {
         if (!window) return;
         const blocklyDiv = this.getBlocksEditorDiv();
-        const containerRect = blocklyDiv.getBoundingClientRect();
-        if (blocklyDiv && this.parent.isTutorial() && containerRect.width > pxt.BREAKPOINT_TABLET) {
+        const containerRect = blocklyDiv?.getBoundingClientRect();
+        if (containerRect && this.parent.isTutorial() && containerRect.width > pxt.BREAKPOINT_TABLET) {
             blocklyFieldView.setEditorBounds({
                 top: containerRect.top,
                 left: containerRect.left,


### PR DESCRIPTION
When a tutorial is open, there's a size threshold where the text in the image editor's top buttons overruns the buttons' bounds. This happens because the tutorial pane severely limits the horizontal space allowed for the popup, but we aren't in tablet mode yet when considering the whole available screen size. Regardless, the space allowed for the popup is too small.

To address this, I've allowed the popup to overlay the tutorial if the **container's** size is smaller than the tablet threshold (as opposed to the whole window). I also increased the weight on the buttons' section of the flexbox so they aren't quite so restricted on either side. Combined, these give us enough flexibility to still look okay until we get to tablet mode, at which point the buttons change into their smaller form and we're good to go. (The tutorial pane is also moved at this point, and still covered up by the popup.)

Sample Build: https://arcade.makecode.com/app/9c9c393a96d2837ab719d34ee832dbd65d923de9-9a2bb76c07--skillmap#racer

![DemoOfFixFor4862EvenSmaller4](https://user-images.githubusercontent.com/69657545/191808920-145207ea-de4a-4994-9eb2-4b39465b54e3.gif)

I considered trying to change the buttons to their image-only (tablet/mobile) form earlier, rather than modifying the popup overlay behavior, but that all happens in css using media screen size, and I didn't see a good way to change that without bringing all of that into javascript, which seemed less ideal, especially since this affects a fairly narrow range of screen sizes and hopefully won't be hit too often.

This fixes https://github.com/microsoft/pxt-arcade/issues/4862