### PR TITLE
Change Shape of Skillmap Learning Objective Tags to Differentiate from Buttons

### DIFF
--- a/skillmap/src/styles/infopanel.css
+++ b/skillmap/src/styles/infopanel.css
@@ -104,6 +104,7 @@
     margin: 0 0.5rem 0.5rem 0;
     white-space: nowrap;
     user-select: none;
+    border-radius: 1rem;
 }
 
 /* Buttons */


### PR DESCRIPTION
Currently, the skillmap info panel has boxes that display a learning objectives, and they look very similar to the buttons lower down on the page, which can be confusing since the learning objective boxes are not interactive. This PR changes the shape of the learning objective containers so they're more visually distinct from the buttons.

Without this change:
![image](https://user-images.githubusercontent.com/69657545/192610355-7f30b71b-d466-4c3b-9697-7d5a67c7727f.png)

With change:
<img width="228" alt="image" src="https://user-images.githubusercontent.com/69657545/192612722-6046ee1b-6539-45b8-8519-1170858b69c2.png">

Fixes https://github.com/microsoft/pxt-arcade/issues/4967