### PR TITLE
cleanup user/client terminology

### DIFF
--- a/multiplayer/src/components/Presence.tsx
+++ b/multiplayer/src/components/Presence.tsx
@@ -32,7 +32,7 @@ export default function Render() {
                             {user?.name}
                             {user && (
                                 <ReactionEmitter
-                                    userId={user.id}
+                                    clientId={user.id}
                                     parentRef={slotRef.current[slot]!}
                                 />
                             )}

--- a/multiplayer/src/components/ReactionEmitter.tsx
+++ b/multiplayer/src/components/ReactionEmitter.tsx
@@ -23,12 +23,12 @@ type Particle = ReactionParticleInstance & {
 const MAX_PARTICLES = 20;
 
 export default function Render(props: {
-    userId: string;
+    clientId: string;
     parentRef: HTMLDivElement;
 }) {
     const { state } = useContext(AppStateContext);
-    const { userId } = props;
-    const reaction = state.reactions[userId];
+    const { clientId } = props;
+    const reaction = state.reactions[clientId];
 
     const [, updateTrigger] = useState(0);
     const forceUpdate = useCallback(() => updateTrigger(x => x + 1), []);

--- a/multiplayer/src/epics/playerJoinedAsync.ts
+++ b/multiplayer/src/epics/playerJoinedAsync.ts
@@ -1,9 +1,9 @@
 import { state, dispatch } from "../state";
 import { showToast } from "../state/actions";
 
-export async function playerJoinedAsync(userId: string) {
+export async function playerJoinedAsync(clientId: string) {
     try {
-        const user = state.presence.users.find(u => u.id === userId);
+        const user = state.presence.users.find(u => u.id === clientId);
         if (user) {
             dispatch(
                 showToast({

--- a/multiplayer/src/epics/playerLeftAsync.ts
+++ b/multiplayer/src/epics/playerLeftAsync.ts
@@ -1,9 +1,9 @@
 import { state, dispatch } from "../state";
 import { showToast } from "../state/actions";
 
-export async function playerLeftAsync(userId: string) {
+export async function playerLeftAsync(clientId: string) {
     try {
-        const user = state.presence.users.find(u => u.id === userId);
+        const user = state.presence.users.find(u => u.id === clientId);
         if (user) {
             dispatch(
                 showToast({

--- a/multiplayer/src/epics/setReactionAsync.ts
+++ b/multiplayer/src/epics/setReactionAsync.ts
@@ -2,13 +2,13 @@ import { state, dispatch } from "../state";
 import { setReaction, clearReaction } from "../state/actions";
 import { nanoid } from "nanoid";
 
-export async function setReactionAsync(userId: string, index: number) {
+export async function setReactionAsync(clientId: string, index: number) {
     try {
         const reactionId = nanoid();
-        dispatch(setReaction(userId, reactionId, index));
+        dispatch(setReaction(clientId, reactionId, index));
         setTimeout(() => {
-            if (state.reactions[userId]?.id === reactionId) {
-                dispatch(clearReaction(userId));
+            if (state.reactions[clientId]?.id === reactionId) {
+                dispatch(clearReaction(clientId));
             }
         }, 1000);
     } catch (e) {

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -201,19 +201,19 @@ class GameClient {
 
     private async recvReactionMessageAsync(msg: Srv2Cli.ReactionMessage) {
         console.log("Server sent reaction");
-        await setReactionAsync(msg.userId, msg.index);
+        await setReactionAsync(msg.clientId, msg.index);
     }
 
     private async recvPlayerJoinedMessageAsync(
         msg: Srv2Cli.PlayerJoinedMessage
     ) {
         console.log("Server sent player joined");
-        await playerJoinedAsync(msg.userId);
+        await playerJoinedAsync(msg.clientId);
     }
 
     private async recvPlayerLeftMessageAsync(msg: Srv2Cli.PlayerLeftMessage) {
         console.log("Server sent player joined");
-        await playerLeftAsync(msg.userId);
+        await playerLeftAsync(msg.clientId);
     }
 }
 

--- a/multiplayer/src/state/actions.ts
+++ b/multiplayer/src/state/actions.ts
@@ -64,14 +64,14 @@ type SetPresence = ActionBase & {
 
 type SetReaction = ActionBase & {
     type: "SET_REACTION";
-    userId: string;
+    clientId: string;
     reactionId: string;
     index: number;
 };
 
 type ClearReaction = ActionBase & {
     type: "CLEAR_REACTION";
-    userId: string;
+    clientId: string;
 };
 
 /**
@@ -150,17 +150,17 @@ export const setPresence = (presence: Presence): SetPresence => ({
 });
 
 export const setReaction = (
-    userId: string,
+    clientId: string,
     reactionId: string,
     index: number
 ): SetReaction => ({
     type: "SET_REACTION",
-    userId,
+    clientId,
     reactionId,
     index,
 });
 
-export const clearReaction = (userId: string): ClearReaction => ({
+export const clearReaction = (clientId: string): ClearReaction => ({
     type: "CLEAR_REACTION",
-    userId,
+    clientId,
 });

--- a/multiplayer/src/state/reducer.ts
+++ b/multiplayer/src/state/reducer.ts
@@ -81,7 +81,7 @@ export default function reducer(state: AppState, action: Action): AppState {
                 ...state,
                 reactions: {
                     ...state.reactions,
-                    [action.userId]: {
+                    [action.clientId]: {
                         id: action.reactionId,
                         index: action.index,
                     },
@@ -93,7 +93,7 @@ export default function reducer(state: AppState, action: Action): AppState {
                 ...state,
                 reactions: {
                     ...state.reactions,
-                    [action.userId]: undefined,
+                    [action.clientId]: undefined,
                 },
             };
         }

--- a/multiplayer/src/state/state.ts
+++ b/multiplayer/src/state/state.ts
@@ -17,7 +17,7 @@ export type AppState = {
     toasts: ToastWithId[];
     presence: Presence;
     reactions: {
-        [userId: string]:
+        [clientId: string]:
             | {
                   id: string;
                   index: number;

--- a/multiplayer/src/types/index.ts
+++ b/multiplayer/src/types/index.ts
@@ -79,6 +79,7 @@ export namespace Srv2Cli {
         role: ClientRole;
         slot: number;
         gameMode: GameMode;
+        clientId: string;
     };
 
     export type StartGameMessage = MessageBase & {
@@ -98,17 +99,17 @@ export namespace Srv2Cli {
     export type ReactionMessage = MessageBase & {
         type: "reaction";
         index: number;
-        userId: string;
+        clientId: string;
     };
 
     export type PlayerJoinedMessage = MessageBase & {
         type: "player-joined";
-        userId: string;
+        clientId: string;
     };
 
     export type PlayerLeftMessage = MessageBase & {
         type: "player-left";
-        userId: string;
+        clientId: string;
     };
 
     export type Message =


### PR DESCRIPTION
Using `clientId` to represent a player in a multiplayer game, to avoid confusion with the existing `userId` from auth world.

This is a breaking change as it affected the format of a network message. I'll merge this and the server-side PR at the same time, and bump the server at that point.
