### PR TITLE
Make it so that only one share action shows up in the completion dialog

### DIFF
--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -231,7 +231,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
                     label={lf("Claim your reward!")}
                     leftIcon="fas fa-gift"
                     onClick={onButtonClick} />
-                {shouldShowShare &&
+                {shouldShowShare && !showMultiplayerShare &&
                     <Button
                         className="primary completion-reward"
                         title={lf("Share your game!")}


### PR DESCRIPTION
As discussed in testing today, making it so that the multiplayer share button replaces the regular share button when enabled in the skillmap