### PR TITLE
multiplayer Mobile safari fixes

### DIFF
--- a/multiplayer/src/components/Reactions.tsx
+++ b/multiplayer/src/components/Reactions.tsx
@@ -42,6 +42,8 @@ export default function Render() {
         };
     });
 
+    const isMobile = pxt.BrowserUtils.isMobile() || pxt.BrowserUtils.isIOS();
+
     return (
         <div>
             <Popup
@@ -59,9 +61,9 @@ export default function Render() {
                                     label={
                                         <div>
                                             <div>{def.emoji}</div>
-                                            <div className="tw-text-xs tw-absolute tw-bottom-[-3px] tw-right-[-3px] tw-text-white tw-bg-gray-500 tw-rounded-xl tw-px-1 ">
+                                            {!isMobile && <div className="tw-text-xs tw-absolute tw-bottom-[-3px] tw-right-[-3px] tw-text-white tw-bg-gray-500 tw-rounded-xl tw-px-1 ">
                                                 {i + 1}
-                                            </div>
+                                            </div>}
                                         </div>
                                     }
                                     title={def.name}
@@ -70,7 +72,7 @@ export default function Render() {
                             );
                         })}
                     </div>
-                    {!pxt.BrowserUtils.isMobile() && (
+                    {!isMobile && (
                         <div className="tw-text-sm tw-p-1">
                             {lf("Use your keyboard to send reactions faster")}
                         </div>

--- a/multiplayer/src/state/state.ts
+++ b/multiplayer/src/state/state.ts
@@ -53,7 +53,7 @@ export const initialAppState: AppState = {
     presence: { ...defaultPresence },
     modal: undefined,
     modalOpts: undefined,
-    muted: false,
+    muted: pxt.BrowserUtils.isSafari(),
     deepLinks: {},
     reactions: {},
     targetConfig: undefined,


### PR DESCRIPTION
* start muted in ios, as they're pretty restrictive on sound. This matches editor behavior, though we should probably do another pass and see if we can handle this better. fix https://github.com/microsoft/pxt-arcade/issues/5306, should improve both editor and multiplayer experience later.
* fix https://github.com/microsoft/pxt-arcade/issues/5309, ios sometimes lies about being desktop which bypasses mobile checks so also check ios