### PR TITLE
add titles / aria labels for hint & next/done buttons

### DIFF
--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -41,10 +41,13 @@ export function TutorialCallout(props: TutorialCalloutProps) {
         toggleCallout(e);
     }
 
+    const buttonTitle = lf("Click to show a hint!");
     return <div className={className}>
         <Button icon={buttonIcon}
             text={buttonLabel}
             className="tutorial-callout-button"
+            title={buttonTitle}
+            ariaLabel={buttonTitle}
             disabled={!children}
             onClick={children ? handleButtonClick : undefined} />
         {visible && <div className={`tutorial-callout no-select`} onClick={captureEvent}>

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -139,9 +139,12 @@ export function TutorialContainer(props: TutorialContainerProps) {
             title: lf("Launch Immersive Reader")
         })
     }
+
+    const doneButtonLabel = lf("Finish the tutorial.");
+    const nextButtonLabel = lf("Go to the next step of the tutorial.");
     const nextButton = showDone
-        ? <Button icon="check circle" text={lf("Done")} onClick={onTutorialComplete} />
-        : <Button icon="arrow circle right" disabled={!showNext} text={lf("Next")} onClick={tutorialStepNext} />;
+        ? <Button icon="check circle" title={doneButtonLabel} ariaLabel={doneButtonLabel} text={lf("Done")} onClick={onTutorialComplete} />
+        : <Button icon="arrow circle right" title={nextButtonLabel} ariaLabel={nextButtonLabel} disabled={!showNext} text={lf("Next")} onClick={tutorialStepNext} />;
 
     const stepCounter = <TutorialStepCounter tutorialId={tutorialId} currentStep={visibleStep} totalSteps={steps.length} title={name} setTutorialStep={setCurrentStep} />;
     const hasHint = !!hintMarkdown;


### PR DESCRIPTION
Not a regression but probably want to sneak this into the release build, I just noticed that the sidepanel tutorials next / hint buttons never got titles / aria labels for accessibility~