### PR TITLE
Add compile option to calculate used parts

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -987,6 +987,7 @@ declare namespace ts.pxtc {
         trace?: boolean;
         justMyCode?: boolean;
         computeUsedSymbols?: boolean;
+        computeUsedParts?: boolean;
         name?: string;
         apisInfo?: ApisInfo;
         bannedCategories?: string[];

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1023,6 +1023,10 @@ namespace ts.pxtc {
             res.usedArguments = {}
         }
 
+        if (opts.computeUsedParts) {
+            res.usedParts = [];
+        }
+
         let allStmts: Statement[] = [];
         if (!opts.forceEmit || res.diagnostics.length == 0) {
             let files = program.getSourceFiles().slice();
@@ -2022,6 +2026,15 @@ ${lbl}: .short 0xffff
 
             if (opts.computeUsedSymbols && decl.symbol)
                 res.usedSymbols[getNodeFullName(checker, decl)] = null
+
+            if (opts.computeUsedParts && pinfo.commentAttrs?.parts) {
+                const partsSplit = pinfo.commentAttrs.parts.split(/[ ,]+/g);
+                for (const part of partsSplit) {
+                    if (res.usedParts.indexOf(part) === -1) {
+                        res.usedParts.push(part);
+                    }
+                }
+            }
 
             if (isStackMachine() && isClassFunction(decl))
                 getIfaceMemberId(getName(decl), true)

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -248,6 +248,7 @@ namespace ts.pxtc {
         blockSourceMap?: pxt.blocks.BlockSourceInterval[]; // mappings id,start,end
         usedSymbols?: pxt.Map<SymbolInfo>; // q-names of symbols used
         usedArguments?: pxt.Map<string[]>;
+        usedParts?: string[];
         needsFullRecompile?: boolean;
         // client options
         saveOnly?: boolean;
@@ -339,8 +340,8 @@ namespace ts.pxtc {
         endingToken?: string;
     }
 
-    export function computeUsedParts(resp: CompileResult, filter?: "onlybuiltin" | "ignorebuiltin"): string[] {
-        if (!resp.usedSymbols || !pxt.appTarget.simulator || !pxt.appTarget.simulator.parts)
+    export function computeUsedParts(resp: CompileResult, filter?: "onlybuiltin" | "ignorebuiltin", force = false): string[] {
+        if (!resp.usedSymbols || !pxt.appTarget.simulator || (!force && !pxt.appTarget.simulator.parts))
             return [];
 
         const parseParts = (partsRaw: string, ps: string[]) => {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -469,6 +469,8 @@ namespace pxt.runner {
         let didUpgrade = false;
         const currentTargetVersion = pxt.appTarget.versions.target;
         let compileResult = await compileAsync(false, opts => {
+            opts.computeUsedParts = true;
+
             if (simOptions.debug)
                 opts.breakpoints = true;
             if (simOptions.assets) {
@@ -522,7 +524,9 @@ namespace pxt.runner {
             console.error("Diagnostics", compileResult.diagnostics);
         }
 
-        return pxtc.buildSimJsInfo(compileResult);
+        const res = pxtc.buildSimJsInfo(compileResult);
+        res.parts = compileResult.usedParts;
+        return res;
     }
 
     function getStoredState(id: string) {


### PR DESCRIPTION
PR 1 of 3 for automatically detecting if a game is multiplayer at compile time.

This adds a PR that makes it so that the compiler keeps track of the used "parts" when compiling a program. By labeling all multiplayer APIs with `parts="multiplayer"`, then if one of those APIs is called by the user program it should show up in the usedParts array in the CompileResult.

This comment annotation is the same one we use to detect if you use a servo in micro:bit, etc.