### PR TITLE
Fix minecraft hoc layout bug

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4630,13 +4630,13 @@ export class ProjectView
                 }
             } else {
                 const tc = document.getElementById("tutorialcard");
-                const flyoutOnly = this.state.editorState?.hasCategories === false;
-                let headerHeight = 0;
-                if (flyoutOnly) {
-                    const headers = document.getElementById("headers");
-                    headerHeight += headers.offsetHeight;
-                }
                 if (tc) {
+                    const flyoutOnly = this.state.editorState?.hasCategories === false;
+                    let headerHeight = 0;
+                    if (flyoutOnly) {
+                        const headers = document.getElementById("headers");
+                        headerHeight = headers.offsetHeight;
+                    }
                     const offset = tc.offsetHeight + headerHeight;
                     this.setState({ editorOffset: `${offset}px` });
                 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1331,6 +1331,7 @@ export class ProjectView
                     this.blocksEditor.hideFlyout()
                 else if (this.editor == this.textEditor)
                     this.textEditor.hideFlyout()
+                this.setEditorOffset();
             });
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4630,16 +4630,18 @@ export class ProjectView
                 }
             } else {
                 const tc = this.refs[ProjectView.tutorialCardId] as tutorial.TutorialCard;
-                const flyoutOnly = this.state.editorState && this.state.editorState.hasCategories === false;
+                const flyoutOnly = this.state.editorState?.hasCategories === false;
                 let headerHeight = 0;
                 if (flyoutOnly) {
                     let headers = document.getElementById("headers");
                     headerHeight += headers.offsetHeight;
                 }
                 if (tc) {
-                    // maxium offset of 18rem
-                    let maxOffset = Math.min(tc.getCardHeight() + headerHeight, parseFloat(getComputedStyle(document.documentElement).fontSize) * 18);
-                    this.setState({ editorOffset: "calc(" + maxOffset + "px + 2em)" }); // 2em for margins
+                    const fontSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
+                    const maxContentHeight = 22;
+                    let maxOffset = Math.min(tc.getCardHeight() + headerHeight, fontSize * maxContentHeight);
+                    this.setState({ editorOffset: `calc(${maxOffset}px + 2rem)` });
+                    // 2rem for margins, e.g. see TutorialCard.getExpandedCardStyle
                 }
             }
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4629,19 +4629,16 @@ export class ProjectView
                     this.setState({ editorOffset: undefined });
                 }
             } else {
-                const tc = this.refs[ProjectView.tutorialCardId] as tutorial.TutorialCard;
+                const tc = document.getElementById("tutorialcard");
                 const flyoutOnly = this.state.editorState?.hasCategories === false;
                 let headerHeight = 0;
                 if (flyoutOnly) {
-                    let headers = document.getElementById("headers");
+                    const headers = document.getElementById("headers");
                     headerHeight += headers.offsetHeight;
                 }
                 if (tc) {
-                    const fontSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
-                    const maxContentHeight = 22;
-                    let maxOffset = Math.min(tc.getCardHeight() + headerHeight, fontSize * maxContentHeight);
-                    this.setState({ editorOffset: `calc(${maxOffset}px + 2rem)` });
-                    // 2rem for margins, e.g. see TutorialCard.getExpandedCardStyle
+                    const offset = tc.offsetHeight + headerHeight;
+                    this.setState({ editorOffset: `${offset}px` });
                 }
             }
         }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/2266 - note that it was the entire blockly workspace that was partially hidden behind the toolbox label / menu bar, not just the toolbox -- you can drag the on start off screeen then too even without other blocks 
<img width="363" alt="image" src="https://user-images.githubusercontent.com/5615930/203388312-a6202ad5-388b-4ec9-8410-b361e3706ec9.png">

It's pretty easy to induce a repro, just make your browser as thin as possible and load https://minecraft.makecode.com/hoc2022?ipc=1&inGame=1&noRunOnX=1#tutorial:/hour-of-code/2022/kitchen_feedhouse . I had a little bit of a hard time narrowing down the exact reason it happens more consistently in game even if the window size is accounted for, but it appeared to be a combination of this window size issue + something that seemed like a race condition where `ProjectView.setEditorOffset` was occasionally not getting called at the right time when state changed (line 1334, though that was made explicitly necessary by the offset calculation now being based off the rendered element instead of the shadow dom state).

and here's the uploadtrg off this branch https://minecraft.makecode.com/app/b302a104ce232a761a7e1f63a7e941fa0016d915-dd9d99094e?ipc=1&inGame=1&noRunOnX=1#tutorial:/hour-of-code/2022/kitchen_feedhouse

one thing to note is that this branch is based off master so there might be a few unrelated tutorial bugs from my changes for arcade, but the same behavior was present as the old tutorial layout hadn't really been touched much (e.g. in widescreen there's a little sim scrollbar that must have snuck through from my playable minisim in tutorial / isn't correctly getting hidden), I tried to make a build off minecraft stable pxt but kept getting errors / didn't want to spend time switching node versions debugging just to make a slightly more accurate build

<img width="192" alt="image" src="https://user-images.githubusercontent.com/5615930/203386871-36796c43-398b-46f3-a430-3b0322cce80a.png">

(and probably worth a clarifying note here, the `// maxium offset of 18rem` portion wasn't actually capping the size of the hint, it was matching the css rule & partially causing this issue)
