### PR TITLE
Remember share anonymous preference in the project header

### DIFF
--- a/localtypings/projectheader.d.ts
+++ b/localtypings/projectheader.d.ts
@@ -21,6 +21,7 @@ declare namespace pxt.workspace {
         pubCurrent: boolean; // is this exactly pubId, or just based on it
         pubVersions?: PublishVersion[];
         pubPermalink?: string; // permanent (persistent) share ID
+        anonymousSharePreference?: boolean; // if true, default to sharing anonymously even when logged in
         githubId?: string;
         githubTag?: string; // the release tag if any (commit.tag)
         githubCurrent?: boolean;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -395,6 +395,8 @@ namespace pxt.editor {
         convertCloudProjectsToLocal(userId: string): Promise<void>;
         setLanguageRestrictionAsync(restriction: pxt.editor.LanguageRestriction): Promise<void>;
         hasHeaderBeenPersistentShared(): boolean;
+        getSharePreferenceForHeader(): boolean;
+        saveSharePreferenceForHeaderAsync(anonymousByDefault: boolean): Promise<void>;
     }
 
     export interface IHexFileImporter {

--- a/react-common/components/share/Share.tsx
+++ b/react-common/components/share/Share.tsx
@@ -21,13 +21,15 @@ export interface ShareProps {
     screenshotUri?: string;
     isLoggedIn?: boolean;
     hasProjectBeenPersistentShared?: boolean;
+    anonymousShareByDefault?: boolean;
+    setAnonymousSharePreference?: (anonymousByDefault: boolean) => void;
 
     simRecorder: SimRecorder;
     publishAsync: (name: string, screenshotUri?: string, forceAnonymous?: boolean) => Promise<ShareData>;
 }
 
 export const Share = (props: ShareProps) => {
-    const { projectName, screenshotUri, isLoggedIn, simRecorder, publishAsync, hasProjectBeenPersistentShared } = props;
+    const { projectName, screenshotUri, isLoggedIn, simRecorder, publishAsync, hasProjectBeenPersistentShared, anonymousShareByDefault, setAnonymousSharePreference } = props;
 
     return <div className="project-share">
         <ShareInfo projectName={projectName}
@@ -35,6 +37,8 @@ export const Share = (props: ShareProps) => {
             screenshotUri={screenshotUri}
             simRecorder={simRecorder}
             publishAsync={publishAsync}
-            hasProjectBeenPersistentShared={hasProjectBeenPersistentShared} />
+            hasProjectBeenPersistentShared={hasProjectBeenPersistentShared}
+            anonymousShareByDefault={anonymousShareByDefault}
+            setAnonymousSharePreference={setAnonymousSharePreference} />
     </div>
 }

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -19,10 +19,13 @@ export interface ShareInfoProps {
     hasProjectBeenPersistentShared?: boolean;
     simRecorder: SimRecorder;
     publishAsync: (name: string, screenshotUri?: string, forceAnonymous?: boolean) => Promise<ShareData>;
+
+    anonymousShareByDefault?: boolean;
+    setAnonymousSharePreference?: (anonymousByDefault: boolean) => void;
 }
 
 export const ShareInfo = (props: ShareInfoProps) => {
-    const { projectName, description, screenshotUri, isLoggedIn, simRecorder, publishAsync, hasProjectBeenPersistentShared } = props;
+    const { projectName, description, screenshotUri, isLoggedIn, simRecorder, publishAsync, hasProjectBeenPersistentShared, anonymousShareByDefault, setAnonymousSharePreference } = props;
     const [ name, setName ] = React.useState(projectName);
     const [ thumbnailUri, setThumbnailUri ] = React.useState(screenshotUri);
     const [ shareState, setShareState ] = React.useState<"share" | "gifrecord" | "publish" | "publishing">("share");
@@ -30,7 +33,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
     const [ embedState, setEmbedState ] = React.useState<"none" | "code" | "editor" | "simulator">("none");
     const [ showQRCode, setShowQRCode ] = React.useState(false);
     const [ copySuccessful, setCopySuccessful ] = React.useState(false);
-    const [ isAnonymous, setIsAnonymous ] = React.useState(!isLoggedIn);
+    const [ isAnonymous, setIsAnonymous ] = React.useState(!isLoggedIn || anonymousShareByDefault);
 
     const showSimulator = !!simRecorder;
     const showDescription = shareState !== "publish";
@@ -141,6 +144,12 @@ export const ShareInfo = (props: ShareInfoProps) => {
         if (ref) inputRef = ref;
     }
 
+    const handleAnonymousShareClick = (newValue: boolean) => {
+        pxt.tickEvent("share.anonymousCheckbox")
+        setIsAnonymous(!newValue);
+        if (setAnonymousSharePreference) setAnonymousSharePreference(!newValue);
+    }
+
     const prePublish = shareState === "share" || shareState === "publishing";
 
     const inputTitle = prePublish ? lf("Project Title") : lf("Project Link")
@@ -180,7 +189,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
                             id="persistent-share-checkbox"
                             label={lf("Update existing share link for this project")}
                             isChecked={!isAnonymous}
-                            onChange={val => setIsAnonymous(!val)}
+                            onChange={handleAnonymousShareClick}
                             />}
                         </>
                     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4023,6 +4023,16 @@ export class ProjectView
         return !!this.state.header?.pubPermalink;
     }
 
+    getSharePreferenceForHeader() {
+        return this.state.header?.anonymousSharePreference;
+    }
+
+    async saveSharePreferenceForHeaderAsync(anonymousByDefault: boolean) {
+        if (!this.state.header) return;
+        this.state.header.anonymousSharePreference = anonymousByDefault;
+        await workspace.saveAsync(this.state.header);
+    }
+
     async saveLocalProjectsToCloudAsync(headerIds: string[]): Promise<pxt.Map<string> | undefined> {
         return cloud.saveLocalProjectsToCloudAsync(headerIds);
     }

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -201,6 +201,8 @@ export class ShareEditor extends auth.Component<ShareEditorProps, ShareEditorSta
         const publishAsync = async (name: string, screenshotUri?: string, forceAnonymous?: boolean) =>
             parent.publishAsync(name, screenshotUri, forceAnonymous)
 
+        const setSharePreference = (anonymousByDefault: boolean) => parent.saveSharePreferenceForHeaderAsync(anonymousByDefault)
+
         return visible
             ? <Modal
                 title={lf("Share Project")}
@@ -212,7 +214,9 @@ export class ShareEditor extends auth.Component<ShareEditorProps, ShareEditorSta
                     isLoggedIn={hasIdentity}
                     publishAsync={publishAsync}
                     hasProjectBeenPersistentShared={hasProjectBeenPersistentShared}
-                    simRecorder={SimRecorderImpl} />
+                    simRecorder={SimRecorderImpl}
+                    anonymousShareByDefault={parent.getSharePreferenceForHeader()}
+                    setAnonymousSharePreference={setSharePreference} />
             </Modal>
             : <></>
     }


### PR DESCRIPTION
Remembers if the "update existing project share link" checkbox is checked for each project