### PR TITLE
Check for flyout only tut option

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4834,12 +4834,12 @@ export class ProjectView
         const isSidebarTutorial = pxt.appTarget.appTheme.sidebarTutorial;
         const isTabTutorial = inTutorial && !pxt.BrowserUtils.useOldTutorialLayout();
         const inTutorialExpanded = inTutorial && tutorialOptions.tutorialStepExpanded;
-        const hideTutorialIteration = inTutorial && tutorialOptions.metadata && tutorialOptions.metadata.hideIteration;
         const inDebugMode = this.state.debugging;
         const inHome = this.state.home && !sandbox;
         const inEditor = !!this.state.header && !inHome;
         const { lightbox, greenScreen, accessibleBlocks } = this.state;
-        const flyoutOnly = this.state.editorState && this.state.editorState.hasCategories === false;
+        const hideTutorialIteration = inTutorial && tutorialOptions.metadata?.hideIteration;
+        const flyoutOnly = this.state.editorState?.hasCategories === false || (inTutorial && tutorialOptions.metadata?.flyoutOnly);
 
         const { hideEditorToolbar, transparentEditorToolbar } = targetTheme;
         const hideMenuBar = targetTheme.hideMenuBar || hideTutorialIteration || (isTabTutorial && pxt.appTarget.appTheme.embeddedTutorial);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4632,7 +4632,7 @@ export class ProjectView
             } else {
                 const tc = document.getElementById("tutorialcard");
                 if (tc) {
-                    const flyoutOnly = this.state.editorState?.hasCategories === false;
+                    const flyoutOnly = this.state.editorState?.hasCategories === false || this.state.tutorialOptions?.metadata?.flyoutOnly;
                     let headerHeight = 0;
                     if (flyoutOnly) {
                         const headers = document.getElementById("headers");


### PR DESCRIPTION
Fix issue where certain hoc tutorials at certain widths under certain race conditions fail to show 'more / less' toggle & are incorrectly sized until you resize window (as there is only one step in these tutorials)

The toolbox block decompilation & `setState` changing `editorState` had to 'go slow' to cause the 'flyoutOnly' class to not be set for a render, causing the wrong font to be shown for a few ms (normal tutorials use the standard font, where minecraft hoc uses the nice `minecraft 7` which is slightly larger), which had to result in a snippet barely fitting in the tutorial text spot (which then had to not fit anymore after the font changed to the correct one), and none of the ~half dozen places that the size gets double checked can occur after the font changed or it would fix itself (so typically, to consistently show up it has to be the first load of that tutorial so no apis are cached yet & `editorState` doesn't get set early). Bleh.

Also worth a note that even though it can be induced in recent builds / beta by throttling cpu in devtools, I could only get it to consistently repro in normal conditions on /v1.6 and when building stable8.1 after using nvm to swap back to node 8.9... for some reason... ＼（〇_ｏ）／ ... probably just random noise that happened to line up

On the plus side this fix ends up getting rid of the 'flashing' of normal tutorial styles while loading hoc tutorials -- you just get normal editor toolbar now for a moment and then it goes to hoc layout. here's an e.g.: https://minecraft.makecode.com/app/2f1730106cef14af2cf933b5302fb06e9b3efd3d-78ef7ed492?ipc=1&inGame=1&noRunOnX=1#tutorial:/hour-of-code/2022/kitchen_feedhouse

let's hope we never have to touch `tutorial.tsx` again until we delete it because trekking through that to figure out why it was misbehaving was not fun.