### PR TITLE
Limit height and add scroll bar for code validation popup

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -952,6 +952,15 @@
     .tutorial-title {
         max-width: calc(100% - 10rem);
     }
+
+    /*******************************
+        Validation
+    *******************************/
+
+    .tutorial-validation-error-container {
+        right: 1rem;
+        left: unset;
+    }
 }
 
 /* thin tablet header */

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -566,6 +566,7 @@
     left: 23rem;
     max-width: 60%;
     min-width: 18.75rem;
+    max-height: 70%;
     background: @white;
     box-shadow: 0 0rem 0.5rem;
     border-radius: 0.5rem;
@@ -617,6 +618,11 @@
     }
 }
 
+.tutorial-validation-answer-key-hint  {
+    max-height: 50vh;
+    overflow: auto;
+    padding-right: 2rem;
+}
 /*******************************
         Media Adjustments
 *******************************/

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -618,10 +618,18 @@
     }
 }
 
-.tutorial-validation-answer-key-hint  {
+.tutorial-validation-answer-key-hint {
     max-height: 50vh;
     overflow: auto;
     padding-right: 2rem;
+}
+
+/* Remove border around blocks in the hint */
+.tutorial-validation-answer-key-hint .lang-blocks .segment.raised {
+    border: none;
+    background: none;
+    box-shadow: none;
+    padding: 0;
 }
 /*******************************
         Media Adjustments

--- a/webapp/src/components/tutorialValidators.tsx
+++ b/webapp/src/components/tutorialValidators.tsx
@@ -120,7 +120,7 @@ export class BlocksExistValidator extends CodeValidatorBase {
         const blockImages = stepInfo?.hintContentMd ? (<div>
             <strong>{lf("Looks like you're missing some blocks.")}</strong>
             <p>{errorDescription}</p>
-            <MarkedContent className="no-select" markdown={stepInfo.hintContentMd} parent={parent} />
+            <MarkedContent className="no-select tutorial-validation-answer-key-hint" markdown={stepInfo.hintContentMd} parent={parent} />
         </div>) : "";
 
         return {


### PR DESCRIPTION
This adds a limit on the height of the code validation popup and adds a scrollbar around the hint blocks if it's needed. It also removes the border around the hint blocks and moves the popup to the right if we're in tablet mode.

![ScrollInsideCodeValidationPopupHint](https://user-images.githubusercontent.com/69657545/213817953-2894376a-eeb7-42f2-b6a5-d03829369bdd.gif)

<img width="626" alt="image" src="https://user-images.githubusercontent.com/69657545/213822086-e1087e6b-9214-409f-9d16-90f153eafb7d.png">

Fixes https://github.com/microsoft/pxt-arcade/issues/5527
Fixes https://github.com/microsoft/pxt-arcade/issues/5530
Fixes https://github.com/microsoft/pxt-arcade/issues/5528