### PR TITLE
Fix Tutorial Next Button After Refresh

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1165,7 +1165,6 @@ declare namespace pxt.tutorial {
 
     interface CodeValidationConfig {
         validatorsMetadata: CodeValidatorMetadata[];
-        validators: pxt.Map<CodeValidator>; // A cache of the parsed validatorsMetadata. Key = validator type, Value = validator.
     }
     
     interface TutorialStepInfo {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -356,10 +356,7 @@ ${code}
           };
         });
 
-        return {
-            validatorsMetadata: sectionedMetadata,
-            validators: undefined
-        }
+        return { validatorsMetadata: sectionedMetadata };
     }
 
     function categorizingValidationRules(listOfRules: pxt.Map<boolean>, title: string) {

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -114,7 +114,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
 
         currentStepInfo.localValidationConfig?.validatorsMetadata?.forEach(v => validators[v.validatorType] = GetValidator(v));
         tutorialOptions.globalValidationConfig?.validatorsMetadata?.forEach(v => {
-            if(!validators[v.validatorType]) {
+            if (!validators[v.validatorType]) {
                 validators[v.validatorType] = GetValidator(v);
             }
         })

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -7,7 +7,7 @@ import { TutorialHint } from "./TutorialHint";
 import { TutorialResetCode } from "./TutorialResetCode";
 import { classList } from "../../../../react-common/components/util";
 import { TutorialValidationErrorMessage } from "./TutorialValidationErrorMessage";
-import { PopulateValidatorCache } from "../tutorialValidators";
+import { GetValidator } from "../tutorialValidators";
 import CodeValidator = pxt.tutorial.CodeValidator;
 import CodeValidationResult = pxt.tutorial.CodeValidationResult;
 
@@ -110,17 +110,14 @@ export function TutorialContainer(props: TutorialContainerProps) {
     const hintMarkdown = steps[visibleStep].hintContentMd;
 
     const validateTutorialStep = async () => {
-        const globalValidators =
-            tutorialOptions.globalValidationConfig?.validators ??
-            PopulateValidatorCache(tutorialOptions.globalValidationConfig);
-        const localValidators =
-            currentStepInfo.localValidationConfig?.validators ??
-            PopulateValidatorCache(currentStepInfo.localValidationConfig);
+        let validators: pxt.Map<CodeValidator> = {};
 
-        let validators: pxt.Map<CodeValidator> = {
-            ...(globalValidators ?? {}),
-            ...(localValidators ?? {})
-        };
+        currentStepInfo.localValidationConfig?.validatorsMetadata?.forEach(v => validators[v.validatorType] = GetValidator(v));
+        tutorialOptions.globalValidationConfig?.validatorsMetadata?.forEach(v => {
+            if(!validators[v.validatorType]) {
+                validators[v.validatorType] = GetValidator(v);
+            }
+        })
 
         let failedResults: CodeValidationResult[] = [];
         for (let validator of Object.values(validators)) {

--- a/webapp/src/components/tutorialValidators.tsx
+++ b/webapp/src/components/tutorialValidators.tsx
@@ -22,22 +22,6 @@ export function GetValidator(metadata: CodeValidatorMetadata): CodeValidator {
     }
 }
 
-export function PopulateValidatorCache(metadata: CodeValidationConfig): pxt.Map<CodeValidator>{
-    if (!metadata?.validatorsMetadata) {
-        return null;
-    }
-
-    metadata.validators = {};
-    metadata.validatorsMetadata.forEach(v => {
-        const validator = GetValidator(v);
-        if (validator) {
-            metadata.validators[v.validatorType] = validator;
-        }
-    });
-
-    return metadata.validators;
-}
-
 abstract class CodeValidatorBase implements CodeValidator {
     enabled: boolean;
     abstract name: string;


### PR DESCRIPTION
We were seeing an issue with code validation, where after refreshing the page, the Next button in a tutorial no longer worked. To fix it, I've removed the caching of tutorial validators on the TutorialInfo and TutorialStepInfo objects.

When a tutorial is reloaded, these objects get serialized and then deserialized, but the "execute" method is not able to be stored in the serialized format, so it's lost in the process. As a result, when we try to call it, we get an error that it doesn't exist.

This cache isn't saving us from much work right now anyway (validation construction is relatively cheap), so I've opted to simply remove it. If we decide we need it later on, we could cache it elsewhere (like on the TutorialContainer itself) and make sure it's cleared/refreshed as needed.

Fixes https://github.com/microsoft/pxt-arcade/issues/5533