### PR TITLE
Fix asset editor button margins, fix palette button padding

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -160,14 +160,16 @@
     }
 }
 
-.asset-editor-sidebar-controls > .common-list-item {
-    display: flex;
+.asset-editor-sidebar-controls {
+    margin: 0 .75rem;
+    .common-list-item {
+        display: flex;
+    }
 }
 
 .asset-editor-button.common-button {
     flex: 1;
     box-shadow: inset 0 0 0 1px rgba(34,36,38,.15), inset 0 -0.3em 0 0 rgba(34,36,38,.15);
-    margin: 0 .25rem;
 }
 
 .create-new.common-button {
@@ -236,7 +238,7 @@
 }
 
 .asset-palette-button.common-button {
-    margin: 1rem .25rem .6rem .25rem;
+    margin-top: 1rem;
     flex: 1;
     box-shadow: inset 0 0 0 1px rgba(34,36,38,.15), inset 0 -0.3em 0 0 rgba(34,36,38,.15);
 }

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -164,9 +164,10 @@
     display: flex;
 }
 
-.asset-editor-button {
+.asset-editor-button.common-button {
     flex: 1;
     box-shadow: inset 0 0 0 1px rgba(34,36,38,.15), inset 0 -0.3em 0 0 rgba(34,36,38,.15);
+    margin: 0 .25rem;
 }
 
 .create-new.common-button {
@@ -235,7 +236,7 @@
 }
 
 .asset-palette-button.common-button {
-    margin: 1rem .25rem .6rem 0;
+    margin: 1rem .25rem .6rem .25rem;
     flex: 1;
     box-shadow: inset 0 0 0 1px rgba(34,36,38,.15), inset 0 -0.3em 0 0 rgba(34,36,38,.15);
 }

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -167,7 +167,7 @@
     }
 }
 
-.asset-editor-button.common-button {
+.asset-editor-button {
     flex: 1;
     box-shadow: inset 0 0 0 1px rgba(34,36,38,.15), inset 0 -0.3em 0 0 rgba(34,36,38,.15);
 }

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -232,7 +232,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
                     leftIcon="icon trash"
                     onClick={this.showDeleteModal} />}
                 <Button className="teal asset-palette-button"
-                    label={lf("Color Palette")}
+                    label={lf("Colors")}
                     title={lf("Open the color palette")}
                     ariaLabel={lf("Open the color palette")}
                     leftIcon="fas fa-palette"


### PR DESCRIPTION
Closes https://github.com/microsoft/pxt-arcade/issues/5489, closes https://github.com/microsoft/pxt-arcade/issues/5501

There's not enough space for "Color Palette" on the button, so I've shortened it to "Colors".
![image](https://user-images.githubusercontent.com/15070078/212422168-3a78af2c-1dad-48c3-a548-69cf1b05d69e.png)
