### PR TITLE
Add toggle for music editor bass clef and better support for sharps/flats

### DIFF
--- a/pxtblocks/fields/field_utils.ts
+++ b/pxtblocks/fields/field_utils.ts
@@ -161,7 +161,7 @@ namespace pxtblockly {
                 if (col > cellsShown) break;
 
                 for (const note of noteEvent.notes) {
-                    const row = 12 - (note % 12);
+                    const row = 12 - (note.note % 12);
                     if (row > notesShown) continue;
 
                     context.fillStyle = colors[trackColors[track.id || song.tracks.indexOf(track)]];

--- a/pxtlib/music.ts
+++ b/pxtlib/music.ts
@@ -42,9 +42,14 @@ namespace pxt.assets.music {
     }
 
     export interface NoteEvent {
-        notes: number[];
+        notes: Note[];
         startTick: number;
         endTick: number;
+    }
+
+    export interface Note {
+        note: number;
+        enharmonicSpelling: "normal" | "flat" | "sharp";
     }
 
     export interface DrumSoundStep {
@@ -354,7 +359,7 @@ namespace pxt.assets.music {
      *     notes byte length
      *     ...note events
      *
-     * instrument(27 bytes)
+     * instrument(28 bytes)
      *     0 waveform
      *     1 amp attack
      *     3 amp decay
@@ -370,6 +375,7 @@ namespace pxt.assets.music {
      *     22 amp lfo amp
      *     24 pitch lfo freq
      *     25 pitch lfo amp
+     *     27 octave
      *
      * drum(5 + 7 * steps bytes)
      *     0 steps
@@ -389,6 +395,12 @@ namespace pxt.assets.music {
      *     4 polyphony
      *     5...notes(1 byte each)
      *
+     * note (1 byte)
+     *     lower six bits = note - (instrumentOctave - 2) * 12
+     *     upper two bits are the enharmonic spelling:
+     *          0 = normal
+     *          1 = flat
+     *          2 = sharp
      */
 
     function encodeSong(song: Song) {
@@ -451,6 +463,7 @@ namespace pxt.assets.music {
         set16BitNumber(out, 22, instrument.ampLFO?.amplitude || 0)
         out[24] = instrument.pitchLFO?.frequency || 0
         set16BitNumber(out, 25, instrument.pitchLFO?.amplitude || 0);
+        out[27] = instrument.octave;
 
         return out;
     }
@@ -479,7 +492,8 @@ namespace pxt.assets.music {
             pitchLFO: {
                 frequency: buf[offset + 24],
                 amplitude: get16BitNumber(buf, 25)
-            }
+            },
+            octave: buf[offset + 27]
         }
     }
 
@@ -528,20 +542,20 @@ namespace pxt.assets.music {
         return res;
     }
 
-    function encodeNoteEvent(event: NoteEvent) {
+    function encodeNoteEvent(event: NoteEvent, instrumentOctave: number, isDrumTrack: boolean) {
         const out = new Uint8Array(5 + event.notes.length);
         set16BitNumber(out, 0, event.startTick);
         set16BitNumber(out, 2, event.endTick);
         out[4] = event.notes.length;
 
         for (let i = 0; i < event.notes.length; i++) {
-            out[5 + i] = event.notes[i];
+            out[5 + i] = encodeNote(event.notes[i], instrumentOctave, isDrumTrack);
         }
 
         return out;
     }
 
-    function decodeNoteEvent(buf: Uint8Array, offset: number): NoteEvent {
+    function decodeNoteEvent(buf: Uint8Array, offset: number, instrumentOctave: number, isDrumTrack: boolean): NoteEvent {
         const res: NoteEvent = {
             startTick: get16BitNumber(buf, offset),
             endTick: get16BitNumber(buf, offset + 2),
@@ -549,9 +563,43 @@ namespace pxt.assets.music {
         };
 
         for (let i = 0; i < buf[offset + 4]; i++) {
-            res.notes.push(buf[offset + 5 + i]);
+            res.notes.push(decodeNote(buf[offset + 5 + i], instrumentOctave, isDrumTrack));
         }
         return res;
+    }
+
+    function encodeNote(note: Note, instrumentOctave: number, isDrumTrack: boolean) {
+        if (isDrumTrack) {
+            return note.note;
+        }
+
+        let flags = 0;
+        if (note.enharmonicSpelling === "flat") {
+            flags = 1;
+        }
+        else if (note.enharmonicSpelling === "sharp") {
+            flags = 2;
+        }
+
+        return (note.note - (instrumentOctave - 2) * 12) | (flags << 6)
+    }
+
+    function decodeNote(note: number, instrumentOctave: number, isDrumTrack: boolean) {
+        const flags = note >> 6;
+
+        const result: Note = {
+            note: isDrumTrack ? note : ((note & 0x3f) + (instrumentOctave - 2) * 12),
+            enharmonicSpelling: "normal"
+        }
+
+        if (flags === 1) {
+            result.enharmonicSpelling = "flat";
+        }
+        else if (flags === 2) {
+            result.enharmonicSpelling = "sharp";
+        }
+
+        return result;
     }
 
     function encodeTrack(track: Track) {
@@ -561,7 +609,7 @@ namespace pxt.assets.music {
 
     function encodeMelodicTrack(track: Track) {
         const encodedInstrument = encodeInstrument(track.instrument);
-        const encodedNotes = track.notes.map(encodeNoteEvent);
+        const encodedNotes = track.notes.map(note => encodeNoteEvent(note, track.instrument.octave, !!track.drums));
         const noteLength = encodedNotes.reduce((d, c) => c.length + d, 0);
 
         const out = new Uint8Array(6 + encodedInstrument.length + noteLength);
@@ -596,7 +644,7 @@ namespace pxt.assets.music {
         let currentOffset = noteStart + 2;
 
         while (currentOffset < noteStart + 2 + noteLength) {
-            res.notes.push(decodeNoteEvent(buf, currentOffset));
+            res.notes.push(decodeNoteEvent(buf, currentOffset, res.instrument.octave, false));
             currentOffset += 5 + res.notes[res.notes.length - 1].notes.length
         }
 
@@ -607,7 +655,7 @@ namespace pxt.assets.music {
         const encodedDrums = track.drums.map(encodeDrumInstrument);
         const drumLength = encodedDrums.reduce((d, c) => c.length + d, 0);
 
-        const encodedNotes = track.notes.map(encodeNoteEvent);
+        const encodedNotes = track.notes.map(note => encodeNoteEvent(note, 0, false));
         const noteLength = encodedNotes.reduce((d, c) => c.length + d, 0);
 
         const out = new Uint8Array(6 + drumLength + noteLength);
@@ -651,7 +699,7 @@ namespace pxt.assets.music {
         currentOffset += 2;
 
         while (currentOffset < offset + 4 + drumByteLength + noteLength) {
-            res.notes.push(decodeNoteEvent(buf, currentOffset));
+            res.notes.push(decodeNoteEvent(buf, currentOffset, 0, true));
             currentOffset += 5 + res.notes[res.notes.length - 1].notes.length
         }
 

--- a/pxtlib/music.ts
+++ b/pxtlib/music.ts
@@ -609,7 +609,7 @@ namespace pxt.assets.music {
 
     function encodeMelodicTrack(track: Track) {
         const encodedInstrument = encodeInstrument(track.instrument);
-        const encodedNotes = track.notes.map(note => encodeNoteEvent(note, track.instrument.octave, !!track.drums));
+        const encodedNotes = track.notes.map(note => encodeNoteEvent(note, track.instrument.octave, false));
         const noteLength = encodedNotes.reduce((d, c) => c.length + d, 0);
 
         const out = new Uint8Array(6 + encodedInstrument.length + noteLength);
@@ -655,7 +655,7 @@ namespace pxt.assets.music {
         const encodedDrums = track.drums.map(encodeDrumInstrument);
         const drumLength = encodedDrums.reduce((d, c) => c.length + d, 0);
 
-        const encodedNotes = track.notes.map(note => encodeNoteEvent(note, 0, false));
+        const encodedNotes = track.notes.map(note => encodeNoteEvent(note, 0, true));
         const noteLength = encodedNotes.reduce((d, c) => c.length + d, 0);
 
         const out = new Uint8Array(6 + drumLength + noteLength);
@@ -795,6 +795,27 @@ namespace pxt.assets.music {
             tracks: [
                 {
                     id: 0,
+                    name: lf("Dog"),
+                    notes: [],
+                    iconURI: "/static/music-editor/dog.png",
+                    instrument: {
+                        waveform: 1,
+                        octave: 4,
+                        ampEnvelope: {
+                            attack: 10,
+                            decay: 100,
+                            sustain: 500,
+                            release: 100,
+                            amplitude: 1024
+                        },
+                        pitchLFO: {
+                            frequency: 5,
+                            amplitude: 0
+                        }
+                    }
+                },
+                {
+                    id: 1,
                     name: lf("Duck"),
                     notes: [],
                     iconURI: "/static/music-editor/duck.png",
@@ -826,7 +847,7 @@ namespace pxt.assets.music {
                     }
                 },
                 {
-                    id: 1,
+                    id: 2,
                     name: lf("Cat"),
                     notes: [],
                     iconURI: "/static/music-editor/cat.png",
@@ -850,27 +871,6 @@ namespace pxt.assets.music {
                         pitchLFO: {
                             frequency: 10,
                             amplitude: 6
-                        }
-                    }
-                },
-                {
-                    id: 2,
-                    name: lf("Dog"),
-                    notes: [],
-                    iconURI: "/static/music-editor/dog.png",
-                    instrument: {
-                        waveform: 1,
-                        octave: 4,
-                        ampEnvelope: {
-                            attack: 10,
-                            decay: 100,
-                            sustain: 500,
-                            release: 100,
-                            amplitude: 1024
-                        },
-                        pitchLFO: {
-                            frequency: 5,
-                            amplitude: 0
                         }
                     }
                 },

--- a/react-common/styles/controls/Checkbox.less
+++ b/react-common/styles/controls/Checkbox.less
@@ -4,6 +4,7 @@
 
     display: flex;
     align-items: center;
+    cursor: pointer;
 
     input {
         margin-right: 0.5rem;

--- a/theme/music-editor/PlaybackControls.less
+++ b/theme/music-editor/PlaybackControls.less
@@ -24,14 +24,20 @@
     & > .common-input-wrapper {
         margin-right: 0.5rem;
     }
+
+    .common-checkbox {
+        margin-right: 1rem;
+    }
+
+    .spacer {
+        flex-grow: 1;
+    }
 }
 
 .music-undo-redo  {
     display: flex;
     flex-direction: row;
     align-items: center;
-    flex-grow: 1;
-    justify-content: end;
     margin-right: 0.5rem;
 
     .square-button {

--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -95,15 +95,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
 
     constructor(props: {}) {
         super(props);
-        this.state = {
-            editing: {
-                id: "",
-                internalID: -1,
-                meta: {},
-                type: pxt.AssetType.Song,
-                song: pxt.assets.music.getEmptySong(2)
-            }
-        };
+        this.state = {};
         pxt.react.getTilemapProject = () => this.tilemapProject;
 
         setTelemetryFunction(tickAssetEditorEvent);
@@ -188,12 +180,12 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
 
     render() {
         if (this.state.editing) {
+            return <ImageFieldEditor
+                ref={this.refHandler}
+                singleFrame={this.state.editing.type !== "animation"}
+                isMusicEditor={this.state.editing.type === "song"}
+                doneButtonCallback={this.callbackOnDoneClick} />
         }
-        return <ImageFieldEditor
-            ref={this.refHandler}
-            singleFrame={true}
-            isMusicEditor={true}
-            doneButtonCallback={this.callbackOnDoneClick} />
 
         return <div></div>
     }

--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -95,7 +95,15 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
 
     constructor(props: {}) {
         super(props);
-        this.state = {};
+        this.state = {
+            editing: {
+                id: "",
+                internalID: -1,
+                meta: {},
+                type: pxt.AssetType.Song,
+                song: pxt.assets.music.getEmptySong(2)
+            }
+        };
         pxt.react.getTilemapProject = () => this.tilemapProject;
 
         setTelemetryFunction(tickAssetEditorEvent);
@@ -180,12 +188,12 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
 
     render() {
         if (this.state.editing) {
-            return <ImageFieldEditor
-                ref={this.refHandler}
-                singleFrame={this.state.editing.type !== "animation"}
-                isMusicEditor={this.state.editing.type === "song"}
-                doneButtonCallback={this.callbackOnDoneClick} />
         }
+        return <ImageFieldEditor
+            ref={this.refHandler}
+            singleFrame={true}
+            isMusicEditor={true}
+            doneButtonCallback={this.callbackOnDoneClick} />
 
         return <div></div>
     }

--- a/webapp/src/components/musicEditor/MusicEditor.tsx
+++ b/webapp/src/components/musicEditor/MusicEditor.tsx
@@ -5,7 +5,7 @@ import { isPlaying, playDrumAsync, playNoteAsync, tickToMs, updatePlaybackSongAs
 import { PlaybackControls } from "./PlaybackControls";
 import { ScrollableWorkspace } from "./ScrollableWorkspace";
 import { GridResolution, TrackSelector } from "./TrackSelector";
-import { addNoteToTrack, changeSongLength, editNoteEventLength, fillDrums, findPreviousNoteEvent, findNoteEventAtPosition, findSelectedRange, noteToRow, removeNoteFromTrack, rowToNote, selectNoteEventsInRange, unselectAllNotes, applySelection as applySelectionMove, deleteSelectedNotes, applySelection } from "./utils";
+import { addNoteToTrack, changeSongLength, editNoteEventLength, fillDrums, findPreviousNoteEvent, findNoteEventAtPosition, findSelectedRange, noteToRow, removeNoteFromTrack, rowToNote, selectNoteEventsInRange, unselectAllNotes, applySelection as applySelectionMove, deleteSelectedNotes, applySelection, removeNoteAtRowFromTrack, isBassClefNote } from "./utils";
 
 export interface MusicEditorProps {
     asset: pxt.Song;
@@ -185,17 +185,71 @@ export const MusicEditor = (props: MusicEditorProps) => {
         setCursorVisible(false);
         const track = currentSong.tracks[selectedTrack];
         const instrument = track.instrument;
-        const note = isDrumTrack ? coord.row : rowToNote(instrument.octave, coord.row, coord.isBassClef, ctrlIsPressed);
+        // const note = isDrumTrack ? coord.row : rowToNote(instrument.octave, coord.row, coord.isBassClef, ctrlIsPressed);
 
         const existingEvent = findPreviousNoteEvent(currentSong, selectedTrack, coord.tick);
 
         clearSelection();
         setCursorTick(coord.tick);
 
-        if (existingEvent?.startTick === coord.tick && existingEvent.notes.indexOf(note) !== -1) {
-            updateSong(unselectAllNotes(removeNoteFromTrack(currentSong, selectedTrack, note, coord.tick)), true);
+        const isAtCoord = (note: pxt.assets.music.Note) => {
+            if (isDrumTrack) return note.note === coord.row;
+            const isBassClef = isBassClefNote(instrument.octave, note);
+
+            if (isBassClef !== coord.isBassClef) return false;
+
+            return noteToRow(instrument.octave, note) === coord.row;
+        }
+
+        if (existingEvent?.startTick === coord.tick && existingEvent.notes.some(isAtCoord)) {
+            const unselected = unselectAllNotes(currentSong);
+
+            if (ctrlIsPressed && !isDrumTrack) {
+                // Change the enharmonic spelling
+                const existingNote = existingEvent.notes.find(isAtCoord);
+
+                const minNote = instrument.octave * 12 - 20;
+                const maxNote = instrument.octave * 12 + 20;
+
+                const removed = removeNoteAtRowFromTrack(unselected, selectedTrack, coord.row, coord.isBassClef, coord.tick);
+
+                let newSpelling: "normal" | "sharp" | "flat";
+                if (existingNote.enharmonicSpelling === "normal" && existingNote.note < maxNote) {
+                    newSpelling = "sharp";
+                }
+                else if (existingNote.enharmonicSpelling === "sharp" && existingNote.note > minNote || existingNote.note === maxNote) {
+                    newSpelling = "flat"
+                }
+                else {
+                    newSpelling = "normal"
+                }
+                const newNote = rowToNote(instrument.octave, coord.row, coord.isBassClef, newSpelling)
+
+                updateSong(
+                    addNoteToTrack(
+                        removed,
+                        selectedTrack,
+                        newNote,
+                        existingEvent.startTick,
+                        existingEvent.endTick
+                    ),
+                    true
+                );
+
+                playNoteAsync(newNote.note, instrument, tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, gridTicks))
+            }
+            else {
+                updateSong(
+                    removeNoteAtRowFromTrack(unselected, selectedTrack, coord.row, coord.isBassClef, coord.tick),
+                    true
+                );
+            }
         }
         else if (!eraserActive) {
+            const note: pxt.assets.music.Note = isDrumTrack ?
+                { note: coord.row, enharmonicSpelling: "normal" } :
+                rowToNote(instrument.octave, coord.row, coord.isBassClef);
+
             const maxTick = currentSong.beatsPerMeasure * currentSong.ticksPerBeat * currentSong.measures;
 
             if (coord.tick === maxTick) return;
@@ -204,10 +258,10 @@ export const MusicEditor = (props: MusicEditorProps) => {
             updateSong(unselectAllNotes(addNoteToTrack(currentSong, selectedTrack, note, coord.tick, coord.tick + noteLength)), true)
 
             if (isDrumTrack) {
-                playDrumAsync(track.drums[note]);
+                playDrumAsync(track.drums[coord.row]);
             }
             else {
-                playNoteAsync(note, instrument, tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, gridTicks))
+                playNoteAsync(note.note, instrument, tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, gridTicks))
             }
         }
         else {
@@ -220,15 +274,8 @@ export const MusicEditor = (props: MusicEditorProps) => {
                 const existingEvent = findPreviousNoteEvent(currentSong, i, coord.tick);
 
                 if (existingEvent?.startTick === coord.tick || existingEvent?.endTick > coord.tick) {
-                    if (existingEvent.notes.indexOf(note) !== -1) {
-                        updateSong(removeNoteFromTrack(currentSong, i, note, existingEvent.startTick), false);
-                    }
-
-                    if (track.drums) continue;
-
-                    const sharp = rowToNote(instrument.octave, coord.row, coord.isBassClef, true);
-                    if (existingEvent.notes.indexOf(sharp) !== -1) {
-                        updateSong(removeNoteFromTrack(currentSong, i, sharp, existingEvent.startTick), false);
+                    if (existingEvent.notes.some(isAtCoord)) {
+                        updateSong(removeNoteAtRowFromTrack(currentSong, i, coord.row, coord.isBassClef, existingEvent.startTick), false);
                     }
                 }
             }
@@ -304,19 +351,20 @@ export const MusicEditor = (props: MusicEditorProps) => {
 
                 const track = currentSong.tracks[i];
                 const instrument = track.instrument;
-                const note = !!track.drums ? end.row : rowToNote(instrument.octave, end.row, end.isBassClef);
                 const existingEvent = findPreviousNoteEvent(currentSong, i, end.tick);
 
+                const isAtCoord = (note: pxt.assets.music.Note) => {
+                    if (isDrumTrack) return note.note === end.row;
+                    const isBassClef = isBassClefNote(instrument.octave, note);
+
+                    if (isBassClef !== end.isBassClef) return false;
+
+                    return noteToRow(instrument.octave, note) === end.row;
+                }
+
                 if (existingEvent?.startTick === end.tick || existingEvent?.endTick > end.tick) {
-                    if (existingEvent.notes.indexOf(note) !== -1) {
-                        updateSong(removeNoteFromTrack(currentSong, i, note, existingEvent.startTick), false);
-                    }
-
-                    if (track.drums) continue;
-
-                    const sharp = rowToNote(instrument.octave, end.row, end.isBassClef, true);
-                    if (existingEvent.notes.indexOf(sharp) !== -1) {
-                        updateSong(removeNoteFromTrack(currentSong, i, sharp, existingEvent.startTick), false);
+                    if (existingEvent.notes.some(isAtCoord)) {
+                        updateSong(removeNoteAtRowFromTrack(currentSong, i, end.row, end.isBassClef, existingEvent.startTick), false);
                     }
                 }
             }
@@ -364,7 +412,7 @@ export const MusicEditor = (props: MusicEditorProps) => {
         if (!isDrumTrack && event && start.tick >= event.startTick && start.tick < event.endTick) {
             let isOnRow = false;
             for (const note of event.notes) {
-                if (noteToRow(currentSong.tracks[selectedTrack].instrument.octave, note, start.isBassClef) === start.row) {
+                if (noteToRow(currentSong.tracks[selectedTrack].instrument.octave, note) === start.row) {
                     isOnRow = true;
                     break;
                 }
@@ -417,7 +465,7 @@ export const MusicEditor = (props: MusicEditorProps) => {
             playDrumAsync(t.drums[0]);
         }
         else {
-            playNoteAsync(rowToNote(t.instrument.octave, 6, false), t.instrument, tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, currentSong.ticksPerBeat / 2));
+            playNoteAsync(rowToNote(t.instrument.octave, 6, false).note, t.instrument, tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, currentSong.ticksPerBeat / 2));
         }
         setSelectedTrack(newTrack);
         if (cursor) setCursor({ ...cursor, track: newTrack });

--- a/webapp/src/components/musicEditor/MusicEditor.tsx
+++ b/webapp/src/components/musicEditor/MusicEditor.tsx
@@ -5,7 +5,7 @@ import { isPlaying, playDrumAsync, playNoteAsync, tickToMs, updatePlaybackSongAs
 import { PlaybackControls } from "./PlaybackControls";
 import { ScrollableWorkspace } from "./ScrollableWorkspace";
 import { GridResolution, TrackSelector } from "./TrackSelector";
-import { addNoteToTrack, changeSongLength, editNoteEventLength, fillDrums, findPreviousNoteEvent, findNoteEventAtPosition, findSelectedRange, noteToRow, removeNoteFromTrack, rowToNote, selectNoteEventsInRange, unselectAllNotes, applySelection as applySelectionMove, deleteSelectedNotes, applySelection, removeNoteAtRowFromTrack, isBassClefNote } from "./utils";
+import { addNoteToTrack, changeSongLength, editNoteEventLength, fillDrums, findPreviousNoteEvent, findNoteEventAtPosition, findSelectedRange, noteToRow, removeNoteFromTrack, rowToNote, selectNoteEventsInRange, unselectAllNotes, applySelection as applySelectionMove, deleteSelectedNotes, applySelection, removeNoteAtRowFromTrack, isBassClefNote, doesSongUseBassClef } from "./utils";
 
 export interface MusicEditorProps {
     asset: pxt.Song;
@@ -41,7 +41,7 @@ export const MusicEditor = (props: MusicEditorProps) => {
     const [selection, setSelection] = React.useState<WorkspaceSelectionState | undefined>();
     const [cursor, setCursor] = React.useState<CursorState>();
     const [cursorVisible, setCursorVisible] = React.useState(false);
-    const [bassClefVisible, setBassClefVisible] = React.useState(false);
+    const [bassClefVisible, setBassClefVisible] = React.useState(doesSongUseBassClef(asset.song));
 
     React.useEffect(() => {
         return () => {
@@ -185,7 +185,6 @@ export const MusicEditor = (props: MusicEditorProps) => {
         setCursorVisible(false);
         const track = currentSong.tracks[selectedTrack];
         const instrument = track.instrument;
-        // const note = isDrumTrack ? coord.row : rowToNote(instrument.octave, coord.row, coord.isBassClef, ctrlIsPressed);
 
         const existingEvent = findPreviousNoteEvent(currentSong, selectedTrack, coord.tick);
 

--- a/webapp/src/components/musicEditor/MusicEditor.tsx
+++ b/webapp/src/components/musicEditor/MusicEditor.tsx
@@ -41,6 +41,7 @@ export const MusicEditor = (props: MusicEditorProps) => {
     const [selection, setSelection] = React.useState<WorkspaceSelectionState | undefined>();
     const [cursor, setCursor] = React.useState<CursorState>();
     const [cursorVisible, setCursorVisible] = React.useState(false);
+    const [bassClefVisible, setBassClefVisible] = React.useState(false);
 
     React.useEffect(() => {
         return () => {
@@ -507,7 +508,7 @@ export const MusicEditor = (props: MusicEditorProps) => {
             onWorkspaceDrag={onNoteDrag}
             gridTicks={gridTicks}
             hideUnselectedTracks={hideTracksActive}
-            showBassClef={true}
+            showBassClef={bassClefVisible}
             selection={selection}
             cursor={cursorVisible ? cursor : undefined}
             onKeydown={onWorkspaceKeydown} />
@@ -517,6 +518,8 @@ export const MusicEditor = (props: MusicEditorProps) => {
             onMeasuresChanged={onMeasuresChanged}
             onUndoClick={undo}
             onRedoClick={redo}
+            showBassClef={bassClefVisible}
+            onBassClefCheckboxClick={setBassClefVisible}
             hasUndo={!!undoStack.length}
             hasRedo={!!redoStack.length} />
         <EditControls

--- a/webapp/src/components/musicEditor/Note.tsx
+++ b/webapp/src/components/musicEditor/Note.tsx
@@ -7,14 +7,14 @@ export interface NoteProps {
     iconURI: string
     opacity?: number;
     length?: number;
-    isSharp?: boolean;
+    enharmonicSpelling?: "sharp" | "flat" | "normal";
     isBassClef: boolean;
     selected?: boolean;
     cursorHighlighted?: boolean;
 }
 
 export const Note = (props: NoteProps) => {
-    const { row, iconURI, length, opacity, isSharp, isBassClef, selected, cursorHighlighted } = props;
+    const { row, iconURI, length, opacity, enharmonicSpelling, isBassClef, selected, cursorHighlighted } = props;
 
     return <g className={classList("music-staff-note", selected && "selected", cursorHighlighted && "cursor-highlighted")} transform={`translate(${-(NOTE_ICON_WIDTH / 2)}, ${rowY(row, isBassClef) - (NOTE_ICON_WIDTH / 2)})`}>
         { row === 0 &&
@@ -41,8 +41,10 @@ export const Note = (props: NoteProps) => {
                 repeatCount="1"
                 begin="indefinite" />
         </image>
-        { isSharp &&
-            <text x={NOTE_ICON_WIDTH} y={0} fontSize={NOTE_ICON_WIDTH / 2}>♯</text>
+        {(enharmonicSpelling && enharmonicSpelling !== "normal") &&
+            <text x={NOTE_ICON_WIDTH} y={0} fontSize={NOTE_ICON_WIDTH / 2}>
+                { enharmonicSpelling === "sharp" ? "♯" : "♭" }
+            </text>
         }
     </g>
 }

--- a/webapp/src/components/musicEditor/NoteGroup.tsx
+++ b/webapp/src/components/musicEditor/NoteGroup.tsx
@@ -3,7 +3,7 @@ import { CursorState } from "./keyboardNavigation";
 import { Note } from "./Note";
 import { addPlaybackStateListener, addTickListener, removePlaybackStateListener, removeTickListener } from "./playback";
 import { tickToX } from "./svgConstants";
-import { isBassClefNote, isSharpNote, noteToRow } from "./utils";
+import { isBassClefNote, noteToRow } from "./utils";
 
 export interface NoteGroupProps {
     song: pxt.assets.music.Song;
@@ -74,18 +74,17 @@ export const NoteGroup = (props: NoteGroupProps) => {
             let isBassClef = false
 
             if (isDrumTrack) {
-                row = note;
+                row = note.note;
             }
             else {
                 isBassClef = isBassClefNote(octave, note);
-                row = noteToRow(octave, note, isBassClef);
+                row = noteToRow(octave, note);
             }
-            const isSharp = isDrumTrack ? false : isSharpNote(octave, note, isBassClef);
             return <Note
                 key={index}
                 isBassClef={isBassClef}
                 row={row}
-                isSharp={isSharp}
+                enharmonicSpelling={note.enharmonicSpelling}
                 iconURI={iconURI}
                 length={noteLength}
                 selected={noteEvent.selected}

--- a/webapp/src/components/musicEditor/PlaybackControls.tsx
+++ b/webapp/src/components/musicEditor/PlaybackControls.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Button } from "../../../../react-common/components/controls/Button";
+import { Checkbox } from "../../../../react-common/components/controls/Checkbox";
 import { Input } from "../../../../react-common/components/controls/Input";
 import { classList } from "../../../../react-common/components/util";
 import { addPlaybackStateListener, isLooping, isPlaying, removePlaybackStateListener, setLooping, startPlaybackAsync, stopPlayback } from "./playback";
@@ -8,6 +9,8 @@ export interface PlaybackControlsProps {
     song: pxt.assets.music.Song;
     onTempoChange: (newTempo: number) => void;
     onMeasuresChanged: (newMeasures: number) => void;
+    showBassClef: boolean;
+    onBassClefCheckboxClick: (newValue: boolean) => void;
 
     hasUndo: boolean;
     hasRedo: boolean;
@@ -26,6 +29,8 @@ export const PlaybackControls = (props: PlaybackControlsProps) => {
         onRedoClick,
         hasUndo,
         hasRedo,
+        showBassClef,
+        onBassClefCheckboxClick
     } = props;
 
     const [state, setState] = React.useState<PlaybackState>("stop");
@@ -110,8 +115,14 @@ export const PlaybackControls = (props: PlaybackControlsProps) => {
             label={lf("Tempo:")}
             initialValue={song.beatsPerMinute.toString()}
             onBlur={handleTempoChange}
-            onEnterKey={handleTempoChange}
-            />
+            onEnterKey={handleTempoChange} />
+        <div className="spacer"/>
+        <Checkbox
+            className="music-editor-label"
+            id="show-bass-clef"
+            label={lf("Show bass clef")}
+            isChecked={showBassClef}
+            onChange={onBassClefCheckboxClick} />
         <div className="music-undo-redo common-button-group">
             <Button
                 className="square-button purple"

--- a/webapp/src/components/musicEditor/keyboardNavigation.ts
+++ b/webapp/src/components/musicEditor/keyboardNavigation.ts
@@ -1,5 +1,5 @@
 import { isPlaying, playNoteAsync, startPlaybackAsync, stopPlayback, tickToMs } from "./playback";
-import { addNoteToTrack, applySelection, deleteSelectedNotes, editNoteEventLength, findNextNoteEvent, findNoteEventAtTick, findPreviousNoteEvent, findSelectedRange, isBassClefNote, moveSelectedNotes, removeNoteEventFromTrack, removeNoteFromTrack, rowToNote, selectNoteEventsInRange, unselectAllNotes } from "./utils";
+import { addNoteToTrack, applySelection, deleteSelectedNotes, editNoteEventLength, findNextNoteEvent, findNoteEventAtTick, findPreviousNoteEvent, findSelectedRange, isBassClefNote, moveSelectedNotes, noteToRow, removeNoteAtRowFromTrack, removeNoteEventFromTrack, removeNoteFromTrack, rowToNote, selectNoteEventsInRange, unselectAllNotes } from "./utils";
 
 /**
  * All shortcuts
@@ -104,9 +104,6 @@ export function handleKeyboardEvent(song: pxt.assets.music.Song, cursor: CursorS
 
     const instrument = song.tracks[cursor.track].instrument;
     const instrumentOctave = instrument.octave;
-    const drums = song.tracks[cursor.track].drums;
-    const minNote = drums ? 0 : instrumentOctave * 12 - 20;
-    const maxNote = drums ? drums.length - 1 : instrumentOctave * 12 + 19;
     const ticksPerMeasure = song.ticksPerBeat * song.beatsPerMeasure;
     const maxTicks = ticksPerMeasure * song.measures;
     const hasSelection = !!cursor.selection;
@@ -123,7 +120,7 @@ export function handleKeyboardEvent(song: pxt.assets.music.Song, cursor: CursorS
 
     const playNoteEvent = (ev: pxt.assets.music.NoteEvent) => {
         for (const note of ev.notes) {
-            playNoteAsync(note, instrument, tickToMs(editedSong.beatsPerMinute, song.ticksPerBeat, ev.endTick - ev.startTick));
+            playNoteAsync(note.note, instrument, tickToMs(editedSong.beatsPerMinute, song.ticksPerBeat, ev.endTick - ev.startTick));
         }
     }
 
@@ -151,24 +148,45 @@ export function handleKeyboardEvent(song: pxt.assets.music.Song, cursor: CursorS
             }
             else {
                 let note = noteEventAtCursor.notes[cursor.noteGroupIndex];
+                const track = editedSong.tracks[cursor.track];
+                let isBass = isBassClefNote(instrumentOctave, note);
+
+                const originalRow = track.drums ? note.note : noteToRow(instrumentOctave, note)
+
+                let row = originalRow;
 
                 const delta = ctrlPressed ? 12 : 1;
-                while (noteEventAtCursor.notes.indexOf(note) !== -1) {
-                    note += delta;
+                while (noteEventAtCursor.notes.some(n => {
+                    if (track.drums) return n.note === row;
+                    if (isBassClefNote(instrumentOctave, n) !== isBass) return false;
+                    return row === noteToRow(instrumentOctave, n)
+                })) {
+                    row += delta;
+
+                    if (row >= 12) {
+                        if (isBass) {
+                            isBass = false;
+                            row -= 12;
+                        }
+                        else {
+                            break;
+                        }
+                    }
                 }
 
-                if (note < minNote || note > maxNote) {
-                    break;
-                }
+                if (row >= 12 || row < 0) break;
 
+                const newNote: pxt.assets.music.Note = track.drums ?
+                    { note: row, enharmonicSpelling: "normal" } :
+                    rowToNote(instrumentOctave, row, isBass, note.enharmonicSpelling)
 
-                editedSong = removeNoteFromTrack(editedSong, cursor.track, noteEventAtCursor.notes[cursor.noteGroupIndex], noteEventAtCursor.startTick);
-                editedSong = addNoteToTrack(editedSong, cursor.track, note, noteEventAtCursor.startTick, noteEventAtCursor.endTick);
+                editedSong = removeNoteAtRowFromTrack(editedSong, cursor.track, originalRow, isBassClefNote(instrumentOctave, note), noteEventAtCursor.startTick);
+                editedSong = addNoteToTrack(editedSong, cursor.track, newNote, noteEventAtCursor.startTick, noteEventAtCursor.endTick);
 
                 const newEvent = findNoteEventAtTick(editedSong, cursor.track, cursor.tick);
-                editedCursor.noteGroupIndex = newEvent.notes.indexOf(note);
+                editedCursor.noteGroupIndex = newEvent.notes.findIndex(n => n.note === newNote.note);
 
-                playNoteAsync(note, instrument, tickToMs(editedSong.beatsPerMinute, song.ticksPerBeat, newEvent.endTick - newEvent.startTick));
+                playNoteAsync(newNote.note, instrument, tickToMs(editedSong.beatsPerMinute, song.ticksPerBeat, newEvent.endTick - newEvent.startTick));
             }
             break;
 
@@ -195,24 +213,46 @@ export function handleKeyboardEvent(song: pxt.assets.music.Song, cursor: CursorS
             }
             else {
                 let note = noteEventAtCursor.notes[cursor.noteGroupIndex];
+                const track = editedSong.tracks[cursor.track];
+                let isBass = isBassClefNote(instrumentOctave, note);
 
-                const delta = ctrlPressed ? 12 : 1;
-                while (noteEventAtCursor.notes.indexOf(note) !== -1) {
-                    note -= delta;
+                const originalRow = track.drums ? note.note : noteToRow(instrumentOctave, note)
+
+                let row = originalRow;
+
+                const delta = ctrlPressed ? -12 : -1;
+
+                while (noteEventAtCursor.notes.some(n => {
+                    if (track.drums) return n.note === row;
+                    if (isBassClefNote(instrumentOctave, n) !== isBass) return false;
+                    return row === noteToRow(instrumentOctave, n)
+                })) {
+                    row += delta;
+
+                    if (row < 0) {
+                        if (!isBass) {
+                            isBass = true;
+                            row += 12;
+                        }
+                        else {
+                            break;
+                        }
+                    }
                 }
 
-                if (note < minNote || note > maxNote) {
-                    break;
-                }
+                if (row >= 12 || row < 0) break;
 
-                editedSong = removeNoteFromTrack(editedSong, cursor.track, noteEventAtCursor.notes[cursor.noteGroupIndex], noteEventAtCursor.startTick);
-                editedSong = addNoteToTrack(editedSong, cursor.track, note, noteEventAtCursor.startTick, noteEventAtCursor.endTick);
+                const newNote: pxt.assets.music.Note = track.drums ?
+                    { note: row, enharmonicSpelling: "normal" } :
+                    rowToNote(instrumentOctave, row, isBass, note.enharmonicSpelling)
+
+                editedSong = removeNoteAtRowFromTrack(editedSong, cursor.track, originalRow, isBassClefNote(instrumentOctave, note), noteEventAtCursor.startTick);
+                editedSong = addNoteToTrack(editedSong, cursor.track, newNote, noteEventAtCursor.startTick, noteEventAtCursor.endTick);
 
                 const newEvent = findNoteEventAtTick(editedSong, cursor.track, cursor.tick);
-                editedCursor.noteGroupIndex = newEvent.notes.indexOf(note);
+                editedCursor.noteGroupIndex = newEvent.notes.findIndex(n => n.note === newNote.note);
 
-                playNoteAsync(note, instrument, tickToMs(editedSong.beatsPerMinute, editedSong.ticksPerBeat, newEvent.endTick - newEvent.startTick));
-            }
+                playNoteAsync(newNote.note, instrument, tickToMs(editedSong.beatsPerMinute, song.ticksPerBeat, newEvent.endTick - newEvent.startTick));            }
             break;
 
         case "ArrowLeft":

--- a/webapp/src/components/musicEditor/playback.ts
+++ b/webapp/src/components/musicEditor/playback.ts
@@ -110,10 +110,10 @@ export async function startPlaybackAsync(song: pxt.assets.music.Song, loop: bool
                 if (noteEvent.startTick === currentTick) {
                     for (const note of noteEvent.notes) {
                         if (track.drums) {
-                            playDrumAsync(track.drums[note], isCancelled);
+                            playDrumAsync(track.drums[note.note], isCancelled);
                         }
                         else {
-                            playNoteAsync(note, track.instrument, tickToMs(playbackState.song.beatsPerMinute, playbackState.song.ticksPerBeat, noteEvent.endTick - noteEvent.startTick), isCancelled);
+                            playNoteAsync(note.note, track.instrument, tickToMs(playbackState.song.beatsPerMinute, playbackState.song.ticksPerBeat, noteEvent.endTick - noteEvent.startTick), isCancelled);
                         }
                     }
                 }

--- a/webapp/src/components/musicEditor/utils.ts
+++ b/webapp/src/components/musicEditor/utils.ts
@@ -468,3 +468,13 @@ function moveNoteEvent(noteEvent: pxt.assets.music.NoteEvent, trackOctave: numbe
 
     return res;
 }
+
+export function doesSongUseBassClef(song: pxt.assets.music.Song) {
+    return song.tracks.some(track =>
+        !track.drums && track.notes.some(noteEvent =>
+            noteEvent.notes.some(note =>
+                isBassClefNote(track.instrument.octave, note)
+            )
+        )
+    );
+}

--- a/webapp/src/components/musicEditor/utils.ts
+++ b/webapp/src/components/musicEditor/utils.ts
@@ -63,12 +63,12 @@ export function addNoteToTrack(song: pxt.assets.music.Song, trackIndex: number, 
         ...song,
         tracks: song.tracks.map((track, index) => index !== trackIndex ? track : {
             ...track,
-            notes: addToNoteArray(track.notes, note, startTick, endTick)
+            notes: addToNoteArray(track.notes, note, startTick, endTick, track.instrument.octave, !!track.drums)
         })
     }
 }
 
-function addToNoteArray(notes: pxt.assets.music.NoteEvent[], note: pxt.assets.music.Note, startTick: number, endTick: number) {
+function addToNoteArray(notes: pxt.assets.music.NoteEvent[], note: pxt.assets.music.Note, startTick: number, endTick: number, octave: number, isDrumTrack: boolean) {
     const noteEvent: pxt.assets.music.NoteEvent = {
         notes: [note],
         startTick,
@@ -86,7 +86,15 @@ function addToNoteArray(notes: pxt.assets.music.NoteEvent[], note: pxt.assets.mu
 
             return notes.map((event, index) => index !== i ? event : {
                 ...event,
-                notes: event.notes.concat([note]).sort()
+                notes: event.notes.concat([note]).sort((a, b) => {
+                    if (isDrumTrack) return a.note - b.note;
+                    const aIsBassClef = isBassClefNote(octave, a);
+                    const bIsBassClef = isBassClefNote(octave, b);
+
+                    if (aIsBassClef === bIsBassClef) return noteToRow(octave, a) - noteToRow(octave, b);
+                    else if (aIsBassClef) return -1;
+                    else return 1;
+                })
             })
         }
     }

--- a/webapp/src/components/musicEditor/utils.ts
+++ b/webapp/src/components/musicEditor/utils.ts
@@ -1,36 +1,64 @@
 
 const staffNoteIntervals = [0, 2, 4, 5, 7, 9, 11, 12, 14, 16, 17, 19];
 
-export function rowToNote(octave: number, row: number, isBassClef: boolean, isSharp?: boolean) {
-    return staffNoteIntervals[row] + octave * 12 + 1 + (isSharp ? 1 : 0) - (isBassClef ? 20 : 0)
+export function rowToNote(octave: number, row: number, isBassClef: boolean, enharmonicSpelling?: "flat" | "sharp" | "normal"): pxt.assets.music.Note {
+    const base = staffNoteIntervals[row] + octave * 12 + 1 - (isBassClef ? 20 : 0);
+
+    if (!enharmonicSpelling || enharmonicSpelling === "normal") {
+        return {
+            note: base,
+            enharmonicSpelling: "normal"
+        };
+    }
+    else if (enharmonicSpelling === "sharp") {
+        return {
+            note: base + 1,
+            enharmonicSpelling
+        }
+    }
+    else {
+        return {
+            note: base - 1,
+            enharmonicSpelling
+        }
+    }
 }
 
-export function noteToRow(octave: number, note: number, isBassClef: boolean) {
-    const offset = note - 1 - octave * 12 + (isBassClef ? 20 : 0);
+export function noteToRow(octave: number, note: pxt.assets.music.Note) {
+    const offset = note.note - 1 - octave * 12 + (isBassClefNote(octave, note) ? 20 : 0);
 
     for (let i = 0; i < staffNoteIntervals.length; i++) {
         if (staffNoteIntervals[i] === offset) {
-            return i;
+            if (note.enharmonicSpelling === "normal") return i;
+            else if (note.enharmonicSpelling === "sharp") return i - 1;
+            else return i + 1;
         }
         else if (staffNoteIntervals[i] > offset) {
-            // sharp note
-            return i - 1;
+            // must be sharp or flat note
+            if (note.enharmonicSpelling === "sharp") return i - 1;
+            else if (note.enharmonicSpelling === "flat") return i;
         }
+    }
+
+    if (note.enharmonicSpelling === "sharp" && offset === staffNoteIntervals[staffNoteIntervals.length - 1] + 1) {
+        return staffNoteIntervals.length - 1;
     }
 
     return -1;
 }
 
-export function isSharpNote(octave: number, note: number, isBassClef: boolean) {
-    return rowToNote(octave, noteToRow(octave, note, isBassClef), isBassClef) !== note;
+export function isBassClefNote(octave: number, note: pxt.assets.music.Note) {
+    if (note.enharmonicSpelling === "flat") {
+        return note.note < octave * 12;
+    }
+    else if (note.enharmonicSpelling === "sharp") {
+        return note.note <= octave * 12 + 1
+    }
+    return note.note < octave * 12 + 1;
 }
 
-export function isBassClefNote(octave: number, note: number) {
-    return note < octave * 12 + 1;
-}
 
-
-export function addNoteToTrack(song: pxt.assets.music.Song, trackIndex: number, note: number, startTick: number, endTick: number) {
+export function addNoteToTrack(song: pxt.assets.music.Song, trackIndex: number, note: pxt.assets.music.Note, startTick: number, endTick: number) {
     return {
         ...song,
         tracks: song.tracks.map((track, index) => index !== trackIndex ? track : {
@@ -40,7 +68,7 @@ export function addNoteToTrack(song: pxt.assets.music.Song, trackIndex: number, 
     }
 }
 
-function addToNoteArray(notes: pxt.assets.music.NoteEvent[], note: number, startTick: number, endTick: number) {
+function addToNoteArray(notes: pxt.assets.music.NoteEvent[], note: pxt.assets.music.Note, startTick: number, endTick: number) {
     const noteEvent: pxt.assets.music.NoteEvent = {
         notes: [note],
         startTick,
@@ -52,7 +80,7 @@ function addToNoteArray(notes: pxt.assets.music.NoteEvent[], note: number, start
             return notes.slice(0, i).concat([noteEvent]).concat(notes.slice(i));
         }
         else if (notes[i].endTick > startTick) {
-            if (notes[i].notes.indexOf(note) !== -1) {
+            if (notes[i].notes.some(n => n.note === note.note && n.enharmonicSpelling === note.enharmonicSpelling)) {
                 return notes.slice();
             }
 
@@ -66,7 +94,7 @@ function addToNoteArray(notes: pxt.assets.music.NoteEvent[], note: number, start
 }
 
 
-export function removeNoteFromTrack(song: pxt.assets.music.Song, trackIndex: number, note: number, startTick: number) {
+export function removeNoteFromTrack(song: pxt.assets.music.Song, trackIndex: number, note: pxt.assets.music.Note, startTick: number) {
     return {
         ...song,
         tracks: song.tracks.map((track, index) => index !== trackIndex ? track : {
@@ -76,14 +104,42 @@ export function removeNoteFromTrack(song: pxt.assets.music.Song, trackIndex: num
     }
 }
 
-function removeNoteFromNoteArray(notes: pxt.assets.music.NoteEvent[], note: number, startTick: number) {
+function removeNoteFromNoteArray(notes: pxt.assets.music.NoteEvent[], note: pxt.assets.music.Note, startTick: number) {
     const res = notes.slice();
 
     for (let i = 0; i < res.length; i++) {
         if (res[i].startTick == startTick) {
             res[i] = {
                 ...res[i],
-                notes: res[i].notes.filter(n => n !== note)
+                notes: res[i].notes.filter(n => n.note !== note.note)
+            }
+            break;
+        }
+    }
+    return res.filter(e => e.notes.length);
+}
+
+export function removeNoteAtRowFromTrack(song: pxt.assets.music.Song, trackIndex: number, row: number, isBassClef: boolean, startTick: number) {
+    return {
+        ...song,
+        tracks: song.tracks.map((track, index) => index !== trackIndex ? track : {
+            ...track,
+            notes: removeNoteAtRowFromNoteArray(track.notes, row, isBassClef, track.instrument.octave, startTick)
+        })
+    }
+}
+
+function removeNoteAtRowFromNoteArray(notes: pxt.assets.music.NoteEvent[], row: number, isBassClef: boolean, octave: number, startTick: number) {
+    const res = notes.slice();
+
+    for (let i = 0; i < res.length; i++) {
+        if (res[i].startTick == startTick) {
+            res[i] = {
+                ...res[i],
+                notes: res[i].notes.filter(n =>
+                    isBassClefNote(octave, n) !== isBassClef ||
+                    noteToRow(octave, n) !== row
+                )
             }
             break;
         }
@@ -136,7 +192,7 @@ function setNoteEventLength(notes: pxt.assets.music.NoteEvent[], startTick: numb
 
 export function fillDrums(song: pxt.assets.music.Song, trackIndex: number, row: number, startTick: number, endTick: number, tickSpacing: number) {
     for (let i = startTick; i < endTick; i += tickSpacing) {
-        song = addNoteToTrack(song, trackIndex, row, i, i + 1)
+        song = addNoteToTrack(song, trackIndex, { note: row, enharmonicSpelling: "normal" }, i, i + 1)
     }
     return song;
 }
@@ -183,7 +239,7 @@ export function findNoteEventAtPosition(song: pxt.assets.music.Song, position: W
     if (trackIndex !== undefined) {
         const event = findNoteEventAtTick(song, trackIndex, position.tick);
 
-        if (event?.notes.some(n => noteToRow(song.tracks[trackIndex].instrument.octave, n, position.isBassClef) === position.row)) {
+        if (event?.notes.some(n => noteToRow(song.tracks[trackIndex].instrument.octave, n) === position.row)) {
             return event;
         }
         return undefined;
@@ -192,7 +248,7 @@ export function findNoteEventAtPosition(song: pxt.assets.music.Song, position: W
     for (let i = 0; i < song.tracks.length; i++) {
         const event = findNoteEventAtTick(song, i, position.tick);
 
-        if (event?.notes.some(n => noteToRow(song.tracks[i].instrument.octave, n, position.isBassClef) === position.row)) {
+        if (event?.notes.some(n => noteToRow(song.tracks[i].instrument.octave, n) === position.row)) {
             return event;
         }
     }
@@ -376,8 +432,7 @@ function moveNoteEvent(noteEvent: pxt.assets.music.NoteEvent, trackOctave: numbe
     else {
         for (const note of noteEvent.notes) {
             let isBass = isBassClefNote(trackOctave, note);
-            let row = noteToRow(trackOctave, note, isBass);
-            let isSharp = isSharpNote(trackOctave, note, isBass);
+            let row = noteToRow(trackOctave, note);
 
             if (row + deltaRows >= staffNoteIntervals.length) {
                 if (isBass) {
@@ -399,7 +454,7 @@ function moveNoteEvent(noteEvent: pxt.assets.music.NoteEvent, trackOctave: numbe
                 continue;
             }
 
-            res.notes.push(rowToNote(trackOctave, newRow, isBass, isSharp));
+            res.notes.push(rowToNote(trackOctave, newRow, isBass, note.enharmonicSpelling));
         }
     }
 


### PR DESCRIPTION
This PR does three things:

1. Adds a "show bass clef" checkbox to the music editor
2. Revamps how sharps/flats are handled to better support changing the enharmonic spelling of a note
3. Reorders the instruments so that the dog is first (sorry duck)

(2) is the big one because I had to change the way notes are represented. Now you can change any note to be sharp or flat by holding ctrl and clicking it. You can also use the **j** keyboard shortcut to cycle through the options on the selected note.

The unfortunate side effect of this PR is that any existing songs will no longer sound right after this is merged. ah, the dangers of living on the bleeding edge.

I will be opening a corresponding pxt-common-packages pr momentarily