### PR TITLE
multiplayer propagate audio

### DIFF
--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -33,6 +33,11 @@ export default function Render() {
         await gameClient.sendInputAsync(button, state);
     };
 
+    const postAudioMsg = async (msg: SimMultiplayer.AudioMessage) => {
+        const { instruction, soundbuf } = msg;
+        await gameClient.sendAudioAsync(instruction, soundbuf);
+    };
+
     const setSimStopped = async () => {
         pxt.runner
             .currentDriver()
@@ -79,6 +84,8 @@ export default function Render() {
                         postInputMsg(data);
                     } else if (origin === "server" && content === "Image") {
                         postImageMsg(data);
+                    } else if (origin === "server" && content === "Audio") {
+                        postAudioMsg(data);
                     }
                     return;
             }

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -27,7 +27,7 @@ import {
 const GAME_HOST_PROD = "https://mp.makecode.com";
 const GAME_HOST_STAGING = "https://multiplayer.staging.pxt.io";
 const GAME_HOST_LOCALHOST = "http://localhost:8082";
-const GAME_HOST_DEV = GAME_HOST_LOCALHOST;
+const GAME_HOST_DEV = GAME_HOST_STAGING;
 const GAME_HOST = (() => {
     if (pxt.BrowserUtils.isLocalHostDev()) {
         return GAME_HOST_DEV;

--- a/multiplayer/src/types/index.ts
+++ b/multiplayer/src/types/index.ts
@@ -49,6 +49,33 @@ export function stringToButtonState(state: string): ButtonState | undefined {
     }
 }
 
+export enum AudioInstruction {
+    MuteAllChannels = 0,
+    PlayInstruction = 1,
+}
+
+export function audioInstructionToString(
+    state: AudioInstruction
+): string | undefined {
+    switch (state) {
+        case AudioInstruction.MuteAllChannels:
+            return "muteallchannels";
+        case AudioInstruction.PlayInstruction:
+            return "playinstructions";
+    }
+}
+
+export function stringToAudioInstruction(
+    state: string
+): AudioInstruction | undefined {
+    switch (state) {
+        case "muteallchannels":
+            return AudioInstruction.MuteAllChannels;
+        case "playinstructions":
+            return AudioInstruction.PlayInstruction;
+    }
+}
+
 export type ToastType = "success" | "info" | "warning" | "error";
 
 export type Toast = {
@@ -108,5 +135,11 @@ export namespace SimMultiplayer {
         state: "Pressed" | "Released" | "Held";
     };
 
-    export type Message = ImageMessage | InputMessage;
+    export type AudioMessage = MessageBase & {
+        content: "Audio";
+        instruction: "playinstructions" | "muteallchannels";
+        soundbuf?: Uint8Array;
+    };
+
+    export type Message = ImageMessage | AudioMessage | InputMessage;
 }

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -232,6 +232,8 @@ namespace pxsim {
         // destination. Used for muting
         let destination: GainNode;
 
+        export let soundEventCallback: (ev: "playinstructions" | "muteallchannels", data?: Uint8Array) => void;
+
         function context(): AudioContext {
             if (!_context) {
                 _context = freshContext();
@@ -496,6 +498,7 @@ namespace pxsim {
 
         let instrStopId = 1
         export function muteAllChannels() {
+            soundEventCallback?.("muteallchannels");
             instrStopId++
             while (channels.length)
                 channels[0].remove()
@@ -661,6 +664,7 @@ namespace pxsim {
 
         export function playInstructionsAsync(instructions: Uint8Array, isCancelled?: () => boolean, onPull?: (freq: number, volume: number) => void) {
             return new Promise<void>(async resolve => {
+                soundEventCallback?.("playinstructions", instructions);
                 let resolved = false;
                 let ctx = context();
                 let channel = new Channel()


### PR DESCRIPTION
send and receive messages between pxt-c-p and pxt-backend, and add a little hook in sim sound that calls back on sound events. 

@riknoll if you see any events I need to propagate besides just mute channels & play buffer let me know, it seems fine as far as I can tell.

here's the bad test sound 'pad' I did: https://arcade.makecode.com/S05411-77245-32862-42860 (I should have asked richard for one of his cool sounds)