### PR TITLE
addd a function to fake p2-4 inputs, check against invalid button commands

### DIFF
--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -81,6 +81,8 @@ export default function Render() {
                                 palette,
                             } as SimMultiplayer.ImageMessage);
                         }
+                        // uncomment for local testing of 'fake players'
+                        // gameClient.startPostingRandomKeys();
                     }
                     return;
                 case "multiplayer":

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -399,14 +399,21 @@ class GameClient {
         const { button, state, slot } =
             Protocol.Binary.unpackInputMessage(reader);
 
-        if (button >= SimKey.Menu || button === SimKey.None || slot < 2) return;
+        const stringifiedState = buttonStateToString(state);
+        if (
+            button <= SimKey.None ||
+            button >= SimKey.Menu ||
+            slot < 2 ||
+            !stringifiedState
+        )
+            return;
 
         this.postToSimFrame(<SimMultiplayer.InputMessage>{
             type: "multiplayer",
             content: "Button",
             clientNumber: slot - 1,
             button: button,
-            state: buttonStateToString(state),
+            state: stringifiedState,
         });
     }
 
@@ -570,7 +577,6 @@ function destroyGameClient() {
     gameClient?.destroy();
     gameClient = undefined;
 }
-
 
 /** Test code for emulating fake users in a multiplayer session **/
 export async function startPostingRandomKeys() {

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -19,6 +19,7 @@ import {
     HTTP_GAME_FULL,
     HTTP_INTERNAL_SERVER_ERROR,
     HTTP_IM_A_TEAPOT,
+    SimKey,
 } from "../types";
 import {
     notifyGameDisconnected,
@@ -398,6 +399,8 @@ class GameClient {
         const { button, state, slot } =
             Protocol.Binary.unpackInputMessage(reader);
 
+        if (button >= SimKey.Menu || button === SimKey.None || slot < 2) return;
+
         this.postToSimFrame(<SimMultiplayer.InputMessage>{
             type: "multiplayer",
             content: "Button",
@@ -566,6 +569,20 @@ let gameClient: GameClient | undefined;
 function destroyGameClient() {
     gameClient?.destroy();
     gameClient = undefined;
+}
+
+
+/** Test code for emulating fake users in a multiplayer session **/
+export async function startPostingRandomKeys() {
+    const states = ["Pressed", "Released"];
+    const currentState = new Array(SimKey.B).fill(0);
+    return setInterval(() => {
+        const key = Math.floor(Math.random() * SimKey.B);
+        gameClient?.sendInputAsync(
+            key + 1,
+            states[currentState[key]++ % 2] as any
+        );
+    }, 300);
 }
 
 export async function hostGameAsync(

--- a/multiplayer/src/types/index.ts
+++ b/multiplayer/src/types/index.ts
@@ -43,6 +43,30 @@ export enum ButtonState {
     Held = 3,
 }
 
+export enum SimKey {
+    None = 0,
+
+    // Player 1
+    Left = 1,
+    Up = 2,
+    Right = 3,
+    Down = 4,
+    A = 5,
+    B = 6,
+
+    Menu = 7,
+
+    // Player 2 = Player 1 + 7
+    // Player 3 = Player 2 + 7
+    // Player 4 = Player 3 + 7
+
+    // system keys
+    Screenshot = -1,
+    Gif = -2,
+    Reset = -3,
+    TogglePause = -4
+}
+
 export function buttonStateToString(state: ButtonState): string | undefined {
     switch (state) {
         case ButtonState.Pressed:


### PR DESCRIPTION
I needed this for testing https://github.com/microsoft/pxt-arcade/issues/5338, and it feels pretty useful / at least enough to keep around as a one line test similar to the vars for swapping on / off staging vs local backends.

Also a small change to catch any invalid inputs, in case e.g. someone tries to fake through messages by directly using the socket.