### PR TITLE
add a flag to allow tutorials to show blocks collapsed in hints, template code

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -40,18 +40,21 @@ namespace pxt.blocks {
             .filter(b => !!b.getCommentText())
             .forEach(b => {
                 const initialCommentText = b.getCommentText();
+                if (/@hide/.test(initialCommentText) && opts.applyHideMetaComment) {
+                    b.dispose(true);
+                    return;
+                }
+
                 let newCommentText = initialCommentText;
                 if (/@highlight/.test(newCommentText)) {
                     newCommentText = newCommentText.replace(/@highlight/g, '').trim();
                     (workspace as Blockly.WorkspaceSvg).highlightBlock?.(b.id, true)
                 }
-                if (/@hide/.test(newCommentText) && opts.applyHideMetaComment) {
-                    b.dispose(true);
-                }
                 if (/@collapsed/.test(newCommentText) && !b.getParent()) {
                     newCommentText = newCommentText.replace(/@collapsed/g, '').trim();
                     b.setCollapsed(true);
                 }
+
                 if (initialCommentText !== newCommentText) {
                     b.setCommentText(newCommentText || null);
                 }

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -10,7 +10,7 @@ namespace pxt.blocks {
     }
 
     export interface DomToWorkspaceOptions {
-        applyMetaComments?: boolean;
+        applyHideMetaComment?: boolean;
     }
 
     /**
@@ -24,9 +24,7 @@ namespace pxt.blocks {
         try {
             Blockly.Events.disable();
             newBlockIds = Blockly.Xml.domToWorkspace(dom, workspace);
-            if (opts?.applyMetaComments) {
-                applyMetaComments(workspace);
-            }
+            applyMetaComments(workspace, opts);
         } catch (e) {
             pxt.reportException(e);
         } finally {
@@ -35,20 +33,27 @@ namespace pxt.blocks {
         return newBlockIds.filter(id => !!workspace.getBlockById(id));
     }
 
-    function applyMetaComments(workspace: Blockly.Workspace) {
+    function applyMetaComments(workspace: Blockly.Workspace, opts?: DomToWorkspaceOptions) {
         // process meta comments
         // @highlight -> highlight block
         workspace.getAllBlocks(false)
             .filter(b => !!b.getCommentText())
             .forEach(b => {
-                const c = b.getCommentText();
-                if (/@highlight/.test(c)) {
-                    const cc = c.replace(/@highlight/g, '').trim();
-                    b.setCommentText(cc || null);
+                const initialCommentText = b.getCommentText();
+                let newCommentText = initialCommentText;
+                if (/@highlight/.test(newCommentText)) {
+                    newCommentText = newCommentText.replace(/@highlight/g, '').trim();
                     (workspace as Blockly.WorkspaceSvg).highlightBlock?.(b.id, true)
                 }
-                if (/@hide/.test(c)) {
+                if (/@hide/.test(newCommentText) && opts.applyHideMetaComment) {
                     b.dispose(true);
+                }
+                if (/@collapsed/.test(newCommentText) && !b.getParent()) {
+                    newCommentText = newCommentText.replace(/@collapsed/g, '').trim();
+                    b.setCollapsed(true);
+                }
+                if (initialCommentText !== newCommentText) {
+                    b.setCommentText(newCommentText || null);
                 }
             });
     }

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -40,7 +40,7 @@ namespace pxt.blocks {
             .filter(b => !!b.getCommentText())
             .forEach(b => {
                 const initialCommentText = b.getCommentText();
-                if (/@hide/.test(initialCommentText) && opts.applyHideMetaComment) {
+                if (/@hide/.test(initialCommentText) && opts?.applyHideMetaComment) {
                     b.dispose(true);
                     return;
                 }

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -103,7 +103,7 @@ namespace pxt.blocks {
             pxt.blocks.domToWorkspaceNoEvents(
                 xml,
                 workspace,
-                { applyMetaComments: true }
+                { applyHideMetaComment: true }
             );
 
             return renderWorkspace(options);


### PR DESCRIPTION
e.g. so if you have a template section in a tutorial like the following it starts off collapsed in order to 'hide' it from view at the start (or if you want to show it exists in a hint, but not in detail)

No bug associated, just a very quick feature that came out of a chat with kiki~

<img width="611" alt="image" src="https://user-images.githubusercontent.com/5615930/214178471-a658320e-d1f8-476d-93b1-5b79506bcd04.png">

Maybe we could even emit this so collapsed / non collapsed state persists through compile / decompile ;)