### PR TITLE
add button to host a multiplayer game to share dialog

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -454,6 +454,7 @@ declare namespace pxt {
         downloadDialogTheme?: DownloadDialogTheme;
         winAppDeprImage?: string; // Image to show on Windows App for deprecation
         showWinAppDeprBanner?: boolean; // show banner announcing Windows App deprecation
+        multiplayerShareButton?: boolean; // display multiplayer button alongside social links
     }
 
     interface DownloadDialogTheme {

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -109,6 +109,19 @@ export const ShareInfo = (props: ShareInfoProps) => {
         }
     };
 
+    const handleMultiplayerShareClick = async () => {
+        // TODO: This won't work on staging (parseScriptId domains check doesn't include staging urls)
+        // but those wouldn't load anyways (as staging multiplayer is currently fetching games from prod links)
+        const shareId = pxt.Cloud.parseScriptId(shareData.url);
+        if (!shareId)
+            return;
+
+        const domain = pxt.BrowserUtils.isLocalHostDev() ? "http://localhost:3000" : "";
+        const multiplayerHostUrl = `${domain}${pxt.webConfig.relprefix}multiplayer?host=${shareId}`;
+
+        window.open(multiplayerHostUrl, "_blank");
+    }
+
     const embedOptions = [{
         name: "code",
         label: lf("Code"),
@@ -263,6 +276,12 @@ export const ShareInfo = (props: ShareInfoProps) => {
                                         ariaLabel={lf("Show device share options")}
                                         leftIcon={"icon share"}
                                         onClick={handleDeviceShareClick}
+                                    />}
+                                    {pxt.appTarget?.appTheme?.multiplayerShareButton && <Button className="square-button multiplayer-host"
+                                        title={lf("Start a multiplayer lobby")}
+                                        ariaLabel={lf("Start a multiplayer lobby")}
+                                        leftIcon={"fas fa-people-arrows"}
+                                        onClick={handleMultiplayerShareClick}
                                     />}
                                 </div>
                                 <Button

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -110,7 +110,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
     };
 
     const handleMultiplayerShareClick = async () => {
-        // TODO: This won't work on staging (parseScriptId domains check doesn't include staging urls)
+        // TODO multiplayer: This won't work on staging (parseScriptId domains check doesn't include staging urls)
         // but those wouldn't load anyways (as staging multiplayer is currently fetching games from prod links)
         const shareId = pxt.Cloud.parseScriptId(shareData.url);
         if (!shareId)

--- a/react-common/styles/controls/Button.less
+++ b/react-common/styles/controls/Button.less
@@ -299,6 +299,11 @@
     color: @buttonTextColorDarkBackground;
 }
 
+.common-button.multiplayer-host {
+    background: #ea1b1b;
+    color: @buttonTextColorDarkBackground;
+}
+
 .common-button.whatsapp {
     background: #59CE72;
     color: @buttonTextColorDarkBackground;


### PR DESCRIPTION
like this:

![hostmult](https://user-images.githubusercontent.com/5615930/198100859-8226507a-824c-4e7a-be1b-7e1cb89979fc.gif)

the button color was picked at random to make it visually stand out from other social opts, would be happy to swap it given a good color

note dev side our share url logic needs some work, it's tangential to this so I didn't do anything to address it but 2/3 envs are broken currently:

* staging: when link is created, it is properly stored in staging but the displayed link is makecode.com/blah and does not work
* localhost: it's created on staging (which is a bit unexpected personally / would prefer to make it on prod as staging share links cannot be distributed) but also displays prod url
* prod is fine

in addition, we don't include the staging domains in the domains check here: https://github.com/microsoft/pxt/blob/master/pxtlib/emitter/cloud.ts#L243 so staging urls get rejected wherever that is used, and multiplayer pulls share urls from prod only. For this reason the games you share on localhost / staging won't end up loading in the multiplayer app (but it hits the right url so should be fine / in theory should work fine on prod site.)