### PR TITLE
multiplayer fix one more case of miscoloring

### DIFF
--- a/multiplayer/src/state/reducer.ts
+++ b/multiplayer/src/state/reducer.ts
@@ -55,6 +55,7 @@ export default function reducer(state: AppState, action: Action): AppState {
         case "CLEAR_GAME_INFO": {
             return {
                 ...state,
+                playerSlot: undefined,
                 gameState: undefined,
                 gameId: undefined,
                 gameMetadata: undefined,


### PR DESCRIPTION
Found one other case similar to https://github.com/microsoft/pxt-arcade/issues/5208 -- this is slightly different as it only applies when hosting a game after previously having joined a game as a guest (where the previous one I fixed / the issue was for guest -> guest). this one causes the sim to be miscolored with the previous color + a useless compile that slows things down for an extra second

The current slot for the player is game specific info that should be cleared when leaving the game. When I swap to incremental compile I'll look at cleaning this up so even if we get into an off state like this we don't get miscolorings, but either way good to have consistent state~