### PR TITLE
don't wait to send 'connect' message in multiplayer socket join

### DIFF
--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -192,13 +192,11 @@ class GameClient {
                     resolve();
                 });
 
-                setTimeout(() => {
-                    this.sendMessage({
-                        type: "connect",
-                        ticket,
-                        version: Protocol.VERSION,
-                    } as Protocol.ConnectMessage);
-                }, 500); // TODO: Why is a short delay necessary here? The socket doesn't seem ready to send messages immediately.
+                this.sendMessage({
+                    type: "connect",
+                    ticket,
+                    version: Protocol.VERSION,
+                } as Protocol.ConnectMessage);
             });
         });
     }


### PR DESCRIPTION
Remove the 'wait 500ms' on sending connect message; I haven't seen any issues right away after disconnecting / reconnecting on a build with this commit on top of https://github.com/microsoft/pxt/pull/9313, so I think that this was possibly getting a race from that or something? I'm not completely sure / don't know if there was more subtlety to the todo. Here's a build with this change we can test either way, nice to get rid of arbitrary waits if we can

https://arcade.makecode.com/app/ca2f71a5e7f450998bc95ade8b2b940432bed5c8-f263de335d--multiplayer