### PR TITLE
Tutorial high contrast bugs

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -866,6 +866,9 @@
     }
     .tutorial-step-label { color: @HCtextColor; }
     .tutorial-step-bar-fill { background-color: @HCtextColor; }
+    .tutorial-step-bubbles > button {
+        border: 1px solid @HCtextColor;
+    }
 
     #editorSidebar .tab-navigation {
         color: @HCtextColor;

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -574,7 +574,7 @@
     }
 
     /* Cards */
-    .card {
+    .card:not(.icon) {
         background: @HCbackground !important;
         border: 2px solid @HCtextColor !important;
         border-radius: initial !important;


### PR DESCRIPTION
* fix https://github.com/microsoft/pxt-arcade/issues/5388. card class on the icon was colliding with the big ole codecard class that's used all over the place, easiest to just say "apply only to things that aren't icons"
![image](https://user-images.githubusercontent.com/5615930/213562514-c50e2eda-01a8-4e79-b073-7f971c9a0053.png)

* fix another bug that I didn't see an issue for; the bubbles were disappearing 
![image](https://user-images.githubusercontent.com/5615930/213561950-fef9690e-ca3c-47ae-bb11-6570e7983660.png)
so now fixed: 
![image](https://user-images.githubusercontent.com/5615930/213562047-491c7f9b-6b47-4fb3-bfac-a35cff839e28.png)
