### PR TITLE
fix nested repos direct add

### DIFF
--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -109,7 +109,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
     function getExtensionFromFetched(extensionUrl: string) {
         const parsedGithubRepo = pxt.github.parseRepoId(extensionUrl);
         if (parsedGithubRepo)
-            return allExtensions.get(parsedGithubRepo.slug.toLowerCase());
+            return allExtensions.get(parsedGithubRepo.fullName.toLowerCase());
 
         const fullName = allExtensions.get(extensionUrl.toLowerCase())
         if (fullName)
@@ -161,11 +161,11 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         let r: { version: string, config: pxt.PackageConfig };
         try {
             core.showLoading("downloadingpackage", lf("downloading extension..."));
-            const pkg = getExtensionFromFetched(scr.repo.slug);
+            const pkg = getExtensionFromFetched(scr.repo.fullName);
             if (pkg) {
                 r = await pxt.github.downloadLatestPackageAsync(pkg.repo);
             } else {
-                const res = await fetchGithubDataAsync([scr.repo.slug]);
+                const res = await fetchGithubDataAsync([scr.repo.fullName]);
                 if (res && res.length > 0) {
                     const parsed = parseGithubRepo(res[0])
                     addExtensionsToPool([parsed])


### PR DESCRIPTION
In https://github.com/microsoft/pxt/pull/9231 I forgot to account for 'nested' repos in the add logic so this is a quick fix for that

Just noticed this, doesn't matter too much as the only thing currently using nested repos is jacdac and that only encourages people to add the base package but good to fix early. If you search `microsoft/pxt-jacdac/accelerometer` and click after that patch it would just add `microsoft/pxt-jacdac`, where it was working before as the package names should be different (though have to double check that, it's very possible a few of the many subpackages had a typo or something.)