### PR TITLE
Skillmap: play game button added to reward node

### DIFF
--- a/skillmap/src/components/RewardActions.tsx
+++ b/skillmap/src/components/RewardActions.tsx
@@ -52,11 +52,20 @@ export class RewardActionsImpl extends React.Component<RewardActionsProps> {
                     label={lf("Claim Reward")}
                     onClick={this.handleActionButtonClick}
                 />
+                <Button
+                    tabIndex={-1}
+                    ariaPosInSet={2}
+                    ariaSetSize={showSignIn ? 2 : 1}
+                    className="primary inverted"
+                    title={lf("Play your game")}
+                    label={lf("Play your game")}
+                    onClick={this.handleActionButtonClick}
+                />
                 {showSignIn &&
                     <Button
                         tabIndex={-1}
-                        ariaPosInSet={2}
-                        ariaSetSize={2}
+                        ariaPosInSet={3}
+                        ariaSetSize={3}
                         className="teal"
                         onClick={dispatchShowLoginModal}
                         label={lf("Sign in to Save")}

--- a/skillmap/src/components/RewardActions.tsx
+++ b/skillmap/src/components/RewardActions.tsx
@@ -54,7 +54,7 @@ export class RewardActionsImpl extends React.Component<RewardActionsProps> {
                 <Button
                     tabIndex={-1}
                     ariaPosInSet={1}
-                    ariaSetSize={showSignIn ? 2 : 1}
+                    ariaSetSize={showSignIn ? 3 : 2}
                     className="primary inverted"
                     title={lf("Claim Reward")}
                     label={lf("Claim Reward")}
@@ -63,7 +63,7 @@ export class RewardActionsImpl extends React.Component<RewardActionsProps> {
                 <Button
                     tabIndex={-1}
                     ariaPosInSet={2}
-                    ariaSetSize={showSignIn ? 2 : 1}
+                    ariaSetSize={showSignIn ? 3 : 2}
                     className="primary inverted"
                     title={lf("Play your game")}
                     label={lf("Play your game")}


### PR DESCRIPTION
We want it to be easy for users to get back to and play the game that they just created with the skillmap.

We are just opening the editor when this button is pressed for now because it is a quick solution. We might want to open a game with the share link or embed the simulator in a pop-up in the future.

Closes: https://github.com/microsoft/pxt-arcade/issues/5346