### PR TITLE
More share fixes

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -394,6 +394,7 @@ namespace pxt.editor {
         requestProjectCloudStatus(headerIds: string[]): Promise<void>;
         convertCloudProjectsToLocal(userId: string): Promise<void>;
         setLanguageRestrictionAsync(restriction: pxt.editor.LanguageRestriction): Promise<void>;
+        hasHeaderBeenPersistentShared(): boolean;
     }
 
     export interface IHexFileImporter {

--- a/react-common/components/share/Share.tsx
+++ b/react-common/components/share/Share.tsx
@@ -20,19 +20,21 @@ export interface ShareProps {
     projectName: string;
     screenshotUri?: string;
     isLoggedIn?: boolean;
+    hasProjectBeenPersistentShared?: boolean;
 
     simRecorder: SimRecorder;
     publishAsync: (name: string, screenshotUri?: string, forceAnonymous?: boolean) => Promise<ShareData>;
 }
 
 export const Share = (props: ShareProps) => {
-    const { projectName, screenshotUri, isLoggedIn, simRecorder, publishAsync} = props;
+    const { projectName, screenshotUri, isLoggedIn, simRecorder, publishAsync, hasProjectBeenPersistentShared } = props;
 
     return <div className="project-share">
         <ShareInfo projectName={projectName}
             isLoggedIn={isLoggedIn}
             screenshotUri={screenshotUri}
             simRecorder={simRecorder}
-            publishAsync={publishAsync} />
+            publishAsync={publishAsync}
+            hasProjectBeenPersistentShared={hasProjectBeenPersistentShared} />
     </div>
 }

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -191,7 +191,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
                                 ? lf("Oops! Your project is too big. You can create a GitHub repository to share it.")
                                 : lf("Oops! There was an error. Please ensure you are connected to the Internet and try again.")}
                         </div>}
-                        <div>
+                        <div className="project-share-publish-actions">
                             {shareState === "share" &&
                                 <Button className="primary share-publish-button"
                                     title={lf("Continue")}

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -16,12 +16,13 @@ export interface ShareInfoProps {
     description?: string;
     screenshotUri?: string;
     isLoggedIn?: boolean;
+    hasProjectBeenPersistentShared?: boolean;
     simRecorder: SimRecorder;
     publishAsync: (name: string, screenshotUri?: string, forceAnonymous?: boolean) => Promise<ShareData>;
 }
 
 export const ShareInfo = (props: ShareInfoProps) => {
-    const { projectName, description, screenshotUri, isLoggedIn, simRecorder, publishAsync } = props;
+    const { projectName, description, screenshotUri, isLoggedIn, simRecorder, publishAsync, hasProjectBeenPersistentShared } = props;
     const [ name, setName ] = React.useState(projectName);
     const [ thumbnailUri, setThumbnailUri ] = React.useState(screenshotUri);
     const [ shareState, setShareState ] = React.useState<"share" | "gifrecord" | "publish" | "publishing">("share");
@@ -175,9 +176,9 @@ export const ShareInfo = (props: ShareInfoProps) => {
                             initialValue={name}
                             placeholder={lf("Name your project")}
                             onChange={setName} />
-                        {isLoggedIn && <Checkbox
+                        {isLoggedIn && hasProjectBeenPersistentShared && <Checkbox
                             id="persistent-share-checkbox"
-                            label={lf("Allow people to see future changes to my project")}
+                            label={lf("Update existing share link for this project")}
                             isChecked={!isAnonymous}
                             onChange={val => setIsAnonymous(!val)}
                             />}

--- a/react-common/components/share/ThumbnailRecorder.tsx
+++ b/react-common/components/share/ThumbnailRecorder.tsx
@@ -37,6 +37,8 @@ export const ThumbnailRecorder = (props: ThumbnailRecorderProps) => {
     const [ recorderRef, setRecorderRef ] = React.useState<SimRecorderRef>(undefined);
     const [ recorderState, setRecorderState ] = React.useState<SimRecorderState>("default");
 
+    let simContainer: HTMLDivElement;
+
     React.useEffect(() => {
         if (!recorderRef) return undefined;
         recorderRef.addStateChangeListener(setRecorderState);
@@ -68,15 +70,22 @@ export const ThumbnailRecorder = (props: ThumbnailRecorderProps) => {
         }
         else if (recorderRef.state === "default") {
             recorderRef.startRecordingAsync();
+            if (simContainer) {
+                const iframe = simContainer.querySelector("iframe");
+                if (iframe) iframe.focus();
+            }
         }
     }
-
-    const targetTheme = pxt.appTarget.appTheme;
 
     const handleSimRecorderRef = (ref: SimRecorderRef) => {
         setRecorderRef(ref);
     }
 
+    const handleSimRecorderContainerRef = (ref: HTMLDivElement) => {
+        if (ref) simContainer = ref;
+    }
+
+    const targetTheme = pxt.appTarget.appTheme;
     const screenshotLabel = lf("Screenshot ({0})", targetTheme.simScreenshotKey);
     const startRecordingLabel = lf("Record ({0})", targetTheme.simGifKey);
     const stopRecordingLabel = lf("Stop recording ({0})", targetTheme.simGifKey);
@@ -99,7 +108,7 @@ export const ThumbnailRecorder = (props: ThumbnailRecorderProps) => {
     return <>
         <div className={classes}>
             <div className="gif-recorder-sim">
-                <div className="gif-recorder-sim-embed">
+                <div className="gif-recorder-sim-embed" ref={handleSimRecorderContainerRef}>
                     {React.createElement(simRecorder, { onSimRecorderInit: handleSimRecorderRef })}
                 </div>
                 <div className="gif-recorder">

--- a/react-common/styles/share/share.less
+++ b/react-common/styles/share/share.less
@@ -32,6 +32,8 @@
 
     .project-share-content {
         flex-grow: 1;
+        display: flex;
+        flex-direction: column;
 
         .name-input .common-input-group {
             height: 3rem;
@@ -107,6 +109,13 @@
     }
 }
 
+.project-share-publish-actions {
+    flex-grow: 1;
+    justify-content: end;
+    display: flex;
+    align-items: end;
+}
+
 
 /////////////////////////////////////////
 //           Embed                     //
@@ -178,12 +187,14 @@
         display: flex;
         flex-direction: column;
         padding: 0 4rem;
+        height: 100%;
 
         .thumbnail-preview {
             display: flex;
             flex-direction: column;
             flex-grow: 1;
             align-items: center;
+            justify-content: center;
 
             & > div {
                 padding-bottom: 1rem;
@@ -201,6 +212,8 @@
         .thumbnail-actions {
             display: flex;
             flex-direction: row;
+            align-items: end;
+            justify-content: end;
         }
     }
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4019,6 +4019,9 @@ export class ProjectView
         }
     }
 
+    hasHeaderBeenPersistentShared() {
+        return !!this.state.header?.pubPermalink;
+    }
 
     async saveLocalProjectsToCloudAsync(headerIds: string[]): Promise<pxt.Map<string> | undefined> {
         return cloud.saveLocalProjectsToCloudAsync(headerIds);

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -196,6 +196,8 @@ export class ShareEditor extends auth.Component<ShareEditorProps, ShareEditorSta
         const thumbnails = pxt.appTarget.cloud && pxt.appTarget.cloud.thumbnails
             && (simScreenshot || simGif);
 
+        const hasProjectBeenPersistentShared = parent.hasHeaderBeenPersistentShared();
+
         const publishAsync = async (name: string, screenshotUri?: string, forceAnonymous?: boolean) =>
             parent.publishAsync(name, screenshotUri, forceAnonymous)
 
@@ -209,6 +211,7 @@ export class ShareEditor extends auth.Component<ShareEditorProps, ShareEditorSta
                     screenshotUri={screenshotUri}
                     isLoggedIn={hasIdentity}
                     publishAsync={publishAsync}
+                    hasProjectBeenPersistentShared={hasProjectBeenPersistentShared}
                     simRecorder={SimRecorderImpl} />
             </Modal>
             : <></>


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/4991
Fixes https://github.com/microsoft/pxt-arcade/issues/4960
Fixes https://github.com/microsoft/pxt-arcade/issues/4964
Fixes https://github.com/microsoft/pxt-arcade/issues/4958

Changes include:

1. Clicking record now auto-focuses the sim
2. The GIF recorder now automatically times out after ten seconds
3. The share dialog buttons are now aligned to the bottom-right
4. The first share of a project is now always persistent, and subsequent shares have a checkbox asking if they want to update the existing link (defaults to checked)

For 4, the checkbox defaults to being checked. I can easily make it unchecked if that's preferred.