### PR TITLE
fix lfs that the regex will miss

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -324,8 +324,12 @@ function buildStrings(out, rootPaths, recursive) {
     fs.writeFileSync(out, JSON.stringify(strings, null, 2));
 
     console.log("Localization extraction: " + fileCnt + " files; " + tr.length + " strings; " + out);
-    if (errCnt > 0)
+    if (errCnt > 0) {
         console.log("%d errors", errCnt);
+        if (process.env.PXT_ENV == 'production') {
+            throw "Broken lfs";
+        }
+    }
 
     return Promise.resolve();
 }

--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -49,6 +49,8 @@ export default function Render(props: GamePageProps) {
         pxt.runner.currentDriver()?.mute(state.muted);
     }, [state.muted]);
 
+    const joinCodeDisplay = lf("Join Code: {0}", state.gameState?.joinCode);
+
     return (
         <div>
             {netMode === "connecting" && (
@@ -74,10 +76,7 @@ export default function Render(props: GamePageProps) {
                             {state.gameState?.joinCode && (
                                 <div>
                                     {state.gameState?.joinCode &&
-                                        lf(
-                                            "Join Code: {0}",
-                                            state.gameState?.joinCode
-                                        )}
+                                        joinCodeDisplay}
                                     <button
                                         onClick={copyJoinCode}
                                         title={lf("Copy Join Code")}

--- a/multiplayer/src/hooks/useAuthDialogMessages.ts
+++ b/multiplayer/src/hooks/useAuthDialogMessages.ts
@@ -8,34 +8,28 @@ export function useAuthDialogMessages(): {
     const { state } = useContext(AppStateContext);
     const { deepLinks } = state;
     const { shareCode, joinCode } = deepLinks;
+    const hostSignIn = lf("Sign in to host multiplayer game {0}", shareCode);
+    const hostSignUp = lf("Sign up to host multiplayer game {0}", shareCode);
+    const joinSignIn = lf("Sign in to join multiplayer game {0}", joinCode);
+    const joinSignUp = lf("Sign up to join multiplayer game {0}", joinCode);
+    const eitherSignIn = lf("Sign in to host or join a multiplayer game");
+    const eitherSignUp = lf("Sign up to host or join a multiplayer game");
 
     const dialogMessages = useMemo(() => {
         if (shareCode) {
             return {
-                signInMessage: lf(
-                    "Sign in to host multiplayer game {0}",
-                    shareCode
-                ),
-                signUpMessage: lf(
-                    "Sign up to host multiplayer game {0}",
-                    shareCode
-                ),
+                signInMessage: hostSignIn,
+                signUpMessage: hostSignUp,
             };
         } else if (joinCode) {
             return {
-                signInMessage: lf(
-                    "Sign in to join multiplayer game {0}",
-                    joinCode
-                ),
-                signUpMessage: lf(
-                    "Sign up to join multiplayer game {0}",
-                    joinCode
-                ),
+                signInMessage: joinSignIn,
+                signUpMessage: joinSignUp,
             };
         } else {
             return {
-                signInMessage: lf("Sign in to host or join a multiplayer game"),
-                signUpMessage: lf("Sign up to host or join a multiplayer game"),
+                signInMessage: eitherSignIn,
+                signUpMessage: eitherSignUp,
             };
         }
     }, [shareCode, joinCode]);


### PR DESCRIPTION
our lf regex is a bit picky about spacing I guess, would slightly prefer to avoid touching the cli lf scraping code as I feel like that's been the same forever / might be dragons. Just pulling out a few strings so that prettier won't mangle them.

<img width="382" alt="image" src="https://user-images.githubusercontent.com/5615930/198106894-2da5330b-ef1a-48a7-a4b0-afee468fdff7.png">

Should probably make it throw in this if https://github.com/microsoft/pxt/blob/fixAuthDialogLfs/gulpfile.js#L327? ~I guess would be a little annoying for local dev, would prefer not to do in this pr either way~ just made it so build will error if env == prod so it'll error in prs like lint but won't prevent you from doing local dev work