### PR TITLE
video pause on hidden, restart at start time

### DIFF
--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -439,7 +439,8 @@ namespace pxt.docs {
                 }
                 const url = new URL(`https://${endpointName}.streaming.media.azure.net/${videoID}/manifest(format=mpd-time-csf).mpd`)
                 if (startTime) {
-                    url.hash = `t=${startTime}`
+                    url.hash = `t=${startTime}`;
+                    url.searchParams.append("startTime", startTime);
                 }
                 if (endTime) {
                     url.searchParams.append("endTime", endTime);

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -587,7 +587,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     }
                 }
             })
-            detailsElement.onkeydown = fireClickOnEnter as any;
+            detailsElement.addEventListener("keydown", fireClickOnEnter as any);
             // Append the summary element to the details element...
             detailsElement.append(hint.summary);
             // ...and any child nodes we detected along the way.

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -324,12 +324,17 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
                     }
                 )
-                if (player.getVideoElement()?.requestPictureInPicture) {
+
+                const videoElement = player.getVideoElement();
+                if (videoElement?.requestPictureInPicture) {
+                    videoElement.addEventListener("leavepictureinpicture", () => {
+                        player.pause()
+                    });
                     const pipButton = document.createElement("button");
                     inlineVideo.parentElement.appendChild(pipButton);
                     pipButton.addEventListener("click", () => {
                         pxt.tickEvent("video.pip.requested");
-                        player.getVideoElement().requestPictureInPicture();
+                        videoElement.requestPictureInPicture();
                     });
                     pipButton.addEventListener("keydown", e => fireClickOnEnter(e as any));
                     pipButton.className = "common-button";

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -327,7 +327,11 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
                 const videoElement = player.getVideoElement();
                 if (videoElement?.requestPictureInPicture) {
+                    videoElement.addEventListener("enterpictureinpicture", () => {
+                        videoElement.setAttribute("data-pip-active", "true");
+                    })
                     videoElement.addEventListener("leavepictureinpicture", () => {
+                        videoElement.setAttribute("data-pip-active", undefined);
                         player.pause()
                     });
                     const pipButton = document.createElement("button");
@@ -569,6 +573,16 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         accordionHints.forEach((hint) => {
             // Create a 'details' element to replace the hint-begin element.
             const detailsElement = document.createElement('details');
+
+            detailsElement.addEventListener("pointerdown", () => {
+                const videoElements = detailsElement.querySelectorAll("video");
+                for (const el of videoElements) {
+                    if (!el.getAttribute("data-pip-active")) {
+                        el.pause();
+                    }
+                }
+            })
+            detailsElement.onkeydown = fireClickOnEnter as any;
             // Append the summary element to the details element...
             detailsElement.append(hint.summary);
             // ...and any child nodes we detected along the way.

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -314,18 +314,23 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     player: "azure",
                     url: src
                 })
-                const END_TIME = url.searchParams.get("endTime");
-                player.on(
-                    dashjs.MediaPlayer.events.PLAYBACK_TIME_UPDATED,
-                    (e: dashjs.PlaybackTimeUpdatedEvent) => {
-                        if (parseInt(END_TIME) <= e.time) {
-                            player.pause();
-                        }
-
-                    }
-                )
 
                 const videoElement = player.getVideoElement();
+                const startTime = parseInt(url.searchParams.get("startTime")) || 0;
+                const endTime = parseInt(url.searchParams.get("endTime"));
+                if (endTime) {
+                    player.on(
+                        dashjs.MediaPlayer.events.PLAYBACK_TIME_UPDATED,
+                        (e: dashjs.PlaybackTimeUpdatedEvent) => {
+                            if (endTime <= e.time) {
+                                videoElement.currentTime = startTime;
+                                player.pause();
+                            }
+
+                        }
+                    )
+                }
+
                 if (videoElement?.requestPictureInPicture) {
                     videoElement.addEventListener("enterpictureinpicture", () => {
                         videoElement.setAttribute("data-pip-active", "true");


### PR DESCRIPTION
Few quick fixes
* pause on exiting picture in picture mode as it's a bit of an 'escape video' behavior: fix https://github.com/microsoft/pxt-arcade/issues/5103
* on toggle accordion hint pause the contained videos (iff the video is not popped out into picture in picture where it is still visible)
* when you get to the endTime in a video, pop back to the beginning of the segment. Currently it just pauses at the end, and if you play again it will immediately pause again when the first PLAYBACK_TIME_UPDATED event is fired, which makes it hard to replay the video if you missed something.