### PR TITLE
multiplayer reenable xor screeen diffs

### DIFF
--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -533,7 +533,7 @@ class GameClient {
         image: Uint8Array,
         palette: Uint8Array | undefined
     ) {
-        const DELTAS_ENABLED = false;
+        const DELTAS_ENABLED = true;
 
         const buffers: Buffer[] = [];
         buffers.push(Buffer.from(image));


### PR DESCRIPTION
Throwing up a build here since I think it's worth a bit of testing: https://arcade.makecode.com/app/a96a8a9ee5c0c294dc223795718b45eef90b5659-739e70271b--multiplayer?host=S72790-46070-28386-52415

I ran it with 4 connections on my pc (and 3 on pc / 1 on my phone) & exitted / reentered into the session about 40 times. I ended up getting screen artifacting 1 time (with my character 'set' mid right side of the screen while still moving on the other side - so something like the bits in that region were swapped), but that was when I had dev tools up / hit breakpoint on host while loading and I wasn't at all able to repro it. I think it's worth testing a bit :)