### PR TITLE
Color palette editor: support for multiple custom palettes

### DIFF
--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -507,6 +507,7 @@ namespace pxt {
     export const TUTORIAL_INFO_FILE = "tutorial-info-cache.json";
     export const TUTORIAL_CUSTOM_TS = "tutorial.custom.ts";
     export const BREAKPOINT_TABLET = 991; // TODO (shakao) revisit when tutorial stuff is more settled
+    export const PALETTES_FILE = "_palettes.json";
 
     export function outputName(trg: pxtc.CompileTarget = null) {
         if (!trg) trg = appTarget.compile

--- a/react-common/components/controls/Modal.tsx
+++ b/react-common/components/controls/Modal.tsx
@@ -10,6 +10,7 @@ export interface ModalAction {
     disabled?: boolean;
     icon?: string;
     xicon?: boolean;
+    leftIcon?: string;
     onClick: () => void;
     url?: string;
 
@@ -117,6 +118,7 @@ export const Modal = (props: ModalProps) => {
                             label={action.label}
                             title={action.label}
                             rightIcon={(action.xicon ? "xicon " : "") + action.icon}
+                            leftIcon={action.leftIcon}
                         />
                     )}
                 </div>

--- a/react-common/components/palette/ColorPickerField.tsx
+++ b/react-common/components/palette/ColorPickerField.tsx
@@ -42,7 +42,7 @@ export const ColorPickerField = (props: ColorPickerFieldProps) => {
         </div>
         <div className="common-color-inputs">
             <input type="color" value={currentColor || color} onBlur={onBlur} onChange={onColorPickerChanged} />
-            <Input initialValue={currentColor || color} onChange={onTextInputChanged} />
+            <Input initialValue={currentColor || color.toUpperCase()} onChange={onTextInputChanged} />
         </div>
         <Button className="circle-button" title={lf("Move color up")} leftIcon="fas fa-arrow-up" onClick={() => onMoveColor(true)} />
         <Button className="circle-button" title={lf("Move color down")} leftIcon="fas fa-arrow-down" onClick={() => onMoveColor(false)} />

--- a/react-common/components/palette/ColorPickerField.tsx
+++ b/react-common/components/palette/ColorPickerField.tsx
@@ -41,7 +41,7 @@ export const ColorPickerField = (props: ColorPickerFieldProps) => {
             {index}
         </div>
         <div className="common-color-inputs">
-            <input type="color" value={currentColor || color} onBlur={onBlur} onChange={onColorPickerChanged} />
+            <input className="color-input" type="color" value={currentColor || color} onBlur={onBlur} onChange={onColorPickerChanged} />
             <Input initialValue={currentColor || color.toUpperCase()} onChange={onTextInputChanged} />
         </div>
         <Button className="circle-button" title={lf("Move color up")} leftIcon="fas fa-arrow-up" onClick={() => onMoveColor(true)} />

--- a/react-common/components/palette/PalettePicker.tsx
+++ b/react-common/components/palette/PalettePicker.tsx
@@ -15,8 +15,7 @@ export const PalettePicker = (props: PalettePickerProps) => {
         onPaletteSelected(palettes.find(p => p.id === id));
     }
 
-    return <div className="common-palette-picker">
-        <Dropdown
+    return <Dropdown
             id="common-palette-picker"
             selectedId={selectedId}
             onItemSelected={onItemSelected}
@@ -26,5 +25,4 @@ export const PalettePicker = (props: PalettePickerProps) => {
                 label: <PaletteSwatch palette={p} />
             }))}
         />
-    </div>
 }

--- a/react-common/components/palette/Palettes.ts
+++ b/react-common/components/palette/Palettes.ts
@@ -2,6 +2,7 @@ export interface Palette {
     name: string;
     id: string;
     colors: string[];
+    custom?: boolean;
 }
 
 export const Adafruit: Palette = {

--- a/react-common/styles/palette/ColorPickerField.less
+++ b/react-common/styles/palette/ColorPickerField.less
@@ -19,7 +19,7 @@
         margin-right: 0.5rem;
     }
 
-    input:hover {
+    .color-input:hover {
         cursor: pointer;
     }
 }

--- a/react-common/styles/palette/ColorPickerField.less
+++ b/react-common/styles/palette/ColorPickerField.less
@@ -1,6 +1,6 @@
 .common-color-picker-field {
     display: grid;
-    grid-template-columns: 1fr 8fr 1fr 1fr;
+    grid-template-columns: 0.5fr 8fr 1fr 1fr;
     align-items: center;
     padding: 0.1rem 0rem;
 }

--- a/react-common/styles/palette/ColorPickerField.less
+++ b/react-common/styles/palette/ColorPickerField.less
@@ -18,4 +18,8 @@
         flex-grow: 1;
         margin-right: 0.5rem;
     }
+
+    input:hover {
+        cursor: pointer;
+    }
 }

--- a/react-common/styles/palette/PalettePicker.less
+++ b/react-common/styles/palette/PalettePicker.less
@@ -2,9 +2,10 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    margin-bottom: 1rem;
 }
 
 .common-palette-editor {
-    max-height: 35rem;
+    max-height: ~"min(35rem, calc(100vh - 15rem))";
     overflow-y: auto;
 }

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -253,6 +253,13 @@
         color: @grey;
     }
 }
+
+.palette-delete-button.common-button {
+    background: none;
+    border: none;
+    padding: 0;
+}
+
 .palette-save-button.common-button.disabled.green {
     background-color: @grey;
     color: @white;

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -243,3 +243,9 @@
         transform: rotate(90deg);
     }
 }
+
+.palette-transparent-button.common-button {
+    background: none transparent;
+    border: none;
+
+}

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -260,7 +260,7 @@
     padding: 0;
 }
 
-.palette-save-button.common-button.disabled.green {
+.palette-apply-button.common-button.disabled.green {
     background-color: @grey;
     color: @white;
 }

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -254,12 +254,6 @@
     }
 }
 
-.palette-delete-button.common-button {
-    background: none;
-    border: none;
-    padding: 0;
-}
-
 .palette-apply-button.common-button.disabled.green,
 .palette-done-button.common-button.disabled.teal {
     background-color: @grey;

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -247,5 +247,13 @@
 .palette-transparent-button.common-button {
     background: none transparent;
     border: none;
-
+    &.disabled {
+        background: none transparent;
+        border: none;
+        color: @grey;
+    }
+}
+.palette-save-button.common-button.disabled.green {
+    background-color: @grey;
+    color: @white;
 }

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -260,7 +260,12 @@
     padding: 0;
 }
 
-.palette-apply-button.common-button.disabled.green {
+.palette-apply-button.common-button.disabled.green,
+.palette-done-button.common-button.disabled.teal {
     background-color: @grey;
     color: @white;
+}
+
+.invalid-palette-name {
+    color: @red;
 }

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -3,8 +3,14 @@ import { useEffect, useRef, useState } from "react";
 import { Modal, ModalAction } from "../../../../react-common/components/controls/Modal";
 import { PalettePicker } from "../../../../react-common/components/palette/PalettePicker";
 import { PaletteEditor } from "../../../../react-common/components/palette/PaletteEditor";
-import { AllPalettes, Palette } from "../../../../react-common/components/palette/Palettes";
+import { AllPalettes as BuiltinPalettes, Palette } from "../../../../react-common/components/palette/Palettes";
+import { Input } from "../../../../react-common/components/controls/Input";
 
+export interface CustomPalettes {
+    nextPaletteID: number;
+    initialPalette: Palette; // could be custom or built-in
+    palettes: Palette[];
+}
 export interface AssetPaletteProps {
     onClose: (paletteChanged: boolean) => void;
 }
@@ -14,64 +20,85 @@ export const AssetPalette = (props: AssetPaletteProps) => {
 
     const [showExitModal, setShowExitModal] = useState<boolean>(false);
 
+    const [showNameModal, setShowNameModal] = useState<boolean>(false);
+
     const inExitModal = useRef<boolean>(false);
 
-    const initialColors = useRef<string[] | undefined>(pkg.mainPkg.config.palette || pxt.appTarget.runtime.palette)
+    const firstRender = useRef<boolean>(true);
 
-    const [prevColors, setPrevColors] = useState<string[] | undefined>(pkg.mainPkg.config.palette || pxt.appTarget.runtime.palette);
+    const customPalettes = useRef<CustomPalettes | undefined>(undefined);
 
-    const [currentColors, setCurrentColors] = useState<string[] | undefined>(pkg.mainPkg.config.palette || pxt.appTarget.runtime.palette);
+    const [prevPalette, setPrevPalette] = useState<Palette | undefined>(undefined);
+
+    const [currentPalette, setCurrentPalette] = useState<Palette | undefined>(undefined);
 
     const [disableButtons, setDisableButtons] = useState<boolean>(true);
 
     useEffect(() => {
+        firstRender.current = false;
+        setPrevPalette(customPalettes.current.initialPalette);
+        setCurrentPalette(customPalettes.current.initialPalette);
+    }, []);
+
+    useEffect(() => {
         // save pxt.json
-        pkg.mainEditorPkg().updateConfigAsync(cfg => cfg.palette = currentColors);
+        pkg.mainEditorPkg().updateConfigAsync(cfg => cfg.palette = currentPalette.colors);
         if (inExitModal.current) {
             onFinalClose();
             inExitModal.current = false;
         }
-    }, [currentColors]);
+    }, [currentPalette]);
 
     const onPaletteEdit = (selected: Palette) => {
-        setCurrentColors(selected.colors);
-        if (!isSameAsCurrentColors(prevColors)) {
+        if (!firstRender.current && !isSameColors(currentPalette.colors, selected.colors)) {
             setDisableButtons(false);
-        } else {
-            setDisableButtons(true);
+            if (selected.id !== currentPalette.id) { // palette selected
+                setCurrentPalette(selected);
+            } else if (isBuiltinPalette(selected)) { // builtin palette edited
+                // create new custom palette and prompt user to name custom palette
+                const customPalette = {
+                    id: "custom" + customPalettes.current.nextPaletteID++,
+                    name: lf("Custom Palette"),
+                    colors: selected.colors,
+                    custom: true
+                }
+                customPalettes.current.palettes.unshift(customPalette);
+                setCurrentPalette(customPalette);
+                setShowNameModal(true);
+            } else { // custom palette edited
+                const i = customPalettes.current.palettes.findIndex(p => p.id === currentPalette.id);
+                customPalettes.current.palettes[i].colors = selected.colors;
+                setCurrentPalette(selected);
+            }
         }
     }
 
     const onFinalClose = () => {
-        const paletteChanged = !isSameAsCurrentColors(initialColors.current);
+        const paletteChanged = !isSameColors(customPalettes.current.initialPalette.colors, prevPalette.colors);
         onClose(paletteChanged);
         if (paletteChanged) {
-            pxt.tickEvent("palette.modified", {id: getCurrentPalette().id})
+            pxt.tickEvent("palette.modified", {id: currentPalette.id})
         }
     }
 
     const onModalClose = () => {
         // check whether exiting without saved changes
-        if (!isSameAsCurrentColors(prevColors)) {
-            setShowExitModal(true);
-        } else {
-            onFinalClose();
-        }
+        (isSameColors(currentPalette.colors, prevPalette.colors)) ? onFinalClose() : setShowExitModal(true);
     }
 
     const onExit = () => {
         inExitModal.current = true;
         setShowExitModal(false);
-        setCurrentColors(prevColors);
+        setCurrentPalette(prevPalette);
     }
 
     const onReset = () => {
-        setCurrentColors(prevColors);
+        setCurrentPalette(prevPalette);
         setDisableButtons(true);
     }
 
     const onSave = () => {
-        setPrevColors(currentColors);
+        setPrevPalette(currentPalette);
         setDisableButtons(true);
     }
 
@@ -79,12 +106,30 @@ export const AssetPalette = (props: AssetPaletteProps) => {
         setShowExitModal(false);
     }
 
-    const renderPaletteModal = () => {
-        const currentPalette = getCurrentPalette();
-        let paletteOptions = AllPalettes.slice();
+    const onNameDone = () => {
+        setShowNameModal(false);
+    }
 
-        if (!paletteOptions.some(p => p.id === currentPalette.id)) {
-            paletteOptions.unshift(currentPalette)
+    const setName = (name: string) => {
+        const i = customPalettes.current.palettes.findIndex(p => p.id === currentPalette.id);
+        customPalettes.current.palettes[i].name = name;
+        setCurrentPalette({...currentPalette, name: name});
+    }
+
+    const renderPaletteModal = () => {
+        if (firstRender.current) {
+            const f = pkg.mainEditorPkg().lookupFile("this/_palettes.json");
+            if (f) {
+                customPalettes.current = JSON.parse(f.content) as CustomPalettes;
+            } else {
+                initiatePalettes();
+            }
+        }
+
+        let paletteOptions = customPalettes.current.palettes.concat(BuiltinPalettes);
+
+        if (!paletteOptions.some(p => p.id === (currentPalette?.id || customPalettes.current.initialPalette.id))) {
+            paletteOptions.unshift(currentPalette || customPalettes.current.initialPalette)
         }
 
         const actions: ModalAction[] = [
@@ -96,43 +141,74 @@ export const AssetPalette = (props: AssetPaletteProps) => {
             { label: lf("Exit"), onClick: onExit, className: 'teal' }
         ];
 
+        const nameActions: ModalAction[] = [
+            { label: lf("Done"), onClick: onNameDone, className: 'teal' }
+        ];
+
         return <div>
             <Modal title={lf("Project Color Palette")} onClose={onModalClose} actions={actions}>
                 <PalettePicker
                     palettes={paletteOptions}
-                    selectedId={currentPalette.id}
+                    selectedId={currentPalette?.id  || customPalettes.current.initialPalette.id}
                     onPaletteSelected={onPaletteEdit} />
-                <PaletteEditor palette={currentPalette} onPaletteChanged={onPaletteEdit} />
+                <PaletteEditor palette={currentPalette || customPalettes.current.initialPalette} onPaletteChanged={onPaletteEdit} />
             </Modal>
             {showExitModal && <Modal title={lf("Exit Without Saving")} onClose={onGoBack} actions={exitActions}>
                 <div>{lf("Exit without saving? Your palette changes will be reverted.")}</div>
             </Modal>}
+            {showNameModal && <Modal title={lf("Name Your Custom Palette")} onClose={onNameDone} actions={nameActions}>
+                <Input
+                    className="palette-name-input"
+                    initialValue={currentPalette.name}
+                    placeholder={lf("Palette Name")}
+                    onBlur={setName}
+                    onEnterKey={setName} />
+            </Modal>}
         </div>
     }
 
-    const getCurrentPalette = () => {
-        if (currentColors) {
-            for (const palette of AllPalettes) {
-                if (isSameAsCurrentColors(palette.colors)) return palette;
-            }
-        }
-
-        return {
-            id: "custom",
-            name: lf("Custom Palette"),
-            colors: currentColors
-        };
-    }
-
-    const isSameAsCurrentColors = (colorSet: string[]) => {
+    const isSameColors = (colorSet1: string[], colorSet2: string[]) => {
         let isEqual = true;
-        for (let i = 0; i < colorSet.length; i++) {
-            if (currentColors[i].toLowerCase() !== colorSet[i].toLowerCase()) {
+        for (let i = 0; i < colorSet1.length; i++) {
+            if (colorSet1[i].toLowerCase() !== colorSet2[i].toLowerCase()) {
                 isEqual = false;
                 break;
             }
         }
         return isEqual;
+    }
+
+    const initiatePalettes = () => {
+        const colors = pkg.mainPkg.config.palette || pxt.appTarget.runtime.palette;
+        let match = false;
+        for (const palette of BuiltinPalettes) {
+            if (isSameColors(colors, palette.colors)) {
+                match = true;
+                customPalettes.current = {
+                    nextPaletteID: 0,
+                    initialPalette: palette,
+                    palettes: []
+                };
+                break;
+            }
+        }
+        if (!match) {
+            const customPalette = {
+                id: "custom0",
+                name: lf("Custom Palette"),
+                colors: colors,
+                custom: true
+            }
+            customPalettes.current = {
+                nextPaletteID: 1,
+                initialPalette: customPalette,
+                palettes: [customPalette]
+            };
+        }
+    }
+
+    const isBuiltinPalette = (palette: Palette) => {
+        return BuiltinPalettes.some(p => p.id === palette.id);
     }
 
     return renderPaletteModal();

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -1,6 +1,6 @@
 import * as pkg from "../../package";
-import { useEffect, useState } from "react";
-import { Modal } from "../../../../react-common/components/controls/Modal";
+import { useEffect, useRef, useState } from "react";
+import { Modal, ModalAction } from "../../../../react-common/components/controls/Modal";
 import { PalettePicker } from "../../../../react-common/components/palette/PalettePicker";
 import { PaletteEditor } from "../../../../react-common/components/palette/PaletteEditor";
 import { AllPalettes, Palette } from "../../../../react-common/components/palette/Palettes";
@@ -12,22 +12,71 @@ export interface AssetPaletteProps {
 export const AssetPalette = (props: AssetPaletteProps) => {
     const { onClose } = props;
 
-    const [initialColors, setInitialColors] = useState<string[] | undefined>(pkg.mainPkg.config.palette || pxt.appTarget.runtime.palette);
+    const [showExitModal, setShowExitModal] = useState<boolean>(false);
+
+    const inExitModal = useRef<boolean>(false);
+
+    const initialColors = useRef<string[] | undefined>(pkg.mainPkg.config.palette || pxt.appTarget.runtime.palette)
+
+    const [prevColors, setPrevColors] = useState<string[] | undefined>(pkg.mainPkg.config.palette || pxt.appTarget.runtime.palette);
 
     const [currentColors, setCurrentColors] = useState<string[] | undefined>(pkg.mainPkg.config.palette || pxt.appTarget.runtime.palette);
+
+    const [disableButtons, setDisableButtons] = useState<boolean>(true);
 
     useEffect(() => {
         // save pxt.json
         pkg.mainEditorPkg().updateConfigAsync(cfg => cfg.palette = currentColors);
+        if (inExitModal.current) {
+            onFinalClose();
+            inExitModal.current = false;
+        }
     }, [currentColors]);
 
     const onPaletteEdit = (selected: Palette) => {
         setCurrentColors(selected.colors);
+        if (!isSameAsCurrentColors(prevColors)) {
+            setDisableButtons(false);
+        } else {
+            setDisableButtons(true);
+        }
+    }
+
+    const onFinalClose = () => {
+        const paletteChanged = !isSameAsCurrentColors(initialColors.current);
+        onClose(paletteChanged);
+        if (paletteChanged) {
+            pxt.tickEvent("palette.modified", {id: getCurrentPalette().id})
+        }
     }
 
     const onModalClose = () => {
-        // check whether there is a change and update project view accordingly
-        onClose(!isSameAsCurrentColors(initialColors));
+        // check whether exiting without saved changes
+        if (!isSameAsCurrentColors(prevColors)) {
+            setShowExitModal(true);
+        } else {
+            onFinalClose();
+        }
+    }
+
+    const onExit = () => {
+        inExitModal.current = true;
+        setShowExitModal(false);
+        setCurrentColors(prevColors);
+    }
+
+    const onReset = () => {
+        setCurrentColors(prevColors);
+        setDisableButtons(true);
+    }
+
+    const onSave = () => {
+        setPrevColors(currentColors);
+        setDisableButtons(true);
+    }
+
+    const onGoBack = () => {
+        setShowExitModal(false);
     }
 
     const renderPaletteModal = () => {
@@ -38,14 +87,27 @@ export const AssetPalette = (props: AssetPaletteProps) => {
             paletteOptions.unshift(currentPalette)
         }
 
-        return <Modal title={lf("Edit Palette")} onClose={onModalClose}>
-            <PalettePicker
-                palettes={paletteOptions}
-                selectedId={currentPalette.id}
-                onPaletteSelected={onPaletteEdit}
-            />
-            <PaletteEditor palette={currentPalette} onPaletteChanged={onPaletteEdit}/>
-        </Modal>
+        const actions: ModalAction[] = [
+            { label: lf("Reset"), onClick: onReset, leftIcon: 'icon undo', className: 'palette-transparent-button', disabled: disableButtons },
+            { label: lf("Save"), onClick: onSave, className: 'green', disabled: disableButtons }
+        ];
+
+        const exitActions: ModalAction[] = [
+            { label: lf("Exit"), onClick: onExit, className: 'teal' }
+        ];
+
+        return <div>
+            <Modal title={lf("Project Color Palette")} onClose={onModalClose} actions={actions}>
+                <PalettePicker
+                    palettes={paletteOptions}
+                    selectedId={currentPalette.id}
+                    onPaletteSelected={onPaletteEdit} />
+                <PaletteEditor palette={currentPalette} onPaletteChanged={onPaletteEdit} />
+            </Modal>
+            {showExitModal && <Modal title={lf("Exit Without Saving")} onClose={onGoBack} actions={exitActions}>
+                <div>{lf("Exit without saving? Your palette changes will be reverted.")}</div>
+            </Modal>}
+        </div>
     }
 
     const getCurrentPalette = () => {

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -122,8 +122,6 @@ export const AssetPalette = (props: AssetPaletteProps) => {
         } else {
             setCurrentPalette(prevPalette);
         }
-
-
     }
 
     const renderPaletteModal = () => {

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -31,6 +31,8 @@ export const AssetPalette = (props: AssetPaletteProps) => {
 
     const [disableButtons, setDisableButtons] = useState<boolean>(true);
 
+    const [invalidName, setInvalidName] = useState<boolean>(false);
+
     useEffect(() => {
         initiatePalettes();
     }, []);
@@ -116,9 +118,17 @@ export const AssetPalette = (props: AssetPaletteProps) => {
 
     const onNameDone = () => {
         setShowNameModal(false);
+        setInvalidName(false);
     }
 
     const setName = (name: string) => {
+        name = name.trim();
+        if (name.length === 0) {
+            setInvalidName(true);
+            return
+        } else {
+            setInvalidName(false);
+        }
         setCustomPalettes({
             ...customPalettes,
             palettes: {
@@ -208,7 +218,7 @@ export const AssetPalette = (props: AssetPaletteProps) => {
     ];
 
     const nameActions: ModalAction[] = [
-        { label: lf("Done"), onClick: onNameDone, className: 'teal' }
+        { label: lf("Done"), onClick: onNameDone, className: 'teal palette-done-button', disabled: invalidName }
     ];
 
     return <div>
@@ -234,10 +244,11 @@ export const AssetPalette = (props: AssetPaletteProps) => {
         {showNameModal && <Modal title={lf("Name Your Custom Palette")} onClose={onNameDone} actions={nameActions}>
             <Input
                 className="palette-name-input"
-                initialValue={currentPalette.name}
+                initialValue={invalidName ? "" : currentPalette.name}
                 placeholder={lf("Palette Name")}
                 onBlur={setName}
                 onEnterKey={setName} />
+            {invalidName && <p className="invalid-palette-name">{lf("Name must not be empty")}</p>}
         </Modal>}
     </div>
 }

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -18,20 +18,13 @@ export interface AssetPaletteProps {
 
 export const AssetPalette = (props: AssetPaletteProps) => {
     const { onClose } = props;
-
-    const [showExitModal, setShowExitModal] = useState<boolean>(false);
-
-    const [showNameModal, setShowNameModal] = useState<boolean>(false);
-
     const [customPalettes, setCustomPalettes] = useState<CustomPalettes>(undefined);
-
     const [initialPalette, setinitialPalette] = useState<Palette | undefined>(undefined);
-
     const [currentPalette, setCurrentPalette] = useState<Palette | undefined>(undefined);
-
-    const [disableButtons, setDisableButtons] = useState<boolean>(true);
-
+    const [showExitModal, setShowExitModal] = useState<boolean>(false);
+    const [showNameModal, setShowNameModal] = useState<boolean>(false);
     const [invalidName, setInvalidName] = useState<boolean>(false);
+    const [disableButtons, setDisableButtons] = useState<boolean>(true);
 
     useEffect(() => {
         initiatePalettes();

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -23,8 +23,6 @@ export const AssetPalette = (props: AssetPaletteProps) => {
 
     const [showNameModal, setShowNameModal] = useState<boolean>(false);
 
-    const inExitModal = useRef<boolean>(false);
-
     const [customPalettes, setCustomPalettes] = useState<CustomPalettes>({nextPaletteID: 0, palettes: []});
 
     const [initialPalette, setinitialPalette] = useState<Palette | undefined>(undefined);
@@ -38,15 +36,6 @@ export const AssetPalette = (props: AssetPaletteProps) => {
     useEffect(() => {
         initiatePalettes();
     }, []);
-
-    useEffect(() => {
-        // save pxt.json
-        pkg.mainEditorPkg().updateConfigAsync(cfg => cfg.palette = currentPalette.colors);
-        if (inExitModal.current) {
-            onFinalClose();
-            inExitModal.current = false;
-        }
-    }, [currentPalette]);
 
     const onPaletteEdit = (selected: Palette) => {
         if (currentPalette && !isSameColors(currentPalette.colors, selected.colors)) {
@@ -79,10 +68,12 @@ export const AssetPalette = (props: AssetPaletteProps) => {
 
     const onFinalClose = () => {
         const paletteChanged = !isSameColors(initialPalette.colors, prevPalette.colors);
-        onClose(paletteChanged);
         if (paletteChanged) {
             pxt.tickEvent("palette.modified", {id: prevPalette.id})
+            // save pxt.json
+            pkg.mainEditorPkg().updateConfigAsync(cfg => cfg.palette = prevPalette.colors);
         }
+        onClose(paletteChanged);
     }
 
     const onModalClose = () => {
@@ -95,9 +86,8 @@ export const AssetPalette = (props: AssetPaletteProps) => {
     }
 
     const onExit = () => {
-        inExitModal.current = true;
         setShowExitModal(false);
-        setCurrentPalette(prevPalette);
+        onFinalClose();
     }
 
     const onReset = () => {

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -2,7 +2,6 @@ import * as pkg from "../../package";
 import { useEffect, useState } from "react";
 import { Modal, ModalAction } from "../../../../react-common/components/controls/Modal";
 import { Input } from "../../../../react-common/components/controls/Input";
-import { Button } from "../../../../react-common/components/controls/Button";
 import { PalettePicker } from "../../../../react-common/components/palette/PalettePicker";
 import { PaletteEditor } from "../../../../react-common/components/palette/PaletteEditor";
 import { AllPalettes as BuiltinPalettes, Arcade, Palette } from "../../../../react-common/components/palette/Palettes";
@@ -74,7 +73,7 @@ export const AssetPalette = (props: AssetPaletteProps) => {
     }
 
     const onFinalClose = (paletteChanged: boolean) => {
-        pkg.mainEditorPkg().setFile("_palettes.json", JSON.stringify(customPalettes, undefined, 4)); // TODO: make virtual file after testing
+        pkg.mainEditorPkg().setFile("_palettes.json", JSON.stringify(customPalettes, undefined, 4));
         if (paletteChanged) {
             pxt.tickEvent("palette.modified", {id: currentPalette.id})
             // save pxt.json
@@ -133,17 +132,6 @@ export const AssetPalette = (props: AssetPaletteProps) => {
             }
         });
         setCurrentPalette({ ...currentPalette, name: name });
-    }
-
-    const deletePalette = () => {
-        setCustomPalettes({
-            ...customPalettes,
-            palettes: {
-                ...customPalettes.palettes,
-                [currentPalette.id]: undefined
-            }
-        });
-        setCurrentPalette(Arcade);
     }
 
     const isSameColors = (colorSet1: string[], colorSet2: string[]) => {
@@ -221,13 +209,6 @@ export const AssetPalette = (props: AssetPaletteProps) => {
                     palettes={paletteOptions}
                     selectedId={currentPalette?.id || Arcade.id}
                     onPaletteSelected={onPaletteEdit} />
-                {(currentPalette?.custom) && <Button
-                    label={lf("Delete")}
-                    title={lf("Delete the selected palete")}
-                    ariaLabel={lf("Delete the selected palette")}
-                    className="palette-delete-button"
-                    leftIcon="icon trash"
-                    onClick={deletePalette} />}
             </div>
             <PaletteEditor palette={currentPalette || Arcade} onPaletteChanged={onPaletteEdit} />
         </Modal>

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -1,10 +1,12 @@
 import * as pkg from "../../package";
 import { useEffect, useRef, useState } from "react";
 import { Modal, ModalAction } from "../../../../react-common/components/controls/Modal";
+import { Input } from "../../../../react-common/components/controls/Input";
+import { Button } from "../../../../react-common/components/controls/Button";
 import { PalettePicker } from "../../../../react-common/components/palette/PalettePicker";
 import { PaletteEditor } from "../../../../react-common/components/palette/PaletteEditor";
-import { AllPalettes as BuiltinPalettes, Palette } from "../../../../react-common/components/palette/Palettes";
-import { Input } from "../../../../react-common/components/controls/Input";
+import { AllPalettes as BuiltinPalettes, Arcade, Palette } from "../../../../react-common/components/palette/Palettes";
+
 
 export interface CustomPalettes {
     nextPaletteID: number;
@@ -120,6 +122,11 @@ export const AssetPalette = (props: AssetPaletteProps) => {
         setCurrentPalette({...currentPalette, name: name});
     }
 
+    const deletePalette = () => {
+        setCurrentPalette(Arcade);
+        customPalettes.current.palettes = customPalettes.current.palettes.filter(p => p.id !== currentPalette.id);
+    }
+
     const renderPaletteModal = () => {
         if (firstRender.current) {
             const f = pkg.mainEditorPkg().lookupFile("this/_palettes.json");
@@ -151,10 +158,19 @@ export const AssetPalette = (props: AssetPaletteProps) => {
 
         return <div>
             <Modal title={lf("Project Color Palette")} onClose={onModalClose} actions={actions}>
-                <PalettePicker
-                    palettes={paletteOptions}
-                    selectedId={currentPalette?.id  || customPalettes.current.initialPalette.id}
-                    onPaletteSelected={onPaletteEdit} />
+                <div className="common-palette-picker">
+                    <PalettePicker
+                        palettes={paletteOptions}
+                        selectedId={currentPalette?.id  || customPalettes.current.initialPalette.id}
+                        onPaletteSelected={onPaletteEdit} />
+                    {(currentPalette?.custom) && <Button
+                        label={lf("Delete")}
+                        title={lf("Delete the selected palete")}
+                        ariaLabel={lf("Delete the selected palette")}
+                        className="palette-delete-button"
+                        leftIcon="icon trash"
+                        onClick={deletePalette} />}
+                </div>
                 <PaletteEditor palette={currentPalette || customPalettes.current.initialPalette} onPaletteChanged={onPaletteEdit} />
             </Modal>
             {showExitModal && <Modal title={lf("Exit Without Saving")} onClose={onGoBack} actions={exitActions}>

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -116,7 +116,14 @@ export const AssetPalette = (props: AssetPaletteProps) => {
     const deletePalette = () => {
         customPalettes.palettes.delete(currentPalette.id);
         setCustomPalettes({...customPalettes, palettes: customPalettes.palettes});
-        setCurrentPalette(Arcade);
+        if (prevPalette.id === currentPalette.id) {
+            setPrevPalette(Arcade);
+            setCurrentPalette(Arcade);
+        } else {
+            setCurrentPalette(prevPalette);
+        }
+
+
     }
 
     const renderPaletteModal = () => {

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -18,7 +18,7 @@ export interface AssetPaletteProps {
 export const AssetPalette = (props: AssetPaletteProps) => {
     const { onClose } = props;
     const [customPalettes, setCustomPalettes] = useState<CustomPalettes>(undefined);
-    const [initialPalette, setinitialPalette] = useState<Palette | undefined>(undefined);
+    const [initialPalette, setInitialPalette] = useState<Palette | undefined>(undefined);
     const [currentPalette, setCurrentPalette] = useState<Palette | undefined>(undefined);
     const [showExitModal, setShowExitModal] = useState<boolean>(false);
     const [showNameModal, setShowNameModal] = useState<boolean>(false);
@@ -26,7 +26,7 @@ export const AssetPalette = (props: AssetPaletteProps) => {
     const [disableButtons, setDisableButtons] = useState<boolean>(true);
 
     useEffect(() => {
-        initiatePalettes();
+        initializePalettes();
     }, []);
 
     useEffect(() => {
@@ -145,7 +145,7 @@ export const AssetPalette = (props: AssetPaletteProps) => {
         return isEqual;
     }
 
-    const initiatePalettes = () => {
+    const initializePalettes = () => {
         const f = pkg.mainEditorPkg().lookupFile("this/" + pxt.PALETTES_FILE);
         let initialCustomPalettes: CustomPalettes = undefined;
         if (f) {
@@ -159,7 +159,7 @@ export const AssetPalette = (props: AssetPaletteProps) => {
         for (const palette of paletteOptions) {
             if (isSameColors(colors, palette.colors)) {
                 match = true;
-                setinitialPalette(palette);
+                setInitialPalette(palette);
                 setCurrentPalette(palette);
                 break;
             }
@@ -172,7 +172,7 @@ export const AssetPalette = (props: AssetPaletteProps) => {
                 custom: true
             }
             initialCustomPalettes.palettes[customPalette.id] = customPalette;
-            setinitialPalette(customPalette);
+            setInitialPalette(customPalette);
             setCurrentPalette(customPalette);
         }
         setCustomPalettes(initialCustomPalettes);

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -83,7 +83,11 @@ export const AssetPalette = (props: AssetPaletteProps) => {
 
     const onModalClose = () => {
         // check whether exiting without saved changes
-        (isSameColors(currentPalette.colors, prevPalette.colors)) ? onFinalClose() : setShowExitModal(true);
+        if (isSameColors(currentPalette.colors, prevPalette.colors)) {
+            onFinalClose();
+        } else {
+            setShowExitModal(true);
+        }
     }
 
     const onExit = () => {
@@ -134,7 +138,7 @@ export const AssetPalette = (props: AssetPaletteProps) => {
 
         const actions: ModalAction[] = [
             { label: lf("Reset"), onClick: onReset, leftIcon: 'icon undo', className: 'palette-transparent-button', disabled: disableButtons },
-            { label: lf("Save"), onClick: onSave, className: 'green', disabled: disableButtons }
+            { label: lf("Save"), onClick: onSave, className: 'green palette-save-button', disabled: disableButtons }
         ];
 
         const exitActions: ModalAction[] = [

--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -73,7 +73,7 @@ export const AssetPalette = (props: AssetPaletteProps) => {
     }
 
     const onFinalClose = (paletteChanged: boolean) => {
-        pkg.mainEditorPkg().setFile("_palettes.json", JSON.stringify(customPalettes, undefined, 4));
+        pkg.mainEditorPkg().setFile(pxt.PALETTES_FILE, JSON.stringify(customPalettes, undefined, 4));
         if (paletteChanged) {
             pxt.tickEvent("palette.modified", {id: currentPalette.id})
             // save pxt.json
@@ -146,7 +146,7 @@ export const AssetPalette = (props: AssetPaletteProps) => {
     }
 
     const initiatePalettes = () => {
-        const f = pkg.mainEditorPkg().lookupFile("this/_palettes.json");
+        const f = pkg.mainEditorPkg().lookupFile("this/" + pxt.PALETTES_FILE);
         let initialCustomPalettes: CustomPalettes = undefined;
         if (f) {
             initialCustomPalettes = JSON.parse(f.content) as CustomPalettes;

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -155,6 +155,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
 
     protected showPaletteModal = () => {
         this.setState({ showPaletteModal: true });
+        pxt.tickEvent("palette.open");
     }
 
     protected hidePaletteModal = (paletteChanged: boolean) => {

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -232,8 +232,9 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
                     leftIcon="icon trash"
                     onClick={this.showDeleteModal} />}
                 <Button className="teal asset-palette-button"
-                    title={lf("Color Palette")}
                     label={lf("Color Palette")}
+                    title={lf("Open the color palette")}
+                    ariaLabel={lf("Open the color palette")}
                     leftIcon="fas fa-palette"
                     onClick={this.showPaletteModal}
                 />

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -456,7 +456,7 @@ export class EditorPackage {
     sortedFiles(): File[] {
         let lst = Util.values(this.files)
         if (!pxt.options.debug)
-            lst = lst.filter(f => f.name != pxt.github.GIT_JSON && f.name != pxt.SIMSTATE_JSON && f.name != pxt.SERIAL_EDITOR_FILE)
+            lst = lst.filter(f => f.name != pxt.github.GIT_JSON && f.name != pxt.SIMSTATE_JSON && f.name != pxt.SERIAL_EDITOR_FILE && f.name != pxt.PALETTES_FILE)
         lst.sort((a, b) => a.weight() - b.weight() || Util.strcmp(a.name, b.name))
         return lst
     }


### PR DESCRIPTION
Users can now create unlimited custom palettes, allowing them to more easily test out how their assets look with different palettes. Before, users were only able to have one custom palette at a time and if they swapped to one of the built-in palettes, they would lose their custom palette. Now, their custom palettes are stored in a hidden file and users can access them through the dropdown.

I also changed the 'save' button to 'apply' which now applies the changes and closes the modal instead of saving and keeping the modal open. With this change, there is no intermediary palette and therefore 'reset' always sets the palette back to what it was when the palette editor was opened.

When a user edits a built-in palette, it automatically becomes a custom palette and prompts the user to name the palette.

Try it out here: https://arcade.makecode.com/app/640a2320e33b39231cea8193bf4cb6ba72e56ace-e43fec8b3b

![image](https://user-images.githubusercontent.com/15070078/210674378-412f6b4d-74f4-4ef6-b5d7-cc0bca8b91fb.png)
![image](https://user-images.githubusercontent.com/15070078/210674442-2df7ec9e-abef-44b7-b087-9fc1183426d9.png)
![image](https://user-images.githubusercontent.com/15070078/210674511-ca653f6b-e66a-4c6d-bc18-146351fe08a4.png)


Still To Do:
- add functionality/UI for deleting custom palettes
- add scroll bar for dropdown (if you add many custom palettes, the dropdown becomes long and gets cut off)
- shorten appearance of long custom palette names within the dropdown (use '...' to indicate the name has been shortened). This will prevent the dropdown from becoming too wide and getting cut off.
- add some separation between the custom palettes and the built-in palettes within the dropdown (ex. horizontal line)
- add ability to rename custom palettes
- add a button to create a new custom palette, either within the dropdown or directly on the modal. Currently, custom palettes are created by making an edit to a built-in palette.

Refer to https://github.com/microsoft/pxt/issues/9267, https://github.com/microsoft/pxt/issues/9269, and https://github.com/microsoft/pxt-arcade/issues/5327