### PR TITLE
slight adjustment to tutorial hint colors, hint icon > key, title

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -838,6 +838,14 @@
         background-color: @HCbackground;
         color: @HCtextColor;
 
+        .hint-title {
+            margin: 0;
+            > span {
+                background-color: @HCbackground;
+                color: @HCtextColor;
+            }
+        }
+
         &:before {
             border-right-color: @HCtextColor;
         }

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -288,7 +288,8 @@
                 font-weight: 700;
                 background-color: @tutorialHintBackgroundColor;
                 color: @tutorialHintForegroundColor;
-                padding: 0.25rem;
+                padding: 0.25rem 0.75rem;
+                border-radius: 0.5rem;
             }
         }
     }

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -11,7 +11,7 @@
 
 @tutorialLinkColor: #0064BF;
 @tutorialLinkHoverColor: #003C94;
-@tutorialHintForegroundColor: #15717D;
+@tutorialHintForegroundColor: #1A6771;
 @tutorialHintBackgroundColor: #CEFFF5;
 
 @tutorialTabletButtonColor: #f3f3f3;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -11,6 +11,8 @@
 
 @tutorialLinkColor: #0064BF;
 @tutorialLinkHoverColor: #003C94;
+@tutorialHintForegroundColor: #15717D;
+@tutorialHintBackgroundColor: #CEFFF5;
 
 @tutorialTabletButtonColor: #f3f3f3;
 @tutorialTabletSimulatorButtonColor: rgba(0, 0, 0, 0.05);
@@ -278,6 +280,17 @@
         bottom: 5rem;
         left: 3rem;
         max-width: 50%;
+        border-color: @tutorialHintBackgroundColor;
+
+        .hint-title {
+            margin-top: -.75rem;
+            > span {
+                font-weight: 700;
+                background-color: @tutorialHintBackgroundColor;
+                color: @tutorialHintForegroundColor;
+                padding: 0.25rem;
+            }
+        }
     }
 
     .tutorial-callout:before {
@@ -522,12 +535,11 @@
 /*********************************
         Accordion Hints (details)
 *********************************/
-
 .tabTutorial details {
     padding: .5rem;
     margin-bottom: 1rem;
-    color: #028b9b;
-    background-color: #b1e3da;
+    color: @tutorialHintForegroundColor;
+    background-color: @tutorialHintBackgroundColor;
     border-radius: .5rem;
 }
 

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -405,8 +405,8 @@ code.lang-filterblocks {
     transform: rotateZ(-135deg);
 }
 
-.tutorialhint > div,
-.tutorial-callout > div {
+.tutorialhint > .hint-content,
+.tutorial-callout > .hint-content {
     max-height: 60vh;
     overflow: auto;
     padding-right: 2rem;

--- a/webapp/src/components/tutorial/TutorialHint.tsx
+++ b/webapp/src/components/tutorial/TutorialHint.tsx
@@ -22,8 +22,11 @@ export function TutorialHint(props: TutorialHintProps) {
     }
 
     return <TutorialCallout className="tutorial-hint"
-            buttonIcon="lightbulb"
-            onClick={onHintClick}>
-                {markdown && <MarkedContent markdown={markdown} unboxSnippets={true} parent={parent} />}
-        </TutorialCallout>
+        buttonIcon="key"
+        onClick={onHintClick}>
+            <div className="hint-title">
+                <span>{lf("Answer Key")}</span>
+            </div>
+            {markdown && <MarkedContent className="hint-content" markdown={markdown} unboxSnippets={true} parent={parent} />}
+    </TutorialCallout>
 }


### PR DESCRIPTION
close https://github.com/microsoft/pxt-arcade/issues/5028

\+ decision from alex + kiki on tutorial hint behavior, changing lightbulb to key + a label for 'answer key':

![image](https://user-images.githubusercontent.com/5615930/193103533-7617f97e-eb59-4157-93bb-f52d773ae201.png)
