### PR TITLE
Fix Deprecation Notification Links for Microbit WinJS App

### DIFF
--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -692,7 +692,6 @@ export function showReportAbuseAsync(pubId?: string) {
 
 function getNewAppClick() {
     pxt.tickEvent("winApp.deprecateModal.installNew", undefined);
-    window.open("https://apps.microsoft.com/store/detail/microsoft-makecode-for-microbit/9NMQDQ2XZKWK", '_blank')
 }
 
 export function showWinAppDeprecateAsync() {
@@ -706,7 +705,7 @@ export function showWinAppDeprecateAsync() {
             <img className="ui medium centered image" src={pxt.appTarget.appTheme.winAppDeprImage} alt={lf("An image of a shrugging board")}/>
             <div>
                 {jsxLF(`This app is no longer supported. {0} for text editing and more new features!`,
-                <strong><sui.Link className="link bold" ariaLabel={lf("Install our new app")} onClick={getNewAppClick}>{lf("Install our new app")}</sui.Link></strong>)}
+                <strong><sui.Link className="link bold" ariaLabel={lf("Install our new app")} onClick={getNewAppClick} href="ms-windows-store://pdp/?ProductId=9NMQDQ2XZKWK">{lf("Install our new app")}</sui.Link></strong>)}
             </div>
         </div>
     })

--- a/webapp/src/notification.tsx
+++ b/webapp/src/notification.tsx
@@ -109,12 +109,10 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
 
     handleBannerClick() {
         pxt.tickEvent("winApp.banner", undefined);
-        window.open("/windows-app", '_blank')
     }
 
-    getNewAppClick() {
+    handleGetNewAppClick() {
         pxt.tickEvent("winApp.banner.installNew", undefined);
-        window.open("https://apps.microsoft.com/store/detail/microsoft-makecode-for-microbit/9NMQDQ2XZKWK", '_blank')
     }
 
     renderCore() {
@@ -129,8 +127,8 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
 
         const errMsg = jsxLF(
             "This app is no longer supported. For the latest updates, {0} to install our new app! {1}",
-            <sui.Link className="link" ariaLabel={lf("click here")} onClick={this.getNewAppClick}>{lf("click here")}</sui.Link>,
-            <sui.Link className="link" ariaLabel={lf("More info")} onClick={this.handleBannerClick}>{lf("Learn More")}</sui.Link>
+            <sui.Link className="link" ariaLabel={lf("click here")} onClick={this.handleGetNewAppClick} href="ms-windows-store://pdp/?ProductId=9NMQDQ2XZKWK">{lf("click here")}</sui.Link>,
+            <sui.Link className="link" ariaLabel={lf("More info")} onClick={this.handleBannerClick} href="/windows-app" target="_blank">{lf("Learn More")}</sui.Link>
         );
 
         if (showWinAppBanner) {


### PR DESCRIPTION
These links worked in the browser but not in the web app, and my hypothesis is that this is because they were using window.open instead of the link's href. (I looked at "Support" in the help menu, which works, and that used href). Unfortunately, I can't test inside the app locally, so this is a best guess. Validated in the browser, but hard to say if it will be 1:1.

I've also updated the link to go directly to the windows store rather than the web version.