### PR TITLE
pause all sims. tweak pause visuals

### DIFF
--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -173,7 +173,7 @@ export default function Render() {
                 "tw-h-[calc(100vh-16rem)] tw-w-screen md:tw-w-[calc(100vw-6rem)]"
             }
             style={{
-                filter: gamePaused ? "grayscale(1)" : "none",
+                filter: gamePaused ? "grayscale(60%) blur(8px)" : "none",
                 transition: "filter .25s",
             }}
         />

--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -173,7 +173,7 @@ export default function Render() {
                 "tw-h-[calc(100vh-16rem)] tw-w-screen md:tw-w-[calc(100vw-6rem)]"
             }
             style={{
-                filter: gamePaused ? "grayscale(70%) blur(3px)" : "none",
+                filter: gamePaused ? "grayscale(70%) blur(1px)" : "none",
                 transition: "filter .25s",
             }}
         />

--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -173,7 +173,7 @@ export default function Render() {
                 "tw-h-[calc(100vh-16rem)] tw-w-screen md:tw-w-[calc(100vw-6rem)]"
             }
             style={{
-                filter: gamePaused ? "grayscale(60%) blur(8px)" : "none",
+                filter: gamePaused ? "grayscale(70%) blur(3px)" : "none",
                 transition: "filter .25s",
             }}
         />

--- a/multiplayer/src/epics/pauseGameAsync.ts
+++ b/multiplayer/src/epics/pauseGameAsync.ts
@@ -10,8 +10,8 @@ export async function pauseGameAsync() {
         if (clientRole === "host") {
             pxt.tickEvent("mp.host.pausegame");
             await gameClient.pauseGameAsync();
-            simDriver()?.resume(pxsim.SimulatorDebuggerCommand.Pause);
         }
+        simDriver()?.resume(pxsim.SimulatorDebuggerCommand.Pause);
         dispatch(setGamePaused(true));
     } catch (e) {
     } finally {

--- a/multiplayer/src/epics/resumeGameAsync.ts
+++ b/multiplayer/src/epics/resumeGameAsync.ts
@@ -10,8 +10,8 @@ export async function resumeGameAsync() {
         if (clientRole === "host") {
             pxt.tickEvent("mp.host.resumegame");
             await gameClient.resumeGameAsync();
-            simDriver()?.resume(pxsim.SimulatorDebuggerCommand.Resume);
         }
+        simDriver()?.resume(pxsim.SimulatorDebuggerCommand.Resume);
         dispatch(setGamePaused(false));
     } catch (e) {
     } finally {


### PR DESCRIPTION
Pause guest sims as well as host, otherwise their controls are still active and it felt odd.

Also adjusted pause state visuals a bit:
* Leave some color rather than go pure grayscale.
* Add a blur affect to help the pause notification stand out from background detail, and really drive the message that the game isn't playable right now. Maybe it won't be performant on low end machines, needs testing.

![image](https://user-images.githubusercontent.com/12176807/200225382-ef83a263-d1eb-4a58-8db6-c59a3a2d4fdc.png)
