### PR TITLE
Remove wide class from share dialog in skillmap

### DIFF
--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -349,7 +349,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
 
         return <Modal
             title={lf("Share Project")}
-            className="sharedialog wide"
+            className="sharedialog"
             parentElement={document.getElementById("root") || undefined}
             onClose={this.handleOnClose}>
             <Share projectName={activity!.displayName}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/4959

Until we get the thumbnail recorder into the skillmap, removing the wide class