### PR TITLE
make next/prev step bar buttons use next / prev ticks

### DIFF
--- a/webapp/src/components/tutorial/TutorialStepCounter.tsx
+++ b/webapp/src/components/tutorial/TutorialStepCounter.tsx
@@ -9,7 +9,7 @@ interface TutorialStepCounterProps {
 }
 
 export function TutorialStepCounter(props: TutorialStepCounterProps) {
-    const { tutorialId, currentStep, totalSteps, title } = props;
+    const { tutorialId, currentStep, totalSteps, title, setTutorialStep } = props;
 
     const MAX_BUBBLES = 7;
     const startPoint = Math.max(0, Math.min(currentStep - Math.floor(MAX_BUBBLES / 2), totalSteps - MAX_BUBBLES));
@@ -20,8 +20,19 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
     }
 
     const handleSetStep = (step: number) => () => {
-        const { setTutorialStep } = props;
-        pxt.tickEvent("tutorial.step", { tutorial: tutorialId, step: step }, { interactiveConsent: true });
+        pxt.tickEvent("tutorial.step", { tutorial: tutorialId, step: step, prevStep: currentStep }, { interactiveConsent: true });
+        setTutorialStep(step);
+    }
+
+    const handleNextStep = () => {
+        const step = Math.min(currentStep + 1, totalSteps - 1);
+        pxt.tickEvent("tutorial.next", { tutorial: tutorialId, step: step, isModal: 0, isStepCounter: 1 }, { interactiveConsent: true });
+        setTutorialStep(step);
+    }
+
+    const handlePreviousStep = () => {
+        const step = Math.max(currentStep - 1, 0);
+        pxt.tickEvent("tutorial.previous", { tutorial: tutorialId, step: step, isModal: 0, isStepCounter: 1 }, { interactiveConsent: true });
         setTutorialStep(step);
     }
 
@@ -39,7 +50,7 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
                 disabled={currentStep == 0}
                 className="square-button"
                 leftIcon="icon left chevron"
-                onClick={handleSetStep(currentStep - 1)}
+                onClick={handlePreviousStep}
                 aria-label={backButtonLabel}
                 title={backButtonLabel}
             />
@@ -59,7 +70,7 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
                 disabled={currentStep == totalSteps - 1}
                 className="square-button"
                 leftIcon="icon right chevron"
-                onClick={handleSetStep(currentStep + 1)}
+                onClick={handleNextStep}
                 aria-label={nextButtonLabel}
                 title={nextButtonLabel}
             />

--- a/webapp/src/components/tutorial/TutorialStepCounter.tsx
+++ b/webapp/src/components/tutorial/TutorialStepCounter.tsx
@@ -24,15 +24,15 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
         setTutorialStep(step);
     }
 
-    const handleNextStep = () => {
-        const step = Math.min(currentStep + 1, totalSteps - 1);
-        pxt.tickEvent("tutorial.next", { tutorial: tutorialId, step: step, isModal: 0, isStepCounter: 1 }, { interactiveConsent: true });
-        setTutorialStep(step);
-    }
-
     const handlePreviousStep = () => {
         const step = Math.max(currentStep - 1, 0);
         pxt.tickEvent("tutorial.previous", { tutorial: tutorialId, step: step, isModal: 0, isStepCounter: 1 }, { interactiveConsent: true });
+        setTutorialStep(step);
+    }
+
+    const handleNextStep = () => {
+        const step = Math.min(currentStep + 1, totalSteps - 1);
+        pxt.tickEvent("tutorial.next", { tutorial: tutorialId, step: step, isModal: 0, isStepCounter: 1 }, { interactiveConsent: true });
         setTutorialStep(step);
     }
 


### PR DESCRIPTION
currently we're just sending the 'set step' tick when the step changes from the step bar, even if they click on the previous or next buttons up there. Make it so those two buttons match the other ones when they appear (e.g. the next at the bottom of the step, the back button that appears in modal steps midway through tutorial. Added a `isStepCounter: 1` field for those two messages to determine whether the user clicked the one in the top bar or anywhere else.

I also added a `prevStep` field to the data for tutorial.step, as that feels useful to determine transitions when the bubbles are used / might as well include it?

and for reference here's where the other two are defined: https://github.com/microsoft/pxt/blob/tutStepCounterNextPrevDiffTicks/webapp/src/components/tutorial/TutorialContainer.tsx#L110