### PR TITLE
keep comments on blocks when loading blocks for tutorial info

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -11,6 +11,7 @@ namespace pxt.blocks {
 
     export interface DomToWorkspaceOptions {
         applyHideMetaComment?: boolean;
+        keepMetaComments?: boolean;
     }
 
     /**
@@ -55,7 +56,7 @@ namespace pxt.blocks {
                     b.setCollapsed(true);
                 }
 
-                if (initialCommentText !== newCommentText) {
+                if (initialCommentText !== newCommentText && !opts?.keepMetaComments) {
                     b.setCommentText(newCommentText || null);
                 }
             });
@@ -128,11 +129,11 @@ namespace pxt.blocks {
     /**
      * Loads the xml into a off-screen workspace (not suitable for size computations)
      */
-    export function loadWorkspaceXml(xml: string, skipReport = false): Blockly.Workspace {
+    export function loadWorkspaceXml(xml: string, skipReport = false, opts?: DomToWorkspaceOptions): Blockly.Workspace {
         const workspace = new Blockly.Workspace() as Blockly.WorkspaceSvg;
         try {
             const dom = Blockly.Xml.textToDom(xml);
-            pxt.blocks.domToWorkspaceNoEvents(dom, workspace);
+            pxt.blocks.domToWorkspaceNoEvents(dom, workspace, opts);
             return workspace;
         } catch (e) {
             if (!skipReport)

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -81,7 +81,7 @@ function getUsedBlocksInternalAsync(code: string[], id: string, language?: strin
                     const blocksXml = xml[i];
                     const snippetHash = pxt.BrowserUtils.getTutorialCodeHash([code[i]]);
 
-                    headless = pxt.blocks.loadWorkspaceXml(blocksXml);
+                    headless = pxt.blocks.loadWorkspaceXml(blocksXml, false, { keepMetaComments: true });
                     if (!headless) {
                         pxt.debug(`used blocks xml failed to load\n${blocksXml}`);
                         throw new Error("blocksXml failed to load");


### PR DESCRIPTION
Last pr made the comments get stripped when decompiling (which was the old behavior / only went away as a sideeffect of the small 'hide blocks' pr back in dec).

Headless workspaces actually don't have a concept of highlighting (`(workspace as Blockly.WorkspaceSvg).highlightBlock?.(b.id, true)` in blocklyimporter bails out on the `?.`), so we have to persist the comments when loading up the workspace so we can read them again when getting usedblocks: https://github.com/microsoft/pxt/blob/master/webapp/src/tutorial.tsx#L104 .