### PR TITLE
Add mute button to tutorial mini sim, expand when going to full editor

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -422,7 +422,7 @@
 
             .simtoolbar, #miniSimOverlay { display: block; }
             .play-button { display: none !important; }
-            .expand-button, .fullscreen-button { display: block !important; }
+            .expand-button, .fullscreen-button, .tutorial.mute-button { display: block !important; }
         }
 
         .tutorial-controls { display: none; }
@@ -457,6 +457,10 @@
 
             .button.hidefullscreen { display: none !important; }
         }
+    }
+
+    &.collapsedEditorTools:not(.fullscreensim) .tab-simulator.tab-content.hidden .simPanel{
+        .fullscreen-button, .tutorial.mute-button { display: none !important; }
     }
 
     #miniSimOverlay {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4525,6 +4525,9 @@ export class ProjectView
                         return this.loadHeaderAsync(curr);
                     }).finally(() => {
                         core.hideLoading("leavingtutorial")
+                        if (this.state.collapseEditorTools) {
+                            this.expandSimulator();
+                        }
                         this.postTutorialProgress();
                     })
                     .then(() => {

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -145,6 +145,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
                 {fullscreen && <sui.Button key='fullscreenbtn' className="fullscreen-button tablet only hidefullscreen" icon="xicon fullscreen" title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}
                 {restart && <sui.Button disabled={!runControlsEnabled} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} />}
                 {run && debug && <sui.Button disabled={!debugBtnEnabled} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="icon bug" title={debugTooltip} onClick={this.toggleDebug} />}
+                {audio && isTabTutorial && <sui.Button key='mutebtn' className={`hidefullscreen tutorial mute-button`} icon={`${isMuted ? 'volume off' : 'volume up'}`} title={muteTooltip} onClick={this.toggleMute} />}
                 {collapse && <sui.Button
                     className={`expand-button portrait only editortools-btn hidefullscreen`}
                     icon={`${collapsed ? 'play' : 'stop'}`}


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/4986
fix https://github.com/microsoft/pxt-arcade/issues/5011 (not directly related but short / accidentally forgot to make a new branch >> )

![image](https://user-images.githubusercontent.com/5615930/192846586-1cbc4239-b3c6-43bc-8f41-ae07f06f7b36.png)
