### PR TITLE
fix expandable hints hc, add pointer cursor

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -882,6 +882,12 @@
         }
     }
 
+    &.tabTutorial details {
+        background-color: @HCbackground !important;
+        border: 2px solid @HCtextColor !important;
+        color: @HCtextColor !important;
+    }
+
     .ui.label {
         background-color: @HCbackground !important;
         border: 2px solid @HCtextColor !important;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -542,6 +542,9 @@
     color: @tutorialHintForegroundColor;
     background-color: @tutorialHintBackgroundColor;
     border-radius: .5rem;
+    summary {
+        cursor: pointer;
+    }
 }
 
 


### PR DESCRIPTION
we should port this one for release

fix https://github.com/microsoft/pxt-arcade/issues/5077

![image](https://user-images.githubusercontent.com/5615930/193333480-5bb06a4b-c926-40a8-8451-991b60df915c.png)

and make it so it shows up as a cursor when you hover over the clickable portion like all other buttons