### PR TITLE
fix bug where 'exit the game' button does nothing

### DIFF
--- a/multiplayer/src/components/Presence.tsx
+++ b/multiplayer/src/components/Presence.tsx
@@ -6,6 +6,27 @@ import Popup from "./Popup";
 import { Button } from "react-common/components/controls/Button";
 import { showModal } from "../state/actions";
 
+function PlayerMenuPopup(
+    props: React.PropsWithChildren<{
+        slot: number;
+        setShowPlayerMenu: (p: number) => void;
+        currentlyDisplayed: number;
+    }>
+) {
+    const { slot, children, currentlyDisplayed, setShowPlayerMenu } = props;
+    return (
+        <Popup
+            className="tw-absolute tw-z-50 tw-translate-y-[-110%] tw-translate-x-[-50%] tw-rounded-lg tw-border-2 tw-border-gray-100"
+            visible={currentlyDisplayed === slot}
+            onClickedOutside={() => setShowPlayerMenu(0)}
+        >
+            <div className="tw-flex tw-flex-row tw-gap-1 tw-p-2 tw-bg-white tw-drop-shadow-xl tw-rounded-md">
+                {children}
+            </div>
+        </Popup>
+    );
+}
+
 export default function Render() {
     const { state, dispatch } = useContext(AppStateContext);
     const { presence, clientRole, playerSlot, gameState } = state;
@@ -31,21 +52,6 @@ export default function Render() {
         dispatch(showModal("leave-game"));
     };
 
-    function PlayerMenuPopup(props: React.PropsWithChildren<{ slot: number }>) {
-        const { slot, children } = props;
-        return (
-            <Popup
-                className="tw-absolute tw-z-50 tw-translate-y-[-110%] tw-translate-x-[-50%] tw-rounded-lg tw-border-2 tw-border-gray-100"
-                visible={showPlayerMenu === slot}
-                onClickedOutside={() => setShowPlayerMenu(0)}
-            >
-                <div className="tw-flex tw-flex-row tw-gap-1 tw-p-2 tw-bg-white tw-drop-shadow-xl tw-rounded-md">
-                    {children}
-                </div>
-            </Popup>
-        );
-    }
-
     const playerMenu = (slot: number) => {
         const isHost = clientRole === "host";
         const isHostSlot = slot === 1;
@@ -55,7 +61,11 @@ export default function Render() {
         if (isHost && isMySlot) {
             // Host's own menu
             return (
-                <PlayerMenuPopup slot={slot}>
+                <PlayerMenuPopup
+                    slot={slot}
+                    currentlyDisplayed={showPlayerMenu}
+                    setShowPlayerMenu={setShowPlayerMenu}
+                >
                     <Button
                         className="tw-m-0 tw-py-2 tw-bg-red-600 tw-text-white"
                         label={lf("End the game")}
@@ -68,7 +78,11 @@ export default function Render() {
         if (isHost && !isHostSlot && !!player) {
             // Host's menu for other players
             return (
-                <PlayerMenuPopup slot={slot}>
+                <PlayerMenuPopup
+                    slot={slot}
+                    currentlyDisplayed={showPlayerMenu}
+                    setShowPlayerMenu={setShowPlayerMenu}
+                >
                     <Button
                         className="tw-m-0 tw-py-2 tw-bg-red-600 tw-text-white"
                         label={lf("Remove from game")}
@@ -81,7 +95,11 @@ export default function Render() {
         if (!isHost && isMySlot) {
             // Guest's own menu
             return (
-                <PlayerMenuPopup slot={slot}>
+                <PlayerMenuPopup
+                    slot={slot}
+                    currentlyDisplayed={showPlayerMenu}
+                    setShowPlayerMenu={setShowPlayerMenu}
+                >
                     <Button
                         className="tw-m-0 tw-py-2 tw-bg-red-600 tw-text-white"
                         label={lf("Leave game")}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/5508

Interesting gotcha bug I hadn't thought of. The issue was that `PlayerMenuPopup` was declared inside the `Presence` component, so the function was getting redeclared every render. This feels like it should be innocuous but it's not; any time ANY state was changing in the app it was causing the component to rerender every frame, as `PlayerMenuProp` was getting counted as a separate component each time (you couldn't even expand div in the dev tools as it kept replacing itself).

This didn't matter before as the calls to render didn't occur quite so frequently (so if you clicked on it and it didn't do anything you'd default to think that you misclicked or something), but the state was changing much more often as a result of the rapidly animating reactions changing so often in my sample game, so this bug became more prominent for that reason - it must've started hitting some internal clean up logic of 'don't run click event as the component is being rerendered / doesn't exist on dom anymore' after the popup `useClickedOutside` intercepted the event for just long enough to make it not be the same button anymore.