### PR TITLE
Add Multiplayer Footer with Privacy and Terms of Use

### DIFF
--- a/multiplayer/src/App.tsx
+++ b/multiplayer/src/App.tsx
@@ -15,6 +15,7 @@ function App() {
     const { state } = useContext(AppStateContext);
     const { signedIn, appMode } = state;
     const { uiMode } = appMode;
+    const targetTheme = pxt?.appTarget?.appTheme;
 
     const loading = useMemo(() => uiMode === "init", [uiMode]);
 
@@ -27,13 +28,22 @@ function App() {
     }, []);
 
     return (
-        <div className={`${pxt.appTarget.id}`}>
+        <div className={`${pxt.appTarget.id} tw-flex tw-flex-col`}>
             {loading && <Loading />}
             {!loading && <HeaderBar />}
             {!loading && !signedIn && <SignInPage />}
             {!loading && signedIn && <SignedInPage />}
             <AppModal />
             <Toast />
+            <div className="tw-flex-grow"/>
+
+            {/* Footer */}
+            {targetTheme?.organizationUrl || targetTheme?.organizationUrl || targetTheme?.privacyUrl || targetTheme?.copyrightText ? <div className="ui horizontal small divided link list tw-text-center" role="contentinfo">
+                {targetTheme.organizationUrl && targetTheme.organization ? <a className="item !tw-text-black" target="_blank" rel="noopener noreferrer" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
+                {targetTheme.termsOfUseUrl ? <a target="_blank" className="item !tw-text-black" href={targetTheme.termsOfUseUrl} rel="noopener noreferrer">{lf("Terms of Use")}</a> : undefined}
+                {targetTheme.privacyUrl ? <a target="_blank" className="item !tw-text-black" href={targetTheme.privacyUrl} rel="noopener noreferrer">{lf("Privacy")}</a> : undefined}
+                {targetTheme.copyrightText ? <div className="ui item copyright !tw-text-black">{targetTheme.copyrightText}</div> : undefined}
+            </div> : undefined}
         </div>
     );
 }

--- a/multiplayer/src/App.tsx
+++ b/multiplayer/src/App.tsx
@@ -6,6 +6,7 @@ import SignedInPage from "./components/SignedInPage";
 import HeaderBar from "./components/HeaderBar";
 import Toast from "./components/Toast";
 import AppModal from "./components/AppModal";
+import Footer from "./components/Footer";
 import * as authClient from "./services/authClient";
 
 // eslint-disable-next-line import/no-unassigned-import
@@ -15,7 +16,6 @@ function App() {
     const { state } = useContext(AppStateContext);
     const { signedIn, appMode } = state;
     const { uiMode } = appMode;
-    const targetTheme = pxt?.appTarget?.appTheme;
 
     const loading = useMemo(() => uiMode === "init", [uiMode]);
 
@@ -36,14 +36,7 @@ function App() {
             <AppModal />
             <Toast />
             <div className="tw-flex-grow"/>
-
-            {/* Footer */}
-            {targetTheme?.organizationUrl || targetTheme?.organizationUrl || targetTheme?.privacyUrl || targetTheme?.copyrightText ? <div className="ui horizontal small divided link list tw-text-center" role="contentinfo">
-                {targetTheme.organizationUrl && targetTheme.organization ? <a className="item !tw-text-black" target="_blank" rel="noopener noreferrer" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
-                {targetTheme.termsOfUseUrl ? <a target="_blank" className="item !tw-text-black" href={targetTheme.termsOfUseUrl} rel="noopener noreferrer">{lf("Terms of Use")}</a> : undefined}
-                {targetTheme.privacyUrl ? <a target="_blank" className="item !tw-text-black" href={targetTheme.privacyUrl} rel="noopener noreferrer">{lf("Privacy")}</a> : undefined}
-                {targetTheme.copyrightText ? <div className="ui item copyright !tw-text-black">{targetTheme.copyrightText}</div> : undefined}
-            </div> : undefined}
+            <Footer />
         </div>
     );
 }

--- a/multiplayer/src/App.tsx
+++ b/multiplayer/src/App.tsx
@@ -35,7 +35,7 @@ function App() {
             {!loading && signedIn && <SignedInPage />}
             <AppModal />
             <Toast />
-            <div className="tw-flex-grow"/>
+            <div className="tw-flex-grow" />
             <Footer />
         </div>
     );

--- a/multiplayer/src/components/Footer.tsx
+++ b/multiplayer/src/components/Footer.tsx
@@ -1,0 +1,10 @@
+export default function Render() {
+    const targetTheme = pxt?.appTarget?.appTheme;
+
+    return (targetTheme?.organizationUrl || targetTheme?.organizationUrl || targetTheme?.privacyUrl || targetTheme?.copyrightText) ? <div className="ui horizontal small divided link list tw-text-center" role="contentinfo">
+        {targetTheme.organizationUrl && targetTheme.organization ? <a className="item !tw-text-black" target="_blank" rel="noopener noreferrer" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
+        {targetTheme.termsOfUseUrl ? <a target="_blank" className="item !tw-text-black" href={targetTheme.termsOfUseUrl} rel="noopener noreferrer">{lf("Terms of Use")}</a> : undefined}
+        {targetTheme.privacyUrl ? <a target="_blank" className="item !tw-text-black" href={targetTheme.privacyUrl} rel="noopener noreferrer">{lf("Privacy")}</a> : undefined}
+        {targetTheme.copyrightText ? <div className="ui item copyright !tw-text-black">{targetTheme.copyrightText}</div> : undefined}
+    </div> : null;
+}

--- a/multiplayer/src/components/Footer.tsx
+++ b/multiplayer/src/components/Footer.tsx
@@ -1,10 +1,49 @@
 export default function Render() {
     const targetTheme = pxt?.appTarget?.appTheme;
 
-    return (targetTheme?.organizationUrl || targetTheme?.organizationUrl || targetTheme?.privacyUrl || targetTheme?.copyrightText) ? <div className="ui horizontal small divided link list tw-text-center" role="contentinfo">
-        {targetTheme.organizationUrl && targetTheme.organization ? <a className="item !tw-text-black" target="_blank" rel="noopener noreferrer" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
-        {targetTheme.termsOfUseUrl ? <a target="_blank" className="item !tw-text-black" href={targetTheme.termsOfUseUrl} rel="noopener noreferrer">{lf("Terms of Use")}</a> : undefined}
-        {targetTheme.privacyUrl ? <a target="_blank" className="item !tw-text-black" href={targetTheme.privacyUrl} rel="noopener noreferrer">{lf("Privacy")}</a> : undefined}
-        {targetTheme.copyrightText ? <div className="ui item copyright !tw-text-black">{targetTheme.copyrightText}</div> : undefined}
-    </div> : null;
+    return targetTheme?.organizationUrl ||
+        targetTheme?.organizationUrl ||
+        targetTheme?.privacyUrl ||
+        targetTheme?.copyrightText ? (
+        <div
+            className="ui horizontal small divided link list tw-text-center"
+            role="contentinfo"
+        >
+            {targetTheme.organizationUrl && targetTheme.organization ? (
+                <a
+                    className="item !tw-text-black"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={targetTheme.organizationUrl}
+                >
+                    {targetTheme.organization}
+                </a>
+            ) : undefined}
+            {targetTheme.termsOfUseUrl ? (
+                <a
+                    target="_blank"
+                    className="item !tw-text-black"
+                    href={targetTheme.termsOfUseUrl}
+                    rel="noopener noreferrer"
+                >
+                    {lf("Terms of Use")}
+                </a>
+            ) : undefined}
+            {targetTheme.privacyUrl ? (
+                <a
+                    target="_blank"
+                    className="item !tw-text-black"
+                    href={targetTheme.privacyUrl}
+                    rel="noopener noreferrer"
+                >
+                    {lf("Privacy")}
+                </a>
+            ) : undefined}
+            {targetTheme.copyrightText ? (
+                <div className="ui item copyright !tw-text-black">
+                    {targetTheme.copyrightText}
+                </div>
+            ) : undefined}
+        </div>
+    ) : null;
 }


### PR DESCRIPTION
The code also supports a copyright section, but we don't have one in the target theme so it doesn't appear here.

This is lifted pretty directly from https://github.com/microsoft/pxt/blob/master/webapp/src/projects.tsx#L209-L216 with some tailwind-ification. I did remove the language section, though, as I suspect that may go in the gear menu. We can add it back here later if needed. I also made the text black because I think the original color wouldn't pass accessibility checks.

Links:
Microsoft MakeCode: https://makecode.com/org
Terms of Use: https://go.microsoft.com/fwlink/?LinkID=206977
Privacy: https://go.microsoft.com/fwlink/?LinkId=521839

![image](https://user-images.githubusercontent.com/69657545/197303345-c38d17e2-4ae5-4d50-8945-3719855311c1.png)

Fixes https://github.com/microsoft/pxt-arcade/issues/5158