### PR TITLE
try and handle crowdin 429s we've been getting

### DIFF
--- a/pxtlib/crowdin.ts
+++ b/pxtlib/crowdin.ts
@@ -183,7 +183,7 @@ namespace pxt.crowdin {
                     .then(() => uploadTranslationAsync(branch, prj, key, filename, data));
             } else if (code == 429 && errorData.error?.code == 55) {
                 // Too many concurrent requests
-                pxt.log(`Maximum concurrent requests, waiting 5s and retry...`)
+                pxt.log(`Maximum concurrent requests, waiting 10s and retry...`)
                 return U.delay(10 * 1000) // wait 10s and try again
                     .then(() => uploadTranslationAsync(branch, prj, key, filename, data));
             } else if (code == 200 || errorData.success) {

--- a/pxtlib/crowdin.ts
+++ b/pxtlib/crowdin.ts
@@ -183,7 +183,7 @@ namespace pxt.crowdin {
                     .then(() => uploadTranslationAsync(branch, prj, key, filename, data));
             } else if (code == 429 && errorData.error?.code == 55) {
                 // Too many concurrent requests
-                pxt.log(`Maximum concurrent requests, waiting 10s and retry...`)
+                pxt.log(`Maximum concurrent requests reached, waiting 10s and retry...`)
                 return U.delay(10 * 1000) // wait 10s and try again
                     .then(() => uploadTranslationAsync(branch, prj, key, filename, data));
             } else if (code == 200 || errorData.success) {

--- a/pxtlib/crowdin.ts
+++ b/pxtlib/crowdin.ts
@@ -173,13 +173,18 @@ namespace pxt.crowdin {
                 pxt.log(`create new translation file: ${filename}`)
                 return uploadAsync("add-file", {})
             }
-            else if (code == 404 && errorData.error && errorData.error.code == 17) {
+            else if (code == 404 && errorData.error?.code == 17) {
                 return createDirectoryAsync(branch, prj, key, filename.replace(/\/[^\/]+$/, ""), incr)
                     .then(() => startAsync())
-            } else if (!errorData.success && errorData.error && errorData.error.code == 53) {
+            } else if (!errorData.success && errorData.error?.code == 53) {
                 // file is being updated
                 pxt.log(`${filename} being updated, waiting 5s and retry...`)
                 return U.delay(5000) // wait 5s and try again
+                    .then(() => uploadTranslationAsync(branch, prj, key, filename, data));
+            } else if (code == 429 && errorData.error?.code == 55) {
+                // Too many concurrent requests
+                pxt.log(`Maximum concurrent requests, waiting 5s and retry...`)
+                return U.delay(10 * 1000) // wait 10s and try again
                     .then(() => uploadTranslationAsync(branch, prj, key, filename, data));
             } else if (code == 200 || errorData.success) {
                 // something crowdin reports 500 with success=true


### PR DESCRIPTION
We've been getting tons of spurious-ish build fails like this: https://github.com/microsoft/pxt-arcade/actions/runs/3147157788/jobs/5116383731#step:6:1552.

I think the root cause might be something changing on crowdin side (I feel like I remember it being 30 concurrent requests but they list 20 now, either way we haven't changed our usage patterns much but we're getting the error more often), but we should handle the error either way.

(this isn't explicitly tested as it's not something that can really be tested without intentionally overloading crowdin api to get it to crash, but it's just an extra case of the existing retry error case for updates so feels pretty safe)