### PR TITLE
fix little scrollbar that shows up in headless sim

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1494,6 +1494,10 @@ p.ui.font.small {
         background: none transparent;
         min-width: inherit;
         max-width: inherit;
+
+        .tab-simulator {
+            display: none;
+        }
     }
 
     #boardview, .filemenu {


### PR DESCRIPTION
fix little sim scrollbar that is showing up when running minecraft with latest pxt due to sim -- this came from a combo of my arcade tutorial layout change + this special casing headless layout for minecraft~

![image](https://user-images.githubusercontent.com/5615930/203393386-de710164-2d8b-4f89-9a39-05b77e2098fd.png)
