### PR TITLE
add support for keyboard emoji reactions

### DIFF
--- a/multiplayer/src/components/Reactions.tsx
+++ b/multiplayer/src/components/Reactions.tsx
@@ -6,9 +6,7 @@ import { Button } from "react-common/components/controls/Button";
 import Popup from "./Popup";
 
 const throttledReaction = pxt.Util.throttle(
-    (ind: number) => {
-        sendReactionAsync(ind);
-    },
+    (ind: number) => sendReactionAsync(ind),
     200,
     true
 );


### PR DESCRIPTION
Felt like adding this as I was testing a game and wanted it, only just saw that you assigned yourself a couple hours ago @eanders-ms, hope I'm not stepping on your toes! I saw a comment on throttling per reaction in sendReactionAsync so when that is implemented can remove throttle in this file

fixes https://github.com/microsoft/pxt-arcade/issues/5182
