### PR TITLE
A few music-related bugs

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -884,7 +884,7 @@ declare namespace ts.pxtc {
         paramHelp?: pxt.Map<string>;
         // foo.defl=12 -> paramDefl: { foo: "12" }; eg.: 12 in arg description will also go here
         paramDefl: pxt.Map<string>;
-        paramSnippets?: pxt.Map<string>;
+        paramSnippets?: pxt.Map<ParamSnippet>;
         // this lists arguments that have .defl as opposed to just eg.: stuff
         explicitDefaults?: string[];
 
@@ -900,6 +900,11 @@ declare namespace ts.pxtc {
         alias?: string; // another symbol alias for this member
         pyAlias?: string; // optional python version of the alias
         blockAliasFor?: string; // qname of the function this block is an alias for
+    }
+
+    interface ParamSnippet {
+        ts?: string;
+        python?: string;
     }
 
     interface ParameterDesc {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -884,6 +884,7 @@ declare namespace ts.pxtc {
         paramHelp?: pxt.Map<string>;
         // foo.defl=12 -> paramDefl: { foo: "12" }; eg.: 12 in arg description will also go here
         paramDefl: pxt.Map<string>;
+        paramSnippets?: pxt.Map<string>;
         // this lists arguments that have .defl as opposed to just eg.: stuff
         explicitDefaults?: string[];
 

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -295,6 +295,10 @@ namespace ts.pxtc.service {
 
             const name = param.name.kind === SK.Identifier ? (param.name as ts.Identifier).text : undefined;
 
+            if (attrs.paramSnippets?.[name]) {
+                return attrs.paramSnippets?.[name];
+            }
+
             // check for explicit default in the attributes
             const paramDefl = attrs?.paramDefl?.[name]
             if (paramDefl) {

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -295,8 +295,12 @@ namespace ts.pxtc.service {
 
             const name = param.name.kind === SK.Identifier ? (param.name as ts.Identifier).text : undefined;
 
-            if (attrs.paramSnippets?.[name]) {
-                return attrs.paramSnippets?.[name];
+            const override = attrs.paramSnippets?.[name];
+            if (override) {
+                if (python) {
+                    if (override.python) return override.python;
+                }
+                else if (override.ts) return override.ts;
             }
 
             // check for explicit default in the attributes

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -881,6 +881,9 @@ namespace ts.pxtc {
                     } else if (U.endsWith(n, ".shadow")) {
                         if (!res._shadowOverrides) res._shadowOverrides = {};
                         res._shadowOverrides[n.slice(0, n.length - 7)] = v;
+                    } else if (U.endsWith(n, ".snippet")) {
+                        if (!res.paramSnippets) res.paramSnippets = {};
+                        res.paramSnippets[n.slice(0, n.length - 8)] = v;
                     } else if (U.endsWith(n, ".fieldEditor")) {
                         if (!res.paramFieldEditor) res.paramFieldEditor = {}
                         res.paramFieldEditor[n.slice(0, n.length - 12)] = v

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -883,7 +883,14 @@ namespace ts.pxtc {
                         res._shadowOverrides[n.slice(0, n.length - 7)] = v;
                     } else if (U.endsWith(n, ".snippet")) {
                         if (!res.paramSnippets) res.paramSnippets = {};
-                        res.paramSnippets[n.slice(0, n.length - 8)] = v;
+                        const paramName = n.slice(0, n.length - 8);
+                        if (!res.paramSnippets[paramName]) res.paramSnippets[paramName] = {};
+                        res.paramSnippets[paramName].ts = v;
+                    } else if (U.endsWith(n, ".pySnippet")) {
+                        if (!res.paramSnippets) res.paramSnippets = {};
+                        const paramName = n.slice(0, n.length - 10);
+                        if (!res.paramSnippets[paramName]) res.paramSnippets[paramName] = {};
+                        res.paramSnippets[paramName].python = v;
                     } else if (U.endsWith(n, ".fieldEditor")) {
                         if (!res.paramFieldEditor) res.paramFieldEditor = {}
                         res.paramFieldEditor[n.slice(0, n.length - 12)] = v

--- a/tests/blocklycompiler-test/commentparsing.spec.ts
+++ b/tests/blocklycompiler-test/commentparsing.spec.ts
@@ -474,10 +474,11 @@ describe("comment attribute parser", () => {
              */
             //% block="foo $bar"
             //% bar.snippet="hello"
+            //% bar.pySnippet="goodbye"
         `);
-        chai.assert(parsed.paramSnippets?.["bar"] === "hello", "bar.snippet === \"hello\"")
-    })
-
+        chai.assert(parsed.paramSnippets?.["bar"].ts === "hello", "bar.snippet === \"hello\"")
+        chai.assert(parsed.paramSnippets?.["bar"].python === "goodbye", "bar.pySnippet === \"goodbye\"")
+    });
 });
 
 function brk(): pxtc.BlockBreak {

--- a/tests/blocklycompiler-test/commentparsing.spec.ts
+++ b/tests/blocklycompiler-test/commentparsing.spec.ts
@@ -465,7 +465,18 @@ describe("comment attribute parser", () => {
         chai.assert(parsed.locs["es|block"] == "SPANISH $bar", JSON.stringify(parsed.locs));
         chai.assert(parsed.locs["fr|jsdoc"] == "bli", JSON.stringify(parsed.locs));
         chai.assert(parsed.locs["fr|param|bar"] == "bah", JSON.stringify(parsed.locs));
-});
+    });
+
+    it("should parse parameter snippets", () => {
+        const parsed = ts.pxtc.parseCommentString(`
+            /**
+             * Bla
+             */
+            //% block="foo $bar"
+            //% bar.snippet="hello"
+        `);
+        chai.assert(parsed.paramSnippets?.["bar"] === "hello", "bar.snippet === \"hello\"")
+    })
 
 });
 

--- a/tests/language-service/snippet_cases/paramOverride.py
+++ b/tests/language-service/snippet_cases/paramOverride.py
@@ -1,0 +1,2 @@
+# testNamespace.paramOverride
+testNamespace.param_override('goodbye')

--- a/tests/language-service/snippet_cases/paramOverride.ts
+++ b/tests/language-service/snippet_cases/paramOverride.ts
@@ -1,0 +1,2 @@
+// testNamespace.paramOverride
+testNamespace.paramOverride('hello')

--- a/tests/language-service/test-package/basic.ts
+++ b/tests/language-service/test-package/basic.ts
@@ -40,6 +40,12 @@ namespace testNamespace {
     export function registerSomeEvent(param1: number, handler: () => void, param2: boolean) {
         handler()
     }
+
+    //% param.snippet="'hello'"
+    //% param.pySnippet="'goodbye'"
+    export function paramOverride(param: string) {
+
+    }
 }
 
 //% fixedInstances decompileIndirectFixedInstances

--- a/webapp/src/components/musicEditor/utils.ts
+++ b/webapp/src/components/musicEditor/utils.ts
@@ -132,22 +132,25 @@ export function removeNoteAtRowFromTrack(song: pxt.assets.music.Song, trackIndex
         ...song,
         tracks: song.tracks.map((track, index) => index !== trackIndex ? track : {
             ...track,
-            notes: removeNoteAtRowFromNoteArray(track.notes, row, isBassClef, track.instrument.octave, startTick)
+            notes: removeNoteAtRowFromNoteArray(track.notes, row, isBassClef, track.instrument.octave, startTick, !!track.drums)
         })
     }
 }
 
-function removeNoteAtRowFromNoteArray(notes: pxt.assets.music.NoteEvent[], row: number, isBassClef: boolean, octave: number, startTick: number) {
+function removeNoteAtRowFromNoteArray(notes: pxt.assets.music.NoteEvent[], row: number, isBassClef: boolean, octave: number, startTick: number, isDrumTrack: boolean) {
     const res = notes.slice();
 
     for (let i = 0; i < res.length; i++) {
         if (res[i].startTick == startTick) {
             res[i] = {
                 ...res[i],
-                notes: res[i].notes.filter(n =>
-                    isBassClefNote(octave, n) !== isBassClef ||
-                    noteToRow(octave, n) !== row
-                )
+                notes: res[i].notes.filter(n =>{
+                    if (isDrumTrack) {
+                        return n.note !== row
+                    }
+                    return isBassClefNote(octave, n) !== isBassClef ||
+                        noteToRow(octave, n) !== row;
+                })
             }
             break;
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5416


This PR addresses 3 bugs with the music editor:

1. Fixes issue where drum notes couldn't be deleted
2. Fixes the rendering of the note editor when a min note is set
3. Adds the ability to override the snippet for a function parameter in the comment attributes of the declaration (part of the fix for https://github.com/microsoft/pxt-arcade/issues/5481)