### PR TITLE
Added title html tag for the blocks playground page

### DIFF
--- a/docs/playground.html
+++ b/docs/playground.html
@@ -9,6 +9,7 @@
         href="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/editor/editor.main.css">
     <link rel="stylesheet" href="/static/shared/iframeeditor.css">
     <link rel="stylesheet" href="/static/playground/playground.css">
+    <title>MakeCode Blocks Playground</title>
 </head>
 
 <body>


### PR DESCRIPTION
Added the title so it displays on the browser tab instead of the url. Closes https://github.com/microsoft/pxt-arcade/issues/3613

![image](https://user-images.githubusercontent.com/15070078/199281655-9d1b2b8c-8410-4251-b1c8-c86fa8ed6708.png)

