### PR TITLE
make simulator a bit more greedy for space, fix mobile reactions going off screen

### DIFF
--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -169,9 +169,7 @@ export default function Render() {
         <div
             id="sim-container"
             ref={simContainerRef}
-            className={
-                "tw-h-[calc(100vh-16rem)] tw-w-screen md:tw-w-[calc(100vw-6rem)]"
-            }
+            className="tw-grow tw-w-screen md:tw-w-[calc(100vw-6rem)]"
             style={{
                 filter: gamePaused ? "grayscale(70%) blur(1px)" : "none",
                 transition: "filter .25s",

--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -34,7 +34,7 @@ export default function Render(props: GamePageProps) {
                 className="tw-flex tw-flex-col tw-items-center tw-grow tw-pb-4"
                 style={
                     state.gameState?.gameMode !== "playing"
-                        ? { visibility: "hidden" }
+                        ? { display: "none" }
                         : undefined
                 }
             >

--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -31,9 +31,12 @@ export default function Render(props: GamePageProps) {
                 </div>
             )}
             <div
-                className={`tw-flex tw-flex-col tw-items-center ${
-                    state.gameState?.gameMode === "playing" ? "" : "hidden"
-                }`}
+                className="tw-flex tw-flex-col tw-items-center tw-grow tw-pb-4"
+                style={
+                    state.gameState?.gameMode !== "playing"
+                        ? { visibility: "hidden" }
+                        : undefined
+                }
             >
                 <ArcadeSimulator />
                 <div className="tw-flex tw-flex-row tw-w-full tw-items-center tw-justify-between tw-mt-1 tw-ml-1">

--- a/multiplayer/src/components/SignedInPage.tsx
+++ b/multiplayer/src/components/SignedInPage.tsx
@@ -8,7 +8,7 @@ export default function Render() {
     const { netMode } = state;
 
     return (
-        <div className="tw-flex tw-flex-col tw-items-center tw-gap-1 tw-h-screen tw-justify-around">
+        <div className="tw-flex tw-flex-col tw-items-center tw-gap-1 tw-grow tw-justify-around">
             {netMode === "init" && <JoinOrHost />}
             {netMode !== "init" && <GamePage />}
         </div>

--- a/multiplayer/src/services/simHost.ts
+++ b/multiplayer/src/services/simHost.ts
@@ -31,7 +31,7 @@ async function loadPackageAsync(runOpts: RunOptions) {
         // as the file can be requested multiple times while loading.
         mp.host().cacheStoreAsync(verspec, undefined!);
         mp._verspec = verspec;
-        await mp.host().downloadPackageAsync(mainPkg());
+        await mp.host().downloadPackageAsync(mainPkg(), []);
         await mainPkg().installAllAsync();
     }
 


### PR DESCRIPTION
Easiest to see with a build: https://arcade.makecode.com/app/99710e6c974bf62478eff348d40682c1d5dca5cc-3935cb69d8--multiplayer

make the sim a bit more greedy for space to fill out the page a bit more:

<img width="1307" alt="image" src="https://user-images.githubusercontent.com/5615930/200966508-13e5b5e7-4903-4a3d-a3bf-274fdaab4ae9.png">

vs

<img width="1289" alt="image" src="https://user-images.githubusercontent.com/5615930/200966579-d8c20338-d9a2-47c1-a725-7bc0191482b8.png">

also should fix the issue where the reactions occasionally go off screen by about 1em on  mobile too (at least it fixes it for me >>)

(also a one line fix for compiler so that it doesn't throw off a spurious error message, a debug message was assuming that optional parameter existed)