### PR TITLE
Multiplayer help links and base page

### DIFF
--- a/common-docs/multiplayer.md
+++ b/common-docs/multiplayer.md
@@ -19,7 +19,7 @@ Choose **Host a multiplayer game** instead of creating a share link to your proj
 Once you choose to host your game, a new window opens with your game's join code. You share this code with the other players so that they can join your game. You invite other players to join your game in one of three ways:
 
 * Give them the six-digit game code and when they navigate to the [MakeCode Game Lobby](https://aka.ms/a9b), or https://aka.ms/a9b, they can enter the code to join.
-* Scan the QR code with your mobile phone and send them a message with the join link.
+* Have your friend scan the QR code with their mobile phone to join the game.
 * Copy the full join URL with the copy button next to the game join code and send that to them. In the case of the "BurgerVSPizza" game example, the join URL is: https://aka.ms/a9b?join=F98987.
 
 Your game session begins when you press the **Start Game** button.

--- a/common-docs/multiplayer.md
+++ b/common-docs/multiplayer.md
@@ -36,7 +36,7 @@ After you press the **Enter** button, your game view will display and you can be
 
 The "online multiplayer" mode is a user-controlled, self-contained sharing system that allows creators to play their games with friends in a safe environment that does not allow exchange of personal information.
 
-Users are expected to must share their game join code with classmates directly, as it is neither stored nor discoverable through the game galleries.
+Users are expected to share their game join code with classmates directly, as it is neither stored nor discoverable through the game galleries.
 
 Once inside an online multiplayer session, MakeCode does not provide tools for messaging any players whether joined to a host's game or not. Also, we do not provide any way to share personal contact information that might lead to opening chat session communication outside of the tool, including names, usernames, and/or profile images.
 

--- a/common-docs/multiplayer.md
+++ b/common-docs/multiplayer.md
@@ -18,7 +18,7 @@ Choose **Host a multiplayer game** instead of creating a share link to your proj
 
 Once you choose to host your game, a new window opens with your game's join code. You share this code with the other players so that they can join your game. You invite other players to join your game in one of three ways:
 
-* Give them the six-digit game code and when they navigate to the [MakeCode Game Lobby](https://aka.ms/a9b), or https://aka.ms/a9b, they can enter the code to join.
+* Give them the six-digit game code and when they navigate to the [MakeCode Game Lobby](https://aka.ms/a9), or https://aka.ms/a9, they can enter the code to join.
 * Have your friend scan the QR code with their mobile phone to join the game.
 * Copy the full join URL with the copy button next to the game join code and send that to them. In the case of the "BurgerVSPizza" game example, the join URL is: https://aka.ms/a9b?join=F98987.
 

--- a/common-docs/multiplayer.md
+++ b/common-docs/multiplayer.md
@@ -1,0 +1,47 @@
+# Multiplayer
+
+### ~ alert
+
+#### Supported editors
+
+The online multiplayer game feature is only available for [Microsoft MakeCode Arcade](https://arcade.makecode.com).
+
+### ~
+
+A multiplayer game is one where **2** or more (up to a maximum of **4**) players can play the same game together at the same time. A game session is started by a _host_ player and other players _join_ the game online with MakeCode's multiplayer game system. If a game is programmed using multiplayer controls, the game creator can choose to host a multiplayer game session and share the game's join code with other players.
+
+## Host a game #host-game
+
+You host a multiplayer game by using the **Share** button at the top of the editor screen.
+
+Choose **Host a multiplayer game** instead of creating a share link to your project.
+
+Once you choose to host your game, a new window opens with your game's join code. You share this code with the other players so that they can join your game. You invite other players to join your game in one of three ways:
+
+* Give them the six-digit game code and when they navigate to the [MakeCode Game Lobby](https://aka.ms/a9b), or https://aka.ms/a9b, they can enter the code to join.
+* Scan the QR code with your mobile phone and send them a message with the join link.
+* Copy the full join URL with the copy button next to the game join code and send that to them. In the case of the "BurgerVSPizza" game example, the join URL is: https://aka.ms/a9b?join=F98987.
+
+Your game session begins when you press the **Start Game** button.
+
+Once your game starts, the host's view of the game displays and you can begin game play or wait for other players to join.
+
+## Join a game #join-game
+
+To join a multiplayer game hosted by another player, you can go to the [MakeCode Game Lobby](https://aka.ms/a9b), or https://aka.ms/a9b, and enter the game's join code that you received from the game host.
+
+After you press the **Enter** button, your game view will display and you can begin playing. If you received a full join URL instead, such as https://aka.ms/a9b?join=F98987, this will take you directly to your player's game window.
+
+## Multiplayer game safety #safety
+
+The "online multiplayer" mode is a user-controlled, self-contained sharing system that allows creators to play their games with friends in a safe environment that does not allow exchange of personal information.
+
+Users are expected to must share their game join code with classmates directly, as it is neither stored nor discoverable through the game galleries.
+
+Once inside an online multiplayer session, MakeCode does not provide tools for messaging any players whether joined to a host's game or not. Also, we do not provide any way to share personal contact information that might lead to opening chat session communication outside of the tool, including names, usernames, and/or profile images.
+
+Communication inside of our online multiplayer tool is limited to an allowed set of emojis.
+
+User privacy and safety is of the utmost importance. As such, we empower all users to flag inappropriate games and/or teammates for immediate removal    at any time during game play. 
+For further information regarding the security and privacy of MakeCode Arcade, please see our [Privacy Policy](https://privacy.microsoft.com/en-us/privacystatement).
+

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -78,7 +78,7 @@ export default function Render() {
                     onClick={onStartGameClick}
                 />
                 <Link
-                    href="/docs/multiplayer#safety"
+                    href="/multiplayer#safety"
                     target="_blank"
                     className="tw-text-sm tw-mt-1 tw-mb-7"
                 >

--- a/multiplayer/src/components/JoinOrHost.tsx
+++ b/multiplayer/src/components/JoinOrHost.tsx
@@ -108,7 +108,7 @@ export default function Render() {
                                     </div>
                                     <div className="tw-text-sm">
                                         <Link
-                                            href="/docs/multiplayer#join-game"
+                                            href="/multiplayer#join-game"
                                             target="_blank"
                                         >
                                             {lf("How do I get a game code?")}
@@ -140,7 +140,7 @@ export default function Render() {
                                     </div>
                                     <div className="tw-text-sm">
                                         <Link
-                                            href="/docs/multiplayer#host-game"
+                                            href="/multiplayer#host-game"
                                             target="_blank"
                                         >
                                             {howToGetLink}


### PR DESCRIPTION
Fixes the help links for the multiplayer UI href elements. Also, a base `multiplayer.md` page is added as a place holder for `@extends`.