### PR TITLE
multiplayer should fix sim colors for now

### DIFF
--- a/multiplayer/src/epics/setGameModeAsync.ts
+++ b/multiplayer/src/epics/setGameModeAsync.ts
@@ -10,6 +10,9 @@ import {
 
 export async function setGameModeAsync(gameMode: GameMode, slot?: number) {
     try {
+        if (slot) {
+            dispatch(setPlayerSlot(slot));
+        }
         dispatch(setGameMode(gameMode));
         if (gameMode === "playing") {
             dispatch(clearModal());
@@ -20,9 +23,6 @@ export async function setGameModeAsync(gameMode: GameMode, slot?: number) {
                     timeoutMs: 5000,
                 })
             );
-        }
-        if (slot) {
-            dispatch(setPlayerSlot(slot));
         }
     } catch (e) {
     } finally {


### PR DESCRIPTION
I believe this should be the fix for https://github.com/microsoft/pxt-arcade/issues/5205 and https://github.com/microsoft/pxt-arcade/issues/5208

I'll hopefully find some time to make it so we propagate sim colors even if the sim has already been running, but this should fix it for now. the issue is that we were hitting the compile & run case before the slot was set, which is used to determine which color the sim should be. Currently, that is determined only when the sim is loaded for the session. (I'm assuming green sim in player 2 is that thomas joined a game, left, then joined another already started game which got the wrong color.)