### PR TITLE
Added new asset tags/categories for localization

### DIFF
--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -304,6 +304,12 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
         // lf("Forest")
         // lf("Space")
         // lf("Aquatic")
+        // lf("Buildings")
+        // lf("Furniture")
+        // lf("Electronics")
+        // lf("Transportation")
+        // lf("Swamp")
+        // lf("Sports")
 
         if (this.galleryAssets) {
             filterAssets.forEach( (asset) => {


### PR DESCRIPTION
We updated arcade gallery asset tags (https://github.com/microsoft/pxt-arcade/pull/5219) so we need to localize them as well.

We still need to extract the strings, so I've filed an issue here: https://github.com/microsoft/pxt-arcade/issues/5197