### PR TITLE
when fetching S link skip the cache

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -111,11 +111,6 @@ namespace pxt.Cloud {
         return privateRequestAsync({
             url: id + "/text" + (id.startsWith("S") ? `?time=${Date.now()}` : ""),
             forceLiveEndpoint: true,
-            // headers: id.startsWith("S") ? {
-            //         "pragma": "no-cache, no-store",
-            //         "cache-control": "no-cache, no-store"
-            //     }
-            //     : undefined,
         }).then(resp => {
             return JSON.parse(resp.text)
         })

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -108,7 +108,15 @@ namespace pxt.Cloud {
     }
 
     export function downloadScriptFilesAsync(id: string): Promise<Map<string>> {
-        return privateRequestAsync({ url: id + "/text", forceLiveEndpoint: true }).then(resp => {
+        return privateRequestAsync({
+            url: id + "/text" + (id.startsWith("S") ? `?time=${Date.now()}` : ""),
+            forceLiveEndpoint: true,
+            // headers: id.startsWith("S") ? {
+            //         "pragma": "no-cache, no-store",
+            //         "cache-control": "no-cache, no-store"
+            //     }
+            //     : undefined,
+        }).then(resp => {
             return JSON.parse(resp.text)
         })
     }


### PR DESCRIPTION
The reason that this does not affect the share page is because the share page makes the /text request for the current version that is embedded directly in the response, and not with the persistent share link