### PR TITLE
Improve Multiplayer Responsiveness to (Vertical) Mobile Screen Sizes

### DIFF
--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -35,13 +35,15 @@ export default function Render(props: GamePageProps) {
                 }`}
             >
                 <ArcadeSimulator />
-                <div className="tw-flex tw-flex-row tw-w-full tw-items-center tw-justify-between tw-mt-1">
+                <div className="tw-flex tw-flex-row tw-w-full tw-items-center tw-justify-between tw-mt-1 tw-ml-1">
                     <div>
                         <ToggleMuteButton />
                         <RemixGameButton />
                     </div>
-                    <JoinCodeLabel />
-                    <div>{lf("Keyboard Controls")}</div>
+                    <div className="tw-mr-1 sm:tw-mr-0">
+                        <JoinCodeLabel />
+                    </div>
+                    <div className="tw-hidden sm:tw-inline">{lf("Keyboard Controls")}</div>
                 </div>
                 <div className="tw-mt-3">
                     <PresenceBar />

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -34,11 +34,11 @@ export default function Render() {
     const joinDeepLink = makeJoinLink(joinCode);
 
     return (
-        <div className="tw-bg-white tw-shadow-lg tw-rounded-lg">
+        <div className="tw-bg-white tw-shadow-lg tw-rounded-lg tw-m-1 tw-min-w-[17rem]">
             <div className="tw-absolute tw-translate-y-[-130%]">
                 <BetaTag />
             </div>
-            <div className="tw-flex tw-flex-col tw-gap-1 tw-items-center tw-justify-between tw-py-[3rem] tw-px-[7rem]">
+            <div className="tw-flex tw-flex-col tw-gap-1 tw-items-center tw-justify-between tw-py-[3rem] tw-px-3 sm:tw-px-14 md:tw-px-[7rem]">
                 <div className="tw-mt-3 tw-text-lg tw-text-center tw-text-neutral-700">
                     {inviteStringSegments[0]}
                     {

--- a/multiplayer/src/components/JoinLobby.tsx
+++ b/multiplayer/src/components/JoinLobby.tsx
@@ -3,11 +3,11 @@ import PresenceBar from "./PresenceBar";
 
 export default function Render() {
     return (
-        <div className="tw-bg-white tw-shadow-lg tw-rounded-lg">
+        <div className="tw-bg-white tw-shadow-lg tw-rounded-lg tw-m-1">
             <div className="tw-absolute tw-translate-y-[-130%]">
                 <BetaTag />
             </div>
-            <div className="tw-flex tw-flex-col tw-items-center tw-py-[2rem] tw-px-[6rem]">
+            <div className="tw-flex tw-flex-col tw-items-center tw-py-[2rem] tw-px-[1.5rem] sm:tw-px-[3.5rem] md:tw-px-[6rem]">
                 <div className="tw-font-bold tw-text-2xl tw-text-neutral-800">
                     {lf("Waiting for players")}
                 </div>

--- a/multiplayer/src/components/JoinOrHost.tsx
+++ b/multiplayer/src/components/JoinOrHost.tsx
@@ -32,7 +32,7 @@ export default function Render() {
 
     return (
         <div className="tw-flex tw-w-screen tw-h-screen tw-justify-center tw-items-center">
-            <div className="tw-bg-white tw-rounded-lg tw-drop-shadow-xl tw-min-h-[17rem] tw-min-w-[25rem]">
+            <div className="tw-bg-white tw-rounded-lg tw-drop-shadow-xl tw-min-h-[17rem] tw-min-w-[17rem] md:tw-min-w-[25rem]">
                 <div className="tw-absolute tw-translate-y-[-130%]">
                     <BetaTag />
                 </div>
@@ -41,11 +41,23 @@ export default function Render() {
                         <div className="tw-flex tw-justify-center">
                             <TabButton
                                 title={lf("Join Game")}
+                                label={
+                                    <>
+                                        <div className="tw-hidden sm:tw-inline">{lf("Join Game")}</div>
+                                        <div className="sm:tw-hidden">{lf("Join")}</div>
+                                    </>
+                                }
                                 selected={currTab === "join"}
                                 onClick={() => setCurrTab("join")}
                             />
                             <TabButton
                                 title={lf("Host Game")}
+                                label={
+                                    <>
+                                        <div className="tw-hidden sm:tw-inline">{lf("Host Game")}</div>
+                                        <div className="sm:tw-hidden">{lf("Host")}</div>
+                                    </>
+                                }
                                 selected={currTab === "host"}
                                 onClick={() => setCurrTab("host")}
                             />

--- a/multiplayer/src/components/RemixGameButton.tsx
+++ b/multiplayer/src/components/RemixGameButton.tsx
@@ -17,12 +17,21 @@ export default function Render() {
     }
 
     return remixUrl ? (
-        <Button
-            leftIcon={"fas fa-bolt"}
-            title={lf("Remix Game")}
-            label={lf("Remix Game")}
-            onClick={handleRemixGameClick}
-            className="tw-border-2 tw-border-slate-400 tw-border-solid tw-p-2 tw-bg-slate-100 hover:tw-bg-slate-200 active:tw-bg-slate-300 tw-ease-linear tw-duration-[50ms]"
-        />
+        // TODO multiplayer : Consolidate these two buttons somehow...
+        <>
+            <Button
+                leftIcon={"fas fa-bolt"}
+                title={lf("Remix Game")}
+                label={lf("Remix Game")}
+                onClick={handleRemixGameClick}
+                className="tw-hidden sm:tw-inline tw-border-2 tw-border-slate-400 tw-border-solid tw-p-2 tw-bg-slate-100 hover:tw-bg-slate-200 active:tw-bg-slate-300 tw-ease-linear tw-duration-[50ms]"
+            />
+            <Button
+                leftIcon={"fas fa-bolt"}
+                title={lf("Remix Game")}
+                onClick={handleRemixGameClick}
+                className="sm:tw-hidden tw-border-2 tw-border-slate-400 tw-border-solid tw-p-2 tw-bg-slate-100 hover:tw-bg-slate-200 active:tw-bg-slate-300 tw-ease-linear tw-duration-[50ms]"
+            />
+        </>
     ) : null;
 }

--- a/multiplayer/src/components/RemixGameButton.tsx
+++ b/multiplayer/src/components/RemixGameButton.tsx
@@ -17,21 +17,12 @@ export default function Render() {
     }
 
     return remixUrl ? (
-        // TODO multiplayer : Consolidate these two buttons somehow...
-        <>
-            <Button
-                leftIcon={"fas fa-bolt"}
-                title={lf("Remix Game")}
-                label={lf("Remix Game")}
-                onClick={handleRemixGameClick}
-                className="tw-hidden sm:tw-inline tw-border-2 tw-border-slate-400 tw-border-solid tw-p-2 tw-bg-slate-100 hover:tw-bg-slate-200 active:tw-bg-slate-300 tw-ease-linear tw-duration-[50ms]"
-            />
-            <Button
-                leftIcon={"fas fa-bolt"}
-                title={lf("Remix Game")}
-                onClick={handleRemixGameClick}
-                className="sm:tw-hidden tw-border-2 tw-border-slate-400 tw-border-solid tw-p-2 tw-bg-slate-100 hover:tw-bg-slate-200 active:tw-bg-slate-300 tw-ease-linear tw-duration-[50ms]"
-            />
-        </>
+        <Button
+            leftIcon={"fas fa-bolt"}
+            title={lf("Remix Game")}
+            label={<div className="tw-hidden sm:tw-inline tw-m-0 tw-p-0">{lf("Remix Game")}</div>}
+            onClick={handleRemixGameClick}
+            className="tw-border-2 tw-border-slate-400 tw-border-solid tw-p-2 tw-bg-slate-100 hover:tw-bg-slate-200 active:tw-bg-slate-300 tw-ease-linear tw-duration-[50ms] tw-pr-1 sm:tw-pr-3"
+        />
     ) : null;
 }

--- a/multiplayer/src/components/SignedInPage.tsx
+++ b/multiplayer/src/components/SignedInPage.tsx
@@ -8,7 +8,7 @@ export default function Render() {
     const { netMode } = state;
 
     return (
-        <div className="tw-pt-3 tw-pb-8 tw-flex tw-flex-col tw-items-center tw-gap-1 tw-h-screen">
+        <div className="tw-flex tw-flex-col tw-items-center tw-gap-1 tw-h-screen tw-justify-around">
             {netMode === "init" && <JoinOrHost />}
             {netMode !== "init" && <GamePage />}
         </div>

--- a/multiplayer/src/components/TabButton.tsx
+++ b/multiplayer/src/components/TabButton.tsx
@@ -3,16 +3,17 @@ import { Button } from "react-common/components/controls/Button";
 export default function Render(props: {
     title: string;
     selected: boolean;
+    label?: string | JSX.Element | undefined;
     onClick: () => void;
 }) {
     return (
         <div>
             <Button
-                className={`tw-m-0 tm-px-8 ${
+                className={`tw-m-0 tw-px-8 ${
                     props.selected ? "tw-font-bold" : ""
                 }`}
                 title={props.title}
-                label={props.title}
+                label={props.label ?? props.title}
                 onClick={props.onClick}
             />
             <div


### PR DESCRIPTION
This is just a first pass. Likely more changes to come, but I wanted to send this out first so the PR doesn't get too large.

Changes include:
1. Padding & margin adjustments
2. Removing "Remix Game" text on small screens (may remove button altogether later, TBD)
3. Remove "Keyboard Controls" on small screens
4. Shrink "Join Game" and "Host Game" to "Join" and "Host" on small screens

Fixes https://github.com/microsoft/pxt-arcade/issues/5215

Partially addresses https://github.com/microsoft/pxt-arcade/issues/5252

<img width="302" alt="image" src="https://user-images.githubusercontent.com/69657545/200072419-8d79c49f-a99b-4368-b6b1-061c6478803d.png">

<img width="298" alt="image" src="https://user-images.githubusercontent.com/69657545/200072287-be710916-bdd6-4664-a361-a1f767ea4abc.png">

<img width="303" alt="image" src="https://user-images.githubusercontent.com/69657545/200072531-63fa7813-6ef5-4006-9927-fffe482f3e08.png">

<img width="298" alt="image" src="https://user-images.githubusercontent.com/69657545/200072383-6963d68b-9551-4fef-9e9d-e102d8b102c6.png">
