### PR TITLE
Add a 'licensing' page to the docs guidance pages

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -40,6 +40,7 @@
     * [User Tutorials](/writing-docs/user-tutorials)
     * [Skillmaps](/writing-docs/skillmaps)
     * [Routing](/writing-docs/routing)
+    * [Licensing](/writing-docs/licensing)
     * [Testing](/writing-docs/testing)
 * [Translations](/translate)
     * [Translation languages](/translate/languages)

--- a/docs/extensions/approval.md
+++ b/docs/extensions/approval.md
@@ -10,7 +10,7 @@ Banned extensions are not allowed to load.
 Whenever you are submitting an extension for approval, please check that you have completed the following tasks:
 
 - [ ] A release has been created in GitHub. You can create a release of the extension when syncing in the MakeCode editor or using the **pxt bump** cli command. The format **must** be ``MAJOR.MINOR.PATCH``.
-- [ ] A license file, `LICENSE.txt`, is present in the root folder. The license type is **MIT License**. See the [Adding a license to a repository](https://help.github.com/en/github/building-a-strong-community/adding-a-license-to-a-repository) topic for more details.
+- [ ] A [license](/writing-docs/licensing#makecode-extensions) file, `LICENSE.txt`, is present in the root folder. The license type is **MIT License**. See the [Adding a license to a repository](https://help.github.com/en/github/building-a-strong-community/adding-a-license-to-a-repository) topic for more details.
 - [ ] An icon image **icon.png** is available in the root folder. It should be 300x200 pixels and **less than 100kb** in size.
 - [ ] A GitHub repo description added that's descriptive enough to help with extension search.
 - [ ] A test file, called ``test.ts``, is present and compiles when running **pxt deploy**.

--- a/docs/writing-docs.md
+++ b/docs/writing-docs.md
@@ -19,4 +19,5 @@ This page was written using this documentation system, check it out at https://g
 * [Tutorials](/writing-docs/tutorials)
 * [User Tutorials](/writing-docs/user-tutorials)
 * [Skillmaps](/writing-docs/skillmaps)
+* [Licensing](/writing-docs/licensing)
 * [Testing](/writing-docs/testing)

--- a/docs/writing-docs/licensing.md
+++ b/docs/writing-docs/licensing.md
@@ -1,5 +1,6 @@
 # Licensing
-WWhen creating content related to use of MakeCode, we strongly recommend that a you include with it a standard license. This includes content that external or contributed but served from a MakeCode website. Related content is commonly in the form of, but not limited to, these:
+
+When creating learning content for MakeCode, we strongly recommend that you include a standard license in your content repository. This includes content that is served from a MakeCode website, commonly in the form of, but not limited to, these:
 
 * [Tutorials](/writing-docs/tutorials)
 * MakeCode projects and [extensions](/extensions) repositories on GitHub
@@ -59,4 +60,3 @@ SOFTWARE.
 ```
 
 This site, https://mit-license.org/, always contains the "official" text for the license.
-.org/, always contains the "official" text for the license.

--- a/docs/writing-docs/licensing.md
+++ b/docs/writing-docs/licensing.md
@@ -1,0 +1,31 @@
+# Licensing
+
+When creating content related to use of MakeCode, we strongly recommend that a you include with it a standard license. This includes content that external or contributed but served from a MakeCode website. Related content is commonly in the form of, but not limited to, these:
+
+* Tutorials
+* MakeCode projects and extensions repositories on GitHub
+* Curriculum based on the use of MakeCode
+* Skillmaps
+
+## Standard licenses
+
+There are many standard licenses available to choose from to include with your content. You can explore the different license choices at https://choosealicense.com. Your choice depends on how restrictive or permissive you want the use of your content to be. With MakeCode related content, it's best that you allow users enough freedom and flexibility to use what you're offering without too many restrictions. The licenses that we recommend are those established by [Creative Commons](https://creativecommons.org/licenses). You can view the general terms of each license and decide which one to use. In particular, these are the license types we suggest you use:
+
+* [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)
+>![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png) CC BY
+* [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/)
+>![Creative Commons License](https://i.creativecommons.org/l/by-sa/4.0/88x31.png) CC BY-SA
+* [Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)](https://creativecommons.org/licenses/by-nd/4.0/)
+>![Creative Commons License](https://i.creativecommons.org/l/by-nd/4.0/88x31.png) CC BY-ND
+
+## License file
+
+As part of your content set, it's typical to include a license file at the root of your file structure tree. Often this file is just named `LICENSE`. Inside this file is either the full legal text of the license or some text referring to a full license located elsewhere. For example, if you wish to use a CC BY license, your `LICENSE` file could contain:
+
+```
+This work is licensed under the Creative Commons Attribution 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+```
+
+Also, if you're contributing a single document or just a few pages, you can simply state that your work is licensed by one of the licenses mentioned above. Include a license reference like this near the beginning of your document:
+
+"This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/)." [![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png)](http://creativecommons.org/licenses/by/4.0/)

--- a/docs/writing-docs/licensing.md
+++ b/docs/writing-docs/licensing.md
@@ -2,10 +2,10 @@
 
 When creating content related to use of MakeCode, we strongly recommend that a you include with it a standard license. This includes content that external or contributed but served from a MakeCode website. Related content is commonly in the form of, but not limited to, these:
 
-* Tutorials
-* MakeCode projects and extensions repositories on GitHub
+* [Tutorials](/writing-docs/tutorials)
+* MakeCode projects and [extensions](/extensions) repositories on GitHub
 * Curriculum based on the use of MakeCode
-* Skillmaps
+* [Skillmaps](/writing-docs/skillmaps)
 
 ## Standard licenses
 
@@ -13,10 +13,9 @@ There are many standard licenses available to choose from to include with your c
 
 * [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)
 >![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png) CC BY
-* [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/)
->![Creative Commons License](https://i.creativecommons.org/l/by-sa/4.0/88x31.png) CC BY-SA
 * [Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)](https://creativecommons.org/licenses/by-nd/4.0/)
 >![Creative Commons License](https://i.creativecommons.org/l/by-nd/4.0/88x31.png) CC BY-ND
+* [MIT License](https://mit-license.org/)
 
 ## License file
 
@@ -29,3 +28,35 @@ This work is licensed under the Creative Commons Attribution 4.0 International L
 Also, if you're contributing a single document or just a few pages, you can simply state that your work is licensed by one of the licenses mentioned above. Include a license reference like this near the beginning of your document:
 
 "This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/)." [![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png)](http://creativecommons.org/licenses/by/4.0/)
+
+## MakeCode extensions
+
+[Extensions](/extensions) for MakeCode, unlike other content types, MUST have the MIT license. For [approval](/extensions/approval) to have MakeCode load your extension, it is required that a `LICENSE` file containing the MIT license be present at the root of the extension repository.
+
+Include a `LICENSE` file with the following text at the root of your extension repository:
+
+```
+MIT License
+
+Copyright (c) [year] [copyright holders]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+This site, https://mit-license.org/, always contains the "official" text for the license.

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -216,7 +216,7 @@ export class ProjectView
             && ((pxt.options.light
                 ? !!pxt.appTarget.simulator.autoRunLight
                 : !!pxt.appTarget.simulator.autoRun)
-                || !!pxt.appTarget.simulator.emptyRunCode);
+                || (this.firstRun && !!pxt.appTarget.simulator.emptyRunCode));
     }
 
     private initSimulatorMessageHandlers() {


### PR DESCRIPTION
This is a base page on recommending the inclusion of a license when creating MakeCode related content. Feel free suggest additional info or any corrections.

Closes #9069