### PR TITLE
when no preferred extensions, don't show all approved exts

### DIFF
--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -217,6 +217,8 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
     }
 
     async function fetchGithubDataAndAddAsync(repos: string[]): Promise<ExtensionMeta[]> {
+        if (!repos.length)
+            return [];
         const fetched = await fetchGithubDataAsync(repos)
         if (!fetched) {
             return []
@@ -552,7 +554,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                             className={currentTab == TabState.InDevelopment ? "selected" : ""}
                                         />
                                     </>}
-                                {!extensionsInDevelopment.length &&
+                                {(!extensionsInDevelopment.length && !!extensionsToShow.length) &&
                                     <h2>{lf("Recommended")}</h2>
                                 }
                             </div>

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -554,7 +554,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                                             className={currentTab == TabState.InDevelopment ? "selected" : ""}
                                         />
                                     </>}
-                                {(!extensionsInDevelopment.length && !!extensionsToShow.length) &&
+                                {(!extensionsInDevelopment.length && !!preferredExts.length) &&
                                     <h2>{lf("Recommended")}</h2>
                                 }
                             </div>


### PR DESCRIPTION
fix issue where approved extensions are showing up as preferred in minecraft as there are no preferred ones yet; issue is that `fetchGithubDataAsync` uses `gh-search`  when <= 1 search terms  are sent, which will return all approved exts (presumably up to a limit in backend) when searching for "" 

I also made it so the 'recommended' header goes away when nothing is recommended as it felt weird having that label with nothing below it -- almost like it was saying 'recommended you use a file instead of github search' or something

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/5615930/203399212-75d84568-01f6-4fe2-98a1-8fa828fa390b.png">
