### PR TITLE
copy over throttle fn to pxsim/runtime

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -118,6 +118,24 @@ namespace pxsim {
             return output;
         }
 
+        // Returns a function, that, as long as it continues to be invoked, will only
+        // trigger every N milliseconds. If `immediate` is passed, trigger the
+        // function on the leading edge, instead of the trailing.
+        export function throttle(func: (...args: any[]) => any, wait: number, immediate?: boolean): any {
+            let timeout: any;
+            return function (this: any) {
+                let context = this;
+                let args = arguments;
+                let later = function () {
+                    timeout = null;
+                    if (!immediate) func.apply(context, args);
+                };
+                let callNow = immediate && !timeout;
+                if (!timeout) timeout = setTimeout(later, wait);
+                if (callNow) func.apply(context, args);
+            };
+        }
+
         export function promiseMapAll<T, V>(values: T[], mapper: (obj: T) => Promise<V>): Promise<V[]> {
             return Promise.all(values.map(v => mapper(v)));
         }


### PR DESCRIPTION
if you poke around `pxtlib/util.ts` you'll see it's *pretty similar* to the function there: https://github.com/microsoft/pxt/blob/master/pxtlib/util.ts#L739 . I need this function available for a change I'm making in arcade sim 

runtime has a number of these things that are just mirrored over (e.g. see `delay` / `nextTick` functions right above where this pr is) -- this is because the pxtsim/runtime code gets included in the sim iframe but pxtlib does not.