### PR TITLE
multiplayer: register both join handlers separately to avoid dropping msgs

### DIFF
--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -60,7 +60,7 @@ class GameClient {
     screen: Buffer | undefined;
     clientRole: ClientRole | undefined;
     gameOverReason: GameOverReason | undefined;
-    joinMessageInTimeHandler: ((a: any) => void) | undefined;
+    receivedJoinMessageInTimeHandler: ((a: any) => void) | undefined;
     paused: boolean = false;
 
     constructor() {
@@ -143,7 +143,8 @@ class GameClient {
                 if (msg.type === "joined") {
                     // We've joined the game. Replace this handler with a direct call to recvMessageAsync
                     if (this.sock) {
-                        this.sock.removeListener("message", this.joinMessageInTimeHandler);
+                        this.sock.removeListener("message", this.receivedJoinMessageInTimeHandler);
+                        this.receivedJoinMessageInTimeHandler = undefined;
                     }
                     resolve();
                 }
@@ -168,13 +169,13 @@ class GameClient {
             this.sock.binaryType = "arraybuffer";
             this.sock.on("open", () => {
                 pxt.debug("socket opened");
-                this.joinMessageInTimeHandler = async payload => {
+                this.receivedJoinMessageInTimeHandler = async payload => {
                     await this.recvMessageWithJoinTimeout(payload, () => {
                         clearTimeout(joinTimeout);
                         resolve();
                     });
                 }
-                this.sock?.on("message", this.joinMessageInTimeHandler);
+                this.sock?.on("message", this.receivedJoinMessageInTimeHandler);
                 this.sock?.on("message", async payload => {
                     try {
                         await this.recvMessageAsync(payload);


### PR DESCRIPTION
fix for https://github.com/microsoft/pxt-arcade/issues/5531

I suspect this is the issue we were hitting with late joiners not getting the initial screen causing screen compression / partial screen updates to fail

here's a build: https://arcade.makecode.com/app/7b49972cc23786e9b7696c213f27dd03ddef93e7-82f76e9ff6--multiplayer (remember to not use the join link it gives you directly as that won't point you to the right build)