### PR TITLE
Add Prefix to Tailwind CSS Classes

### DIFF
--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -82,14 +82,14 @@ export default function Render() {
     const fullUrl = `${pxt.webConfig.runUrl}?${queryParameters.join("&")}`;
     return (
         /* eslint-disable @microsoft/sdl/react-iframe-missing-sandbox */
-        <div id="sim-container" className="grow mt-5">
+        <div id="sim-container" className="tw-grow mt-5">
             <iframe
                 id="sim-iframe"
                 ref={simIframeRef}
                 src={fullUrl}
                 allowFullScreen={true}
                 // TODO:  this calc is weird, needs cleaning.
-                className="h-[calc(100vh-26rem)] w-screen"
+                className="tw-h-[calc(100vh-26rem)] tw-w-screen"
                 sandbox="allow-popups allow-forms allow-scripts allow-same-origin"
                 title={lf("Arcade Game Simulator")}
             />

--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -82,7 +82,7 @@ export default function Render() {
     const fullUrl = `${pxt.webConfig.runUrl}?${queryParameters.join("&")}`;
     return (
         /* eslint-disable @microsoft/sdl/react-iframe-missing-sandbox */
-        <div id="sim-container" className="tw-grow mt-5">
+        <div id="sim-container" className="tw-grow tw-mt-5">
             <iframe
                 id="sim-iframe"
                 ref={simIframeRef}

--- a/multiplayer/src/components/HostGame.tsx
+++ b/multiplayer/src/components/HostGame.tsx
@@ -32,10 +32,10 @@ export default function Render() {
 
     return (
         <>
-            <div className="mt-2 h-max">
-                <div className="text-2xl font-bold">{"Hosting a Game"}</div>
+            <div className="tw-mt-2 tw-h-max">
+                <div className="tw-text-2xl tw-font-bold">{"Hosting a Game"}</div>
                 {netMode === "init" && (
-                    <div className="flex flex-row gap-1 items-end">
+                    <div className="tw-flex tw-flex-row tw-gap-1 tw-items-end">
                         <Input
                             label={lf("Game URL or Share Code")}
                             title={lf("Game URL or Share Code")}
@@ -53,21 +53,21 @@ export default function Render() {
                     </div>
                 )}
                 {netMode === "connecting" && (
-                    <div className="text-lg font-bold mt-5">
+                    <div className="tw-text-lg tw-font-bold tw-mt-5">
                         {lf("Connecting")}
                     </div>
                 )}
                 {netMode === "connected" && (
-                    <div className="flex flex-col gap-1">
-                        <div className="mt-5">
+                    <div className="tw-flex tw-flex-col tw-gap-1">
+                        <div className="tw-mt-5">
                             Join Code:{" "}
-                            <span className="p-2 tracking-[.25rem] border-1 border-black bg-slate-600 solid rounded text-white">
+                            <span className="tw-p-2 tw-tracking-[.25rem] tw-border-1 tw-border-black tw-bg-slate-600 tw-solid tw-rounded tw-text-white">
                                 {state.gameState?.joinCode}
                             </span>
                         </div>
                         {state.gameState?.gameMode === "lobby" && (
-                            <div className="mt-5">
-                                <div className="text-lg font-bold">
+                            <div className="tw-mt-5">
+                                <div className="tw-text-lg tw-font-bold">
                                     {lf("In the lobby")}
                                 </div>
                                 <Button
@@ -79,13 +79,13 @@ export default function Render() {
                             </div>
                         )}
                         {state.gameState?.gameMode === "playing" && (
-                            <div className="mt-5">
-                                <div className="text-lg font-bold">
+                            <div className="tw-mt-5">
+                                <div className="tw-text-lg tw-font-bold">
                                     {lf("Game Started!")}
                                 </div>
                             </div>
                         )}
-                        <div className="mt-1">
+                        <div className="tw-mt-1">
                             <Button
                                 className={"gray"}
                                 label={lf("Leave Game")}
@@ -96,13 +96,13 @@ export default function Render() {
                     </div>
                 )}
             </div>
-            <div className="grow" />
+            <div className="tw-grow" />
             {state.gameState?.gameMode && (
                 <>
-                    <div className="mt-5">
+                    <div className="tw-mt-5">
                         <Presence />
                     </div>
-                    <div className="mt-5">
+                    <div className="tw-mt-5">
                         <Reactions />
                     </div>
                 </>

--- a/multiplayer/src/components/JoinGame.tsx
+++ b/multiplayer/src/components/JoinGame.tsx
@@ -28,10 +28,10 @@ export default function Render() {
 
     return (
         <>
-            <div className="mt-2">
-                <div className="text-2xl font-bold">{"Joining a Game"}</div>
+            <div className="tw-mt-2">
+                <div className="tw-text-2xl tw-font-bold">{"Joining a Game"}</div>
                 {netMode === "init" && (
-                    <div className="flex flex-row gap-1 items-end">
+                    <div className="tw-flex tw-flex-row tw-gap-1 tw-items-end">
                         <Input
                             label={lf("Join Code")}
                             title={lf("Join Code")}
@@ -49,27 +49,27 @@ export default function Render() {
                     </div>
                 )}
                 {netMode === "connecting" && (
-                    <div className="text-lg font-bold mt-5">
+                    <div className="tw-text-lg tw-font-bold tw-mt-5">
                         {lf("Connecting")}
                     </div>
                 )}
                 {netMode === "connected" && (
-                    <div className="flex flex-col gap-1">
+                    <div className="tw-flex tw-flex-col tw-gap-1">
                         {state.gameState?.gameMode === "lobby" && (
-                            <div className="mt-5">
-                                <div className="text-lg font-bold">
+                            <div className="tw-mt-5">
+                                <div className="tw-text-lg tw-font-bold">
                                     {lf("In the lobby")}
                                 </div>
                             </div>
                         )}
                         {state.gameState?.gameMode === "playing" && (
-                            <div className="mt-5">
-                                <div className="text-lg font-bold">
+                            <div className="tw-mt-5">
+                                <div className="tw-text-lg tw-font-bold">
                                     {lf("Game Started!")}
                                 </div>
                             </div>
                         )}
-                        <div className="mt-1">
+                        <div className="tw-mt-1">
                             <Button
                                 className={"gray"}
                                 label={lf("Leave Game")}
@@ -80,13 +80,13 @@ export default function Render() {
                     </div>
                 )}
             </div>
-            <div className="grow" />
+            <div className="tw-grow" />
             {state.gameState?.gameMode && (
                 <>
-                    <div className="mt-5">
+                    <div className="tw-mt-5">
                         <Presence />
                     </div>
-                    <div className="mt-5">
+                    <div className="tw-mt-5">
                         <Reactions />
                     </div>
                 </>

--- a/multiplayer/src/components/Presence.tsx
+++ b/multiplayer/src/components/Presence.tsx
@@ -19,15 +19,15 @@ export default function Render() {
 
     return (
         <div>
-            <div className="text-lg font-bold">{lf("Players")}</div>
-            <div className="flex flex-row items-center justify-center gap-2 mt-2">
+            <div className="tw-text-lg tw-font-bold">{lf("Players")}</div>
+            <div className="tw-flex tw-flex-row tw-items-center tw-justify-center tw-gap-2 tw-mt-2">
                 {[1, 2, 3, 4].map(slot => {
                     const user = players.find(u => u.slot === slot);
                     return (
                         <div
                             key={slot}
                             ref={ref => (slotRef.current[slot] = ref)}
-                            className="flex p-1 border border-slate-300 rounded-full min-h-[2.25rem] min-w-[2.25rem] bg-neutral-50"
+                            className="tw-flex tw-p-1 tw-border tw-border-slate-300 tw-rounded-full tw-min-h-[2.25rem] tw-min-w-[2.25rem] tw-bg-neutral-50"
                         >
                             {user?.name}
                             {user && (

--- a/multiplayer/src/components/ReactionEmitter.tsx
+++ b/multiplayer/src/components/ReactionEmitter.tsx
@@ -113,7 +113,7 @@ export default function Render(props: {
 
     return (
         <div>
-            <div className="flex flex-row">
+            <div className="tw-flex tw-flex-row">
                 {activeParticles.map(p => {
                     return <ReactionParticle key={p.id} particle={p} />;
                 })}

--- a/multiplayer/src/components/ReactionParticle.tsx
+++ b/multiplayer/src/components/ReactionParticle.tsx
@@ -11,7 +11,7 @@ export default function Render(props: { particle: Particle }) {
 
     return (
         <div
-            className="fixed"
+            className="tw-fixed"
             style={{
                 left: particle.x + vars.xOffset,
                 top: particle.y + vars.yOffset,

--- a/multiplayer/src/components/Reactions.tsx
+++ b/multiplayer/src/components/Reactions.tsx
@@ -8,12 +8,12 @@ export default function Render() {
 
     return (
         <div>
-            <div className="text-lg font-bold">{lf("Reactions")}</div>
-            <div className="flex flex-row gap-1 mt-1">
+            <div className="tw-text-lg tw-font-bold">{lf("Reactions")}</div>
+            <div className="tw-flex tw-flex-row tw-gap-1 tw-mt-1">
                 {ReactionDb.map((def, i) => {
                     return (
                         <div
-                            className="cursor-pointer select-none border rounded-full border-slate-300 bg-neutral-50 hover:scale-150 ease-linear duration-[50ms] active:bg-neutral-200"
+                            className="tw-cursor-pointer tw-select-none tw-border tw-rounded-full tw-border-slate-300 tw-bg-neutral-50 hover:tw-scale-150 tw-ease-linear tw-duration-[50ms] active:tw-bg-neutral-200"
                             key={i}
                             onClick={() => onReactionClick(i)}
                         >

--- a/multiplayer/src/components/SignInPage.tsx
+++ b/multiplayer/src/components/SignInPage.tsx
@@ -33,7 +33,7 @@ export default function Render() {
     }, [signedIn, setShowSignInModal]);
 
     return (
-        <div className="pt-3 flex flex-col items-center gap-1">
+        <div className="tw-pt-3 tw-flex tw-flex-col tw-items-center tw-gap-1">
             <Button
                 className="primary"
                 label={lf("Sign In")}

--- a/multiplayer/src/components/SignedInPage.tsx
+++ b/multiplayer/src/components/SignedInPage.tsx
@@ -18,7 +18,7 @@ export default function Render() {
     const authButtonLabel = lf("Sign Out");
 
     return (
-        <div className="pt-3 pb-8 flex flex-col items-center gap-1 h-screen">
+        <div className="tw-pt-3 tw-pb-8 tw-flex tw-flex-col tw-items-center tw-gap-1 tw-h-screen">
             <Button
                 className="primary"
                 label={authButtonLabel}

--- a/multiplayer/src/components/Toast.tsx
+++ b/multiplayer/src/components/Toast.tsx
@@ -11,17 +11,17 @@ import { dismissToast } from "../state/actions";
 import "../App.css";
 
 const backgroundColors: { [type in ToastType]: string } = {
-    success: "bg-green-300",
-    info: "bg-sky-300",
-    warning: "bg-amber-300",
-    error: "bg-red-300",
+    success: "tw-bg-green-300",
+    info: "tw-bg-sky-300",
+    warning: "tw-bg-amber-300",
+    error: "tw-bg-red-300",
 };
 
 const sliderColors: { [type in ToastType]: string } = {
-    success: "bg-green-500",
-    info: "bg-sky-500",
-    warning: "bg-amber-500",
-    error: "bg-red-500",
+    success: "tw-bg-green-500",
+    info: "tw-bg-sky-500",
+    warning: "tw-bg-amber-500",
+    error: "tw-bg-red-500",
 };
 
 const icons: { [type in ToastType]: string } = {
@@ -60,50 +60,50 @@ function Toast(props: ToastWithId) {
     };
 
     const sliderWidth = useCallback(() => {
-        return sliderActive ? "w-0" : "w-full";
+        return sliderActive ? "tw-w-0" : "tw-w-full";
     }, [sliderActive]);
 
     return (
         <div
             className={
-                "flex flex-col mr-0 md:mr-4 border-none rounded shadow-md overflow-hidden pointer-events-auto " +
+                "tw-flex tw-flex-col tw-mr-0 md:tw-mr-4 tw-border-none tw-rounded tw-shadow-md tw-overflow-hidden tw-pointer-events-auto " +
                 [
                     props.textColorClass || "text-black",
                     props.backgroundColorClass || backgroundColors[props.type],
                 ].join(" ")
             }
         >
-            <div className={"flex gap-2 p-3 text-lg"}>
+            <div className={"tw-flex tw-gap-2 tw-p-3 tw-text-lg"}>
                 {!props.hideIcon && (
                     <div
                         className={
-                            "flex justify-center border-0 rounded-full " +
+                            "tw-flex tw-justify-center tw-border-0 tw-rounded-full " +
                             sliderColors[props.type]
                         }
                     >
                         {icons[props.type]}
                     </div>
                 )}
-                <div className="flex flex-col text-left">
+                <div className="tw-flex tw-flex-col tw-text-left">
                     {props.text && (
-                        <div className="whitespace-nowrap text-md overflow-ellipsis">
+                        <div className="tw-whitespace-nowrap tw-text-md tw-overflow-ellipsis">
                             {props.text}
                         </div>
                     )}
                     {props.detail && (
-                        <div className="text-sm">{props.detail}</div>
+                        <div className="tw-text-sm">{props.detail}</div>
                     )}
                     {props.jsx && <div>{props.jsx}</div>}
                 </div>
                 {!props.hideDismissBtn && !props.showSpinner && (
                     <div
-                        className="flex flex-grow justify-end"
+                        className="tw-flex tw-flex-grow tw-justify-end"
                         onClick={handleDismissClicked}
                     >
                         <div>
                             <FontAwesomeIcon
                                 className={
-                                    "cursor-pointer hover:scale-125 transition-all"
+                                    "tw-cursor-pointer hover:tw-scale-125 tw-transition-all"
                                 }
                                 icon={faTimesCircle}
                             />
@@ -111,7 +111,7 @@ function Toast(props: ToastWithId) {
                     </div>
                 )}
                 {props.showSpinner && (
-                    <div className="flex flex-grow justify-end">
+                    <div className="tw-flex tw-flex-grow tw-justify-end">
                         <div>
                             <FontAwesomeIcon
                                 icon={faCircleNotch}
@@ -126,7 +126,7 @@ function Toast(props: ToastWithId) {
                     <div
                         ref={sliderRef}
                         className={
-                            "h-1 transition-all ease-linear " +
+                            "tw-h-1 tw-transition-all tw-ease-linear " +
                             [sliderWidth(), sliderColors[props.type]].join(" ")
                         }
                         style={{ transitionDuration: `${props.timeoutMs}ms` }}
@@ -142,7 +142,7 @@ export default function Render() {
     const { toasts } = state;
 
     return (
-        <div className="flex gap-2 flex-col-reverse items-end fixed bottom-0 right-0 mb-8 mr-4 z-50 pointer-events-none">
+        <div className="tw-flex tw-gap-2 tw-flex-col-reverse tw-items-end tw-fixed tw-bottom-0 tw-right-0 tw-mb-8 tw-mr-4 tw-z-50 tw-pointer-events-none">
             <AnimatePresence>
                 {toasts.map(item => (
                     <motion.div

--- a/multiplayer/tailwind.config.js
+++ b/multiplayer/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  prefix: 'tw-',
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
   ],


### PR DESCRIPTION
This helps avoid conflicts with existing css classes, like "hidden", which can break tailwind behavior.

For example, I noticed an issue where tailwind could not properly adjust if something was shown or hidden based on screen size. The tailwind css classes to make that happen are `hidden md:block`. According to [the docs](https://tailwindcss.com/docs/responsive-design#mobile-first), this should hide the item when the screen is smaller than md and show the item when the screen is md or larger. However, the behavior I saw was that the item was always hidden, regardless of screen size. This was happening because we already have a `hidden` css class in our common theme (see [here](https://github.com/microsoft/pxt/blob/master/theme/common.less#L860-L862)). That class prevented tailwind from being able to override the display value on md+ screen sizes.

We could do a one-off workaround for `hidden`, but that may be error-prone if devs aren't aware of it, and it's possible we may encounter similar issues for other classes later on, so adding a prefix seemed like a more robust solution. And better to do it now while it's still a manageable amount to change.

Ideally, this doesn't have any functional impact, though it's possible I missed the prefix in a few places in which case some layout may look off. We may need to just update those as we notice them, though I'm hoping there aren't many.

Tailwind docs on prefixes: https://tailwindcss.com/docs/configuration#prefix