### PR TITLE
Multiplayer: persist mute and hide sim until start

### DIFF
--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -21,6 +21,7 @@ export default function Render() {
     ];
     const selectedPlayerTheme = playerThemes[(playerSlot || 0) - 1];
     const isHost = playerSlot == 1;
+    const isPlayingMode = gameState?.gameMode === "playing";
 
     const postImageMsg = async (msg: SimMultiplayer.ImageMessage) => {
         const { image, palette } = msg;
@@ -154,7 +155,9 @@ export default function Render() {
         <div
             id="sim-container"
             ref={simContainerRef}
-            className="tw-h-[calc(100vh-16rem)] tw-w-[calc(100vw-6rem)]"
+            className={`tw-h-[calc(100vh-16rem)] tw-w-[calc(100vw-6rem)] ${
+                !isPlayingMode ? "tw-invisible" : ""
+            }`}
         />
     );
 }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -19,6 +19,7 @@ namespace pxt.runner {
         builtJsInfo?: pxtc.BuiltSimJsInfo;
         // single simulator frame, no message simulators
         single?: boolean;
+        mute?: boolean;
         hideSimButtons?: boolean;
         autofocus?: boolean;
         additionalQueryParameters?: string;
@@ -423,6 +424,7 @@ namespace pxt.runner {
         let storedState: Map<string> = getStoredState(simOptions.id)
         let runOptions: pxsim.SimulatorRunOptions = {
             debug: simOptions.debug,
+            mute: simOptions.mute,
             boardDefinition: board,
             parts: parts,
             builtinParts: usedBuiltinParts,


### PR DESCRIPTION
Don't show sim until the player presses start, just load in background.

@thsparks for your mute pr to make it so we persist mute setting I added a pxtrunner opt to propagate mute state -- we'll need to add the muted state to getOpts here https://github.com/microsoft/pxt/blob/multMuteAndHideUntilStart/multiplayer/src/components/ArcadeSimulator.tsx#L93 after this and your pr are both merged, can update either pr when the other is merged.