### PR TITLE
Add Beta Indicator to Multiplayer Pages

### DIFF
--- a/multiplayer/src/components/BetaTag.tsx
+++ b/multiplayer/src/components/BetaTag.tsx
@@ -1,8 +1,8 @@
 export default function Render() {
     return (
         <div className="tw-text-sm">
-            <span className="tw-bg-white tw-shadow-sm tw-text-primary-color tw-rounded-md tw-font-bold tw-px-1 tw-pt-[0.05rem] tw-pb-[0.15rem] tw-mr-1">
-                {lf("BETA")}
+            <span className="tw-bg-white tw-shadow-sm tw-uppercase tw-text-primary-color tw-rounded-md tw-font-bold tw-px-1 tw-pt-[0.05rem] tw-pb-[0.15rem] tw-mr-1">
+                {lf("Beta")}
             </span>
             <span className="tw-text-white">{lf("Multiplayer")}</span>
         </div>

--- a/multiplayer/src/components/BetaTag.tsx
+++ b/multiplayer/src/components/BetaTag.tsx
@@ -1,0 +1,10 @@
+export default function Render() {
+    return (
+        <div className="tw-text-sm">
+            <span className="tw-bg-white tw-shadow-sm tw-text-primary-color tw-rounded-md tw-font-bold tw-px-1 tw-pt-[0.05rem] tw-pb-[0.15rem] tw-mr-1">
+                {lf("BETA")}
+            </span>
+            <span className="tw-text-white">{lf("Multiplayer")}</span>
+        </div>
+    );
+}

--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 import { AppStateContext } from "../state/AppStateContext";
 import ArcadeSimulator from "./ArcadeSimulator";
+import BetaTag from "./BetaTag";
 import HostLobby from "./HostLobby";
 import JoinCodeLabel from "./JoinCodeLabel";
 import JoinLobby from "./JoinLobby";
@@ -20,11 +21,15 @@ export default function Render(props: GamePageProps) {
                     {lf("Connecting...")}
                 </div>
             )}
-
             {state.gameState?.gameMode === "lobby" && (
                 <div className="tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-full tw-h-full">
                     {clientRole === "host" && <HostLobby />}
                     {clientRole === "guest" && <JoinLobby />}
+                </div>
+            )}
+            {state.gameState?.gameMode === "playing" && (
+                <div className="tw-mx-2 tw-self-start tw-mb-1">
+                    <BetaTag />
                 </div>
             )}
             <div

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -5,8 +5,8 @@ import { startGameAsync } from "../epics";
 import { clearModal } from "../state/actions";
 import { AppStateContext } from "../state/AppStateContext";
 import { makeJoinLink, SHORT_LINK } from "../util";
+import BetaTag from "./BetaTag";
 import CopyButton from "./CopyButton";
-import Loading from "./Loading";
 import PresenceBar from "./PresenceBar";
 
 export default function Render() {
@@ -33,39 +33,44 @@ export default function Render() {
     const joinDeepLink = makeJoinLink(joinCode);
 
     return (
-        <div className="tw-flex tw-flex-col tw-gap-1 tw-items-center tw-justify-between tw-bg-white tw-py-[3rem] tw-px-[7rem] tw-shadow-lg tw-rounded-lg">
-            <div className="tw-mt-3 tw-text-lg tw-text-center tw-text-neutral-700">
-                {inviteStringSegments[0]}
-                {
-                    <Link
-                        href={shortLink}
-                        target="_blank"
-                        className="tw-text-primary-color tw-font-bold hover:tw-text-orange-300"
-                    >
-                        {shortLink}
-                    </Link>
-                }
-                {inviteStringSegments[1]}
+        <div className="tw-bg-white tw-shadow-lg tw-rounded-lg">
+            <div className="tw-absolute tw-translate-y-[-130%]">
+                <BetaTag />
             </div>
-            <div className="tw-text-4xl tw-mt-4 tw-flex tw-flex-row tw-items-center">
-                <span className="tw-font-bold tw-text-neutral-700">
-                    {displayJoinCode}
-                </span>
-                <div className="tw-ml-2 tw-text-[50%]">
-                    <CopyButton
-                        copyValue={joinDeepLink}
-                        title={lf("Copy join link")}
-                        eventName="mp.hostlobby.copyjoinlink"
-                    />
+            <div className="tw-flex tw-flex-col tw-gap-1 tw-items-center tw-justify-between tw-py-[3rem] tw-px-[7rem]">
+                <div className="tw-mt-3 tw-text-lg tw-text-center tw-text-neutral-700">
+                    {inviteStringSegments[0]}
+                    {
+                        <Link
+                            href={shortLink}
+                            target="_blank"
+                            className="tw-text-primary-color tw-font-bold hover:tw-text-orange-300"
+                        >
+                            {shortLink}
+                        </Link>
+                    }
+                    {inviteStringSegments[1]}
                 </div>
+                <div className="tw-text-4xl tw-mt-4 tw-flex tw-flex-row tw-items-center">
+                    <span className="tw-font-bold tw-text-neutral-700">
+                        {displayJoinCode}
+                    </span>
+                    <div className="tw-ml-2 tw-text-[50%]">
+                        <CopyButton
+                            copyValue={joinDeepLink}
+                            title={lf("Copy join link")}
+                            eventName="mp.hostlobby.copyjoinlink"
+                        />
+                    </div>
+                </div>
+                <Button
+                    className={"primary tw-mt-5 tw-mb-7 tw-font-sans"}
+                    label={lf("Start Game")}
+                    title={lf("Start Game")}
+                    onClick={onStartGameClick}
+                />
+                <PresenceBar />
             </div>
-            <Button
-                className={"primary tw-mt-5 tw-mb-7 tw-font-sans"}
-                label={lf("Start Game")}
-                title={lf("Start Game")}
-                onClick={onStartGameClick}
-            />
-            <PresenceBar />
         </div>
     );
 }

--- a/multiplayer/src/components/JoinLobby.tsx
+++ b/multiplayer/src/components/JoinLobby.tsx
@@ -1,9 +1,13 @@
+import BetaTag from "./BetaTag";
 import PresenceBar from "./PresenceBar";
 
 export default function Render() {
     return (
-        <div>
-            <div className="tw-flex tw-flex-col tw-items-center tw-bg-white tw-py-[2rem] tw-px-[7rem] tw-shadow-lg tw-rounded-lg">
+        <div className="tw-bg-white tw-shadow-lg tw-rounded-lg">
+            <div className="tw-absolute tw-translate-y-[-130%]">
+                <BetaTag />
+            </div>
+            <div className="tw-flex tw-flex-col tw-items-center tw-py-[2rem] tw-px-[6rem]">
                 <div className="tw-font-bold tw-text-2xl tw-text-neutral-800">
                     {lf("Waiting for players")}
                 </div>

--- a/multiplayer/src/components/JoinOrHost.tsx
+++ b/multiplayer/src/components/JoinOrHost.tsx
@@ -5,6 +5,7 @@ import { Input } from "react-common/components/controls/Input";
 import { Link } from "react-common/components/controls/Link";
 import { hostGameAsync, joinGameAsync } from "../epics";
 import TabButton from "./TabButton";
+import BetaTag from "./BetaTag";
 
 export default function Render() {
     const [currTab, setCurrTab] = useState<"join" | "host">("join");
@@ -31,85 +32,94 @@ export default function Render() {
 
     return (
         <div className="tw-flex tw-w-screen tw-h-screen tw-justify-center tw-items-center">
-            <div className="tw-bg-white tw-rounded-lg tw-drop-shadow-xl tw-py-5 tw-px-10 tw-min-h-[17rem] tw-min-w-[25rem]">
-                <div className="tw-pt-2">
-                    <div className="tw-flex tw-justify-center">
-                        <TabButton
-                            title={lf("Join Game")}
-                            selected={currTab === "join"}
-                            onClick={() => setCurrTab("join")}
-                        />
-                        <TabButton
-                            title={lf("Host Game")}
-                            selected={currTab === "host"}
-                            onClick={() => setCurrTab("host")}
-                        />
-                    </div>
+            <div className="tw-bg-white tw-rounded-lg tw-drop-shadow-xl tw-min-h-[17rem] tw-min-w-[25rem]">
+                <div className="tw-absolute tw-translate-y-[-130%]">
+                    <BetaTag />
+                </div>
+                <div className="tw-py-5 tw-px-10 ">
                     <div className="tw-pt-2">
-                        {currTab === "join" && (
-                            <div className="tw-w-full tw-flex tw-flex-col tw-gap-4 tw-mt-2 tw-justify-center tw-items-center">
-                                <div className="tw-w-full">
-                                    <Input
-                                        groupClassName="tw-w-full tw-border-1 tw-h-full tw-rounded"
-                                        inputClassName="tw-text-center tw-p-2"
-                                        title={lf("Join Code")}
-                                        autoComplete={false}
-                                        handleInputRef={setJoinCodeRef}
-                                        preserveValueOnBlur={true}
-                                        onEnterKey={onJoinGameClick}
-                                        placeholder={lf("Enter game code")}
-                                    />
+                        <div className="tw-flex tw-justify-center">
+                            <TabButton
+                                title={lf("Join Game")}
+                                selected={currTab === "join"}
+                                onClick={() => setCurrTab("join")}
+                            />
+                            <TabButton
+                                title={lf("Host Game")}
+                                selected={currTab === "host"}
+                                onClick={() => setCurrTab("host")}
+                            />
+                        </div>
+                        <div className="tw-pt-2">
+                            {currTab === "join" && (
+                                <div className="tw-w-full tw-flex tw-flex-col tw-gap-4 tw-mt-2 tw-justify-center tw-items-center">
+                                    <div className="tw-w-full">
+                                        <Input
+                                            groupClassName="tw-w-full tw-border-1 tw-h-full tw-rounded"
+                                            inputClassName="tw-text-center tw-p-2"
+                                            title={lf("Join Code")}
+                                            autoComplete={false}
+                                            handleInputRef={setJoinCodeRef}
+                                            preserveValueOnBlur={true}
+                                            onEnterKey={onJoinGameClick}
+                                            placeholder={lf("Enter game code")}
+                                        />
+                                    </div>
+                                    <div>
+                                        <Button
+                                            className={"primary tw-px-10"}
+                                            label={lf("Enter")}
+                                            title={lf("Join Game")}
+                                            onClick={onJoinGameClick}
+                                        />
+                                    </div>
+                                    <div className="tw-text-sm">
+                                        <Link
+                                            href="/docs/multiplayer#join-game"
+                                            target="_blank"
+                                        >
+                                            {lf("How do I get a game code?")}
+                                        </Link>
+                                    </div>
                                 </div>
-                                <div>
-                                    <Button
-                                        className={"primary tw-px-10"}
-                                        label={lf("Enter")}
-                                        title={lf("Join Game")}
-                                        onClick={onJoinGameClick}
-                                    />
+                            )}
+                            {currTab === "host" && (
+                                <div className="tw-w-full tw-flex tw-flex-col tw-gap-4 tw-mt-2 tw-justify-center tw-items-center">
+                                    <div className="tw-w-full">
+                                        <Input
+                                            groupClassName="tw-w-full tw-border-1 tw-h-full tw-rounded"
+                                            inputClassName="tw-p-2"
+                                            title={lf("Share Code")}
+                                            autoComplete={false}
+                                            handleInputRef={setShareCodeRef}
+                                            preserveValueOnBlur={true}
+                                            onEnterKey={onHostGameClick}
+                                            placeholder={lf(
+                                                "Enter share code or link"
+                                            )}
+                                        />
+                                    </div>
+                                    <div>
+                                        <Button
+                                            className={"primary tw-px-10"}
+                                            label={lf("Launch")}
+                                            title={lf("Host Game")}
+                                            onClick={onHostGameClick}
+                                        />
+                                    </div>
+                                    <div className="tw-text-sm">
+                                        <Link
+                                            href="/docs/multiplayer#host-game"
+                                            target="_blank"
+                                        >
+                                            {lf(
+                                                "How do I get a share code or link?"
+                                            )}
+                                        </Link>
+                                    </div>
                                 </div>
-                                <div className="tw-text-sm">
-                                    <Link
-                                        href="/docs/multiplayer#join-game"
-                                        target="_blank"
-                                    >
-                                        {lf("How do I get a game code?")}
-                                    </Link>
-                                </div>
-                            </div>
-                        )}
-                        {currTab === "host" && (
-                            <div className="tw-w-full tw-flex tw-flex-col tw-gap-4 tw-mt-2 tw-justify-center tw-items-center">
-                                <div className="tw-w-full">
-                                    <Input
-                                        groupClassName="tw-w-full tw-border-1 tw-h-full tw-rounded"
-                                        inputClassName="tw-p-2"
-                                        title={lf("Share Code")}
-                                        autoComplete={false}
-                                        handleInputRef={setShareCodeRef}
-                                        preserveValueOnBlur={true}
-                                        onEnterKey={onHostGameClick}
-                                        placeholder={lf("Enter share code or link")}
-                                    />
-                                </div>
-                                <div>
-                                    <Button
-                                        className={"primary tw-px-10"}
-                                        label={lf("Launch")}
-                                        title={lf("Host Game")}
-                                        onClick={onHostGameClick}
-                                    />
-                                </div>
-                                <div className="tw-text-sm">
-                                    <Link
-                                        href="/docs/multiplayer#host-game"
-                                        target="_blank"
-                                    >
-                                        {lf("How do I get a share code or link?")}
-                                    </Link>
-                                </div>
-                            </div>
-                        )}
+                            )}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/multiplayer/src/components/JoinOrHost.tsx
+++ b/multiplayer/src/components/JoinOrHost.tsx
@@ -94,9 +94,7 @@ export default function Render() {
                                             handleInputRef={setShareCodeRef}
                                             preserveValueOnBlur={true}
                                             onEnterKey={onHostGameClick}
-                                            placeholder={lf(
-                                                "Enter share code or link"
-                                            )}
+                                            placeholder={lf("Enter share code or link")}
                                         />
                                     </div>
                                     <div>
@@ -112,9 +110,7 @@ export default function Render() {
                                             href="/docs/multiplayer#host-game"
                                             target="_blank"
                                         >
-                                            {lf(
-                                                "How do I get a share code or link?"
-                                            )}
+                                            {lf("How do I get a share code or link?")}
                                         </Link>
                                     </div>
                                 </div>


### PR DESCRIPTION
This adds a little "beta" tag to the home page, lobbies, and game page. Margins on the sim were a bit weird, so I just put it in the corner of the page in that scenario for now. If needed, we can revisit this later, but it may require css updates on the sim-side of things.

Also, I don't know the "right" way to position stuff in css/html so feel free to offer alternate suggestions.

Fixes https://github.com/microsoft/pxt-arcade/issues/5162

<img width="349" alt="image" src="https://user-images.githubusercontent.com/69657545/198740527-57230cf8-740f-4bbd-b7c2-656915d0e4ca.png">

![image](https://user-images.githubusercontent.com/69657545/198740536-e0cf0e63-3d20-4403-9f05-23e0ce8e60f1.png)

![image](https://user-images.githubusercontent.com/69657545/198740553-34503633-fcb6-440f-ad83-da1d1856883b.png)

![image](https://user-images.githubusercontent.com/69657545/198740576-7b8df5ec-cd67-4805-a252-073142cc155e.png)

![image](https://user-images.githubusercontent.com/69657545/198740583-753d780f-cd92-4063-9bec-5055914a0b16.png)
