### PR TITLE
Fix excessive padding for project name area, cloud icon

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1532,8 +1532,11 @@ p.ui.font.small {
     }
 }
 
-#projectNameArea input {
-    font-size: 0.95rem;
+#editortools #projectNameArea {
+    padding: 1rem 0;
+    input {
+        font-size: 0.95rem;
+    }
 }
 
 .cloudstatusarea {


### PR DESCRIPTION
closes https://github.com/microsoft/pxt-arcade/issues/4990

**Before**:
In tutorial
![image](https://user-images.githubusercontent.com/15070078/212762806-f38f5069-b1a1-4653-b099-8e8eaac40b59.png)
In project
![image](https://user-images.githubusercontent.com/15070078/212762817-e95b4cdd-0fac-4eff-80e9-16641fc2c714.png)

**After**:
In tutorial
![image](https://user-images.githubusercontent.com/15070078/212762845-1600fcf1-9709-438f-a951-01c7492d153f.png)
In project
![image](https://user-images.githubusercontent.com/15070078/212762863-d61b2499-38bc-467e-bd13-c3ef968c6380.png)


