### PR TITLE
Rework Modals for Multiplayer

### DIFF
--- a/multiplayer/src/App.tsx
+++ b/multiplayer/src/App.tsx
@@ -28,8 +28,8 @@ function App() {
 
     return (
         <div className={`${pxt.appTarget.id}`}>
-            <HeaderBar />
             {loading && <Loading />}
+            {!loading && <HeaderBar />}
             {!loading && !signedIn && <SignInPage />}
             {!loading && signedIn && <SignedInPage />}
             <AppModal />

--- a/multiplayer/src/App.tsx
+++ b/multiplayer/src/App.tsx
@@ -7,6 +7,7 @@ import SignInPage from "./components/SignInPage";
 import SignedInPage from "./components/SignedInPage";
 import HeaderBar from "./components/HeaderBar"
 import Toast from "./components/Toast";
+import AppModal from "./components/AppModal";
 import * as authClient from "./services/authClient";
 
 // eslint-disable-next-line import/no-unassigned-import
@@ -38,18 +39,11 @@ function App() {
 
     return (
         <div className={`${pxt.appTarget.id}`}>
-            <HeaderBar handleSignIn={handleSignIn} handleSignOut={handleSignOut} />
+            <HeaderBar handleSignOut={handleSignOut} />
             {loading && <Loading />}
-            {!loading && !signedIn && <SignInPage handleSignIn={handleSignIn} />}
+            {!loading && !signedIn && <SignInPage />}
             {!loading && signedIn && <SignedInPage handleSignOut={handleSignOut}/>}
-            {showSignInModal && (
-                <SignInModal
-                    onClose={() => setShowSignInModal(false)}
-                    onSignIn={async (provider, rememberMe) => {
-                        await signInAsync(provider.id, rememberMe);
-                    }}
-                />
-            )}
+            <AppModal />
             <Toast />
         </div>
     );

--- a/multiplayer/src/App.tsx
+++ b/multiplayer/src/App.tsx
@@ -1,7 +1,5 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo } from "react";
 import { AppStateContext } from "./state/AppStateContext";
-import { SignInModal } from "../../react-common/components/profile/SignInModal";
-import { signInAsync, signOutAsync } from "./epics";
 import Loading from "./components/Loading";
 import SignInPage from "./components/SignInPage";
 import SignedInPage from "./components/SignedInPage";
@@ -17,17 +15,8 @@ function App() {
     const { state } = useContext(AppStateContext);
     const { signedIn, appMode } = state;
     const { uiMode } = appMode;
-    const [showSignInModal, setShowSignInModal] = useState(false);
 
     const loading = useMemo(() => uiMode === "init", [uiMode]);
-
-    const handleSignIn = useCallback(async () => {
-        setShowSignInModal(true);
-    }, [signedIn, setShowSignInModal]);
-
-    const handleSignOut = useCallback(async () => {
-        await signOutAsync();
-    }, [signedIn]);
 
     useEffect(() => {
         // On mount, check if user is signed in
@@ -39,10 +28,10 @@ function App() {
 
     return (
         <div className={`${pxt.appTarget.id}`}>
-            <HeaderBar handleSignOut={handleSignOut} />
+            <HeaderBar />
             {loading && <Loading />}
             {!loading && !signedIn && <SignInPage />}
-            {!loading && signedIn && <SignedInPage handleSignOut={handleSignOut}/>}
+            {!loading && signedIn && <SignedInPage />}
             <AppModal />
             <Toast />
         </div>

--- a/multiplayer/src/components/AppModal.tsx
+++ b/multiplayer/src/components/AppModal.tsx
@@ -1,0 +1,26 @@
+import { useContext } from "react";
+import { Modal } from "react-common/components/controls/Modal";
+import { SignInModal } from "react-common/components/profile/SignInModal";
+import { signInAsync } from "../epics";
+import { clearModal } from "../state/actions";
+import { AppStateContext, dispatch } from "../state/AppStateContext";
+
+export default function Render() {
+    const { state } = useContext(AppStateContext);
+
+    switch(state.modal) {
+        case "sign-in":
+            return <SignInModal
+                onClose={() => dispatch(clearModal())}
+                onSignIn={async (provider, rememberMe) => {
+                    await signInAsync(provider.id, rememberMe);
+                }}
+            />
+        case "report-abuse":
+            return <Modal title={lf("Report Abuse")} onClose={() => dispatch(clearModal())}>
+                Report Abuse Placeholder  {/*TODO multiplayer*/}
+            </Modal>
+        default:
+            return <div />
+    }
+}

--- a/multiplayer/src/components/HeaderBar.tsx
+++ b/multiplayer/src/components/HeaderBar.tsx
@@ -50,9 +50,9 @@ export default function Render() {
         dispatch(showModal("sign-in"))
     }
 
-    const onSignOutClicked = () => {
+    const onSignOutClicked = async () => {
         pxt.tickEvent(`mp.usermenu.signout`);
-        signOutAsync();
+        await signOutAsync();
     }
 
     const getOrganizationLogo = (targetTheme: pxt.AppTheme) => {

--- a/multiplayer/src/components/HeaderBar.tsx
+++ b/multiplayer/src/components/HeaderBar.tsx
@@ -6,14 +6,11 @@ import { useContext } from "react";
 import { Button } from "../../../react-common/components/controls/Button";
 import { MenuBar } from "../../../react-common/components/controls/MenuBar";
 import { MenuDropdown, MenuItem } from "../../../react-common/components/controls/MenuDropdown";
+import { signOutAsync } from "../epics";
 import { showModal } from "../state/actions";
 import { AppStateContext } from "../state/AppStateContext";
 
-interface HeaderBarProps {
-    handleSignOut: () => Promise<void>;
-}
-
-export default function Render(props: HeaderBarProps) {
+export default function Render() {
     const { state, dispatch } = useContext(AppStateContext);
     const { signedIn, profile } = state;
 
@@ -55,7 +52,7 @@ export default function Render(props: HeaderBarProps) {
 
     const onSignOutClicked = () => {
         pxt.tickEvent(`mp.usermenu.signout`);
-        props.handleSignOut();
+        signOutAsync();
     }
 
     const getOrganizationLogo = (targetTheme: pxt.AppTheme) => {

--- a/multiplayer/src/components/HeaderBar.tsx
+++ b/multiplayer/src/components/HeaderBar.tsx
@@ -6,20 +6,19 @@ import { useContext } from "react";
 import { Button } from "../../../react-common/components/controls/Button";
 import { MenuBar } from "../../../react-common/components/controls/MenuBar";
 import { MenuDropdown, MenuItem } from "../../../react-common/components/controls/MenuDropdown";
+import { showModal } from "../state/actions";
 import { AppStateContext } from "../state/AppStateContext";
 
 interface HeaderBarProps {
-    handleSignIn: () => Promise<void>;
     handleSignOut: () => Promise<void>;
 }
 
 export default function Render(props: HeaderBarProps) {
-    const { state } = useContext(AppStateContext);
+    const { state, dispatch } = useContext(AppStateContext);
     const { signedIn, profile } = state;
 
     const hasIdentity = pxt.auth.hasIdentity();
     const appTheme = pxt.appTarget?.appTheme;
-    const reportAbuseUrl = ""; // TODO multiplayer : how will this work?
     const helpUrl = ""; // TODO multiplayer
 
     const onHelpClicked = () => {
@@ -29,7 +28,7 @@ export default function Render(props: HeaderBarProps) {
 
     const onReportAbuseClicked = () => {
         pxt.tickEvent("mp.settingsmenu.reportabuse");
-        window.open(reportAbuseUrl);
+        dispatch(showModal("report-abuse"))
     }
 
     const onHomeClicked = () => {
@@ -51,7 +50,7 @@ export default function Render(props: HeaderBarProps) {
 
     const onSignInClicked = () => {
         pxt.tickEvent(`mp.signin`);
-        props.handleSignIn();
+        dispatch(showModal("sign-in"))
     }
 
     const onSignOutClicked = () => {

--- a/multiplayer/src/components/SignInPage.tsx
+++ b/multiplayer/src/components/SignInPage.tsx
@@ -1,15 +1,11 @@
 import { useCallback, useContext, useMemo, useState, useEffect } from "react";
 import { AppStateContext } from "../state/AppStateContext";
 import { signInAsync } from "../epics";
-import { dismissToast, showToast } from "../state/actions";
+import { dismissToast, showModal, showToast } from "../state/actions";
 import { SignInModal } from "../../../react-common/components/profile/SignInModal";
 import { Button } from "../../../react-common/components/controls/Button";
 
-export interface SignInPageProps {
-    handleSignIn: () => Promise<void>;
-}
-
-export default function Render(props: SignInPageProps) {
+export default function Render() {
     const { state, dispatch } = useContext(AppStateContext);
     const [showSignInModal, setShowSignInModal] = useState(false);
     const { signedIn } = state;
@@ -38,7 +34,7 @@ export default function Render(props: SignInPageProps) {
                 className="primary"
                 label={lf("Sign In")}
                 title={lf("Sign In")}
-                onClick={props.handleSignIn}
+                onClick={() => dispatch(showModal("sign-in"))}
             />
         </div>
     );

--- a/multiplayer/src/components/SignedInPage.tsx
+++ b/multiplayer/src/components/SignedInPage.tsx
@@ -1,17 +1,14 @@
-import { useCallback, useContext, useMemo, useState } from "react";
+import { useContext } from "react";
 import { AppStateContext } from "../state/AppStateContext";
 import { Button } from "../../../react-common/components/controls/Button";
+import { signOutAsync } from "../epics";
 import JoinOrHost from "./JoinOrHost";
 import HostGame from "./HostGame";
 import JoinGame from "./JoinGame";
 
-export interface SignedInPageProps {
-    handleSignOut: () => Promise<void>;
-}
-
-export default function Render(props: SignedInPageProps) {
+export default function Render() {
     const { state } = useContext(AppStateContext);
-    const { signedIn, appMode } = state;
+    const { appMode } = state;
     const { uiMode } = appMode;
 
     const authButtonLabel = lf("Sign Out");
@@ -22,7 +19,7 @@ export default function Render(props: SignedInPageProps) {
                 className="primary"
                 label={authButtonLabel}
                 title={authButtonLabel}
-                onClick={props.handleSignOut}
+                onClick={signOutAsync}
             />
             {uiMode === "home" && <JoinOrHost />}
             {uiMode === "host" && <HostGame />}

--- a/multiplayer/src/state/actions.ts
+++ b/multiplayer/src/state/actions.ts
@@ -7,6 +7,7 @@ import {
     UiMode,
     NetMode,
     Presence,
+    ModalType,
 } from "../types";
 
 // Changes to app state are performed by dispatching actions to the reducer
@@ -84,6 +85,15 @@ type ClearReaction = ActionBase & {
     clientId: string;
 };
 
+type ShowModal = ActionBase & {
+    type: "SHOW_MODAL"
+    modalType: ModalType
+}
+
+type ClearModal = ActionBase & {
+    type: "CLEAR_MODAL"
+}
+
 /**
  * Union of all actions
  */
@@ -101,7 +111,9 @@ export type Action =
     | DismissToast
     | SetPresence
     | SetReaction
-    | ClearReaction;
+    | ClearReaction
+    | ShowModal
+    | ClearModal;
 
 /**
  * Action creators
@@ -186,3 +198,12 @@ export const clearReaction = (clientId: string): ClearReaction => ({
     type: "CLEAR_REACTION",
     clientId,
 });
+
+export const showModal = (modalType: ModalType): ShowModal => ({
+    type: "SHOW_MODAL",
+    modalType
+})
+
+export const clearModal = (): ClearModal => ({
+    type: "CLEAR_MODAL"
+})

--- a/multiplayer/src/state/reducer.ts
+++ b/multiplayer/src/state/reducer.ts
@@ -109,5 +109,17 @@ export default function reducer(state: AppState, action: Action): AppState {
                 },
             };
         }
+        case "SHOW_MODAL": {
+            return {
+                ...state,
+                modal: action.modalType
+            }
+        }
+        case "CLEAR_MODAL": {
+            return {
+                ...state,
+                modal: undefined
+            }
+        }
     }
 }

--- a/multiplayer/src/state/state.ts
+++ b/multiplayer/src/state/state.ts
@@ -5,6 +5,7 @@ import {
     ToastWithId,
     Presence,
     defaultPresence,
+    ModalType,
 } from "../types";
 
 export type AppState = {
@@ -17,6 +18,7 @@ export type AppState = {
     gameState: GameState | undefined;
     toasts: ToastWithId[];
     presence: Presence;
+    modal: ModalType | undefined;
     reactions: {
         [clientId: string]:
             | {
@@ -37,5 +39,6 @@ export const initialAppState: AppState = {
     gameState: undefined,
     toasts: [],
     presence: { ...defaultPresence },
+    modal: undefined,
     reactions: {},
 };

--- a/multiplayer/src/types/index.ts
+++ b/multiplayer/src/types/index.ts
@@ -1,5 +1,6 @@
 export type UiMode = "init" | "home" | "host" | "join";
 export type NetMode = "init" | "connecting" | "connected";
+export type ModalType = "sign-in" | "report-abuse";
 
 export type AppMode = {
     uiMode: UiMode;


### PR DESCRIPTION
This is a follow up from comments in https://github.com/microsoft/pxt/pull/9117. The design is based loosely on the skillmap modal design.

We want to create a simple way to show modals without having to pass around a bunch of callbacks. To do that, I've created a `modal` field in the app state which defines what type of modal (if any) is visible. The `AppModal` component handles displaying the actual modal based on this field's value. To display a modal, we can call into the dispatcher and fire the ShowModal event, passing in the type of modal to show.