### PR TITLE
Hide the song editor behind a flag

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -455,6 +455,7 @@ declare namespace pxt {
         winAppDeprImage?: string; // Image to show on Windows App for deprecation
         showWinAppDeprBanner?: boolean; // show banner announcing Windows App deprecation
         multiplayerShareButton?: boolean; // display multiplayer button alongside social links
+        songEditor?: boolean; // enable the song asset type and field editor
     }
 
     interface DownloadDialogTheme {

--- a/pxtblocks/blocklycustomeditor.ts
+++ b/pxtblocks/blocklycustomeditor.ts
@@ -36,7 +36,9 @@ namespace pxt.blocks {
         registerFieldEditor('melody', pxtblockly.FieldCustomMelody);
         registerFieldEditor('soundeffect', pxtblockly.FieldSoundEffect);
         registerFieldEditor('autocomplete', pxtblockly.FieldAutoComplete);
-        registerFieldEditor('musiceditor', pxtblockly.FieldMusicEditor);
+        if (pxt.appTarget.appTheme?.songEditor) {
+            registerFieldEditor('musiceditor', pxtblockly.FieldMusicEditor);
+        }
     }
 
     export function registerFieldEditor(selector: string, field: Blockly.FieldCustomConstructor, validator?: any) {

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -42,9 +42,14 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
             { label: lf("Image"), icon: "picture", handler: this.getCreateAssetHandler(pxt.AssetType.Image) },
             { label: lf("Tile"), icon: "clone", handler: this.getCreateAssetHandler(pxt.AssetType.Tile) },
             { label: lf("Tilemap"), icon: "map", handler: this.getCreateAssetHandler(pxt.AssetType.Tilemap) },
-            { label: lf("Animation"), icon: "video", handler: this.getCreateAssetHandler(pxt.AssetType.Animation) },
-            { label: lf("Song"), icon: "music", handler: this.getCreateAssetHandler(pxt.AssetType.Song) }
+            { label: lf("Animation"), icon: "video", handler: this.getCreateAssetHandler(pxt.AssetType.Animation) }
         ]
+
+        if (pxt.appTarget.appTheme?.songEditor) {
+            this.assetCreateOptions.push(
+                { label: lf("Song"), icon: "music", handler: this.getCreateAssetHandler(pxt.AssetType.Song) }
+            );
+        }
     }
 
     protected showCreateModal = () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5288

Putting the song editor behind a flag so that not even clever extension authors can get to it! Still requires a change to pxt-common-packages to get rid of the block.