### PR TITLE
fix clickable snippets when capitalization differs

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -370,8 +370,15 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
             }).filter(el => !!el);
         compiler.getBlocksAsync()
             .then(blocksInfo => {
+                const namespaceNames = Object.keys(blocksInfo.apis.byQName)
+                    .filter(qname => blocksInfo.apis.byQName[qname]?.kind === pxtc.SymbolKind.Module);
                 for (const inlineBlock of inlineBlocks) {
                     let ns = inlineBlock.getAttribute("data-ns");
+                    // fix capitalization issues, e.g. ``||math: instead of ``||Math:
+                    const exactNamespaceName = namespaceNames.find(el => ns.toLowerCase() == el.toLowerCase());
+                    if (exactNamespaceName && (ns !== exactNamespaceName)) {
+                        ns = exactNamespaceName;
+                    }
                     const bi = blocksInfo.apis.byQName[ns];
                     let color = bi?.attributes?.color;
                     if (/^logic$/i.test(ns)) {


### PR DESCRIPTION
I don't think there was an issue for this? but richard noticed during testing, lots of the time we have different capitalization in md vs namespace names -- in particular with `Math` as it's capitalization is a bit weird.

e.g. 

```md
``||math:pick random||``
```

instead of 

```md
``||Math:pick random||``
```

this fixes that so it checks for namespaces ignoring case