### PR TITLE
Add meta marker for deleting block

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -32,7 +32,7 @@ namespace pxt.blocks {
         } finally {
             Blockly.Events.enable();
         }
-        return newBlockIds.filter(id => workspace.getBlockById(id));
+        return newBlockIds.filter(id => !!workspace.getBlockById(id));
     }
 
     function applyMetaComments(workspace: Blockly.Workspace) {

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -9,18 +9,24 @@ namespace pxt.blocks {
         extensions?: string[]; // currently unpopulated. list of extensions used in screenshotted projects
     }
 
+    export interface DomToWorkspaceOptions {
+        applyMetaComments?: boolean;
+    }
+
     /**
      * Converts a DOM into workspace without triggering any Blockly event. Returns the new block ids
      * @param dom
      * @param workspace
      */
-    export function domToWorkspaceNoEvents(dom: Element, workspace: Blockly.Workspace): string[] {
+    export function domToWorkspaceNoEvents(dom: Element, workspace: Blockly.Workspace, opts?: DomToWorkspaceOptions): string[] {
         pxt.tickEvent(`blocks.domtow`)
         let newBlockIds: string[] = [];
         try {
             Blockly.Events.disable();
             newBlockIds = Blockly.Xml.domToWorkspace(dom, workspace);
-            applyMetaComments(workspace);
+            if (opts?.applyMetaComments) {
+                applyMetaComments(workspace);
+            }
         } catch (e) {
             pxt.reportException(e);
         } finally {
@@ -41,7 +47,7 @@ namespace pxt.blocks {
                     b.setCommentText(cc || null);
                     (workspace as Blockly.WorkspaceSvg).highlightBlock?.(b.id)
                 }
-                if (/@tutorialdelete/.test(c)) {
+                if (/@hide/.test(c)) {
                     b.dispose(true);
                 }
             });

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -26,7 +26,7 @@ namespace pxt.blocks {
         } finally {
             Blockly.Events.enable();
         }
-        return newBlockIds;
+        return newBlockIds.filter(id => workspace.getBlockById(id));
     }
 
     function applyMetaComments(workspace: Blockly.Workspace) {
@@ -40,6 +40,9 @@ namespace pxt.blocks {
                     const cc = c.replace(/@highlight/g, '').trim();
                     b.setCommentText(cc || null);
                     (workspace as Blockly.WorkspaceSvg).highlightBlock?.(b.id)
+                }
+                if (/@tutorialdelete/.test(c)) {
+                    b.dispose(true);
                 }
             });
     }

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -100,7 +100,11 @@ namespace pxt.blocks {
         try {
             let text = blocksXml || `<xml xmlns="http://www.w3.org/1999/xhtml"></xml>`;
             let xml = Blockly.Xml.textToDom(text);
-            pxt.blocks.domToWorkspaceNoEvents(xml, workspace);
+            pxt.blocks.domToWorkspaceNoEvents(
+                xml,
+                workspace,
+                { applyMetaComments: true }
+            );
 
             return renderWorkspace(options);
         } catch (e) {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/4647; add a way to elide blocks from hints, such as functions variable declarations. (variable declarations we could already get around by just declaring without setting, but that's kinda weird / really gotta know that as a gotcha so I'd say it's nicer to have an explicit annotation)

Also added an options bag as an option parameter to `domToWorkspaceNoEvents`; the highlight only matters when it's called through rendering / this one should be the same, so making that explicit. This way ts -> blocks with the meta flags won't remove the comments / mess things up (e.g. any `@highlight` in a comment was previously getting deleted, which doesn't matter much but better to just not do it).

and for an example; the following markdown hint produces the snippet below

````markdown
```blocks
// @hide
function doSomething (num: number, list: any[]) {

}
// @hide
let mySprite = sprites.create(img`
    . . . . . . . . . . . . . . . .
    . . . . . . . . . . . . . . . .
    . . . . . . . . . . . . . . . .
    . . . . . . . . 3 3 . . . . . .
    . . . . . . . 3 . 3 3 . . . . .
    . . . . . . 3 3 . . 3 . . . . .
    . . . 3 3 3 3 3 . . 3 . . . . .
    . . . 3 . . 3 3 . . 3 . . . . .
    . . . 3 . . . . . . 3 . . . . .
    . . . . 3 . . . . . 3 . . . . .
    . . . . . 3 . . . 3 . . . . . .
    . . . . . . 3 . 3 . . . . . . .
    . . . . . . . 3 . . . . . . . .
    . . . . . . . . . . . . . . . .
    . . . . . . . . . . . . . . . .
    . . . . . . . . . . . . . . . .
    `, SpriteKind.Player)
// @highlight
mySprite.vy += 0
let list = [0, 1]
doSomething(1, list)
```
````

<img width="393" alt="image" src="https://user-images.githubusercontent.com/5615930/206025712-545f5d7d-e488-456c-aa1d-92a197e7c63b.png">

(I think it's worth some brainstorming on what else we can add here, as it's a pretty nice / easy place to slot in features for rendering; e.g. if we wanted to be fancy we could probably attach markers onto block.data or something and use those to grab the blocks later on to add an arrow svg pointing at it or anything of the sort, or to programmatically animate it being dragged in. Maybe also worth bring over the 'unmodified' coloring from the git diff as an option to emphasize changed blocks in hints even more)
