### PR TITLE
Fix a few thumbnail recorder share bugs

### DIFF
--- a/react-common/components/share/ThumbnailRecorder.tsx
+++ b/react-common/components/share/ThumbnailRecorder.tsx
@@ -142,15 +142,15 @@ export const ThumbnailRecorder = (props: ThumbnailRecorderProps) => {
                     </div>
                 </div>
                 <div className="thumbnail-actions">
+                    <Button title={lf("Cancel")}
+                        label={lf("Cancel")}
+                        onClick={onCancel} />
                     {uri && recorderState === "default" &&
                         <Button className="primary"
                             title={lf("Apply")}
                             label={lf("Apply")}
                             onClick={handleApplyClick} />
                     }
-                    <Button title={lf("Cancel")}
-                        label={lf("Cancel")}
-                        onClick={onCancel} />
                 </div>
             </div>
         </div>

--- a/react-common/components/share/ThumbnailRecorder.tsx
+++ b/react-common/components/share/ThumbnailRecorder.tsx
@@ -124,16 +124,25 @@ export const ThumbnailRecorder = (props: ThumbnailRecorderProps) => {
                                 label={lf("Try again?")}
                                 onClick={() => setUri(undefined)} />
                         </div>
-                        <div className="thumbnail-image">
-                            {(uri || initialUri)
+                        <div className="project-share-thumbnail">
+                            {recorderState !== "default" &&
+                                <div className="project-thumbnail-placeholder">
+                                    <div className="common-spinner" />
+                                    <div className="project-thumbnail-label">
+                                        {recorderState === "recording" ? lf("Recording...") : lf("Rendering GIF...")}
+                                    </div>
+                                </div>
+                            }
+                            { recorderState === "default" &&
+                                ((uri || initialUri)
                                 ? <img src={uri || initialUri} />
-                                : <div className="thumbnail-placeholder" />
+                                : <div className="thumbnail-placeholder" />)
                             }
                         </div>
                     </div>
                 </div>
                 <div className="thumbnail-actions">
-                    {uri &&
+                    {uri && recorderState === "default" &&
                         <Button className="primary"
                             title={lf("Apply")}
                             label={lf("Apply")}

--- a/react-common/components/share/ThumbnailRecorder.tsx
+++ b/react-common/components/share/ThumbnailRecorder.tsx
@@ -79,7 +79,16 @@ export const ThumbnailRecorder = (props: ThumbnailRecorderProps) => {
 
     const screenshotLabel = lf("Screenshot ({0})", targetTheme.simScreenshotKey);
     const startRecordingLabel = lf("Record ({0})", targetTheme.simGifKey);
-    const stopRecordingLabel = lf("Stop recording ({0})", targetTheme.simGifKey) ;
+    const stopRecordingLabel = lf("Stop recording ({0})", targetTheme.simGifKey);
+    const renderingLabel = lf("Rendering...");
+
+    let recordLabel: string;
+
+    switch (recorderState) {
+        case "default": recordLabel = startRecordingLabel; break;
+        case "recording": recordLabel = stopRecordingLabel; break;
+        case "rendering": recordLabel = renderingLabel; break;
+    }
 
     const thumbnailLabel = uri ? lf("New Thumbnail") : lf("Current Thumbnail");
     const classes = classList(
@@ -95,14 +104,17 @@ export const ThumbnailRecorder = (props: ThumbnailRecorderProps) => {
                 </div>
                 <div className="gif-recorder">
                     <div className="gif-recorder-actions">
+                        {recorderState === "default" &&
+                            <Button className="teal inverted"
+                                title={screenshotLabel}
+                                label={screenshotLabel}
+                                leftIcon="fas fa-camera"
+                                onClick={handleScreenshotClick} />
+                        }
                         <Button className="teal inverted"
-                            title={screenshotLabel}
-                            label={screenshotLabel}
-                            leftIcon="fas fa-camera"
-                            onClick={handleScreenshotClick} />
-                        <Button className="teal inverted"
-                            title={recorderState === "recording" ? stopRecordingLabel : startRecordingLabel}
-                            label={recorderState === "recording" ? stopRecordingLabel : startRecordingLabel}
+                            disabled={recorderState === "rendering"}
+                            title={recordLabel}
+                            label={recordLabel}
                             leftIcon={`fas fa-${recorderState === "recording" ? "square" : "circle"}`}
                             onClick={handleRecordClick} />
                         <div className="spacer mobile-only" />

--- a/react-common/styles/share/share.less
+++ b/react-common/styles/share/share.less
@@ -233,6 +233,13 @@
 
 .gif-recorder-actions {
     display: flex;
+    width: 100%;
+
+    .common-button {
+        padding-left: 0;
+        padding-right: 0;
+        flex: 1;
+    }
 }
 
 .thumbnail-image,

--- a/react-common/styles/share/share.less
+++ b/react-common/styles/share/share.less
@@ -77,6 +77,8 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        flex-direction: column;
+        gap: 0.5rem;
 
         .common-spinner {
             width: 5rem;

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -174,9 +174,17 @@ export class ShareEditor extends auth.Component<ShareEditorProps, ShareEditorSta
             uri = await this.props.parent.requestScreenshotAsync();
         }
 
-        this.setState({
-            screenshotUri: uri
-        });
+        if (!uri) {
+            setTimeout(() => {
+                this.renderInitialScreenshotAsync();
+            }, 500)
+        }
+        else {
+            this.setState({
+                screenshotUri: uri
+            });
+        }
+
     }
 
     renderCore() {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/4954
Fixes https://github.com/microsoft/pxt-arcade/issues/4962
Fixes https://github.com/microsoft/pxt-arcade/issues/4965

Fixing a few of the thumbnail recording bugs. Each commit is broken out into one change.

Summary of the changes:

1. We now try and retake the screenshot if the thumbnail doesn't load
2. The screenshot button now disappears when you are recording a GIF
3. The thumbnail changes into a spinner when you're recording/rendering to make it more obvious when recording has started or stopped
4. Swapped the order of the "apply" and "cancel" buttons

![thumbnail-fixes](https://user-images.githubusercontent.com/13754588/192351348-19f2171d-848c-4808-be1a-88af179eb24d.gif)
