### PR TITLE
don't show 'saving' text in sidepanel tutorial editortoolbar

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -551,6 +551,10 @@
         #editorSidebar {
             bottom: 0;
         }
+
+        .cloudstatusarea .cloudtext {
+            display: none;
+        }
     }
     .tutorial-container .tutorial-step-counter {
         .tutorial-step-label {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/5036