### PR TITLE
multiplayer fix remixurl

### DIFF
--- a/multiplayer/src/components/RemixGameButton.tsx
+++ b/multiplayer/src/components/RemixGameButton.tsx
@@ -6,7 +6,7 @@ export default function Render() {
     const { state } = useContext(AppStateContext);
 
     const remixUrl = state.gameId
-        ? `${pxt.webConfig.relprefix.slice(0, -3)}#pub:${state.gameId}`
+        ? `${pxt.webConfig.relprefix.replace(/-+$/, "")}#pub:${state.gameId}`
         : undefined;
 
     function handleRemixGameClick() {


### PR DESCRIPTION
This should fix the issue for now, the webconfig values are still slightly wrong in multiplayer at the moment (pointing at live instead of beta when in beta) but good enough to test for now / that's a separate fix that might be bundled into my worker change later.

![image](https://user-images.githubusercontent.com/5615930/199830716-50d76d20-cd8a-468f-bbb0-6ca8bf079380.png)

vs skillmap which has the correct values in webConfig 
![image](https://user-images.githubusercontent.com/5615930/199831172-a54ff131-bd19-4474-8a24-41bc816c47b2.png)
