### PR TITLE
Fix bug where first color change of builtin palette doesn't save

### DIFF
--- a/webapp/src/components/assetEditor/assetPalette.tsx
+++ b/webapp/src/components/assetEditor/assetPalette.tsx
@@ -53,7 +53,7 @@ export const AssetPalette = (props: AssetPaletteProps) => {
                 setCurrentPalette(selected);
             } else if (!isSameColors(currentPalette.colors, selected.colors)) {
                 if (isBuiltinPalette(selected) ) { // builtin palette edited
-                    createNewPalette();
+                    createNewPalette(selected);
                 } else { // custom palette edited
                     setCustomPalettes({
                         ...customPalettes,
@@ -69,11 +69,11 @@ export const AssetPalette = (props: AssetPaletteProps) => {
         }
     }
 
-    const createNewPalette = () => {
+    const createNewPalette = (selected?: Palette) => {
         const customPalette = {
             id: "custom" + customPalettes.nextPaletteID,
             name: lf("Custom"),
-            colors: currentPalette.colors,
+            colors: selected?.colors || currentPalette.colors,
             custom: true
         }
         setCustomPalettes({


### PR DESCRIPTION
The selected colors are now preserved when a custom palette is created via an edit to a builtin palette.
Closes #https://github.com/microsoft/pxt-arcade/issues/5503