### PR TITLE
don't duplicate persistent share links when importing

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5387,9 +5387,18 @@ async function importGithubProject(repoid: string, requireSignin?: boolean) {
 
 function loadHeaderBySharedId(id: string) {
     core.showLoading("loadingheader", lf("loading project..."));
+    let previousHeader: pxt.workspace.Header;
+    if (id.startsWith("S") && auth.hasIdentity() && data.getData<string>(auth.LOGGED_IN)) {
+        // if loading a persistent url, check for existing headers
+        previousHeader = workspace.getHeaders().find(h => h.pubPermalink === id);
+    }
 
-    workspace.installByIdAsync(id)
-        .then(hd => theEditor.loadHeaderAsync(hd, null))
+    const projHeaderPromise = previousHeader
+        ? Promise.resolve(previousHeader)
+        : workspace.installByIdAsync(id);
+
+    projHeaderPromise
+        .then(hd => theEditor.loadHeaderAsync(hd, null, !!previousHeader))
         .catch(e => {
             theEditor.openHome();
             core.handleNetworkError(e);


### PR DESCRIPTION
When loading a persistent share link, check if we already have the header for it, and if so load it. Here's a build:

https://arcade.makecode.com/app/1542f0098ae8cd9614e77e373590f0623ff8129d-57379544fb

@eanders-ms question, when you first login to a browser do we sync all the headers? I tried to check if this would have trouble immediately following logging in or cache being cleared, but the project I was testing always ended up being loaded while the page reloaded so I couldn't test if there was a case where loading old projects could run into an issue or anything of the sort.