### PR TITLE
auto focus on sim in multiplayer

### DIFF
--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -95,6 +95,7 @@ export default function Render() {
             embedId: "multiplayer-sim",
             additionalQueryParameters: selectedPlayerTheme,
             single: true,
+            autofocus: true,
             fullScreen: true,
             /** Enabling debug mode so that we can stop at breakpoints as a 'global pause' **/
             debug: true,


### PR DESCRIPTION
Forgot this flag when moving things around, autofocus so initial keyboard / gamepad events should work in sim. Will eventually need to do a little more to grapple with focus issues though