### PR TITLE
add a grayscale on presence icon if playeris not in game

### DIFF
--- a/multiplayer/src/components/icons/UserIcon.tsx
+++ b/multiplayer/src/components/icons/UserIcon.tsx
@@ -3,7 +3,14 @@ export default function Render(props: { slot: number; dataUri?: string }) {
 
     if (dataUri) {
         return (
-            <img className="pixel-art-image tw-w-[65%]" src={dataUri} alt={lf("User set icon for player {0}", slot)} />
+            <img
+                className="pixel-art-image tw-w-[65%]"
+                style={{
+                    filter: slot === 0 ? "grayscale(1)" : undefined,
+                }}
+                src={dataUri}
+                alt={lf("User set icon for player {0}", slot)}
+            />
         );
     }
 


### PR DESCRIPTION
add a filter on non-present players so it's more clear they still didn't join:

![image](https://user-images.githubusercontent.com/5615930/212392766-2c4cab0b-7949-4d79-b669-f0fb10542563.png)
