### PR TITLE
Adding lang as customDimension for every tick

### DIFF
--- a/multiplayer/src/index.tsx
+++ b/multiplayer/src/index.tsx
@@ -12,7 +12,7 @@ import App from "./App";
 import { AppStateProvider } from "./state/AppStateContext";
 
 function enableAnalytics() {
-    pxt.analytics.enable();
+    pxt.analytics.enable(pxt.BrowserUtils.getCookieLang());
 
     const stats: pxt.Map<string | number> = {};
     if (typeof window !== "undefined") {

--- a/multiplayer/src/index.tsx
+++ b/multiplayer/src/index.tsx
@@ -12,7 +12,7 @@ import App from "./App";
 import { AppStateProvider } from "./state/AppStateContext";
 
 function enableAnalytics() {
-    pxt.analytics.enable(pxt.BrowserUtils.getCookieLang());
+    pxt.analytics.enable(pxt.Util.userLanguage());
 
     const stats: pxt.Map<string | number> = {};
     if (typeof window !== "undefined") {

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -20,10 +20,15 @@ namespace pxt.analytics {
         });
     }
 
-    export function enable() {
+    export function enable(lang : string) {
         if (!pxt.aiTrackException || !pxt.aiTrackEvent || enabled) return;
 
         enabled = true;
+        if (typeof lang != "string" || lang.length == 0) {
+            lang = "en"; //Always have a default language.
+        }
+        addDefaultProperties({ lang: lang })
+
         pxt.debug('setting up app insights')
 
         const te = pxt.tickEvent;

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1362,6 +1362,7 @@ namespace pxt.BrowserUtils {
             const expiration = new Date();
             expiration.setTime(expiration.getTime() + (pxt.Util.langCookieExpirationDays * 24 * 60 * 60 * 1000));
             document.cookie = `${pxt.Util.pxtLangCookieId}=${langId}; expires=${expiration.toUTCString()}; path=/`;
+            pxt?.analytics?.addDefaultProperties({lang: langId}); //set the new language in analytics.
         }
     }
 

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1362,7 +1362,6 @@ namespace pxt.BrowserUtils {
             const expiration = new Date();
             expiration.setTime(expiration.getTime() + (pxt.Util.langCookieExpirationDays * 24 * 60 * 60 * 1000));
             document.cookie = `${pxt.Util.pxtLangCookieId}=${langId}; expires=${expiration.toUTCString()}; path=/`;
-            pxt?.analytics?.addDefaultProperties({lang: langId}); //set the new language in analytics.
         }
     }
 

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1288,6 +1288,7 @@ namespace ts.pxtc.Util {
             .then((translations) => {
                 if (translations) {
                     setUserLanguage(code);
+                    pxt.analytics?.addDefaultProperties({lang: code}); //set the new language in analytics.
                     setLocalizedStrings(translations);
                 }
 

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -1292,7 +1292,7 @@ namespace pxt.runner {
     }
 
     export function renderAsync(options?: ClientRenderOptions): Promise<void> {
-        pxt.analytics.enable();
+        pxt.analytics.enable(pxt.BrowserUtils.getCookieLang());
         if (!options) options = defaultClientRenderOptions();
         if (options.pxtUrl) options.pxtUrl = options.pxtUrl.replace(/\/$/, '');
         if (options.showEdit) options.showEdit = !pxt.BrowserUtils.isIFrame();

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -1292,7 +1292,7 @@ namespace pxt.runner {
     }
 
     export function renderAsync(options?: ClientRenderOptions): Promise<void> {
-        pxt.analytics.enable(pxt.BrowserUtils.getCookieLang());
+        pxt.analytics.enable(pxt.Util.userLanguage());
         if (!options) options = defaultClientRenderOptions();
         if (options.pxtUrl) options.pxtUrl = options.pxtUrl.replace(/\/$/, '');
         if (options.showEdit) options.showEdit = !pxt.BrowserUtils.isIFrame();

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -176,6 +176,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
         if (pxt.Util.isLocaleEnabled(useLang!)) {
             pxt.BrowserUtils.setCookieLang(useLang!);
             pxt.Util.setUserLanguage(useLang!);
+            pxt.analytics?.addDefaultProperties({lang: useLang!}); //set the new language in analytics
         }
 
         if (force && useLang) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5079,7 +5079,7 @@ function getsrc() {
 }
 
 function enableAnalytics() {
-    pxt.analytics.enable(pxt.BrowserUtils.getCookieLang());
+    pxt.analytics.enable(pxt.Util.userLanguage());
     pxt.editor.enableControllerAnalytics();
 
     const stats: pxt.Map<string | number> = {}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5079,7 +5079,7 @@ function getsrc() {
 }
 
 function enableAnalytics() {
-    pxt.analytics.enable();
+    pxt.analytics.enable(pxt.BrowserUtils.getCookieLang());
     pxt.editor.enableControllerAnalytics();
 
     const stats: pxt.Map<string | number> = {}


### PR DESCRIPTION
When the telemetry is enabled, we set the lang as custom dimension and if the user changes the language to new one, we observe setcookielang and update this.
This is dependent on language cookie which all our properties use to determine the locale.

Joey noted this won't work for forcelang and in context translation as they don't set the cookie. However, these are not the primary user scenarios, and I am ok not being right in these cases. Piggy backing cookie seemed cleaner to me.