### PR TITLE
Move auth check. Add init state.

### DIFF
--- a/multiplayer/src/App.tsx
+++ b/multiplayer/src/App.tsx
@@ -1,20 +1,34 @@
-import { useCallback, useContext, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo } from "react";
 import { AppStateContext } from "./state/AppStateContext";
+import Loading from "./components/Loading";
 import SignInPage from "./components/SignInPage";
 import SignedInPage from "./components/SignedInPage";
 import Toast from "./components/Toast";
+import * as authClient from "./services/authClient";
 
 // eslint-disable-next-line import/no-unassigned-import
 import "./App.css";
 
 function App() {
     const { state } = useContext(AppStateContext);
-    const { signedIn } = state;
+    const { signedIn, appMode } = state;
+    const { uiMode } = appMode;
+
+    const loading = useMemo(() => uiMode === "init", [uiMode]);
+
+    useEffect(() => {
+        // On mount, check if user is signed in
+        authClient
+            .authCheckAsync()
+            .then(() => {})
+            .catch(() => {});
+    }, []);
 
     return (
         <div className={`${pxt.appTarget.id}`}>
-            {!signedIn && <SignInPage />}
-            {signedIn && <SignedInPage />}
+            {loading && <Loading />}
+            {!loading && !signedIn && <SignInPage />}
+            {!loading && signedIn && <SignedInPage />}
             <Toast />
         </div>
     );

--- a/multiplayer/src/components/HostGame.tsx
+++ b/multiplayer/src/components/HostGame.tsx
@@ -44,7 +44,9 @@ export default function Render() {
     return (
         <>
             <div className="tw-mt-2 tw-h-max">
-                <div className="tw-text-2xl tw-font-bold">{"Hosting a Game"}</div>
+                <div className="tw-text-2xl tw-font-bold">
+                    {"Hosting a Game"}
+                </div>
                 {netMode === "init" && (
                     <div className="tw-flex tw-flex-row tw-gap-1 tw-items-end">
                         <Input

--- a/multiplayer/src/components/JoinGame.tsx
+++ b/multiplayer/src/components/JoinGame.tsx
@@ -30,7 +30,9 @@ export default function Render() {
     return (
         <>
             <div className="tw-mt-2">
-                <div className="tw-text-2xl tw-font-bold">{"Joining a Game"}</div>
+                <div className="tw-text-2xl tw-font-bold">
+                    {"Joining a Game"}
+                </div>
                 {netMode === "init" && (
                     <div className="tw-flex tw-flex-row tw-gap-1 tw-items-end">
                         <Input

--- a/multiplayer/src/components/Loading.tsx
+++ b/multiplayer/src/components/Loading.tsx
@@ -1,0 +1,7 @@
+export default function Render() {
+    return (
+        <div className="tw-w-screen tw-h-screen tw-flex tw-justify-center tw-items-center tw-text-2xl">
+            {lf("Loading...")}
+        </div>
+    );
+}

--- a/multiplayer/src/epics/setUserProfileAsync.ts
+++ b/multiplayer/src/epics/setUserProfileAsync.ts
@@ -1,5 +1,5 @@
 import { dispatch } from "../state";
-import { clearUserProfile, setUserProfile } from "../state/actions";
+import { clearUserProfile, setUiMode, setUserProfile } from "../state/actions";
 
 export async function setUserProfileAsync(
     profile: pxt.auth.UserProfile | undefined
@@ -10,6 +10,7 @@ export async function setUserProfileAsync(
         } else {
             dispatch(clearUserProfile());
         }
+        dispatch(setUiMode("home"));
     } catch (e) {
     } finally {
     }

--- a/multiplayer/src/index.tsx
+++ b/multiplayer/src/index.tsx
@@ -28,7 +28,3 @@ ReactDOM.render(
     </React.StrictMode>,
     document.getElementById("root")
 );
-
-document.addEventListener("DOMContentLoaded", async () => {
-    await authClient.authCheckAsync();
-});

--- a/multiplayer/src/types/index.ts
+++ b/multiplayer/src/types/index.ts
@@ -1,4 +1,4 @@
-export type UiMode = "home" | "host" | "join";
+export type UiMode = "init" | "home" | "host" | "join";
 export type NetMode = "init" | "connecting" | "connected";
 
 export type AppMode = {
@@ -7,7 +7,7 @@ export type AppMode = {
 };
 
 export const defaultAppMode: AppMode = {
-    uiMode: "home",
+    uiMode: "init",
     netMode: "init",
 };
 


### PR DESCRIPTION
When served from staging, it looks like the auth check can complete before the app's first render. This change moves the auth check downstream, to a point where the app is initialized and ready to receive state changes.

I also added a "Loading..." state. This is shown at startup while the auth check is running and login status of the user is undetermined.
