### PR TITLE
improved error pathing in connect/join flow

### DIFF
--- a/multiplayer/src/components/CopyButton.tsx
+++ b/multiplayer/src/components/CopyButton.tsx
@@ -26,6 +26,7 @@ export default function Render(props: {
                     showToast({
                         type: "success",
                         text: props.toastMessage,
+                        icon: "✅",
                         timeoutMs: 5000,
                     })
                 );

--- a/multiplayer/src/epics/gameDisconnected.ts
+++ b/multiplayer/src/epics/gameDisconnected.ts
@@ -38,9 +38,10 @@ export function gameDisconnected(reason: GameOverReason | undefined) {
                 pxt.tickEvent("mp.gamefull");
                 return dispatch(
                     showToast({
-                        type: "info",
+                        type: "warning",
                         text: lf("Game is full"),
                         timeoutMs: 5000,
+                        icon: "😤"
                     })
                 );
             case "rejected":

--- a/multiplayer/src/epics/hostGameAsync.ts
+++ b/multiplayer/src/epics/hostGameAsync.ts
@@ -29,23 +29,25 @@ export async function hostGameAsync(shareCode: string | undefined) {
         dispatch(setNetMode("connecting"));
         dispatch(connectingToast);
 
-        const gameInfo = await gameClient.hostGameAsync(shareCode);
-        console.log(gameInfo);
+        const hostResult = await gameClient.hostGameAsync(shareCode);
+        console.log(hostResult);
 
-        dispatch(
-            showToast({
-                type: "success",
-                text: lf("Connected!"),
-                timeoutMs: 5000,
-            })
-        );
-
-        dispatch(setClientRole("host"));
-        dispatch(setGameInfo(gameInfo));
-        dispatch(setNetMode("connected"));
+        if (hostResult.success) {
+            dispatch(
+                showToast({
+                    type: "success",
+                    text: lf("Connected!"),
+                    timeoutMs: 5000,
+                })
+            );
+            dispatch(setClientRole("host"));
+            dispatch(setGameInfo(hostResult));
+            dispatch(setNetMode("connected"));
+        } else {
+            throw new Error(`host http response: ${hostResult.statusCode}`);
+        }
     } catch (e) {
         console.log("error", e);
-        dispatch(setNetMode("init"));
         dispatch(
             showToast({
                 type: "error",
@@ -53,6 +55,7 @@ export async function hostGameAsync(shareCode: string | undefined) {
                 timeoutMs: 5000,
             })
         );
+        dispatch(setNetMode("init"));
     } finally {
         dispatch(dismissToast(connectingToast.toast.id));
     }

--- a/multiplayer/src/epics/index.ts
+++ b/multiplayer/src/epics/index.ts
@@ -9,7 +9,7 @@ export { leaveGameAsync } from "./leaveGameAsync";
 export { setGameModeAsync } from "./setGameModeAsync";
 export { signInAsync } from "./signInAsync";
 export { signOutAsync } from "./signOutAsync";
-export { gameDisconnected } from "./gameDisconnected";
+export { notifyGameDisconnected } from "./notifyGameDisconnected";
 export { setPresenceAsync } from "./setPresenceAsync";
 export { sendReactionAsync } from "./sendReactionAsync";
 export { setReactionAsync } from "./setReactionAsync";

--- a/multiplayer/src/epics/joinGameAsync.ts
+++ b/multiplayer/src/epics/joinGameAsync.ts
@@ -46,23 +46,26 @@ export async function joinGameAsync(joinCode: string | undefined) {
         } else {
             dispatch(
                 showToast({
-                    type: "info",
+                    type: "warning",
                     text: lf("Game not found"),
                     timeoutMs: 5000,
+                    icon: "😟"
                 })
             );
             dispatch(setNetMode("init"));
         }
     } catch (e) {
-        console.log("error", e);
-        dispatch(setNetMode("init"));
-        dispatch(
-            showToast({
-                type: "error",
-                text: lf("Something went wrong. Please try again."),
-                timeoutMs: 5000,
-            })
-        );
+        if (typeof e !== "string") {
+            console.log("error", e);
+            dispatch(setNetMode("init"));
+            dispatch(
+                showToast({
+                    type: "error",
+                    text: lf("Something went wrong. Please try again."),
+                    timeoutMs: 5000,
+                })
+            );
+        }
     } finally {
         dispatch(dismissToast(connectingToast.toast.id));
     }

--- a/multiplayer/src/epics/joinGameAsync.ts
+++ b/multiplayer/src/epics/joinGameAsync.ts
@@ -7,7 +7,9 @@ import {
     showToast,
     setClientRole,
 } from "../state/actions";
+import { HTTP_GAME_FULL, HTTP_GAME_NOT_FOUND } from "../types";
 import { cleanupJoinCode } from "../util";
+import { notifyGameDisconnected } from ".";
 
 export async function joinGameAsync(joinCode: string | undefined) {
     joinCode = cleanupJoinCode(joinCode);
@@ -44,28 +46,26 @@ export async function joinGameAsync(joinCode: string | undefined) {
             dispatch(setGameInfo(joinResult));
             dispatch(setNetMode("connected"));
         } else {
-            dispatch(
-                showToast({
-                    type: "warning",
-                    text: lf("Game not found"),
-                    timeoutMs: 5000,
-                    icon: "😟"
-                })
-            );
-            dispatch(setNetMode("init"));
+            if (joinResult.statusCode === HTTP_GAME_NOT_FOUND) {
+                notifyGameDisconnected("not-found");
+                dispatch(setNetMode("init"));
+            } else if (joinResult.statusCode === HTTP_GAME_FULL) {
+                // notification handled by gameClient
+                dispatch(setNetMode("init"));
+            } else {
+                throw new Error(`join http response: ${joinResult.statusCode}`);
+            }
         }
     } catch (e) {
-        if (typeof e !== "string") {
-            console.log("error", e);
-            dispatch(setNetMode("init"));
-            dispatch(
-                showToast({
-                    type: "error",
-                    text: lf("Something went wrong. Please try again."),
-                    timeoutMs: 5000,
-                })
-            );
-        }
+        console.log("error", e);
+        dispatch(
+            showToast({
+                type: "error",
+                text: lf("Something went wrong. Please try again."),
+                timeoutMs: 5000,
+            })
+        );
+        dispatch(setNetMode("init"));
     } finally {
         dispatch(dismissToast(connectingToast.toast.id));
     }

--- a/multiplayer/src/epics/notifyGameDisconnected.ts
+++ b/multiplayer/src/epics/notifyGameDisconnected.ts
@@ -2,7 +2,7 @@ import { dispatch } from "../state";
 import { showToast, setNetMode } from "../state/actions";
 import { GameOverReason } from "../types";
 
-export function gameDisconnected(reason: GameOverReason | undefined) {
+export function notifyGameDisconnected(reason: GameOverReason | undefined) {
     try {
         dispatch(setNetMode("init"));
         switch (reason) {
@@ -51,6 +51,16 @@ export function gameDisconnected(reason: GameOverReason | undefined) {
                         type: "error",
                         text: lf("Game rejected your join request"),
                         timeoutMs: 5000,
+                    })
+                );
+            case "not-found":
+                pxt.tickEvent("mp.gamenotfound");
+                return dispatch(
+                    showToast({
+                        type: "warning",
+                        text: lf("Game not found"),
+                        timeoutMs: 5000,
+                        icon: "😟",
                     })
                 );
             default:

--- a/multiplayer/src/types/index.ts
+++ b/multiplayer/src/types/index.ts
@@ -1,3 +1,9 @@
+export const HTTP_OK = 200;
+export const HTTP_GAME_FULL = 507; // Insuffient storage. Using this HTTP status code to indicate the game is full.
+export const HTTP_GAME_NOT_FOUND = 404; // Not found. Using this HTTP status code to indicate the game was not found.
+export const HTTP_IM_A_TEAPOT = 418; // I'm a teapot. Using this HTTP status code to indicate look elsewhere for the reason.
+export const HTTP_INTERNAL_SERVER_ERROR = 500;
+
 export type NetMode = "init" | "connecting" | "connected";
 export type ModalType =
     | "sign-in"
@@ -7,7 +13,7 @@ export type ModalType =
 
 export type ClientRole = "host" | "guest" | "none";
 export type GameMode = "lobby" | "playing";
-export type GameOverReason = "kicked" | "ended" | "left" | "full" | "rejected";
+export type GameOverReason = "kicked" | "ended" | "left" | "full" | "rejected" | "not-found";
 
 export type GameInfo = {
     joinCode?: string;


### PR DESCRIPTION
There were a few conditions, such as when a game is full, where the client would appear to still be connecting and eventually show a "something went wrong" error. This change fixes that, and generally strengthens the error pathways in the connect/join process.

That said, it's still more complex than it should be. Will revisit someday.