### PR TITLE
fix color order on presence bar, yellow -> orange to match sim

### DIFF
--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -13,10 +13,10 @@ export default function Render() {
     const simContainerRef = useRef<HTMLDivElement>(null);
 
     const playerThemes = [
-        "background-color=ED3636&button-stroke=8d2525",
-        "background-color=4E4EE9&button-stroke=3333a1",
-        "background-color=FFDF1A&button-stroke=c1a916",
-        "background-color=4EB94E&button-stroke=245d24",
+        "background-color=ED3636&button-stroke=8D2525",
+        "background-color=4E4EE9&button-stroke=3333A1",
+        "background-color=FF9A14&button-stroke=B0701A",
+        "background-color=4EB94E&button-stroke=245D24",
     ];
     const selectedPlayerTheme = playerThemes[(playerSlot || 0) - 1];
     const isHost = playerSlot == 1;

--- a/multiplayer/src/index.css
+++ b/multiplayer/src/index.css
@@ -6,6 +6,6 @@
     --slot-0-color: 77, 77, 77;
     --slot-1-color: 255, 0, 0;
     --slot-2-color: 0, 56, 255;
-    --slot-3-color: 77, 166, 77;
-    --slot-4-color: 228, 204, 0;
+    --slot-3-color: 255, 154, 20;
+    --slot-4-color: 77, 166, 77;
 }


### PR DESCRIPTION
A little pumpkiny, but swapping from yellow to orange to fix contrast issues & match the player 3 theme in arcade game engine (e.g. when you set player 3 health)

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/5615930/198739206-35bce259-2dfa-40cc-832c-04798beee12e.png">

also fix order on presence bar to match player color order on sim and in game