### PR TITLE
make it so multiplayer sample games don't clip bottom of gs/ys

### DIFF
--- a/multiplayer/src/components/HostGameButton.tsx
+++ b/multiplayer/src/components/HostGameButton.tsx
@@ -33,10 +33,10 @@ export default function Render(props: {
                         src={bkgdImage}
                         alt={thumbnailAltText}
                     />
-                    <div className="tw-text-left tw-px-2 tw-pt-1 tw-hidden tw-truncate sm:tw-block">
+                    <div className="tw-text-left tw-px-2 tw-pt-1 tw-hidden tw-truncate tw-leading-normal sm:tw-block">
                         {pxt.U.rlf(title)}
                     </div>
-                    <div className="tw-text-left tw-px-2 tw-text-sm tw-text-gray-500 tw-truncate tw-hidden md:tw-block">
+                    <div className="tw-text-left tw-px-2 tw-text-sm tw-text-gray-500 tw-truncate tw-leading-normal tw-hidden md:tw-block">
                         {pxt.U.rlf(subtitle)}
                     </div>
                 </>


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/5336, I guess the line height was just getting set to something weird

![image](https://user-images.githubusercontent.com/5615930/213581408-5cbb33a6-bd17-49f4-8d49-14ce0a321334.png)
