### PR TITLE
fix snippets in monaco after blocks editor has been opened

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -403,7 +403,10 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                         inlineBlock.style.borderColor = pxt.toolbox.fadeColor(color, 0.1, false);
                     }
                     inlineBlock.addEventListener("click", e => {
-                        const toolboxRow = document.querySelector<HTMLDivElement>(`.blocklyTreeRow[data-ns="${ns}"]`);
+                        // need to filter out editors that are currently hidden as we leave toolboxes in dom
+                        const editorSelector = `#maineditor > div:not([style*="display:none"]):not([style*="display: none"])`;
+                        const toolboxSelector = `${editorSelector} .blocklyTreeRow[data-ns="${ns}"]`;
+                        const toolboxRow = document.querySelector<HTMLDivElement>(toolboxSelector);
                         toolboxRow?.click();
                     });
                     inlineBlock.addEventListener("keydown", e => fireClickOnEnter(e as any))


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/4995 -- when you open the blocks editor before starting a monaco editor tutorial the snippets would fail to open toolbox categories.

Issue was that we retain the toolboxes in the dom and just display:none the editor div that encompasses them, so the querySelector always found the blocks toolbox category instead of the monaco toolbox category when both exist. This change filters out non-visible editor divs when opening the category.

(if there's an easier way to grab active editor div I'd love a pointer, couldn't remember one when you don't have access to the ProjectView component)