### PR TITLE
add a 'pop out video' button to ams videoseos when pip available

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -867,8 +867,19 @@
 
 .tutorial-video-embed {
     display: flex;
-    align-content: center;
+    align-items: center;
     justify-content: center;
+    flex-direction: column;
+    > button {
+        display: block;
+        margin-top: .5rem;
+        border: solid 1px @tutorialPrimaryColor;
+        color: @tutorialPrimaryColor;
+    }
+}
+
+.tutorial-step-content video {
+    max-width: 100%;
 }
 
 /* Mobile */

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -326,7 +326,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                 )
                 if (player.getVideoElement()?.requestPictureInPicture) {
                     const pipButton = document.createElement("button");
-                    inlineVideo.parentElement.insertBefore(pipButton, inlineVideo.nextSibling);
+                    inlineVideo.parentElement.appendChild(pipButton);
                     pipButton.addEventListener("click", () => {
                         pxt.tickEvent("video.pip.requested");
                         player.getVideoElement().requestPictureInPicture();

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -324,6 +324,19 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
                     }
                 )
+                if (player.getVideoElement().requestPictureInPicture) {
+                    const pipButton = document.createElement("button");
+                    inlineVideo.parentElement.insertBefore(pipButton, inlineVideo.nextSibling);
+                    pipButton.addEventListener("click", () => {
+                        pxt.tickEvent("video.pip.requested");
+                        player.getVideoElement().requestPictureInPicture();
+                    });
+                    pipButton.addEventListener("keydown", fireClickOnEnter as any);
+                    pipButton.className = "common-button";
+                    pipButton.textContent = lf("Pop out video");
+                    pipButton.ariaLabel = lf("Open video in picture-in-picture mode");
+                    pipButton.title = pipButton.ariaLabel;
+                }
 
                 player.on(dashjs.MediaPlayer.events.PLAYBACK_STARTED,
                     (e: dashjs.PlaybackStartedEvent) => {

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -324,7 +324,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
                     }
                 )
-                if (player.getVideoElement().requestPictureInPicture) {
+                if (player.getVideoElement()?.requestPictureInPicture) {
                     const pipButton = document.createElement("button");
                     inlineVideo.parentElement.insertBefore(pipButton, inlineVideo.nextSibling);
                     pipButton.addEventListener("click", () => {

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -331,7 +331,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                         pxt.tickEvent("video.pip.requested");
                         player.getVideoElement().requestPictureInPicture();
                     });
-                    pipButton.addEventListener("keydown", fireClickOnEnter as any);
+                    pipButton.addEventListener("keydown", e => fireClickOnEnter(e as any));
                     pipButton.className = "common-button";
                     pipButton.textContent = lf("Pop out video");
                     pipButton.ariaLabel = lf("Open video in picture-in-picture mode");


### PR DESCRIPTION
Adds a button to pop out video for azure media service videos (when supported https://caniuse.com/picture-in-picture -- good support chrome / edge, pretty good safari, no firefox)

![pop out video button](https://user-images.githubusercontent.com/5615930/192646668-6e519c4e-75dd-4db7-8cf6-7620785a688d.gif)
