### PR TITLE
Removed semicolon from create array snippet in JS toolbox

### DIFF
--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -313,7 +313,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 {
                     name: "array_create",
                     snippetName: "create",
-                    snippet: `let ${lf("{id:snippets}list")} = [1, 2, 3];`,
+                    snippet: `let ${lf("{id:snippets}list")} = [1, 2, 3]`,
                     pySnippet: `${lf("{id:snippets}list")} = [1, 2, 3]`,
                     snippetOnly: true,
                     attributes: {


### PR DESCRIPTION
Closes https://github.com/microsoft/pxt-arcade/issues/4621