### PR TITLE
handle outside clicks better in hint popup

### DIFF
--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -13,6 +13,7 @@ interface TutorialCalloutProps extends React.PropsWithChildren<{}> {
 export function TutorialCallout(props: TutorialCalloutProps) {
     const { children, className, buttonIcon, buttonLabel } = props;
     const [ visible, setVisible ] = React.useState(false);
+    const popupRef = React.useRef<HTMLDivElement>(null);
 
     const captureEvent = (e: any) => {
         e.preventDefault();
@@ -21,16 +22,22 @@ export function TutorialCallout(props: TutorialCalloutProps) {
     }
 
     const closeCallout = (e: any) => {
-        document.removeEventListener("click", closeCallout);
+        document.removeEventListener("click", closeCalloutIfClickedOutside, true);
         setVisible(false);
+    }
+
+    const closeCalloutIfClickedOutside = (e: PointerEvent) => {
+        if (!popupRef?.current?.contains(e.target as Node)) {
+            closeCallout(e);
+        }
     }
 
     const toggleCallout = (e: any) => {
         captureEvent(e);
         if (!visible) {
-            document.addEventListener("click", closeCallout);
+            document.addEventListener("click", closeCalloutIfClickedOutside, true);
         } else {
-            document.removeEventListener("click", closeCallout);
+            document.removeEventListener("click", closeCalloutIfClickedOutside, true);
         }
         setVisible(!visible);
     }
@@ -42,7 +49,7 @@ export function TutorialCallout(props: TutorialCalloutProps) {
     }
 
     const buttonTitle = lf("Click to show a hint!");
-    return <div className={className}>
+    return <div ref={popupRef} className={className}>
         <Button icon={buttonIcon}
             text={buttonLabel}
             className="tutorial-callout-button"


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/5105

the issue is that react-common buttons swallow events by default, so we have to listen for the outside click in the bubbling phase to see when someone is interacting outside the screen - simulator clicks / download button side menu / etc were also not collapsing the hint.

@eanders-ms Probably not for this release but we should probably move your Popup class / `useClickedOutside.tsx` into react common and replace our other popups with it