### PR TITLE
Add Safety Links to Gear Menu and Host Lobby

### DIFF
--- a/multiplayer/src/components/HeaderBar.tsx
+++ b/multiplayer/src/components/HeaderBar.tsx
@@ -21,10 +21,11 @@ export default function Render() {
 
     const hasIdentity = pxt.auth.hasIdentity();
     const appTheme = pxt.appTarget?.appTheme;
-    const helpUrl = ""; // TODO multiplayer
 
+    const helpUrl = ""; // TODO multiplayer
     const privacyUrl = pxt?.appTarget?.appTheme?.privacyUrl;
     const termsOfUseUrl = pxt?.appTarget?.appTheme?.termsOfUseUrl;
+    const safetyUrl = "/docs/multiplayer#safety";
 
     const dialogMessages = useAuthDialogMessages();
 
@@ -46,6 +47,11 @@ export default function Render() {
     const onTermsofUseClicked = () => {
         pxt.tickEvent("mp.settingsmenu.termsofuse");
         window.open(termsOfUseUrl);
+    };
+
+    const onOnlineSafetyClicked = () => {
+        pxt.tickEvent("mp.settingsmenu.onlinesafety");
+        window.open(safetyUrl);
     };
 
     const onHomeClicked = () => {
@@ -227,6 +233,13 @@ export default function Render() {
                 onClick: onTermsofUseClicked,
             });
         }
+
+        items.push({
+            id: "safety",
+            title: lf("Online Safety"),
+            label: lf("Online Safety"),
+            onClick: onOnlineSafetyClicked,
+        });
 
         if (shareCode) {
             items.push({

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -71,11 +71,18 @@ export default function Render() {
                     </div>
                 </div>
                 <Button
-                    className={"primary tw-mt-5 tw-mb-7 tw-font-sans tw-mr-0"}
+                    className={"primary tw-mt-5 tw-font-sans tw-mr-0"}
                     label={lf("Start Game")}
                     title={lf("Start Game")}
                     onClick={onStartGameClick}
                 />
+                <Link
+                    href="/docs/multiplayer#safety"
+                    target="_blank"
+                    className="tw-text-sm tw-mt-1 tw-mb-7"
+                >
+                    {lf("Multiplayer Online Safety")}
+                </Link>
                 <PresenceBar />
             </div>
         </div>


### PR DESCRIPTION
The link doesn't go anywhere yet, but I am assuming it will be created in the future. I followed the same pattern as our docs links in the JoinOrHost page.

I tried to find some way to incorporate it into the join lobby too, but struggled to make it look good, so for now I'm just relying on the gear menu option there (which, admittedy, people are unlikely to find on their own). Open to suggestions.

<img width="385" alt="image" src="https://user-images.githubusercontent.com/69657545/200655555-b25b838e-3943-4a66-8bc5-a2155cc0aab2.png">

<img width="154" alt="image" src="https://user-images.githubusercontent.com/69657545/200655773-1f46cb97-a98c-4077-8651-d920e19b8366.png">

Fixes https://github.com/microsoft/pxt-arcade/issues/5274