### PR TITLE
Preserve Existing Highlights When Processing Typescript Metadata Comments

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -39,7 +39,7 @@ namespace pxt.blocks {
                 if (/@highlight/.test(c)) {
                     const cc = c.replace(/@highlight/g, '').trim();
                     b.setCommentText(cc || null);
-                    (workspace as Blockly.WorkspaceSvg).highlightBlock?.(b.id)
+                    (workspace as Blockly.WorkspaceSvg).highlightBlock?.(b.id, true)
                 }
             });
     }


### PR DESCRIPTION
This allows multiple blocks to be highlighted in a tutorial hint.

From blockly docs, this additional boolean parameter (when set) prevents other highlight blocks from being reset when highlightBlock is called: https://developers.google.com/blockly/reference/js/blockly.workspacesvg_class.highlightblock_1_method

Multiple blocks highlighted in hint:
![image](https://user-images.githubusercontent.com/69657545/206012459-bbabd689-dc81-4366-91a6-1c409a381309.png)

Fixes https://github.com/microsoft/pxt-arcade/issues/4856
