### PR TITLE
fix parsing for shared scripts query params / hashes

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -244,7 +244,7 @@ namespace pxt.Cloud {
         const domainCheck = `(?:(?:https:\/\/)?(?:${domains.join('|')})\/)`;
         const versionRefCheck = "(?:v[0-9]+\/)";
         const oembedCheck = "api\/oembed\\?url=.*%2F([^&#]*)&.*";
-        const sharePageCheck = "([a-z0-9\-_]+)(?:[#?&].*)?";
+        const sharePageCheck = "([a-z0-9\\-_]+)(?:[#?&].*)?";
         const scriptIdCheck = `^${domainCheck}?${versionRefCheck}?(?:(?:${oembedCheck})|(?:${sharePageCheck}))$`;
         const m = new RegExp(scriptIdCheck, 'i').exec(uri.trim());
         const scriptid = m?.[1] /** oembed res **/ || m?.[2] /** share page res **/;

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -233,7 +233,7 @@ namespace pxt.Cloud {
 
     export function parseScriptId(uri: string): string {
         const target = pxt.appTarget;
-        if (!uri || !target.appTheme || !target.cloud || !target.cloud.sharing) return undefined;
+        if (!uri || !target.appTheme || !target.cloud?.sharing) return undefined;
 
         let domains = ["makecode.com"];
         if (target.appTheme.embedUrl)
@@ -241,16 +241,15 @@ namespace pxt.Cloud {
         if (target.appTheme.shareUrl)
             domains.push(target.appTheme.shareUrl);
         domains = Util.unique(domains, d => d).map(d => Util.escapeForRegex(Util.stripUrlProtocol(d).replace(/\/$/, '')).toLowerCase());
-        const rx = `^((https:\/\/)?(?:${domains.join('|')})\/)?(?:v[0-9]+\/)?(api\/oembed\?url=.*%2F([^&]*)&.*?|([a-z0-9\-_]+))$`;
-        const m = new RegExp(rx, 'i').exec(uri.trim());
-        const scriptid = m && (!m[1] || domains.indexOf(Util.escapeForRegex(m[1].replace(/https:\/\//, '').replace(/\/$/, '')).toLowerCase()) >= 0) && (m[3] || m[4]) ? (m[3] ? m[3] : m[4]) : null
+        const domainCheck = `(?:(?:https:\/\/)?(?:${domains.join('|')})\/)`;
+        const versionRefCheck = "(?:v[0-9]+\/)";
+        const oembedCheck = "api\/oembed\\?url=.*%2F([^&#]*)&.*";
+        const sharePageCheck = "([a-z0-9\-_]+)(?:[#?&].*)?";
+        const scriptIdCheck = `^${domainCheck}?${versionRefCheck}?(?:(?:${oembedCheck})|(?:${sharePageCheck}))$`;
+        const m = new RegExp(scriptIdCheck, 'i').exec(uri.trim());
+        const scriptid = m?.[1] /** oembed res **/ || m?.[2] /** share page res **/;
 
-        if (!scriptid) return undefined;
-
-        if (scriptid[0] == "_" && scriptid.length == 13)
-            return scriptid;
-
-        if (scriptid.length == 23 && /^[0-9\-]+$/.test(scriptid) || scriptid.length == 24 && /^S[0-9\-]+$/.test(scriptid))
+        if (/^(_.{12}|S?[0-9\-]{23})$/.test(scriptid))
             return scriptid;
 
         return undefined;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/5134

The regex produced by this for arcade can be tested here: https://regex101.com/r/qk2y2e/1, it's this whole thing:

```
/^(?:(?:https:\/\/)?(?:makecode\.com|arcade\.makecode\.com)\/)?(?:v[0-9]+\/)?(?:(?:api\/oembed\?url=.*%2F([^&#]*)&.*)|(?:([a-z0-9-_]+)(?:[#?&].*)?))$/i
```

The link I shared above has that (with the global and multi line flags enabled to allow for multiple test strings at once)

few quick notes;
* oembed check was already broken so I 'fixed it' but don't have a url handy to try it / don't know how a user would really end up using that as a share code. (the broken bit in particular was that it was checking `oembed?` instead of `oembed\?` in the produced regex)
* the domains check on line 246 was redundant -- we've already checked listed domains and valid domains would not match the _asdfasdfasdf / credit card number check below and shouldn't be able to match the domain portion above anyways