### PR TITLE
Multiplayer preload simulator before compile

### DIFF
--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -72,6 +72,7 @@ export default function Render() {
 
     const getOpts = () => {
         const opts: pxt.runner.SimulateOptions = {
+            embedId: "multiplayer-sim",
             additionalQueryParameters: selectedPlayerTheme,
             single: true,
             fullScreen: true,
@@ -123,8 +124,11 @@ export default function Render() {
         const codeReadyToCompile =
             playerSlot! > 1 || (playerSlot == 1 && gameId);
         if (codeReadyToCompile && gameState?.gameMode !== "playing") {
-            preloadSim();
-            compileSimCode();
+            preloadSim()
+                .then(compileSimCode);
+        }
+        if (!playerSlot) {
+            builtSimJsInfo = undefined;
         }
     }, [playerSlot, gameId]);
 

--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -95,6 +95,10 @@ export default function Render() {
         return await builtSimJsInfo;
     };
 
+    const preloadSim = async () => {
+        pxt.runner.preloadSim(simContainerRef.current!, getOpts());
+    }
+
     const runSimulator = async () => {
         const simOpts = getOpts();
         if (builtSimJsInfo) {
@@ -119,6 +123,7 @@ export default function Render() {
         const codeReadyToCompile =
             playerSlot! > 1 || (playerSlot == 1 && gameId);
         if (codeReadyToCompile && gameState?.gameMode !== "playing") {
+            preloadSim();
             compileSimCode();
         }
     }, [playerSlot, gameId]);

--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -98,7 +98,7 @@ export default function Render() {
 
     const preloadSim = async () => {
         pxt.runner.preloadSim(simContainerRef.current!, getOpts());
-    }
+    };
 
     const runSimulator = async () => {
         const simOpts = getOpts();
@@ -124,8 +124,7 @@ export default function Render() {
         const codeReadyToCompile =
             playerSlot! > 1 || (playerSlot == 1 && gameId);
         if (codeReadyToCompile && gameState?.gameMode !== "playing") {
-            preloadSim()
-                .then(compileSimCode);
+            preloadSim().then(compileSimCode);
         }
         if (!playerSlot) {
             builtSimJsInfo = undefined;

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -384,7 +384,6 @@ namespace pxt.runner {
         simDriver.options.messageSimulators = pxt.appTarget?.simulator?.messageSimulators;
         simDriver.options.onSimulatorCommand = msg => {
             if (msg.command === "restart") {
-                simDriver
                 runOptions.storedState = getStoredState(simOptions.id)
                 simDriver.run(js, runOptions);
             }

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -472,8 +472,10 @@ namespace pxsim {
             return wrapper;
         }
 
-        public preload(aspectRatio: number) {
+        public preload(aspectRatio: number, clearRuntime?: boolean) {
             if (!this.simFrames().length) {
+                if (clearRuntime)
+                    this._currentRuntime = undefined;
                 this.container.appendChild(this.createFrame());
                 this.applyAspectRatio(aspectRatio);
                 this.setStarting();
@@ -631,8 +633,12 @@ namespace pxsim {
             });
         }
 
-        public run(js: string, opts: SimulatorRunOptions = {}) {
+        public setRunOptions(opts: SimulatorRunOptions = {}) {
             this._runOptions = opts;
+        }
+
+        public run(js: string, opts: SimulatorRunOptions = {}) {
+            this.setRunOptions(opts);
             this.runId = this.nextId();
             // store information
             this._currentRuntime = {


### PR DESCRIPTION
When we're waiting for the host to start the game, preload the simulator so it's ready to go / there's not a big blank space on the page until users join in. 

Took a little bit more fiddling to get right than I expected, lots of subtle life cycle things across runner / simdriver / sim. Did notice and fix a memory leak along the way (pxtrunner creates a new simdriver each time simulate async is called, which attaches a message listener to window, which contains a ref to itself -- this wouldn't be a big deal but this means it keeps around it's _currentRuntime which contains the binary js / is multiple mb, and occasionally it would also send random messages / in this case when the container happened to be kept around it would start with old code.)