### PR TITLE
add help button for how to pop out video in firefox

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -350,6 +350,18 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     pipButton.textContent = lf("Pop out video");
                     pipButton.ariaLabel = lf("Open video in picture-in-picture mode");
                     pipButton.title = pipButton.ariaLabel;
+                } else if (pxt.BrowserUtils.isFirefox()) {
+                    const pipInstructionButton = document.createElement("button");
+                    inlineVideo.parentElement.appendChild(pipInstructionButton);
+                    pipInstructionButton.addEventListener("click", () => {
+                        pxt.tickEvent("video.pip.firefoxHelp");
+                        window.open("/firefox-picture-in-picture", "_blank");
+                    });
+                    pipInstructionButton.addEventListener("keydown", e => fireClickOnEnter(e as any));
+                    pipInstructionButton.className = "common-button";
+                    pipInstructionButton.textContent = lf("How to pop out video");
+                    pipInstructionButton.ariaLabel = lf("Instructions on how to open video in picture-in-picture mode");
+                    pipInstructionButton.title = pipInstructionButton.ariaLabel;
                 }
 
                 player.on(dashjs.MediaPlayer.events.PLAYBACK_STARTED,

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -359,7 +359,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     });
                     pipInstructionButton.addEventListener("keydown", e => fireClickOnEnter(e as any));
                     pipInstructionButton.className = "common-button";
-                    pipInstructionButton.textContent = lf("How to pop out video");
+                    pipInstructionButton.textContent = lf("Pop out video");
                     pipInstructionButton.ariaLabel = lf("Instructions on how to open video in picture-in-picture mode");
                     pipInstructionButton.title = pipInstructionButton.ariaLabel;
                 }


### PR DESCRIPTION
Possible quick fix for https://github.com/microsoft/pxt-arcade/issues/5490, since firefox doesn't support picture in picture api / have there own way to do it. 

<img width="251" alt="image" src="https://user-images.githubusercontent.com/5615930/213285112-bf9946da-c63c-4176-8469-2290c76cd0b5.png">

We'd have to write a quick markdown page at `/firefox-picture-in-picture` which I didn't do, but would likely largely be similar to https://support.mozilla.org/en-US/kb/about-picture-picture-firefox