### PR TITLE
Use Deep Links for Copying Multiplayer Join Code, Update Host Lobby Appearance 

### DIFF
--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -156,7 +156,7 @@ export default function Render() {
         <div
             id="sim-container"
             ref={simContainerRef}
-            className={"tw-h-[calc(100vh-16rem)] tw-w-[calc(100vw-6rem)]"}
+            className={"tw-h-[calc(100vh-16rem)] tw-w-screen md:tw-w-[calc(100vw-6rem)]"}
         />
     );
 }

--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -156,7 +156,9 @@ export default function Render() {
         <div
             id="sim-container"
             ref={simContainerRef}
-            className={"tw-h-[calc(100vh-16rem)] tw-w-screen md:tw-w-[calc(100vw-6rem)]"}
+            className={
+                "tw-h-[calc(100vh-16rem)] tw-w-screen md:tw-w-[calc(100vw-6rem)]"
+            }
         />
     );
 }

--- a/multiplayer/src/components/CopyButton.tsx
+++ b/multiplayer/src/components/CopyButton.tsx
@@ -1,0 +1,53 @@
+import { faCopy } from "@fortawesome/free-regular-svg-icons";
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useContext, useEffect, useState } from "react";
+import { AppStateContext } from "../state/AppStateContext";
+
+export default function Render(props: {
+    copyValue: string;
+    title: string;
+    eventName?: string;
+}) {
+    const { state } = useContext(AppStateContext);
+    const [copySuccessful, setCopySuccessful] = useState(false);
+    const copyTimeoutMs = 2500;
+
+    const copyValue = async () => {
+        if (props.eventName) pxt.tickEvent(props.eventName);
+        if (state.gameState?.joinCode) {
+            navigator.clipboard.writeText(props.copyValue);
+            setCopySuccessful(true);
+        }
+    };
+
+    useEffect(() => {
+        if (copySuccessful) {
+            let resetCopyTimer = setTimeout(() => {
+                setCopySuccessful(false);
+            }, copyTimeoutMs);
+            return () => {
+                clearTimeout(resetCopyTimer);
+            };
+        }
+    }, [copySuccessful]);
+
+    return (
+        <button onClick={copyValue} title={props.title}>
+            <div>
+                {!copySuccessful && (
+                    <FontAwesomeIcon
+                        icon={faCopy}
+                        className="hover:tw-scale-110 tw-ease-linear tw-duration-[50ms]"
+                    />
+                )}
+                {copySuccessful && (
+                    <FontAwesomeIcon
+                        icon={faCheck}
+                        className="tw-text-green-600"
+                    />
+                )}
+            </div>
+        </button>
+    );
+}

--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -36,7 +36,10 @@ export default function Render(props: GamePageProps) {
                 <ArcadeSimulator />
                 <div className="tw-flex tw-flex-row tw-w-full tw-items-center tw-justify-between tw-mt-1">
                     <ToggleMuteButton />
-                    <JoinCodeLabel />
+                    <div className="tw-flex tw-flex-row">
+                        <div className="tw-pr-[0.3rem]">{lf("Join Code: ")}</div>
+                        <JoinCodeLabel />
+                    </div>
                     <div>{lf("Keyboard Controls")}</div>
                 </div>
                 <div className="tw-mt-3">

--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -36,10 +36,7 @@ export default function Render(props: GamePageProps) {
                 <ArcadeSimulator />
                 <div className="tw-flex tw-flex-row tw-w-full tw-items-center tw-justify-between tw-mt-1">
                     <ToggleMuteButton />
-                    <div className="tw-flex tw-flex-row">
-                        <div className="tw-pr-[0.3rem] tw-font-bold">{lf("Code: ")}</div>
-                        <JoinCodeLabel />
-                    </div>
+                    <JoinCodeLabel />
                     <div>{lf("Keyboard Controls")}</div>
                 </div>
                 <div className="tw-mt-3">

--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -37,7 +37,7 @@ export default function Render(props: GamePageProps) {
                 <div className="tw-flex tw-flex-row tw-w-full tw-items-center tw-justify-between tw-mt-1">
                     <ToggleMuteButton />
                     <div className="tw-flex tw-flex-row">
-                        <div className="tw-pr-[0.3rem]">{lf("Join Code: ")}</div>
+                        <div className="tw-pr-[0.3rem] tw-font-bold">{lf("Code: ")}</div>
                         <JoinCodeLabel />
                     </div>
                     <div>{lf("Keyboard Controls")}</div>

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -4,7 +4,8 @@ import { Input } from "react-common/components/controls/Input";
 import { startGameAsync } from "../epics";
 import { clearModal } from "../state/actions";
 import { AppStateContext } from "../state/AppStateContext";
-import JoinCodeLabel from "./JoinCodeLabel";
+import CopyButton from "./CopyButton";
+import Loading from "./Loading";
 import PresenceBar from "./PresenceBar";
 
 export default function Render() {
@@ -18,35 +19,31 @@ export default function Render() {
         await startGameAsync();
     };
 
-    const handleCopyClick = () => {
-        pxt.tickEvent("mp.hostlobby.copyjoinlink");
-        if (pxt.BrowserUtils.isIpcRenderer()) {
-            if (inputRef.current) {
-                setCopySuccessful(
-                    pxt.BrowserUtils.legacyCopyText(inputRef.current)
-                );
-            }
-        } else {
-            navigator.clipboard.writeText(joinLink);
-            setCopySuccessful(true);
-        }
-    };
+    const joinCode = state.gameState?.joinCode;
+    if (!joinCode) {
+        return <Loading />;
+    }
 
-    const handleCopyBlur = () => {
-        setCopySuccessful(false);
-    };
+    const displayJoinCode = joinCode?.slice(0, 3) + " " + joinCode?.slice(3);
 
     const joinLinkBaseUrl = "aka.ms/a9";
     const inviteString = lf("Go to {0} and enter code", joinLinkBaseUrl);
+    const fullJoinLink = `${joinLinkBaseUrl}?join=${joinCode}`; // TODO multiplayer : create full link
 
-    const joinLink = `${state.gameState?.joinCode}`; // TODO multiplayer : create full link
     return (
         <div className="tw-flex tw-flex-col tw-gap-1 tw-items-center tw-justify-between tw-bg-white tw-py-[3rem] tw-px-[7rem] tw-shadow-lg tw-rounded-lg">
             <div className="tw-mt-3 tw-text-lg tw-text-center tw-text-neutral-700">
                 {inviteString}
             </div>
-            <div className="tw-text-4xl tw-mt-4">
-                <JoinCodeLabel />
+            <div className="tw-text-4xl tw-mt-4 tw-flex tw-flex-row tw-items-center">
+                {displayJoinCode}
+                <div className="tw-ml-2 tw-text-[75%]">
+                    <CopyButton
+                        copyValue={joinCode}
+                        title={lf("Copy join link")}
+                        eventName="mp.hostlobby.copyjoinlink"
+                    />
+                </div>
             </div>
             <Button
                 className={"primary tw-mt-5 tw-mb-7"}

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -47,7 +47,7 @@ export default function Render() {
                 </div>
             </div>
             <Button
-                className={"primary tw-mt-5 tw-mb-7"}
+                className={"primary tw-mt-5 tw-mb-7 tw-font-sans"}
                 label={lf("Start Game")}
                 title={lf("Start Game")}
                 onClick={onStartGameClick}

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -4,13 +4,13 @@ import { Input } from "react-common/components/controls/Input";
 import { startGameAsync } from "../epics";
 import { clearModal } from "../state/actions";
 import { AppStateContext } from "../state/AppStateContext";
+import JoinCodeLabel from "./JoinCodeLabel";
 import PresenceBar from "./PresenceBar";
 
 export default function Render() {
     const { state, dispatch } = useContext(AppStateContext);
     const [copySuccessful, setCopySuccessful] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
-    const inviteString = lf("Invite anyone to join your game instantly. Just send them a link!");
 
     const onStartGameClick = async () => {
         pxt.tickEvent("mp.hostlobby.startgame");
@@ -36,30 +36,20 @@ export default function Render() {
         setCopySuccessful(false);
     };
 
+    const joinLinkBaseUrl = "aka.ms/a9";
+    const inviteString = lf("Go to {0} and enter code", joinLinkBaseUrl);
+
     const joinLink = `${state.gameState?.joinCode}`; // TODO multiplayer : create full link
     return (
         <div className="tw-flex tw-flex-col tw-gap-1 tw-items-center tw-justify-between tw-bg-white tw-py-[3rem] tw-px-[7rem] tw-shadow-lg tw-rounded-lg">
             <div className="tw-mt-3 tw-text-lg tw-text-center tw-text-neutral-700">
                 {inviteString}
             </div>
-            <div className="common-input-attached-button tw-mt-5 tw-w-full">
-                <Input
-                    ariaLabel={lf("join game link")}
-                    handleInputRef={inputRef}
-                    initialValue={joinLink}
-                    readOnly={true}
-                />
-                <Button
-                    className={copySuccessful ? "green" : "primary"}
-                    title={lf("Copy link")}
-                    label={copySuccessful ? lf("Copied!") : lf("Copy")}
-                    leftIcon="fas fa-link"
-                    onClick={handleCopyClick}
-                    onBlur={handleCopyBlur}
-                />
+            <div className="tw-text-4xl tw-mt-4">
+                <JoinCodeLabel />
             </div>
             <Button
-                className={"teal tw-m-5"}
+                className={"primary tw-mt-5 tw-mb-7"}
                 label={lf("Start Game")}
                 title={lf("Start Game")}
                 onClick={onStartGameClick}

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -22,14 +22,19 @@ export default function Render() {
         return <Loading />;
     }
 
+    
+    // To get a link in the middle of the invite string, we actually preserve the {0} and insert the link manually as an html element later.
+    const inviteString = lf("Go to {0} and enter code", "{0}");
+    const inviteStringSegments = inviteString.split("{0}");
+    const shortLink = SHORT_LINK();
+
     const displayJoinCode = joinCode?.slice(0, 3) + " " + joinCode?.slice(3);
-    const inviteString = lf("Go to {0} and enter code", SHORT_LINK());
     const joinDeepLink = makeJoinLink(joinCode);
 
     return (
         <div className="tw-flex tw-flex-col tw-gap-1 tw-items-center tw-justify-between tw-bg-white tw-py-[3rem] tw-px-[7rem] tw-shadow-lg tw-rounded-lg">
             <div className="tw-mt-3 tw-text-lg tw-text-center tw-text-neutral-700">
-                {inviteString}
+                {inviteStringSegments[0]}{<a href={shortLink} target="_blank" className="tw-text-primary-color tw-font-bold hover:tw-text-orange-300">{shortLink}</a>}{inviteStringSegments[1]}
             </div>
             <div className="tw-text-4xl tw-mt-4 tw-flex tw-flex-row tw-items-center">
                 {displayJoinCode}

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -1,5 +1,6 @@
 import { useContext, useRef, useState } from "react";
 import { Button } from "react-common/components/controls/Button";
+import { Link } from "react-common/components/controls/Link";
 import { startGameAsync } from "../epics";
 import { clearModal } from "../state/actions";
 import { AppStateContext } from "../state/AppStateContext";
@@ -36,13 +37,13 @@ export default function Render() {
             <div className="tw-mt-3 tw-text-lg tw-text-center tw-text-neutral-700">
                 {inviteStringSegments[0]}
                 {
-                    <a
+                    <Link
                         href={shortLink}
                         target="_blank"
                         className="tw-text-primary-color tw-font-bold hover:tw-text-orange-300"
                     >
                         {shortLink}
-                    </a>
+                    </Link>
                 }
                 {inviteStringSegments[1]}
             </div>

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -27,6 +27,7 @@ export default function Render() {
     const inviteStringSegments = inviteString.split("{0}");
     const shortLink = SHORT_LINK();
 
+    // Insert a space to make the join code easier to read.
     const displayJoinCode = joinCode?.slice(0, 3) + " " + joinCode?.slice(3);
     const joinDeepLink = makeJoinLink(joinCode);
 

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -1,17 +1,15 @@
 import { useContext, useRef, useState } from "react";
 import { Button } from "react-common/components/controls/Button";
-import { Input } from "react-common/components/controls/Input";
 import { startGameAsync } from "../epics";
 import { clearModal } from "../state/actions";
 import { AppStateContext } from "../state/AppStateContext";
+import { makeJoinLink, SHORT_LINK } from "../util";
 import CopyButton from "./CopyButton";
 import Loading from "./Loading";
 import PresenceBar from "./PresenceBar";
 
 export default function Render() {
     const { state, dispatch } = useContext(AppStateContext);
-    const [copySuccessful, setCopySuccessful] = useState(false);
-    const inputRef = useRef<HTMLInputElement>(null);
 
     const onStartGameClick = async () => {
         pxt.tickEvent("mp.hostlobby.startgame");
@@ -25,10 +23,8 @@ export default function Render() {
     }
 
     const displayJoinCode = joinCode?.slice(0, 3) + " " + joinCode?.slice(3);
-
-    const joinLinkBaseUrl = "aka.ms/a9";
-    const inviteString = lf("Go to {0} and enter code", joinLinkBaseUrl);
-    const fullJoinLink = `${joinLinkBaseUrl}?join=${joinCode}`; // TODO multiplayer : create full link
+    const inviteString = lf("Go to {0} and enter code", SHORT_LINK());
+    const joinDeepLink = makeJoinLink(joinCode);
 
     return (
         <div className="tw-flex tw-flex-col tw-gap-1 tw-items-center tw-justify-between tw-bg-white tw-py-[3rem] tw-px-[7rem] tw-shadow-lg tw-rounded-lg">
@@ -39,7 +35,7 @@ export default function Render() {
                 {displayJoinCode}
                 <div className="tw-ml-2 tw-text-[75%]">
                     <CopyButton
-                        copyValue={joinCode}
+                        copyValue={joinDeepLink}
                         title={lf("Copy join link")}
                         eventName="mp.hostlobby.copyjoinlink"
                     />

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -22,7 +22,6 @@ export default function Render() {
         return <Loading />;
     }
 
-    
     // To get a link in the middle of the invite string, we actually preserve the {0} and insert the link manually as an html element later.
     const inviteString = lf("Go to {0} and enter code", "{0}");
     const inviteStringSegments = inviteString.split("{0}");
@@ -34,7 +33,17 @@ export default function Render() {
     return (
         <div className="tw-flex tw-flex-col tw-gap-1 tw-items-center tw-justify-between tw-bg-white tw-py-[3rem] tw-px-[7rem] tw-shadow-lg tw-rounded-lg">
             <div className="tw-mt-3 tw-text-lg tw-text-center tw-text-neutral-700">
-                {inviteStringSegments[0]}{<a href={shortLink} target="_blank" className="tw-text-primary-color tw-font-bold hover:tw-text-orange-300">{shortLink}</a>}{inviteStringSegments[1]}
+                {inviteStringSegments[0]}
+                {
+                    <a
+                        href={shortLink}
+                        target="_blank"
+                        className="tw-text-primary-color tw-font-bold hover:tw-text-orange-300"
+                    >
+                        {shortLink}
+                    </a>
+                }
+                {inviteStringSegments[1]}
             </div>
             <div className="tw-text-4xl tw-mt-4 tw-flex tw-flex-row tw-items-center">
                 {displayJoinCode}

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -20,7 +20,7 @@ export default function Render() {
 
     const joinCode = state.gameState?.joinCode;
     if (!joinCode) {
-        return <Loading />;
+        return null;
     }
 
     // To get a link in the middle of the invite string, we actually preserve the {0} and insert the link manually as an html element later.

--- a/multiplayer/src/components/JoinCodeLabel.tsx
+++ b/multiplayer/src/components/JoinCodeLabel.tsx
@@ -1,13 +1,13 @@
 import { useContext, useEffect, useState } from "react";
 import { AppStateContext } from "../state/AppStateContext";
+import { makeJoinLink } from "../util";
 import CopyButton from "./CopyButton";
 
 export default function Render() {
     const { state } = useContext(AppStateContext);
-    const [copySuccessful, setCopySuccessful] = useState(false);
-    const copyTimeoutMs = 2500;
 
     const joinCode = state.gameState?.joinCode;
+    const joinDeepLink = joinCode ? makeJoinLink(joinCode) : "";
     return (
         <div>
             {joinCode && (
@@ -16,9 +16,9 @@ export default function Render() {
                     <div className="tw-mx-1">{joinCode}</div>
                     <div className="tw-text-[75%]">
                         <CopyButton
-                            copyValue={joinCode}
-                            title={lf("Copy join code")}
-                            eventName="mp.copyjoincode"
+                            copyValue={joinDeepLink}
+                            title={lf("Copy join link")}
+                            eventName="mp.copyjoinlink"
                         />
                     </div>
                 </div>

--- a/multiplayer/src/components/JoinCodeLabel.tsx
+++ b/multiplayer/src/components/JoinCodeLabel.tsx
@@ -32,9 +32,9 @@ export default function Render() {
         <div className="tw-justify-self-center">
             {state.gameState?.joinCode && (
                 <div>
-                    {lf("Join Code: {0}", state.gameState?.joinCode)}
+                    {state.gameState?.joinCode}
                     <button onClick={copyJoinCode} title={lf("Copy Join Code")}>
-                        <div className="tw-text-sm tw-ml-1">
+                        <div className="tw-ml-1">
                             {!copySuccessful && (
                                 <FontAwesomeIcon
                                     icon={faCopy}

--- a/multiplayer/src/components/JoinCodeLabel.tsx
+++ b/multiplayer/src/components/JoinCodeLabel.tsx
@@ -28,29 +28,27 @@ export default function Render() {
         }
     }, [copySuccessful]);
 
-    return (
-        <div className="tw-justify-self-center">
-            {state.gameState?.joinCode && (
-                <div>
-                    {state.gameState?.joinCode}
-                    <button onClick={copyJoinCode} title={lf("Copy Join Code")}>
-                        <div className="tw-ml-1">
-                            {!copySuccessful && (
-                                <FontAwesomeIcon
-                                    icon={faCopy}
-                                    className="hover:tw-scale-110 tw-ease-linear tw-duration-[50ms] tw-mb-[0.1rem]"
-                                />
-                            )}
-                            {copySuccessful && (
-                                <FontAwesomeIcon
-                                    icon={faCheck}
-                                    className="tw-text-green-600 tw-mb-[0.1rem]"
-                                />
-                            )}
-                        </div>
-                    </button>
+    const joinCode = state.gameState?.joinCode;
+    const displayJoinCode = joinCode?.slice(0, 3) + " " + joinCode?.slice(3);
+    return joinCode ? (
+        <div>
+            {displayJoinCode}
+            <button onClick={copyJoinCode} title={lf("Copy Join Code")}>
+                <div className="tw-ml-1 tw-text-[80%]">
+                    {!copySuccessful && (
+                        <FontAwesomeIcon
+                            icon={faCopy}
+                            className="hover:tw-scale-110 tw-ease-linear tw-duration-[50ms] tw-mb-[0.1rem]"
+                        />
+                    )}
+                    {copySuccessful && (
+                        <FontAwesomeIcon
+                            icon={faCheck}
+                            className="tw-text-green-600 tw-mb-[0.1rem]"
+                        />
+                    )}
                 </div>
-            )}
+            </button>
         </div>
-    );
+    ) : null;
 }

--- a/multiplayer/src/components/JoinCodeLabel.tsx
+++ b/multiplayer/src/components/JoinCodeLabel.tsx
@@ -1,54 +1,28 @@
-import { faCopy } from "@fortawesome/free-regular-svg-icons";
-import { faCheck } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useContext, useEffect, useState } from "react";
 import { AppStateContext } from "../state/AppStateContext";
+import CopyButton from "./CopyButton";
 
 export default function Render() {
     const { state } = useContext(AppStateContext);
     const [copySuccessful, setCopySuccessful] = useState(false);
     const copyTimeoutMs = 2500;
 
-    const copyJoinCode = async () => {
-        pxt.tickEvent("mp.copyjoincode");
-        if (state.gameState?.joinCode) {
-            navigator.clipboard.writeText(state.gameState?.joinCode);
-            setCopySuccessful(true);
-        }
-    };
-
-    useEffect(() => {
-        if (copySuccessful) {
-            let resetCopyTimer = setTimeout(() => {
-                setCopySuccessful(false);
-            }, copyTimeoutMs);
-            return () => {
-                clearTimeout(resetCopyTimer);
-            };
-        }
-    }, [copySuccessful]);
-
     const joinCode = state.gameState?.joinCode;
-    const displayJoinCode = joinCode?.slice(0, 3) + " " + joinCode?.slice(3);
-    return joinCode ? (
+    return (
         <div>
-            {displayJoinCode}
-            <button onClick={copyJoinCode} title={lf("Copy Join Code")}>
-                <div className="tw-ml-1 tw-text-[80%]">
-                    {!copySuccessful && (
-                        <FontAwesomeIcon
-                            icon={faCopy}
-                            className="hover:tw-scale-110 tw-ease-linear tw-duration-[50ms] tw-mb-[0.1rem]"
+            {joinCode && (
+                <div className="tw-flex tw-flex-row tw-items-center tw-align-middle">
+                    <div className="tw-font-bold">{lf("Code:")}</div>
+                    <div className="tw-mx-1">{joinCode}</div>
+                    <div className="tw-text-[75%]">
+                        <CopyButton
+                            copyValue={joinCode}
+                            title={lf("Copy join code")}
+                            eventName="mp.copyjoincode"
                         />
-                    )}
-                    {copySuccessful && (
-                        <FontAwesomeIcon
-                            icon={faCheck}
-                            className="tw-text-green-600 tw-mb-[0.1rem]"
-                        />
-                    )}
+                    </div>
                 </div>
-            </button>
+            )}
         </div>
-    ) : null;
+    );
 }

--- a/multiplayer/src/util/index.ts
+++ b/multiplayer/src/util/index.ts
@@ -46,7 +46,7 @@ export function cleanupJoinCode(
     joinCode: string | undefined
 ): string | undefined {
     if (!joinCode) return undefined;
-    joinCode = joinCode.replaceAll(' ', '');
+    joinCode = joinCode.replaceAll(" ", "");
     if (joinCode.length !== 6) return undefined;
     joinCode = joinCode.toUpperCase().replace(/[^A-Z0-9]/g, "");
     if (joinCode.length !== 6) return undefined;

--- a/multiplayer/src/util/index.ts
+++ b/multiplayer/src/util/index.ts
@@ -46,7 +46,7 @@ export function cleanupJoinCode(
     joinCode: string | undefined
 ): string | undefined {
     if (!joinCode) return undefined;
-    joinCode = joinCode.trim();
+    joinCode = joinCode.replaceAll(' ', '');
     if (joinCode.length !== 6) return undefined;
     joinCode = joinCode.toUpperCase().replace(/[^A-Z0-9]/g, "");
     if (joinCode.length !== 6) return undefined;

--- a/multiplayer/src/util/index.ts
+++ b/multiplayer/src/util/index.ts
@@ -80,8 +80,6 @@ export function cleanupJoinCode(
     joinCode: string | undefined
 ): string | undefined {
     if (!joinCode) return undefined;
-    joinCode = joinCode.replaceAll(" ", "");
-    if (joinCode.length !== 6) return undefined;
     joinCode = joinCode.toUpperCase().replace(/[^A-Z0-9]/g, "");
     if (joinCode.length !== 6) return undefined;
     return joinCode;


### PR DESCRIPTION
This updates the host lobby appearance to match the latest designs more closely, and it will copy a deep link rather than the code itself when the copy button is pressed (on both the host lobby and the game page).

Also sneaking in a fix to make the sim use the full screen width when on a smaller screen.

<img width="487" alt="image" src="https://user-images.githubusercontent.com/69657545/198403800-80f7c185-41da-4093-9f3a-f64fdf10c98d.png">

<img width="174" alt="image" src="https://user-images.githubusercontent.com/69657545/198403863-9d2df222-a446-4a90-ae6d-ab7d463a4583.png">
