### PR TITLE
Remove the Help Button from the Multiplayer Gear Menu

### DIFF
--- a/multiplayer/src/components/HeaderBar.tsx
+++ b/multiplayer/src/components/HeaderBar.tsx
@@ -22,17 +22,11 @@ export default function Render() {
     const hasIdentity = pxt.auth.hasIdentity();
     const appTheme = pxt.appTarget?.appTheme;
 
-    const helpUrl = ""; // TODO multiplayer
     const privacyUrl = pxt?.appTarget?.appTheme?.privacyUrl;
     const termsOfUseUrl = pxt?.appTarget?.appTheme?.termsOfUseUrl;
     const safetyUrl = "/docs/multiplayer#safety";
 
     const dialogMessages = useAuthDialogMessages();
-
-    const onHelpClicked = () => {
-        pxt.tickEvent("mp.settingsmenu.help");
-        window.open(helpUrl);
-    };
 
     const onReportAbuseClicked = () => {
         pxt.tickEvent("mp.settingsmenu.reportabuse");
@@ -208,13 +202,6 @@ export default function Render() {
 
     const getSettingItems = () => {
         const items: MenuItem[] = [];
-
-        items.push({
-            id: "help",
-            title: lf("Help"),
-            label: lf("Help"),
-            onClick: onHelpClicked,
-        });
 
         if (privacyUrl) {
             items.push({


### PR DESCRIPTION
It's not clear that this will be necessary. Most "help" is already accessible through other parts of the page, like the keyboard controls button or the "online safety" item in the gear menu. Removing for now, can add back later if needed.