### PR TITLE
Update Microbit App Deprecation Notifications

### DIFF
--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -9,6 +9,7 @@ import * as cloudsync from "./cloudsync";
 
 import Cloud = pxt.Cloud;
 import Util = pxt.Util;
+import { jsxLF } from "./util";
 
 let dontShowDownloadFlag = false;
 
@@ -689,6 +690,11 @@ export function showReportAbuseAsync(pubId?: string) {
     })
 }
 
+function getNewAppClick() {
+    pxt.tickEvent("winApp.deprecateModal.installNew", undefined);
+    window.open("https://apps.microsoft.com/store/detail/microsoft-makecode-for-microbit/9NMQDQ2XZKWK", '_blank')
+}
+
 export function showWinAppDeprecateAsync() {
     pxt.tickEvent("winApp.dialog", undefined)
     return core.confirmAsync({
@@ -699,8 +705,8 @@ export function showWinAppDeprecateAsync() {
         jsx: <div>
             <img className="ui medium centered image" src={pxt.appTarget.appTheme.winAppDeprImage} alt={lf("An image of a shrugging board")}/>
             <div>
-                {lf(`This app is being deprecated. Text editing is only available on the MakeCode website `)}
-                {`(https://${pxt.appTarget.name}).`}
+                {jsxLF(`This app is no longer supported. {0} for text editing and more new features!`,
+                <strong><sui.Link className="link bold" ariaLabel={lf("Install our new app")} onClick={getNewAppClick}>{lf("Install our new app")}</sui.Link></strong>)}
             </div>
         </div>
     })

--- a/webapp/src/notification.tsx
+++ b/webapp/src/notification.tsx
@@ -111,6 +111,11 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
         window.open("/windows-app", '_blank')
     }
 
+    getNewAppClick() {
+        pxt.tickEvent("winApp.banner.installNew", undefined);
+        window.open("https://apps.microsoft.com/store/detail/microsoft-makecode-for-microbit/9NMQDQ2XZKWK", '_blank')
+    }
+
     renderCore() {
         const targetTheme = pxt.appTarget.appTheme;
         const isApp = pxt.winrt.isWinRT() || pxt.BrowserUtils.isElectron();
@@ -121,7 +126,11 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
         const showExperiments = pxt.editor.experiments.someEnabled() && !/experiments=1/.test(window.location.href);
         const showWinAppBanner = pxt.appTarget.appTheme.showWinAppDeprBanner && pxt.BrowserUtils.isWinRT();
 
-        const errMsg = lf("This app is being deprecated. Please use the website instead.");
+        const errMsg = this.jsxLF(
+            "This app is no longer supported. For the latest updates, {0} to install our new app! {1}",
+            <sui.Link className="link" ariaLabel={lf("click here")} onClick={this.getNewAppClick}>{lf("click here")}</sui.Link>,            
+            <sui.Link className="link" ariaLabel={lf("More info")} onClick={this.handleBannerClick}>{lf("Learn More")}</sui.Link>
+        );
 
         if (showWinAppBanner) {
             return <GenericBanner id="winAppBanner" parent={this.props.parent} bannerType={"negative"}>
@@ -129,8 +138,6 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
                 <div className="header">
                     {errMsg}
                 </div>
-                <sui.Link className="link" ariaLabel={lf("More info")} onClick={this.handleBannerClick}>{lf("More info")}</sui.Link>
-
             </GenericBanner>
         }
 
@@ -155,5 +162,32 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
         }
 
         return <div></div>;
+    }
+
+    // Based on https://github.com/microsoft/pxt/blob/master/react-common/components/util.tsx#L15.
+    jsxLF(loc: string, ...rest: JSX.Element[]) {
+        const indices: number[] = [];
+    
+        loc.replace(/\{\d\}/g, match => {
+            indices.push(parseInt(match.substr(1, 1)));
+            return match;
+        });
+    
+        const out: JSX.Element[] = [];
+    
+        let parts: string[];
+    
+        let i = 0;
+    
+        for (const index of indices) {
+            parts = loc.split(`{${index}}`);
+            pxt.U.assert(parts.length === 2);
+            out.push(<span key={i++}>{parts[0]}</span>);
+            out.push(<span key={i++}>{rest[index]}</span>);
+            loc = parts[1];
+        }
+        out.push(<span key={i++}>{loc}</span>);
+    
+        return out;
     }
 }

--- a/webapp/src/notification.tsx
+++ b/webapp/src/notification.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import * as data from "./data";
 import * as sui from "./sui";
+import { jsxLF } from "./util";
 
 import Cloud = pxt.Cloud;
 
@@ -126,9 +127,9 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
         const showExperiments = pxt.editor.experiments.someEnabled() && !/experiments=1/.test(window.location.href);
         const showWinAppBanner = pxt.appTarget.appTheme.showWinAppDeprBanner && pxt.BrowserUtils.isWinRT();
 
-        const errMsg = this.jsxLF(
+        const errMsg = jsxLF(
             "This app is no longer supported. For the latest updates, {0} to install our new app! {1}",
-            <sui.Link className="link" ariaLabel={lf("click here")} onClick={this.getNewAppClick}>{lf("click here")}</sui.Link>,            
+            <sui.Link className="link" ariaLabel={lf("click here")} onClick={this.getNewAppClick}>{lf("click here")}</sui.Link>,
             <sui.Link className="link" ariaLabel={lf("More info")} onClick={this.handleBannerClick}>{lf("Learn More")}</sui.Link>
         );
 
@@ -162,32 +163,5 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
         }
 
         return <div></div>;
-    }
-
-    // Based on https://github.com/microsoft/pxt/blob/master/react-common/components/util.tsx#L15.
-    jsxLF(loc: string, ...rest: JSX.Element[]) {
-        const indices: number[] = [];
-
-        loc.replace(/\{\d\}/g, match => {
-            indices.push(parseInt(match.substr(1, 1)));
-            return match;
-        });
-
-        const out: JSX.Element[] = [];
-
-        let parts: string[];
-
-        let i = 0;
-
-        for (const index of indices) {
-            parts = loc.split(`{${index}}`);
-            pxt.U.assert(parts.length === 2);
-            out.push(<span key={i++}>{parts[0]}</span>);
-            out.push(<span key={i++}>{rest[index]}</span>);
-            loc = parts[1];
-        }
-        out.push(<span key={i++}>{loc}</span>);
-
-        return out;
     }
 }

--- a/webapp/src/notification.tsx
+++ b/webapp/src/notification.tsx
@@ -167,18 +167,18 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
     // Based on https://github.com/microsoft/pxt/blob/master/react-common/components/util.tsx#L15.
     jsxLF(loc: string, ...rest: JSX.Element[]) {
         const indices: number[] = [];
-    
+
         loc.replace(/\{\d\}/g, match => {
             indices.push(parseInt(match.substr(1, 1)));
             return match;
         });
-    
+
         const out: JSX.Element[] = [];
-    
+
         let parts: string[];
-    
+
         let i = 0;
-    
+
         for (const index of indices) {
             parts = loc.split(`{${index}}`);
             pxt.U.assert(parts.length === 2);
@@ -187,7 +187,7 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
             loc = parts[1];
         }
         out.push(<span key={i++}>{loc}</span>);
-    
+
         return out;
     }
 }

--- a/webapp/src/util.tsx
+++ b/webapp/src/util.tsx
@@ -1,0 +1,28 @@
+import React = require("react");
+
+// Based on https://github.com/microsoft/pxt/blob/master/react-common/components/util.tsx#L15.
+export function jsxLF(loc: string, ...rest: JSX.Element[]) {
+    const indices: number[] = [];
+
+    loc.replace(/\{\d\}/g, match => {
+        indices.push(parseInt(match.substr(1, 1)));
+        return match;
+    });
+
+    const out: JSX.Element[] = [];
+
+    let parts: string[];
+
+    let i = 0;
+
+    for (const index of indices) {
+        parts = loc.split(`{${index}}`);
+        pxt.U.assert(parts.length === 2);
+        out.push(<span key={i++}>{parts[0]}</span>);
+        out.push(<span key={i++}>{rest[index]}</span>);
+        loc = parts[1];
+    }
+    out.push(<span key={i++}>{loc}</span>);
+
+    return out;
+}


### PR DESCRIPTION
This updates the top-bar notification and the no-text-editor modal that both appear in the WinJS app to signal deprecation. Now, they both point to the new windows app. The documentation link hasn't changed, but we'll probably want to update the docs to explain the new bulk download/upload options.

I wanted to be able to inject JSX into an LF statement, but the "jsxLF" function doesn't exist in stable7.0 so I just copied it in. Hopefully that's alright.

![image](https://user-images.githubusercontent.com/69657545/202537981-f3195de9-6509-4c1d-a5c3-69b8be72ec5a.png)

![image](https://user-images.githubusercontent.com/69657545/202537994-5c969a41-44e9-41a2-98b9-1b3682d6f539.png)

