### PR TITLE
Multiplayer post recieve play icons

### DIFF
--- a/multiplayer/src/App.css
+++ b/multiplayer/src/App.css
@@ -8,7 +8,7 @@
 
   --header-height: 4rem;
   --header-padding-top: 1rem;
-  
+
   --body-font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
@@ -42,6 +42,18 @@ code {
   background: var(--tertiary-color);
   color: #fff;
   border: 1px solid var(--tertiary-color);
+}
+
+img.pixel-art-image {
+  image-rendering: optimizeSpeed;
+  image-rendering: -moz-crisp-edges;
+  image-rendering: -webkit-optimize-contrast;
+  image-rendering: optimize-contrast;
+  image-rendering: pixelated;
+  -ms-interpolation-mode: nearest-neighbor;
+
+  object-fit: contain;
+  height: auto;
 }
 
 #root {

--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -46,6 +46,11 @@ export default function Render() {
         const { instruction, soundbuf } = msg;
         await gameClient.sendAudioAsync(instruction, soundbuf);
     };
+    const postIconMsg = async (msg: SimMultiplayer.MultiplayerIconMessage) => {
+        const { iconType, palette, icon, slot } = msg;
+        const { data } = icon;
+        await gameClient.sendIconAsync(iconType, slot, palette, icon);
+    };
 
     const setSimStopped = async () => {
         simDriver()?.resume(pxsim.SimulatorDebuggerCommand.Pause);
@@ -93,6 +98,8 @@ export default function Render() {
                         postImageMsg(data);
                     } else if (origin === "server" && content === "Audio") {
                         postAudioMsg(data);
+                    } else if (origin === "server" && content === "Icon") {
+                        postIconMsg(data);
                     }
                     return;
             }

--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -49,7 +49,7 @@ export default function Render() {
     const postIconMsg = async (msg: SimMultiplayer.MultiplayerIconMessage) => {
         const { iconType, palette, icon, slot } = msg;
         const { data } = icon;
-        await gameClient.sendIconAsync(iconType, slot, palette, icon);
+        await gameClient.sendIconAsync(iconType, slot, palette, data);
     };
 
     const setSimStopped = async () => {

--- a/multiplayer/src/components/Presence.tsx
+++ b/multiplayer/src/components/Presence.tsx
@@ -8,7 +8,8 @@ import { showModal } from "../state/actions";
 
 export default function Render() {
     const { state, dispatch } = useContext(AppStateContext);
-    const { presence, clientRole, playerSlot } = state;
+    const { presence, clientRole, playerSlot, gameState } = state;
+    const presenceIconOverrides = gameState?.presenceIconOverrides;
 
     const [showPlayerMenu, setShowPlayerMenu] = useState(0);
 
@@ -100,6 +101,7 @@ export default function Render() {
                 const menu = playerMenu(slot);
                 const isEmpty = !user;
                 const isMySlot = slot === playerSlot;
+                const iconOverride = presenceIconOverrides?.[slot];
                 return (
                     <div key={slot}>
                         <div className="tw-px-[50%]">{menu}</div>
@@ -121,7 +123,10 @@ export default function Render() {
                                         }-color))`,
                                     }}
                                 >
-                                    <UserIcon slot={isEmpty ? 0 : slot} />
+                                    <UserIcon
+                                        slot={isEmpty ? 0 : slot}
+                                        datauri={iconOverride}
+                                    />
                                     {user && (
                                         <ReactionEmitter clientId={user.id} />
                                     )}

--- a/multiplayer/src/components/Presence.tsx
+++ b/multiplayer/src/components/Presence.tsx
@@ -125,7 +125,7 @@ export default function Render() {
                                 >
                                     <UserIcon
                                         slot={isEmpty ? 0 : slot}
-                                        datauri={iconOverride}
+                                        dataUri={iconOverride}
                                     />
                                     {user && (
                                         <ReactionEmitter clientId={user.id} />

--- a/multiplayer/src/components/ReactionParticle.tsx
+++ b/multiplayer/src/components/ReactionParticle.tsx
@@ -1,9 +1,13 @@
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
+import { AppStateContext } from "../state/AppStateContext";
 import { Reactions, Particle } from "../types/reactions";
 
 export default function Render(props: { particle: Particle }) {
     const { particle } = props;
     const { index } = particle;
+    const { state } = useContext(AppStateContext);
+    const { gameState } = state;
+    const reactionIconOverrides = gameState?.reactionIconOverrides;
 
     const emoji = Reactions[index].emoji;
 
@@ -25,12 +29,25 @@ export default function Render(props: { particle: Particle }) {
         };
     }, []);
 
+    const override = reactionIconOverrides?.[index + 1];
+    const display = override ? (
+        <img
+            className="pixel-art-image tw-w-[100%]"
+            src={override}
+            alt={lf(`Game reaction image ${index + 1}`)}
+        />
+    ) : (
+        emoji
+    );
+
     return (
         <div
             className="tw-absolute tw-select-none tw-pointer-events-none tw-z-[100]"
             style={{
                 animation: `reaction-fly-up linear ${parms.flyUpDuration}s forwards,
                 ${parms.horzAnim} linear ${parms.flyHorzDuration}s forwards`,
+                width: override ? "1.5rem" : undefined,
+                height: override ? "1.5rem" : undefined,
             }}
         >
             <div
@@ -39,7 +56,7 @@ export default function Render(props: { particle: Particle }) {
                     animation: `${parms.rotationAnim} ease-in-out ${parms.rotationDuration}s infinite`,
                 }}
             >
-                {emoji}
+                {display}
             </div>
         </div>
     );

--- a/multiplayer/src/components/ReactionParticle.tsx
+++ b/multiplayer/src/components/ReactionParticle.tsx
@@ -34,7 +34,7 @@ export default function Render(props: { particle: Particle }) {
         <img
             className="pixel-art-image tw-w-[100%]"
             src={override}
-            alt={lf(`Game reaction image ${index + 1}`)}
+            alt={lf("Game reaction image {0}", index + 1)}
         />
     ) : (
         emoji

--- a/multiplayer/src/components/Reactions.tsx
+++ b/multiplayer/src/components/Reactions.tsx
@@ -63,7 +63,7 @@ export default function Render() {
                                 <img
                                     className="pixel-art-image tw-w-6"
                                     src={override}
-                                    alt={lf(`Game reaction image ${i + 1}`)}
+                                    alt={lf("Game reaction image {0}", i + 1)}
                                 />
                             ) : (
                                 def.emoji

--- a/multiplayer/src/components/Reactions.tsx
+++ b/multiplayer/src/components/Reactions.tsx
@@ -1,12 +1,16 @@
 import { Reactions } from "../types/reactions";
 import { sendReactionAsync } from "../epics";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import ReactionsIcon from "./icons/ReactionsIcon";
 import { Button } from "react-common/components/controls/Button";
 import Popup from "./Popup";
+import { AppStateContext } from "../state/AppStateContext";
 
 export default function Render() {
+    const { state } = useContext(AppStateContext);
     const [showReactionPicker, setShowReactionPicker] = useState(false);
+    const { gameState } = state;
+    const reactionIconOverrides = gameState?.reactionIconOverrides;
 
     const onReactionClick = async (index: number) => {
         await sendReactionAsync(index);
@@ -54,16 +58,28 @@ export default function Render() {
                 <div className="tw-flex tw-flex-col tw-bg-white tw-drop-shadow-xl tw-rounded-md tw-border-2 tw-border-gray-100">
                     <div className="tw-flex tw-flex-row tw-gap-3 tw-p-2 tw-pb-3 tw-pr-3">
                         {Reactions.map((def, i) => {
+                            const override = reactionIconOverrides?.[i + 1];
+                            const display = override ? (
+                                <img
+                                    className="pixel-art-image tw-w-6"
+                                    src={override}
+                                    alt={lf(`Game reaction image ${i + 1}`)}
+                                />
+                            ) : (
+                                def.emoji
+                            );
                             return (
                                 <Button
                                     className="tw-flex tw-items-center tw-justify-center tw-m-0 tw-p-0 tw-cursor-pointer tw-select-none tw-scale-110 hover:tw-scale-125 tw-ease-linear tw-duration-[50ms] tw-h-8 tw-w-8 tw-text-2xl"
                                     key={i + 1}
                                     label={
                                         <div>
-                                            <div>{def.emoji}</div>
-                                            {!isMobile && <div className="tw-text-xs tw-absolute tw-bottom-[-5px] tw-right-[-5px] tw-text-white tw-bg-gray-400 tw-rounded-sm tw-border-[1px] tw-border-solid tw-border-gray-500 tw-drop-shadow-lg tw-px-1 tw-leading-tight">
-                                                {i + 1}
-                                            </div>}
+                                            <div>{display}</div>
+                                            {!isMobile && (
+                                                <div className="tw-text-xs tw-absolute tw-bottom-[-5px] tw-right-[-5px] tw-text-white tw-bg-gray-400 tw-rounded-sm tw-border-[1px] tw-border-solid tw-border-gray-500 tw-drop-shadow-lg tw-px-1 tw-leading-tight">
+                                                    {i + 1}
+                                                </div>
+                                            )}
                                         </div>
                                     }
                                     title={def.name}

--- a/multiplayer/src/components/icons/UserIcon.tsx
+++ b/multiplayer/src/components/icons/UserIcon.tsx
@@ -1,5 +1,11 @@
-export default function Render(props: { slot: number }) {
-    const { slot } = props;
+export default function Render(props: { slot: number; datauri?: string }) {
+    const { slot, datauri } = props;
+
+    if (datauri) {
+        return (
+            <img src={datauri} alt={lf("User set icon for player {0}", slot)} />
+        );
+    }
 
     return (
         <svg

--- a/multiplayer/src/components/icons/UserIcon.tsx
+++ b/multiplayer/src/components/icons/UserIcon.tsx
@@ -3,7 +3,7 @@ export default function Render(props: { slot: number; datauri?: string }) {
 
     if (datauri) {
         return (
-            <img src={datauri} alt={lf("User set icon for player {0}", slot)} />
+            <img className="pixel-art-image tw-w-[65%]" src={datauri} alt={lf("User set icon for player {0}", slot)} />
         );
     }
 

--- a/multiplayer/src/components/icons/UserIcon.tsx
+++ b/multiplayer/src/components/icons/UserIcon.tsx
@@ -1,9 +1,9 @@
-export default function Render(props: { slot: number; datauri?: string }) {
-    const { slot, datauri } = props;
+export default function Render(props: { slot: number; dataUri?: string }) {
+    const { slot, dataUri } = props;
 
-    if (datauri) {
+    if (dataUri) {
         return (
-            <img className="pixel-art-image tw-w-[65%]" src={datauri} alt={lf("User set icon for player {0}", slot)} />
+            <img className="pixel-art-image tw-w-[65%]" src={dataUri} alt={lf("User set icon for player {0}", slot)} />
         );
     }
 

--- a/multiplayer/src/epics/index.ts
+++ b/multiplayer/src/epics/index.ts
@@ -24,3 +24,4 @@ export { pauseGameAsync } from "./pauseGameAsync";
 export { resumeGameAsync } from "./resumeGameAsync";
 export { visibilityChanged } from "./visibilityChanged";
 export { sendAbuseReportAsync } from "./sendAbuseReportAsync";
+export { setCustomIconAsync } from "./setCustomIconAsync";

--- a/multiplayer/src/epics/setCustomIconAsync.ts
+++ b/multiplayer/src/epics/setCustomIconAsync.ts
@@ -1,0 +1,23 @@
+import { IconType } from "../types";
+
+import { dispatch } from "../state";
+import {
+    setPresenceIconOverride,
+    setReactionIconOverride,
+} from "../state/actions";
+
+export async function setCustomIconAsync(
+    iconType: IconType,
+    slot: number,
+    pngDataUri?: string
+) {
+    try {
+        const actionHandler =
+            iconType === IconType.Player
+                ? setPresenceIconOverride
+                : setReactionIconOverride;
+        dispatch(actionHandler(slot, pngDataUri));
+    } catch (e) {
+    } finally {
+    }
+}

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -459,21 +459,18 @@ class GameClient {
             const unzipped = await gunzipAsync(iconBuffer);
             const imgConv = new pxt.ImageConverter();
             const iconPalette = unzipped.slice(0, 48);
-            const iconImage = iconBuffer.slice(48);
+            const iconImage = unzipped.slice(48);
             const paletteAsTripletArray: number[][] = [];
 
             for (let i = 0; i < 16; i++) {
                 paletteAsTripletArray.push([
-                    iconPalette[i * 3 + 0],
-                    iconPalette[i * 3 + 1],
                     iconPalette[i * 3 + 2],
+                    iconPalette[i * 3 + 1],
+                    iconPalette[i * 3 + 0],
+                    255
                 ]);
             }
             imgConv.setPalette(paletteAsTripletArray);
-            // const stringifiedRefBuffer = iconImage.reduce(
-            //     (prev, curr) => prev + String.fromCharCode(curr),
-            //     ""
-            // );
             const stringifiedRefBuffer = String.fromCharCode.apply(
                 null,
                 iconImage as any as number[]

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -458,8 +458,8 @@ class GameClient {
         if (iconBuffer) {
             const unzipped = await gunzipAsync(iconBuffer);
             const imgConv = new pxt.ImageConverter();
-            const iconPalette = unzipped.slice(0, 48);
-            const iconImage = unzipped.slice(48);
+            const iconPalette = unzipped.slice(0, PALETTE_BUFFER_SIZE);
+            const iconImage = unzipped.slice(PALETTE_BUFFER_SIZE);
             const paletteAsTripletArray: number[][] = [];
 
             for (let i = 0; i < 16; i++) {
@@ -467,7 +467,7 @@ class GameClient {
                     iconPalette[i * 3 + 2],
                     iconPalette[i * 3 + 1],
                     iconPalette[i * 3 + 0],
-                    255
+                    255,
                 ]);
             }
             imgConv.setPalette(paletteAsTripletArray);

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -34,12 +34,8 @@ import {
     gameOverAsync,
     pauseGameAsync as epic_pauseGameAsync,
     resumeGameAsync as epic_resumeGameAsync,
+    setCustomIconAsync,
 } from "../epics";
-import { dispatch } from "../state";
-import {
-    setPresenceIconOverride,
-    setReactionIconOverride,
-} from "../state/actions";
 import { simDriver } from "./simHost";
 
 const GAME_HOST_PROD = "https://mp.makecode.com";
@@ -441,17 +437,14 @@ class GameClient {
         const { iconType, iconSlot, iconBuffer } =
             Protocol.Binary.unpackIconMessage(reader);
 
-        let dispatchHandler;
         if (iconType === IconType.Player && iconSlot >= 1 && iconSlot <= 4) {
-            dispatchHandler = setPresenceIconOverride;
         } else if (
             iconType === IconType.Reaction &&
             iconSlot >= 1 &&
             iconSlot <= 6
         ) {
-            dispatchHandler = setReactionIconOverride;
         } else {
-            // unhandled icon type, ignore.
+            // unhandled icon type or invalid slot, ignore.
             return;
         }
 
@@ -482,10 +475,10 @@ class GameClient {
 
             const iconPngDataUri = imgConv.convert(jresFormattedIconBuffer);
 
-            dispatch(dispatchHandler(iconSlot, iconPngDataUri));
+            setCustomIconAsync(iconType, iconSlot, iconPngDataUri);
         } else {
             // clear this value from overrides list if set
-            dispatch(dispatchHandler(iconSlot));
+            setCustomIconAsync(iconType, iconSlot);
         }
     }
 

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -45,7 +45,7 @@ import { simDriver } from "./simHost";
 const GAME_HOST_PROD = "https://mp.makecode.com";
 const GAME_HOST_STAGING = "https://multiplayer.staging.pxt.io";
 const GAME_HOST_LOCALHOST = "http://localhost:8082";
-const GAME_HOST_DEV = GAME_HOST_LOCALHOST;
+const GAME_HOST_DEV = GAME_HOST_STAGING;
 const GAME_HOST = (() => {
     if (pxt.BrowserUtils.isLocalHostDev()) {
         return GAME_HOST_DEV;

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -45,7 +45,7 @@ import { simDriver } from "./simHost";
 const GAME_HOST_PROD = "https://mp.makecode.com";
 const GAME_HOST_STAGING = "https://multiplayer.staging.pxt.io";
 const GAME_HOST_LOCALHOST = "http://localhost:8082";
-const GAME_HOST_DEV = GAME_HOST_STAGING;
+const GAME_HOST_DEV = GAME_HOST_LOCALHOST;
 const GAME_HOST = (() => {
     if (pxt.BrowserUtils.isLocalHostDev()) {
         return GAME_HOST_DEV;
@@ -485,10 +485,10 @@ class GameClient {
 
             const iconPngDataUri = imgConv.convert(jresFormattedIconBuffer);
 
-            dispatchHandler(iconSlot, iconPngDataUri);
+            dispatch(dispatchHandler(iconSlot, iconPngDataUri));
         } else {
             // clear this value from overrides list if set
-            dispatchHandler(iconSlot);
+            dispatch(dispatchHandler(iconSlot));
         }
     }
 

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -20,6 +20,8 @@ import {
     HTTP_INTERNAL_SERVER_ERROR,
     HTTP_IM_A_TEAPOT,
     SimKey,
+    IconMessage,
+    IconType,
 } from "../types";
 import {
     notifyGameDisconnected,
@@ -33,6 +35,11 @@ import {
     pauseGameAsync as epic_pauseGameAsync,
     resumeGameAsync as epic_resumeGameAsync,
 } from "../epics";
+import { dispatch } from "../state";
+import {
+    setPresenceIconOverride,
+    setReactionIconOverride,
+} from "../state/actions";
 import { simDriver } from "./simHost";
 
 const GAME_HOST_PROD = "https://mp.makecode.com";
@@ -99,6 +106,8 @@ class GameClient {
                     return await this.recvInputMessageAsync(reader);
                 case Protocol.Binary.MessageType.Audio:
                     return await this.recvAudioMessageAsync(reader);
+                case Protocol.Binary.MessageType.Icon:
+                    return await this.recvIconMessageAsync(reader);
             }
         } else if (typeof payload === "string") {
             //-------------------------------------------------
@@ -428,6 +437,61 @@ class GameClient {
         });
     }
 
+    private async recvIconMessageAsync(reader: SmartBuffer) {
+        const { iconType, iconSlot, iconBuffer } =
+            Protocol.Binary.unpackIconMessage(reader);
+
+        let dispatchHandler;
+        if (iconType === IconType.Player && iconSlot >= 1 && iconSlot <= 4) {
+            dispatchHandler = setPresenceIconOverride;
+        } else if (
+            iconType === IconType.Reaction &&
+            iconSlot >= 1 &&
+            iconSlot <= 6
+        ) {
+            dispatchHandler = setReactionIconOverride;
+        } else {
+            // unhandled icon type, ignore.
+            return;
+        }
+
+        if (iconBuffer) {
+            const unzipped = await gunzipAsync(iconBuffer);
+            const imgConv = new pxt.ImageConverter();
+            const iconPalette = unzipped.slice(0, 48);
+            const iconImage = iconBuffer.slice(48);
+            const paletteAsTripletArray: number[][] = [];
+
+            for (let i = 0; i < 16; i++) {
+                paletteAsTripletArray.push([
+                    iconPalette[i * 3 + 0],
+                    iconPalette[i * 3 + 1],
+                    iconPalette[i * 3 + 2],
+                ]);
+            }
+            imgConv.setPalette(paletteAsTripletArray);
+            // const stringifiedRefBuffer = iconImage.reduce(
+            //     (prev, curr) => prev + String.fromCharCode(curr),
+            //     ""
+            // );
+            const stringifiedRefBuffer = String.fromCharCode.apply(
+                null,
+                iconImage as any as number[]
+            );
+
+            const jresFormattedIconBuffer = `data:image/x-mkcd-f4;base64,${btoa(
+                stringifiedRefBuffer
+            )}`;
+
+            const iconPngDataUri = imgConv.convert(jresFormattedIconBuffer);
+
+            dispatchHandler(iconSlot, iconPngDataUri);
+        } else {
+            // clear this value from overrides list if set
+            dispatchHandler(iconSlot);
+        }
+    }
+
     private postToSimFrame(msg: SimMultiplayer.Message) {
         simDriver()?.postMessage(msg);
     }
@@ -454,6 +518,28 @@ class GameClient {
             Buffer.from(soundbuf!)
         );
         this.sendMessage(buffer);
+    }
+
+    public async sendIconAsync(
+        type: IconType,
+        slot: number,
+        palette: Uint8Array | undefined,
+        img: Uint8Array | undefined
+    ) {
+        let zippedIconBuffer: Buffer | undefined;
+
+        if (palette && img) {
+            const iconDataBuf = Buffer.concat([palette, img]);
+            zippedIconBuffer = await gzipAsync(iconDataBuf);
+        }
+
+        const msgBuffer = Protocol.Binary.packIconMessage(
+            type,
+            slot,
+            zippedIconBuffer
+        );
+
+        this.sendMessage(msgBuffer);
     }
 
     public async sendScreenUpdateAsync(
@@ -634,6 +720,15 @@ export async function sendAudioAsync(
     await gameClient?.sendAudioAsync(instruction, soundbuf);
 }
 
+export async function sendIconAsync(
+    iconType: IconType,
+    slot: number,
+    palette: Uint8Array,
+    icon: Uint8Array
+) {
+    await gameClient?.sendIconAsync(iconType, slot, palette, icon);
+}
+
 export async function sendScreenUpdateAsync(
     img: Uint8Array,
     palette: Uint8Array
@@ -793,6 +888,7 @@ namespace Protocol {
             Input = 1,
             CompressedScreen = 3,
             Audio = 4,
+            Icon = 5,
         }
 
         // Input
@@ -871,6 +967,38 @@ namespace Protocol {
             return {
                 instruction,
                 soundbuf,
+            };
+        }
+
+        // Icon
+        export function packIconMessage(
+            iconType: IconType,
+            iconSlot: number,
+            iconBuffer?: Buffer
+        ): Buffer {
+            const writer = new SmartBuffer();
+            writer.writeUInt16LE(MessageType.Icon);
+            writer.writeUInt8(iconType);
+            writer.writeUInt8(iconSlot);
+            if (iconBuffer) {
+                writer.writeBuffer(iconBuffer);
+            }
+            return writer.toBuffer();
+        }
+        export function unpackIconMessage(reader: SmartBuffer): IconMessage {
+            // `type` field has already been read
+            const iconType = reader.readUInt8();
+            const iconSlot = reader.readUInt8();
+            let iconBuffer: Buffer | undefined;
+            let iconPalette: Buffer | undefined;
+            if (reader.remaining()) {
+                iconBuffer = reader.readBuffer();
+            }
+
+            return {
+                iconType,
+                iconSlot,
+                iconBuffer,
             };
         }
     }

--- a/multiplayer/src/state/actions.ts
+++ b/multiplayer/src/state/actions.ts
@@ -122,6 +122,18 @@ type SetTargetConfig = ActionBase & {
     targetConfig: pxt.TargetConfig;
 };
 
+type SetPresenceIconOverride = ActionBase & {
+    type: "SET_PRESENCE_ICON_OVERRIDE";
+    slot: number;
+    icon: string | undefined;
+}
+
+type SetReactionIconOverride = ActionBase & {
+    type: "SET_REACTION_ICON_OVERRIDE";
+    slot: number;
+    icon: string | undefined;
+}
+
 /**
  * Union of all actions
  */
@@ -146,7 +158,9 @@ export type Action =
     | SetDeepLinks
     | SetMute
     | SetGamePaused
-    | SetTargetConfig;
+    | SetTargetConfig
+    | SetPresenceIconOverride
+    | SetReactionIconOverride;
 
 /**
  * Action creators
@@ -281,4 +295,16 @@ export const setGamePaused = (gamePaused: boolean): SetGamePaused => ({
 export const setTargetConfig = (trgCfg: pxt.TargetConfig): SetTargetConfig => ({
     type: "SET_TARGET_CONFIG",
     targetConfig: JSON.parse(JSON.stringify(trgCfg)),
+});
+
+export const setPresenceIconOverride = (slot: number, icon?: string): SetPresenceIconOverride => ({
+    type: "SET_PRESENCE_ICON_OVERRIDE",
+    slot,
+    icon
+});
+
+export const setReactionIconOverride = (slot: number, icon?: string): SetReactionIconOverride => ({
+    type: "SET_REACTION_ICON_OVERRIDE",
+    slot,
+    icon
 });

--- a/multiplayer/src/state/reducer.ts
+++ b/multiplayer/src/state/reducer.ts
@@ -182,7 +182,7 @@ export default function reducer(state: AppState, action: Action): AppState {
         }
         case "SET_REACTION_ICON_OVERRIDE": {
             let nextReactionIcons =
-                state.gameState?.presenceIconOverrides?.slice() || [];
+                state.gameState?.reactionIconOverrides?.slice() || [];
             nextReactionIcons[action.slot] = action.icon;
             return {
                 ...state,

--- a/multiplayer/src/state/reducer.ts
+++ b/multiplayer/src/state/reducer.ts
@@ -168,5 +168,29 @@ export default function reducer(state: AppState, action: Action): AppState {
                 targetConfig: action.targetConfig,
             };
         }
+        case "SET_PRESENCE_ICON_OVERRIDE": {
+            let nextPresenceIcon =
+                state.gameState?.presenceIconOverrides?.slice() || [];
+            nextPresenceIcon[action.slot] = action.icon;
+            return {
+                ...state,
+                gameState: {
+                    ...state.gameState,
+                    presenceIconOverrides: nextPresenceIcon,
+                },
+            };
+        }
+        case "SET_REACTION_ICON_OVERRIDE": {
+            let nextReactionIcons =
+                state.gameState?.presenceIconOverrides?.slice() || [];
+            nextReactionIcons[action.slot] = action.icon;
+            return {
+                ...state,
+                gameState: {
+                    ...state.gameState,
+                    reactionIconOverrides: nextReactionIcons,
+                },
+            };
+        }
     }
 }

--- a/multiplayer/src/types/index.ts
+++ b/multiplayer/src/types/index.ts
@@ -42,6 +42,9 @@ export type GameMetadata = {
 
 export type GameState = GameInfo & {
     gameMode?: GameMode;
+    // png data uris
+    presenceIconOverrides?: (string | undefined)[];
+    reactionIconOverrides?: (string | undefined)[];
 };
 
 export enum ButtonState {
@@ -49,6 +52,17 @@ export enum ButtonState {
     Released = 2,
     Held = 3,
 }
+
+export enum IconType {
+    Player = 0,
+    Reaction = 1,
+}
+
+export type IconMessage = {
+    iconType: IconType;
+    iconSlot: number;
+    iconBuffer?: Buffer;
+};
 
 export enum SimKey {
     None = 0,
@@ -71,7 +85,7 @@ export enum SimKey {
     Screenshot = -1,
     Gif = -2,
     Reset = -3,
-    TogglePause = -4
+    TogglePause = -4,
 }
 
 export function buttonStateToString(state: ButtonState): string | undefined {
@@ -189,5 +203,18 @@ export namespace SimMultiplayer {
         soundbuf?: Uint8Array;
     };
 
-    export type Message = ImageMessage | AudioMessage | InputMessage;
+    export type MultiplayerIconMessage = MessageBase & {
+        content: "Icon";
+        icon: any; // pxsim.RefBuffer
+        slot: number;
+        iconType: IconType;
+        // 48bytes, [r0,g0,b0,r1,g1,b1,...]
+        palette: Uint8Array;
+    };
+
+    export type Message =
+        | ImageMessage
+        | AudioMessage
+        | InputMessage
+        | MultiplayerIconMessage;
 }

--- a/pxtlib/imageConverter.ts
+++ b/pxtlib/imageConverter.ts
@@ -36,19 +36,8 @@ namespace pxt {
                 return [(v >> 0) & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, 0xff]
             }
 
-
             if (!this.palette) {
-                let arrs = pxt.appTarget.runtime.palette.map(htmlColorToBytes);
-
-                // Set the alpha for transparency at index 0
-                arrs[0][3] = 0;
-                this.palette = new Uint8Array(arrs.length * 4)
-                for (let i = 0; i < arrs.length; ++i) {
-                    this.palette[i * 4 + 0] = arrs[i][0]
-                    this.palette[i * 4 + 1] = arrs[i][1]
-                    this.palette[i * 4 + 2] = arrs[i][2]
-                    this.palette[i * 4 + 3] = arrs[i][3]
-                }
+                this.setPalette(pxt.appTarget.runtime.palette.map(htmlColorToBytes));
             }
 
             if (magic == 0xe1) {
@@ -57,6 +46,19 @@ namespace pxt {
 
             const scaleFactor = ((pxt.BrowserUtils.isEdge() || pxt.BrowserUtils.isIE()) && w < 100 && h < 100) ? 3 : 1;
             return this.genColor(data, w, h, scaleFactor);
+        }
+
+        // p: [[r,g,b,a?], [r,g,b,a?], ...]
+        setPalette(paletteArrays: number[][]) {
+            // Set the alpha for transparency at index 0
+            paletteArrays[0][3] = 0;
+            this.palette = new Uint8Array(paletteArrays.length * 4);
+            for (let i = 0; i < paletteArrays.length; ++i) {
+                this.palette[i * 4 + 0] = paletteArrays[i][0];
+                this.palette[i * 4 + 1] = paletteArrays[i][1];
+                this.palette[i * 4 + 2] = paletteArrays[i][2];
+                this.palette[i * 4 + 3] = paletteArrays[i][3];
+            }
         }
 
         genMonochrome(data: string, w: number, h: number) {


### PR DESCRIPTION
Support for passing up / down icons (imgs up to 64x64) from host -> all for use in reactions, player icons

![image](https://user-images.githubusercontent.com/5615930/211690848-92522a95-ade9-408c-97e9-1ea4c7c5cd72.png)

closes https://github.com/microsoft/pxt-arcade/issues/5432
closes https://github.com/microsoft/pxt-arcade/issues/5431

I might take a pass at the sizing for the `pixel-art-image`s again after I add the player chooser sim / other things are ready, as sizing them correctly to fit in within rounded edges was slightly tricky to get right / might have missed some sizes if someone makes extra wide / tall images -- will be easier to test when it's in /beta as with just local host it's a bit tricky (e.g. have to push up a broken project as all user projects are pulled from prod and localhost can't push share scripts to prod)

![image](https://user-images.githubusercontent.com/5615930/211696773-47bc6aea-ecbd-4304-898d-d7ffcb783428.png)
