### PR TITLE
use a symlink to link to docs for multiplayer/skillmap build

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2068,7 +2068,6 @@ function buildReactAppAsync(app: string, parsed: commandParser.ParsedCommand, op
     };
     // local serve
     const appRoot = `node_modules/pxt-core/${app}`;
-    const docsPath = parsed.flags["docs"];
     return rimrafAsync(`${appRoot}/public/blb`, {})
         .then(() => rimrafAsync(`${appRoot}/build/assets`, {}))
         .then(() => rimrafAsync(`${appRoot}/public/docs`, {}))
@@ -2095,11 +2094,8 @@ function buildReactAppAsync(app: string, parsed: commandParser.ParsedCommand, op
                 nodeutil.cpR(`docs/static/${app}/assets`, `${appRoot}/public/assets`);
             }
 
-            if (docsPath) {
-                // copy docs over from specified path
-                nodeutil.cpR(`docs/${docsPath}`, `${appRoot}/public/docs/${docsPath}`);
-                nodeutil.cpR(`docs/static/${docsPath}`, `${appRoot}/public/static/${docsPath}`);
-            }
+            fs.symlinkSync(path.resolve(`docs`), path.resolve(`${appRoot}/public/docs`), "junction");
+            fs.symlinkSync(path.resolve(`docs/static`), path.resolve(`${appRoot}/public/static`), "junction");
 
             return nodeutil.spawnAsync({
                 cmd: os.platform() === "win32" ? "npm.cmd" : "npm",
@@ -6977,7 +6973,8 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
                 description: "Serve the skill map locally after building (npm start)"
             },
             docs: {
-                description: "Path to local docs folder to copy into skillmap",
+                description: "DEPRECATED: Path to local docs folder to copy into skillmap",
+                deprecated: true,
                 type: "string",
                 argument: "docs"
             }
@@ -6994,7 +6991,8 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
                 description: "Serve the authcode app locally after building (npm start)"
             },
             docs: {
-                description: "Path to local docs folder to copy into authcode",
+                description: "DEPRECATED: Path to local docs folder to copy into authcode",
+                deprecated: true,
                 type: "string",
                 argument: "docs"
             }
@@ -7011,7 +7009,8 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
                 description: "Serve the multiplayer app locally after building (npm start)"
             },
             docs: {
-                description: "Path to local docs folder to copy into multiplayer",
+                description: "DEPRECATED: Path to local docs folder to copy into multiplayer",
+                deprecated: true,
                 type: "string",
                 argument: "docs"
             }

--- a/multiplayer/README.md
+++ b/multiplayer/README.md
@@ -4,14 +4,14 @@ This app allows users to play a MakeCode Arcade game together in online multipla
 
 ## First-time dev setup
 
-This doc assumes you have a functioning pxt development environment. Refer here for setup instructions: https://github.com/microsoft/pxt-arcade#local-dev-setup 
+This doc assumes you have a functioning pxt development environment. Refer here for setup instructions: https://github.com/microsoft/pxt-arcade#local-dev-setup
 
 ## Developing
 
 1. In the `pxt` folder, run `gulp build` or `gulp watch` to ensure latest changes to `pxtlib`, `react-common`, and other dependencies are built.
 1. *If you need authentication:* In the `pxt-arcade` folder, run `pxt serve --rebundle`. This will serve the main Arcade webapp. *This is required for sign-in to work on localhost.*
   * This is because the app will try to read the auth token from the cli listening on `localhost:3232`.
-1. In another terminal, in the `pxt-arcade` folder, run `pxt multiplayer --docs .`. This will start the multiplayer app dev server.
+1. In another terminal, in the `pxt-arcade` folder, run `pxt multiplayer`. This will start the multiplayer app dev server.
 1. You're all set. Go forth and develop.
 
 


### PR DESCRIPTION
a little bit nicer to not have to wait for all of our docs folder to get copied over (twice for everything in static) when serving multiplayer / skillmap, and also makes it so you can do local testing of skillmap files without constantly reserving. Also removes requirement to have `--docs .` when serving multiplayer

note the 'junction' param, normal symlinks for dirs get blocked in node because they are deemed a security risk (I believe?) and restrict to admin env only.  The important thing to note is that that it's restricted to local paths only, but I doubt that affects anyone? https://stackoverflow.com/questions/9042542

Probably worth getting someone to test this real quick on mac or linux (wsl) real quick? just make sure `pxt multiplayer` looks valid / has the right icons and maybe check that `localhost:3000/?nolocalhost=1#local:skillmap/intermediate-skillmap`, but it looks like skillmap is broken locally for me right now? throws a bunch of errors for me e.g. `Uncaught Error: Invalid hook call. ` with 
<img width="378" alt="image" src="https://user-images.githubusercontent.com/5615930/197252356-44cca305-a9d7-4848-8748-e8782c12f9ad.png">
and also 
<img width="301" alt="image" src="https://user-images.githubusercontent.com/5615930/197252409-d85862a2-7a7c-4fcf-9cd7-d01b9091390f.png">

but this also occurs on master~