### PR TITLE
multiplayer reactions keyboard ui updates from testing

### DIFF
--- a/multiplayer/src/components/KeyboardControlsInfo.tsx
+++ b/multiplayer/src/components/KeyboardControlsInfo.tsx
@@ -36,7 +36,7 @@ export default function Render() {
             })}
             <div className="keymap-row tw-flex tw-flex-row tw-items-center">
                 <div className="keymap-key tw-align-middle tw-min-w-[2.5rem] tw-text-center tw-pb-[2.1rem]">
-                    1-6
+                    1 - 6
                 </div>
                 <span className="keymap-name tw-font-semibold tw-text-center">
                     <ReactionsIcon />

--- a/multiplayer/src/components/KeyboardControlsInfo.tsx
+++ b/multiplayer/src/components/KeyboardControlsInfo.tsx
@@ -1,3 +1,5 @@
+import ReactionsIcon from "./icons/ReactionsIcon";
+
 export default function Render() {
     const keyData = {
         [lf("up")]: ["↑", "W"],
@@ -32,6 +34,14 @@ export default function Render() {
                     </div>
                 );
             })}
+            <div className="keymap-row tw-flex tw-flex-row tw-items-center">
+                <div className="keymap-key tw-align-middle tw-min-w-[2.5rem] tw-text-center tw-pb-[2.1rem]">
+                    1-6
+                </div>
+                <span className="keymap-name tw-font-semibold tw-text-center">
+                    <ReactionsIcon className="hover:tw-scale-125 tw-ease-linear tw-duration-[50ms]" />
+                </span>
+            </div>
         </div>
     );
 }

--- a/multiplayer/src/components/KeyboardControlsInfo.tsx
+++ b/multiplayer/src/components/KeyboardControlsInfo.tsx
@@ -39,7 +39,7 @@ export default function Render() {
                     1-6
                 </div>
                 <span className="keymap-name tw-font-semibold tw-text-center">
-                    <ReactionsIcon className="hover:tw-scale-125 tw-ease-linear tw-duration-[50ms]" />
+                    <ReactionsIcon />
                 </span>
             </div>
         </div>

--- a/multiplayer/src/components/Reactions.tsx
+++ b/multiplayer/src/components/Reactions.tsx
@@ -52,7 +52,7 @@ export default function Render() {
                 onClickedOutside={() => setShowReactionPicker(false)}
             >
                 <div className="tw-flex tw-flex-col tw-bg-white tw-drop-shadow-xl tw-rounded-md tw-border-2 tw-border-gray-100">
-                    <div className="tw-flex tw-flex-row tw-gap-3 tw-p-2">
+                    <div className="tw-flex tw-flex-row tw-gap-3 tw-p-2 tw-pb-3 tw-pr-3">
                         {Reactions.map((def, i) => {
                             return (
                                 <Button
@@ -61,7 +61,7 @@ export default function Render() {
                                     label={
                                         <div>
                                             <div>{def.emoji}</div>
-                                            {!isMobile && <div className="tw-text-xs tw-absolute tw-bottom-[-3px] tw-right-[-3px] tw-text-white tw-bg-gray-500 tw-rounded-xl tw-px-1 ">
+                                            {!isMobile && <div className="tw-text-xs tw-absolute tw-bottom-[-5px] tw-right-[-5px] tw-text-white tw-bg-gray-400 tw-rounded-sm tw-border-[1px] tw-border-solid tw-border-gray-500 tw-drop-shadow-lg tw-px-1 tw-leading-tight">
                                                 {i + 1}
                                             </div>}
                                         </div>
@@ -72,11 +72,6 @@ export default function Render() {
                             );
                         })}
                     </div>
-                    {!isMobile && (
-                        <div className="tw-text-sm tw-p-1">
-                            {lf("Use your keyboard to send reactions faster")}
-                        </div>
-                    )}
                 </div>
             </Popup>
             <Button


### PR DESCRIPTION
Feedback in testing this am was that reactions pane looked a little worse with all the keyboard hint, so took a stab at rearranging to hopefully look a little more inviting again.

* make the numbers on the emojis look a little 'like keys' as some weren't sure that users would understand the circled numbers:
![image](https://user-images.githubusercontent.com/5615930/200679097-6bb8de4a-9f34-4ed8-9b72-cbf7677a94a6.png)

* move from a text description under the reactions to the 'keyboard controls dialog'
![image](https://user-images.githubusercontent.com/5615930/200679205-bba99c63-6ca5-428d-9e56-79ae50ec9b96.png)

took the same icon as the one on the reactions button to hopefully guide them to press that if they see it and haven't noticed the reactions yet.

@unthinkmedia let me know what you think~