### PR TITLE
Make Full Join Code Clickable for Copying Link

### DIFF
--- a/multiplayer/src/components/CopyButton.tsx
+++ b/multiplayer/src/components/CopyButton.tsx
@@ -9,7 +9,7 @@ export default function Render(props: {
     copyValue: string;
     title: string;
     eventName?: string;
-    label?: JSX.Element | undefined;
+    label?: string | JSX.Element | undefined;
     toastMessage?: string | undefined;
 }) {
     const { state } = useContext(AppStateContext);
@@ -22,11 +22,13 @@ export default function Render(props: {
             navigator.clipboard.writeText(props.copyValue);
             setCopySuccessful(true);
             if (props.toastMessage) {
-                dispatch(showToast({
-                type: "success",
-                text: props.toastMessage,
-                timeoutMs: 5000,
-                }));
+                dispatch(
+                    showToast({
+                        type: "success",
+                        text: props.toastMessage,
+                        timeoutMs: 5000,
+                    })
+                );
             }
         }
     };
@@ -46,27 +48,25 @@ export default function Render(props: {
         <button
             onClick={copyValue}
             title={props.title}
-            className="tw-flex tw-items-center"
+            className="tw-flex tw-items-center tw-align-middle"
         >
             {props.label && (
                 <span className="tw-mr-1 hover:tw-opacity-80">
                     {props.label}
                 </span>
             )}
-            <span>
-                {!copySuccessful && (
-                    <FontAwesomeIcon
-                        icon={faCopy}
-                        className="hover:tw-scale-110 tw-ease-linear tw-duration-[50ms]"
-                    />
-                )}
-                {copySuccessful && (
-                    <FontAwesomeIcon
-                        icon={faCheck}
-                        className="tw-text-green-600"
-                    />
-                )}
-            </span>
+            {!copySuccessful && (
+                <FontAwesomeIcon
+                    icon={faCopy}
+                    className="tw-text-[65%] hover:tw-scale-110 tw-ease-linear tw-duration-[50ms]"
+                />
+            )}
+            {copySuccessful && (
+                <FontAwesomeIcon
+                    icon={faCheck}
+                    className="tw-text-[65%] tw-text-green-600"
+                />
+            )}
         </button>
     );
 }

--- a/multiplayer/src/components/CopyButton.tsx
+++ b/multiplayer/src/components/CopyButton.tsx
@@ -2,12 +2,15 @@ import { faCopy } from "@fortawesome/free-regular-svg-icons";
 import { faCheck } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useContext, useEffect, useState } from "react";
-import { AppStateContext } from "../state/AppStateContext";
+import { showToast } from "../state/actions";
+import { AppStateContext, dispatch } from "../state/AppStateContext";
 
 export default function Render(props: {
     copyValue: string;
     title: string;
     eventName?: string;
+    label?: JSX.Element | undefined;
+    toastMessage?: string | undefined;
 }) {
     const { state } = useContext(AppStateContext);
     const [copySuccessful, setCopySuccessful] = useState(false);
@@ -18,6 +21,13 @@ export default function Render(props: {
         if (state.gameState?.joinCode) {
             navigator.clipboard.writeText(props.copyValue);
             setCopySuccessful(true);
+            if (props.toastMessage) {
+                dispatch(showToast({
+                type: "success",
+                text: props.toastMessage,
+                timeoutMs: 5000,
+                }));
+            }
         }
     };
 
@@ -33,8 +43,17 @@ export default function Render(props: {
     }, [copySuccessful]);
 
     return (
-        <button onClick={copyValue} title={props.title}>
-            <div>
+        <button
+            onClick={copyValue}
+            title={props.title}
+            className="tw-flex tw-items-center"
+        >
+            {props.label && (
+                <span className="tw-mr-1 hover:tw-opacity-80">
+                    {props.label}
+                </span>
+            )}
+            <span>
                 {!copySuccessful && (
                     <FontAwesomeIcon
                         icon={faCopy}
@@ -47,7 +66,7 @@ export default function Render(props: {
                         className="tw-text-green-600"
                     />
                 )}
-            </div>
+            </span>
         </button>
     );
 }

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -52,13 +52,13 @@ export default function Render() {
                     }
                     {inviteStringSegments[1]}
                 </div>
-                <div className="tw-text-xl tw-mt-4 tw-flex tw-flex-row tw-items-center tw-ml-2">
+                <div className="tw-text-4xl tw-mt-4 tw-flex tw-flex-row tw-items-center tw-ml-2">
                     <CopyButton
                         copyValue={joinDeepLink}
                         title={lf("Copy join link")}
                         eventName="mp.hostlobby.copyjoinlink"
                         label={
-                            <span className="tw-font-bold tw-text-neutral-700 tw-text-4xl">
+                            <span className="tw-font-bold tw-text-neutral-700 tw-mr-1">
                                 {displayJoinCode}
                             </span>
                         }

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -52,17 +52,18 @@ export default function Render() {
                     }
                     {inviteStringSegments[1]}
                 </div>
-                <div className="tw-text-4xl tw-mt-4 tw-flex tw-flex-row tw-items-center">
-                    <span className="tw-font-bold tw-text-neutral-700">
-                        {displayJoinCode}
-                    </span>
-                    <div className="tw-ml-2 tw-text-[50%]">
-                        <CopyButton
-                            copyValue={joinDeepLink}
-                            title={lf("Copy join link")}
-                            eventName="mp.hostlobby.copyjoinlink"
-                        />
-                    </div>
+                <div className="tw-text-xl tw-mt-4 tw-flex tw-flex-row tw-items-center tw-ml-2">
+                    <CopyButton
+                        copyValue={joinDeepLink}
+                        title={lf("Copy join link")}
+                        eventName="mp.hostlobby.copyjoinlink"
+                        label={
+                            <span className="tw-font-bold tw-text-neutral-700 tw-text-4xl">
+                                {displayJoinCode}
+                            </span>
+                        }
+                        toastMessage={lf("Join link copied")}
+                    />
                 </div>
                 <div className="tw-flex tw-flex-col tw-items-center tw-mt-5 tw-text-sm tw-gap-1 tw-max-h-24 md:tw-max-h-36">
                     <QRCodeSVG value={joinDeepLink} />

--- a/multiplayer/src/components/JoinCodeLabel.tsx
+++ b/multiplayer/src/components/JoinCodeLabel.tsx
@@ -13,15 +13,13 @@ export default function Render() {
             {joinCode && (
                 <div className="tw-flex tw-flex-row tw-items-center tw-align-middle">
                     <div className="tw-font-bold tw-mr-1">{lf("Code:")}</div>
-                    <div className="tw-text-[75%]">
                         <CopyButton
                             copyValue={joinDeepLink}
                             title={lf("Copy join link")}
                             eventName="mp.copyjoinlink"
-                            label={<div className="tw-text-base">{joinCode}</div>}
+                            label={joinCode}
                             toastMessage={lf("Join link copied")}
                         />
-                    </div>
                 </div>
             )}
         </div>

--- a/multiplayer/src/components/JoinCodeLabel.tsx
+++ b/multiplayer/src/components/JoinCodeLabel.tsx
@@ -12,13 +12,14 @@ export default function Render() {
         <div>
             {joinCode && (
                 <div className="tw-flex tw-flex-row tw-items-center tw-align-middle">
-                    <div className="tw-font-bold">{lf("Code:")}</div>
-                    <div className="tw-mx-1">{joinCode}</div>
+                    <div className="tw-font-bold tw-mr-1">{lf("Code:")}</div>
                     <div className="tw-text-[75%]">
                         <CopyButton
                             copyValue={joinDeepLink}
                             title={lf("Copy join link")}
                             eventName="mp.copyjoinlink"
+                            label={<div className="tw-text-base">{joinCode}</div>}
+                            toastMessage={lf("Join link copied")}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
This makes the full join code clickable to copy the join link, rather than just the icon to the side. To make it work in a way that felt smooth, I had to do some refactoring of the CopyButton to allow for a label attached to the button (rather than managing them separately). It will also display a toast when the copy is successful.

![JoinCodeCopyButtonWithToast1](https://user-images.githubusercontent.com/69657545/200911668-a86e5e6a-e827-4594-a962-7ce2256b7281.gif)

![JoinCodeCopyButtonWithToast2](https://user-images.githubusercontent.com/69657545/200911688-c58e5875-6515-497d-b291-1d390bc923be.gif)