### PR TITLE
Disable AutoRun in Light Mode

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -216,7 +216,7 @@ export class ProjectView
             && ((pxt.options.light
                 ? !!pxt.appTarget.simulator.autoRunLight
                 : !!pxt.appTarget.simulator.autoRun)
-                || !!pxt.appTarget.simulator.emptyRunCode);
+                || (this.firstRun && !!pxt.appTarget.simulator.emptyRunCode));
     }
 
     private initSimulatorMessageHandlers() {


### PR DESCRIPTION
The `emptyRunCode` var is a string with code in it, so `!!emptyRunCode` always returns true (as long as the string is set in pxttarget.json, which it usually is). As a result, we always return true for `autoRunOnStart()`, even if light mode is enabled. As I understand it, we should only do an empty code run if it's also the first run, so I've added an additional check to account for that.

This fixes the first part of https://github.com/microsoft/pxt-arcade/issues/2313: "Autorun should always be disabled for light mode"