### PR TITLE
kick player, game over, player menu, misc refinements

### DIFF
--- a/multiplayer/src/components/AppModal.tsx
+++ b/multiplayer/src/components/AppModal.tsx
@@ -1,13 +1,14 @@
 import { useContext } from "react";
 import { Modal } from "react-common/components/controls/Modal";
 import { SignInModal } from "react-common/components/profile/SignInModal";
-import { signInAsync } from "../epics";
+import { signInAsync, kickPlayer, leaveGameAsync } from "../epics";
 import { clearModal } from "../state/actions";
 import { AppStateContext, dispatch } from "../state/AppStateContext";
+import ConfirmModal from "./modals/ConfirmModal";
 
 export default function Render() {
     const { state } = useContext(AppStateContext);
-    const { deepLinks } = state;
+    const { deepLinks, clientRole } = state;
     const { shareCode, joinCode } = deepLinks;
 
     switch (state.modal) {
@@ -34,6 +35,44 @@ export default function Render() {
                     Report Abuse Placeholder {/*TODO multiplayer*/}
                 </Modal>
             );
+        case "kick-player":
+            return (
+                <ConfirmModal
+                    title={lf("Kick Player")}
+                    message={lf("Kick this player? They will be blocked from rejoining the game.")}
+                    onConfirm={() => {
+                        dispatch(clearModal());
+                        kickPlayer(state.modalOpts.clientId);
+                    }}
+                    onCancel={() => dispatch(clearModal())}
+                />
+            );
+        case "leave-game":
+            if (clientRole === "host") {
+                return (
+                    <ConfirmModal
+                        title={lf("End the Game")}
+                        message={lf("End this game? All players will be disconnected.")}
+                        onConfirm={async () => {
+                            dispatch(clearModal());
+                            await leaveGameAsync("ended");
+                        }}
+                        onCancel={() => dispatch(clearModal())}
+                    />
+                );
+            } else {
+                return (
+                    <ConfirmModal
+                        title={lf("Leave Game")}
+                        message={lf("Leave the game?")}
+                        onConfirm={async () => {
+                            dispatch(clearModal());
+                            await leaveGameAsync("left");
+                        }}
+                        onCancel={() => dispatch(clearModal())}
+                    />
+                );
+            }
         default:
             return null;
     }

--- a/multiplayer/src/components/AppModal.tsx
+++ b/multiplayer/src/components/AppModal.tsx
@@ -51,8 +51,8 @@ export default function Render() {
             if (clientRole === "host") {
                 return (
                     <ConfirmModal
-                        title={lf("End the Game")}
-                        message={lf("End this game? All players will be disconnected.")}
+                        title={lf("Leave Game")}
+                        message={lf("Leave the game? All players will be disconnected.")}
                         onConfirm={async () => {
                             dispatch(clearModal());
                             await leaveGameAsync("ended");

--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -17,11 +17,7 @@ export default function Render(props: GamePageProps) {
 
     return (
         <>
-            {netMode === "connecting" && (
-                <div className="tw-text-xl tw-text-white tw-mt-5">
-                    {lf("Connecting...")}
-                </div>
-            )}
+            {netMode === "connecting" && <></>}
             {state.gameState?.gameMode === "lobby" && (
                 <div className="tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-full tw-h-full">
                     {clientRole === "host" && <HostLobby />}

--- a/multiplayer/src/components/HeaderBar.tsx
+++ b/multiplayer/src/components/HeaderBar.tsx
@@ -65,11 +65,6 @@ export default function Render() {
         await signOutAsync();
     };
 
-    const onLeaveGameClick = async () => {
-        pxt.tickEvent("mp.leavegame");
-        await leaveGameAsync();
-    };
-
     const getOrganizationLogo = (targetTheme: pxt.AppTheme) => {
         const logoUrl = targetTheme.organizationWideLogo;
         return (
@@ -226,16 +221,6 @@ export default function Render() {
                 {getTargetLogo(appTheme)}
             </div>
             <div className="tw-select-none tw-flex-grow" />
-            {state.gameState?.gameMode && (
-                <div className="tw-select-none tw-flex tw-items-center tw-align-middle tw-h-full hover:tw-bg-black/10">
-                    <Button
-                        className="tw-bg-transparent tw-text-white tw-text-2xl tw-m-0 tw-p-4"
-                        title={lf("Leave Game")}
-                        onClick={onLeaveGameClick}
-                        leftIcon="fas fa-arrow-left large"
-                    />
-                </div>
-            )}
             <div className="tw-select-none tw-text-lg tw-font-bold tw-flex tw-items-center tw-pr-[var(--header-padding-top)] tw-h-full">
                 {settingItems?.length > 0 && (
                     <MenuDropdown

--- a/multiplayer/src/components/Popup.tsx
+++ b/multiplayer/src/components/Popup.tsx
@@ -1,0 +1,25 @@
+import { useRef, useCallback, useState } from "react";
+import { useClickedOutside } from "../hooks";
+
+export default function Render(
+    props: React.PropsWithChildren<{
+        className?: string;
+        visible: boolean;
+        onClickedOutside: () => any;
+    }>
+) {
+    const { children, visible, className, onClickedOutside } = props;
+
+    const ref = useRef<Element | null>();
+    const setRef = useCallback((el: Element | null) => {
+        ref.current = el;
+    }, []);
+
+    useClickedOutside(ref, () => onClickedOutside());
+
+    return visible ? (
+        <div ref={setRef} className={className}>
+            {children}
+        </div>
+    ) : null;
+}

--- a/multiplayer/src/components/Presence.tsx
+++ b/multiplayer/src/components/Presence.tsx
@@ -60,8 +60,8 @@ export default function Render() {
                 <PlayerMenuPopup slot={slot}>
                     <Button
                         className={"tw-m-0 tw-py-2 tw-bg-red-600 tw-text-white"}
-                        label={lf("End the game")}
-                        title={lf("End the game")}
+                        label={lf("Leave game")}
+                        title={lf("Leave game")}
                         onClick={() => onLeaveGameClicked()}
                     />
                 </PlayerMenuPopup>

--- a/multiplayer/src/components/ReactionParticle.tsx
+++ b/multiplayer/src/components/ReactionParticle.tsx
@@ -27,18 +27,16 @@ export default function Render(props: { particle: Particle }) {
 
     return (
         <div
-            className="tw-absolute tw-select-none tw-pointer-events-none"
+            className="tw-absolute tw-select-none tw-pointer-events-none tw-z-[100]"
             style={{
                 animation: `reaction-fly-up linear ${parms.flyUpDuration}s forwards,
                 ${parms.horzAnim} linear ${parms.flyHorzDuration}s forwards`,
-                zIndex: 100,
             }}
         >
             <div
                 className="tw-select-none tw-pointer-events-none"
                 style={{
                     animation: `${parms.rotationAnim} ease-in-out ${parms.rotationDuration}s infinite`,
-                    zIndex: 100,
                 }}
             >
                 {emoji}

--- a/multiplayer/src/components/Reactions.tsx
+++ b/multiplayer/src/components/Reactions.tsx
@@ -3,6 +3,7 @@ import { sendReactionAsync } from "../epics";
 import { useState } from "react";
 import ReactionsIcon from "./icons/ReactionsIcon";
 import { Button } from "react-common/components/controls/Button";
+import Popup from "./Popup";
 
 export default function Render() {
     const [showReactionPicker, setShowReactionPicker] = useState(false);
@@ -17,24 +18,28 @@ export default function Render() {
 
     return (
         <div>
-            {showReactionPicker && (
+            <Popup
+                className={"tw-absolute tw-translate-y-[-120%]"}
+                visible={showReactionPicker}
+                onClickedOutside={() => setShowReactionPicker(false)}
+            >
                 <div
-                    className={`tw-flex tw-flex-row tw-gap-1 tw-p-2 tw-absolute tw-translate-x-[-5.8rem]
-                    tw-translate-y-[-120%] tw-bg-white tw-drop-shadow-md tw-rounded-md`}
+                    className={`tw-flex tw-flex-row tw-gap-3 tw-p-2
+                    tw-bg-white tw-drop-shadow-xl tw-rounded-md`}
                 >
                     {Reactions.map((def, i) => {
                         return (
-                            <div
-                                className="tw-flex tw-items-center tw-justify-center tw-cursor-pointer tw-select-none tw-border tw-rounded-full tw-border-slate-300 tw-bg-neutral-50 hover:tw-scale-125 tw-ease-linear tw-duration-[50ms] active:tw-bg-neutral-200 tw-h-8 tw-w-8 tw-text-2xl"
+                            <Button
+                                className="tw-flex tw-items-center tw-justify-center tw-m-0 tw-p-0 tw-cursor-pointer tw-select-none tw-scale-110 hover:tw-scale-125 tw-ease-linear tw-duration-[50ms] tw-h-8 tw-w-8 tw-text-2xl"
                                 key={i}
+                                label={def.emoji}
+                                title={def.name}
                                 onClick={() => onReactionClick(i)}
-                            >
-                                {def.emoji}
-                            </div>
+                            />
                         );
                     })}
                 </div>
-            )}
+            </Popup>
             <Button
                 label={buttonLabel()}
                 title={lf("Reactions")}

--- a/multiplayer/src/components/Toast.tsx
+++ b/multiplayer/src/components/Toast.tsx
@@ -78,7 +78,7 @@ function Toast(props: ToastWithId) {
                 {!props.hideIcon && (
                     <div
                         className={
-                            "tw-flex tw-justify-center tw-border-0 tw-rounded-full " +
+                            "tw-flex tw-items-center tw-justify-center tw-border-0 tw-rounded-full tw-w-7 tw-h-7 " +
                             sliderColors[props.type]
                         }
                     >

--- a/multiplayer/src/components/Toast.tsx
+++ b/multiplayer/src/components/Toast.tsx
@@ -82,7 +82,7 @@ function Toast(props: ToastWithId) {
                             sliderColors[props.type]
                         }
                     >
-                        {icons[props.type]}
+                        {props.icon ?? icons[props.type]}
                     </div>
                 )}
                 <div className="tw-flex tw-flex-col tw-text-left">

--- a/multiplayer/src/components/modals/ConfirmModal.tsx
+++ b/multiplayer/src/components/modals/ConfirmModal.tsx
@@ -1,0 +1,29 @@
+import { Modal, ModalAction } from "react-common/components/controls/Modal";
+
+export default function Render(props: {
+    title: string;
+    message: string | JSX.Element;
+    onConfirm: () => any;
+    onCancel: () => any;
+}) {
+    const { title, message, onConfirm, onCancel } = props;
+
+    const actions: ModalAction[] = [
+        {
+            label: lf("Cancel"),
+            onClick: onCancel,
+        },
+        {
+            label: lf("Confirm"),
+            onClick: onConfirm,
+        },
+    ];
+
+    return (
+        <Modal title={title} actions={actions} onClose={onCancel}>
+            <div className="tw-flex tw-flex-col tw-gap-4">
+                <div className="">{message}</div>
+            </div>
+        </Modal>
+    );
+}

--- a/multiplayer/src/epics/gameDisconnected.ts
+++ b/multiplayer/src/epics/gameDisconnected.ts
@@ -1,17 +1,50 @@
 import { dispatch } from "../state";
 import { showToast, setClientRole, setNetMode } from "../state/actions";
+import { GameOverReason } from "../types";
 
-export function gameDisconnected() {
+export function gameDisconnected(reason: GameOverReason | undefined) {
     try {
         dispatch(setClientRole(undefined));
         dispatch(setNetMode("init"));
-        dispatch(
-            showToast({
-                type: "error",
-                text: lf("Game disconnected."),
-                timeoutMs: 5000,
-            })
-        );
+        switch (reason) {
+            case "kicked":
+                pxt.tickEvent("mp.gotkicked");
+                return dispatch(
+                    showToast({
+                        type: "info",
+                        text: lf("Host kicked you from the game."),
+                        icon: "🤔",
+                        timeoutMs: 5000,
+                    })
+                );
+            case "ended":
+                pxt.tickEvent("mp.gameover");
+                return dispatch(
+                    showToast({
+                        type: "info",
+                        text: lf("Game ended"),
+                        timeoutMs: 5000,
+                    })
+                );
+            case "left":
+                pxt.tickEvent("mp.leftgame");
+                return dispatch(
+                    showToast({
+                        type: "info",
+                        text: lf("You left the game"),
+                        timeoutMs: 5000,
+                    })
+                );
+            default:
+                pxt.tickEvent("mp.disconnected");
+                return dispatch(
+                    showToast({
+                        type: "error",
+                        text: lf("Game disconnected."),
+                        timeoutMs: 5000,
+                    })
+                );
+        }
     } catch (e) {
     } finally {
     }

--- a/multiplayer/src/epics/gameOverAsync.ts
+++ b/multiplayer/src/epics/gameOverAsync.ts
@@ -1,0 +1,10 @@
+import { GameOverReason } from "../types";
+import * as gameClient from "../services/gameClient";
+
+export async function gameOverAsync(reason: GameOverReason) {
+    try {
+        gameClient.gameOver(reason);
+    } catch (e) {
+    } finally {
+    }
+}

--- a/multiplayer/src/epics/index.ts
+++ b/multiplayer/src/epics/index.ts
@@ -18,3 +18,5 @@ export { playerLeftAsync } from "./playerLeftAsync";
 export { userSignedInAsync } from "./userSignedInAsync";
 export { setUserProfileAsync } from "./setUserProfileAsync";
 export { setGameMetadataAsync } from "./setGameMetadataAsync";
+export { kickPlayer } from "./kickPlayer";
+export { gameOverAsync } from "./gameOverAsync";

--- a/multiplayer/src/epics/kickPlayer.ts
+++ b/multiplayer/src/epics/kickPlayer.ts
@@ -1,0 +1,19 @@
+import * as gameClient from "../services/gameClient";
+import { dispatch } from "../state";
+import { showToast } from "../state/actions";
+
+export function kickPlayer(clientId: string) {
+    try {
+        pxt.tickEvent("mp.kickplayer");
+        gameClient.kickPlayer(clientId);
+        dispatch(
+            showToast({
+                type: "info",
+                text: lf("Player kicked"),
+                timeoutMs: 5000,
+            })
+        );
+    } catch (e) {
+    } finally {
+    }
+}

--- a/multiplayer/src/epics/leaveGameAsync.ts
+++ b/multiplayer/src/epics/leaveGameAsync.ts
@@ -1,10 +1,12 @@
 import * as gameClient from "../services/gameClient";
 import { dispatch } from "../state";
 import { clearGameInfo, clearGameMetadata } from "../state/actions";
+import { GameOverReason } from "../types";
 
-export async function leaveGameAsync() {
+export async function leaveGameAsync(reason: GameOverReason) {
     try {
-        await gameClient.leaveGameAsync();
+        pxt.tickEvent("mp.leavegame");
+        await gameClient.leaveGameAsync(reason);
         dispatch(clearGameInfo());
         dispatch(clearGameMetadata());
     } catch (e) {

--- a/multiplayer/src/hooks/index.ts
+++ b/multiplayer/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useWindowSize } from "./useWindowSize";
 export { useElementBounds } from "./useElementBounds";
 export { useAuthDialogMessages } from "./useAuthDialogMessages";
+export { useClickedOutside } from "./useClickedOutside";

--- a/multiplayer/src/hooks/useClickedOutside.ts
+++ b/multiplayer/src/hooks/useClickedOutside.ts
@@ -1,0 +1,20 @@
+import { useEffect, RefObject } from "react";
+
+export function useClickedOutside(
+    ref: RefObject<Element | undefined>,
+    cb: (ev?: Event) => any
+) {
+    useEffect(() => {
+        const handleMouseDown = (ev: Event) => {
+            const el = ref?.current;
+            if (el && !el.contains(ev.target as Node)) {
+                cb?.(ev);
+            }
+        };
+
+        document.addEventListener("mousedown", handleMouseDown);
+        return () => {
+            document.removeEventListener("mousedown", handleMouseDown);
+        };
+    }, [ref]);
+}

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -29,7 +29,7 @@ import {
 const GAME_HOST_PROD = "https://mp.makecode.com";
 const GAME_HOST_STAGING = "https://multiplayer.staging.pxt.io";
 const GAME_HOST_LOCALHOST = "http://localhost:8082";
-const GAME_HOST_DEV = GAME_HOST_LOCALHOST;
+const GAME_HOST_DEV = GAME_HOST_STAGING;
 const GAME_HOST = (() => {
     if (pxt.BrowserUtils.isLocalHostDev()) {
         return GAME_HOST_DEV;

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -13,6 +13,7 @@ import {
     Presence,
     stringToAudioInstruction,
     stringToButtonState,
+    GameOverReason,
 } from "../types";
 import {
     gameDisconnected,
@@ -22,12 +23,13 @@ import {
     playerJoinedAsync,
     playerLeftAsync,
     setGameMetadataAsync,
+    gameOverAsync,
 } from "../epics";
 
 const GAME_HOST_PROD = "https://mp.makecode.com";
 const GAME_HOST_STAGING = "https://multiplayer.staging.pxt.io";
 const GAME_HOST_LOCALHOST = "http://localhost:8082";
-const GAME_HOST_DEV = GAME_HOST_STAGING;
+const GAME_HOST_DEV = GAME_HOST_LOCALHOST;
 const GAME_HOST = (() => {
     if (pxt.BrowserUtils.isLocalHostDev()) {
         return GAME_HOST_DEV;
@@ -43,9 +45,9 @@ const PALETTE_BUFFER_SIZE = 48;
 
 class GameClient {
     sock: Socket | undefined;
-    heartbeatTimer: NodeJS.Timeout | undefined;
     screen: Buffer | undefined;
     clientRole: ClientRole | undefined;
+    gameOverReason: GameOverReason | undefined;
 
     constructor() {
         this.recvMessageWithJoinTimeout =
@@ -57,8 +59,6 @@ class GameClient {
         try {
             this.sock?.close();
             this.sock = undefined;
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            this.heartbeatTimer && clearInterval(this.heartbeatTimer);
         } catch (e) {}
     }
 
@@ -111,6 +111,8 @@ class GameClient {
                         return await this.recvPlayerJoinedMessageAsync(msg);
                     case "player-left":
                         return await this.recvPlayerLeftMessageAsync(msg);
+                    case "game-over":
+                        return await this.recvGameOverMessageAsync(msg);
                 }
             } else {
                 console.error("Unknown payload type", payload);
@@ -168,8 +170,7 @@ class GameClient {
                 );
                 this.sock?.on("close", () => {
                     console.log("socket disconnected");
-                    clearTimeout(this.heartbeatTimer);
-                    gameDisconnected();
+                    gameDisconnected(this.gameOverReason);
                 });
 
                 this.sock?.on("error", err => {
@@ -236,7 +237,8 @@ class GameClient {
         } as Protocol.StartGameMessage);
     }
 
-    public async leaveGameAsync() {
+    public async leaveGameAsync(reason: GameOverReason) {
+        this.gameOverReason = reason;
         this.sock?.close();
     }
 
@@ -288,6 +290,11 @@ class GameClient {
     private async recvPlayerLeftMessageAsync(msg: Protocol.PlayerLeftMessage) {
         console.log("Server sent player joined");
         await playerLeftAsync(msg.clientId);
+    }
+
+    private async recvGameOverMessageAsync(msg: Protocol.GameOverMessage) {
+        console.log("Server sent game over");
+        await gameOverAsync(msg.reason);
     }
 
     private async recvCompressedScreenMessageAsync(reader: SmartBuffer) {
@@ -419,6 +426,19 @@ class GameClient {
         }
     }
 
+    public kickPlayer(clientId: string) {
+        const msg: Protocol.KickPlayerMessage = {
+            type: "kick-player",
+            clientId,
+        };
+        this.sendMessage(msg);
+    }
+
+    public gameOver(reason: GameOverReason) {
+        this.gameOverReason = reason;
+        destroyGameClient();
+    }
+
     public getCurrentScreen(): {
         image: Uint8Array | undefined;
         palette: Uint8Array | undefined;
@@ -468,8 +488,8 @@ export async function startGameAsync() {
     await gameClient?.startGameAsync();
 }
 
-export async function leaveGameAsync() {
-    await gameClient?.leaveGameAsync();
+export async function leaveGameAsync(reason: GameOverReason) {
+    await gameClient?.leaveGameAsync(reason);
     destroyGameClient();
 }
 
@@ -496,6 +516,14 @@ export async function sendScreenUpdateAsync(
     palette: Uint8Array
 ) {
     await gameClient?.sendScreenUpdateAsync(img, palette);
+}
+
+export function kickPlayer(clientId: string) {
+    gameClient?.kickPlayer(clientId);
+}
+
+export function gameOver(reason: GameOverReason) {
+    gameClient?.gameOver(reason);
 }
 
 export function getCurrentScreen(): {
@@ -588,6 +616,16 @@ namespace Protocol {
         clientId: string;
     };
 
+    export type KickPlayerMessage = MessageBase & {
+        type: "kick-player";
+        clientId: string;
+    };
+
+    export type GameOverMessage = MessageBase & {
+        type: "game-over";
+        reason: GameOverReason;
+    };
+
     export type Message =
         | ConnectMessage
         | StartGameMessage
@@ -598,7 +636,9 @@ namespace Protocol {
         | PresenceMessage
         | JoinedMessage
         | PlayerJoinedMessage
-        | PlayerLeftMessage;
+        | PlayerLeftMessage
+        | KickPlayerMessage
+        | GameOverMessage;
 
     export type SimMessage = ScreenMessage | SoundMessage | InputMessage;
 

--- a/multiplayer/src/types/index.ts
+++ b/multiplayer/src/types/index.ts
@@ -1,8 +1,13 @@
 export type NetMode = "init" | "connecting" | "connected";
-export type ModalType = "sign-in" | "report-abuse";
+export type ModalType =
+    | "sign-in"
+    | "report-abuse"
+    | "kick-player"
+    | "leave-game";
 
 export type ClientRole = "host" | "guest" | "none";
 export type GameMode = "lobby" | "playing";
+export type GameOverReason = "kicked" | "ended" | "left";
 
 export type GameInfo = {
     joinCode?: string;
@@ -91,6 +96,7 @@ export type Toast = {
     hideDismissBtn?: boolean; // if true, will hide the dismiss button
     showSpinner?: boolean; // if true, will show a spinner icon
     hideIcon?: boolean; // if true, will hide the type-specific icon
+    icon?: string; // if provided, will override the type-specific icon
 };
 
 export type ToastWithId = Toast & {

--- a/multiplayer/src/types/reactions.ts
+++ b/multiplayer/src/types/reactions.ts
@@ -10,27 +10,27 @@ export type Particle = {
 };
 export const Reactions: ReactionDef[] = [
     {
-        name: lf("smile"),
+        name: lf("smile emoji"),
         emoji: "😃",
     },
     {
-        name: lf("laugh"),
+        name: lf("laugh emoji"),
         emoji: "🤣",
     },
     {
-        name: lf("surprise"),
+        name: lf("surprise emoji"),
         emoji: "😯",
     },
     {
-        name: lf("cry"),
+        name: lf("cry emoji"),
         emoji: "😫",
     },
     {
-        name: lf("scared"),
+        name: lf("scared emoji"),
         emoji: "😬",
     },
     {
-        name: lf("angry"),
+        name: lf("angry emoji"),
         emoji: "😠",
     },
 ];

--- a/react-common/components/controls/Button.tsx
+++ b/react-common/components/controls/Button.tsx
@@ -7,7 +7,8 @@ export interface ButtonViewProps extends ControlProps {
     label?: string | JSX.Element;
     leftIcon?: string;
     rightIcon?: string;
-    disabled?: boolean;
+    disabled?: boolean;     // Disables the button in an accessible-friendly way.
+    hardDisabled?: boolean; // Disables the button and prevents clicks. Not recommended. Use `disabled` instead.
     href?: string;
     target?: string;
     tabIndex?: number;
@@ -52,11 +53,18 @@ export const Button = (props: ButtonProps) => {
         label,
         leftIcon,
         rightIcon,
-        disabled,
+        hardDisabled,
         href,
         target,
         tabIndex
     } = props;
+
+    let {
+        disabled
+    } = props;
+
+    disabled = disabled || hardDisabled;
+
 
     const classes = classList(
         "common-button",
@@ -83,6 +91,7 @@ export const Button = (props: ButtonProps) => {
             onBlur={onBlur}
             role={role || "button"}
             tabIndex={tabIndex || (disabled ? -1 : 0)}
+            disabled={hardDisabled}
             aria-label={ariaLabel}
             aria-hidden={ariaHidden}
             aria-controls={ariaControls}


### PR DESCRIPTION
* Host can kick a player, and the user will be perma-banned from that game session.
* Better "game over" messaging. User will be told why the socket disconnected, if we know. "got kicked", "game ended", "you left the game", etc.
* Added a player popup menu to the presence bar. It is contextual to whether the player clicked on is you or someone else, and whether or not you're the host.
* Emoji buttons are now based on react-common/Button, for better accessibility.
* Clicking outside the reaction palette closes it.
* Centered the reaction palette over the presence bar, for better experience on mobile (isn't half off-screen)

**Host's own popup**
![image](https://user-images.githubusercontent.com/12176807/199865898-dca87bfa-8325-4a72-aa7e-d5f854731956.png)

**Host's popup for player 2**
![image](https://user-images.githubusercontent.com/12176807/199865921-8688b111-6d87-4a58-a3bc-5b2c5f136da3.png)

**Player 2's own popup**
![image](https://user-images.githubusercontent.com/12176807/199865908-fcd28302-1123-49ed-993c-ceb8ad8a3a62.png)

**Improved game over messaging**
![image](https://user-images.githubusercontent.com/12176807/199866059-afef8c83-25c0-419b-89bd-110c7a53eda2.png)
![image](https://user-images.githubusercontent.com/12176807/199866089-0bb5849b-3764-4312-b444-460fa11fdee2.png)
![image](https://user-images.githubusercontent.com/12176807/199866193-cac5b8b7-aea0-4f3b-ba99-5c772bb676a5.png)

**Centered reaction palette**
![image](https://user-images.githubusercontent.com/12176807/199866357-d9159b1b-e992-4329-91bd-ee08361f9c4d.png)


