### PR TITLE
Multiplayer Game Page Refactor & Quality of Life Updates

### DIFF
--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -1,9 +1,7 @@
-import { faCopy } from "@fortawesome/free-regular-svg-icons";
-import { faCheck } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useContext, useEffect, useState } from "react";
-import { AppStateContext, dispatch } from "../state/AppStateContext";
+import { useContext } from "react";
+import { AppStateContext } from "../state/AppStateContext";
 import ArcadeSimulator from "./ArcadeSimulator";
+import JoinCodeLabel from "./JoinCodeLabel";
 import Presence from "./Presence";
 import Reactions from "./Reactions";
 import ToggleMuteButton from "./ToggleMuteButton";
@@ -14,27 +12,6 @@ export default function Render(props: GamePageProps) {
     const { state } = useContext(AppStateContext);
     const { appMode } = state;
     const { netMode } = appMode;
-    const [copySuccessful, setCopySuccessful] = useState(false);
-    const copyTimeoutMs = 1000;
-
-    const copyJoinCode = async () => {
-        pxt.tickEvent("mp.copyjoincode");
-        if (state.gameState?.joinCode) {
-            navigator.clipboard.writeText(state.gameState?.joinCode);
-            setCopySuccessful(true);
-        }
-    };
-
-    useEffect(() => {
-        if (copySuccessful) {
-            let resetCopyTimer = setTimeout(() => {
-                setCopySuccessful(false);
-            }, copyTimeoutMs);
-            return () => {
-                clearTimeout(resetCopyTimer);
-            };
-        }
-    }, [copySuccessful]);
 
     return (
         <div>
@@ -48,36 +25,7 @@ export default function Render(props: GamePageProps) {
                     {state.playerSlot && <ArcadeSimulator />}
                     <div className="tw-flex tw-flex-row tw-w-full tw-items-center tw-justify-between tw-mt-1">
                         <ToggleMuteButton />
-                        <div className="tw-justify-self-center">
-                            {state.gameState?.joinCode && (
-                                <div>
-                                    {state.gameState?.joinCode &&
-                                        lf(
-                                            "Join Code: {0}",
-                                            state.gameState?.joinCode
-                                        )}
-                                    <button
-                                        onClick={copyJoinCode}
-                                        title={lf("Copy Join Code")}
-                                    >
-                                        <div className="tw-text-sm tw-ml-1">
-                                            {!copySuccessful && (
-                                                <FontAwesomeIcon
-                                                    icon={faCopy}
-                                                    className="hover:tw-scale-105 tw-mb-[0.1rem]"
-                                                />
-                                            )}
-                                            {copySuccessful && (
-                                                <FontAwesomeIcon
-                                                    icon={faCheck}
-                                                    className="tw-text-green-600 tw-mb-[0.1rem]"
-                                                />
-                                            )}
-                                        </div>
-                                    </button>
-                                </div>
-                            )}
-                        </div>
+                        <JoinCodeLabel />
                         <div>{lf("Keyboard Controls")}</div>
                     </div>
                     <div className="tw-flex tw-flex-row tw-space-x-2 tw-items-center tw-align-middle tw-justify-center tw-mt-3">

--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -1,17 +1,12 @@
 import { faCopy } from "@fortawesome/free-regular-svg-icons";
-import {
-    faCheck,
-    faVolumeHigh,
-    faVolumeMute,
-} from "@fortawesome/free-solid-svg-icons";
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useContext, useEffect, useState } from "react";
-import { Button } from "react-common/components/controls/Button";
-import { setMute } from "../state/actions";
 import { AppStateContext, dispatch } from "../state/AppStateContext";
 import ArcadeSimulator from "./ArcadeSimulator";
 import Presence from "./Presence";
 import Reactions from "./Reactions";
+import ToggleMuteButton from "./ToggleMuteButton";
 
 export interface GamePageProps {}
 
@@ -30,10 +25,6 @@ export default function Render(props: GamePageProps) {
         }
     };
 
-    const toggleMute = () => {
-        dispatch(setMute(!state.muted));
-    };
-
     useEffect(() => {
         if (copySuccessful) {
             let resetCopyTimer = setTimeout(() => {
@@ -44,10 +35,6 @@ export default function Render(props: GamePageProps) {
             };
         }
     }, [copySuccessful]);
-
-    useEffect(() => {
-        pxt.runner.currentDriver()?.mute(state.muted);
-    }, [state.muted]);
 
     return (
         <div>
@@ -60,16 +47,7 @@ export default function Render(props: GamePageProps) {
                 <div className="tw-flex tw-flex-col tw-items-center">
                     {state.playerSlot && <ArcadeSimulator />}
                     <div className="tw-flex tw-flex-row tw-w-full tw-items-center tw-justify-between tw-mt-1">
-                        <Button
-                            leftIcon={
-                                state.muted
-                                    ? "fas fa-volume-mute"
-                                    : "fas fa-volume-up"
-                            }
-                            title={lf("Toggle Mute")}
-                            className="tw-border-2 tw-border-slate-400 tw-border-solid tw-py-2 tw-pl-2 tw-pr-1 tw-bg-slate-100 hover:tw-bg-slate-200 active:tw-bg-slate-300"
-                            onClick={toggleMute}
-                        />
+                        <ToggleMuteButton />
                         <div className="tw-justify-self-center">
                             {state.gameState?.joinCode && (
                                 <div>

--- a/multiplayer/src/components/HostGame.tsx
+++ b/multiplayer/src/components/HostGame.tsx
@@ -42,6 +42,11 @@ export default function Render() {
                         handleInputRef={inputRef}
                         preserveValueOnBlur={true}
                         onEnterKey={onHostGameClick}
+                        initialValue={
+                            pxt.BrowserUtils.isLocalHostDev()
+                                ? "https://makecode.com/_VvPX5u9bx7fx"
+                                : undefined
+                        }
                     />
                     <Button
                         className={"teal"}

--- a/multiplayer/src/components/JoinCodeLabel.tsx
+++ b/multiplayer/src/components/JoinCodeLabel.tsx
@@ -32,8 +32,7 @@ export default function Render() {
         <div className="tw-justify-self-center">
             {state.gameState?.joinCode && (
                 <div>
-                    {state.gameState?.joinCode &&
-                        lf("Join Code: {0}", state.gameState?.joinCode)}
+                    {lf("Join Code: {0}", state.gameState?.joinCode)}
                     <button onClick={copyJoinCode} title={lf("Copy Join Code")}>
                         <div className="tw-text-sm tw-ml-1">
                             {!copySuccessful && (

--- a/multiplayer/src/components/JoinCodeLabel.tsx
+++ b/multiplayer/src/components/JoinCodeLabel.tsx
@@ -1,0 +1,57 @@
+import { faCopy } from "@fortawesome/free-regular-svg-icons";
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useContext, useEffect, useState } from "react";
+import { AppStateContext } from "../state/AppStateContext";
+
+export default function Render() {
+    const { state } = useContext(AppStateContext);
+    const [copySuccessful, setCopySuccessful] = useState(false);
+    const copyTimeoutMs = 1000;
+
+    const copyJoinCode = async () => {
+        pxt.tickEvent("mp.copyjoincode");
+        if (state.gameState?.joinCode) {
+            navigator.clipboard.writeText(state.gameState?.joinCode);
+            setCopySuccessful(true);
+        }
+    };
+
+    useEffect(() => {
+        if (copySuccessful) {
+            let resetCopyTimer = setTimeout(() => {
+                setCopySuccessful(false);
+            }, copyTimeoutMs);
+            return () => {
+                clearTimeout(resetCopyTimer);
+            };
+        }
+    }, [copySuccessful]);
+
+    return (
+        <div className="tw-justify-self-center">
+            {state.gameState?.joinCode && (
+                <div>
+                    {state.gameState?.joinCode &&
+                        lf("Join Code: {0}", state.gameState?.joinCode)}
+                    <button onClick={copyJoinCode} title={lf("Copy Join Code")}>
+                        <div className="tw-text-sm tw-ml-1">
+                            {!copySuccessful && (
+                                <FontAwesomeIcon
+                                    icon={faCopy}
+                                    className="hover:tw-scale-105 tw-mb-[0.1rem]"
+                                />
+                            )}
+                            {copySuccessful && (
+                                <FontAwesomeIcon
+                                    icon={faCheck}
+                                    className="tw-text-green-600 tw-mb-[0.1rem]"
+                                />
+                            )}
+                        </div>
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/multiplayer/src/components/ToggleMuteButton.tsx
+++ b/multiplayer/src/components/ToggleMuteButton.tsx
@@ -1,0 +1,25 @@
+import { useContext, useEffect } from "react";
+import { Button } from "react-common/components/controls/Button";
+import { setMute } from "../state/actions";
+import { AppStateContext, dispatch } from "../state/AppStateContext";
+
+export default function Render() {
+    const { state } = useContext(AppStateContext);
+
+    const toggleMute = () => {
+        dispatch(setMute(!state.muted));
+    };
+
+    useEffect(() => {
+        pxt.runner.currentDriver()?.mute(state.muted);
+    }, [state.muted]);
+
+    return (
+        <Button
+            leftIcon={state.muted ? "fas fa-volume-mute" : "fas fa-volume-up"}
+            title={lf("Toggle Mute")}
+            className="tw-border-2 tw-border-slate-400 tw-border-solid tw-py-2 tw-pl-2 tw-pr-1 tw-bg-slate-100 hover:tw-bg-slate-200 active:tw-bg-slate-300"
+            onClick={toggleMute}
+        />
+    );
+}


### PR DESCRIPTION
This change cleans up the multiplayer game page, moving the mute button and the join code label into their own components. It also adds a small quality of life improvement for the dev inner loop by including a default host share project when in local dev mode (saves on a few seconds of copy/paste when debugging).

I used Joey's https://makecode.com/_VvPX5u9bx7fx project for the default debugging project. Initially, I tried an aka.ms link so we could update it without a code change, but then it can't parse the share code. That may be an improvement for another time :)

To test the non-local-debugging scenario and ensure Host Project input is *not* populated, I used this: https://arcade.makecode.com/app/e9f0145aa441a8ce2728ea4492acecf78cb5c2f9-06259d28cd--multiplayer