### PR TITLE
Notifications added for kiosk submission errors

### DIFF
--- a/react-common/components/share/Kiosk.ts
+++ b/react-common/components/share/Kiosk.ts
@@ -1,20 +1,17 @@
 export const addGameToKioskAsync = async (kioskId: string, gameId: string) => {
     const updateKioskUrl = "https://makecode.com/api/kiosk/updatecode";
-    try {
-        const response: Response = await fetch(updateKioskUrl, {
-            method: 'POST',
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                "kioskCode": kioskId,
-                "shareId": gameId
-            }),
-        });
-        await response.json();
-    }
-    catch (error) {
-        throw new Error(error.message);
+    const response: Response = await fetch(updateKioskUrl, {
+        method: 'POST',
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            "kioskCode": kioskId,
+            "shareId": gameId
+        }),
+    });
+    if (!response.ok) {
+        throw new Error(lf(response.statusText));
     }
 }

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -12,6 +12,7 @@ import { Checkbox } from "../controls/Checkbox";
 import { SimRecorder } from "./ThumbnailRecorder";
 import { MultiplayerConfirmation } from "./MultiplayerConfirmation";
 import { addGameToKioskAsync } from "./Kiosk";
+import { pushNotificationMessage } from "../Notification";
 
 export interface ShareInfoProps {
     projectName: string;
@@ -116,10 +117,33 @@ export const ShareInfo = (props: ShareInfoProps) => {
                 setKioskSubmitSuccessful(true);
                 try {
                     await addGameToKioskAsync(validKioskId, gameId);
+                    pushNotificationMessage({
+                        kind: 'info',
+                        text: lf("Game submitted to kiosk {0} successfully!", validKioskId),
+                        hc: false
+                    })
+
                 } catch (error) {
-                    pxt.log(error.message);
-                    //TODO: give some feedback to the user, no kiosk exists...
+                    if (error.message === "Not Found") {
+                        pushNotificationMessage({
+                            kind: 'err',
+                            text: lf("Kiosk Code not found"),
+                            hc: false
+                        });
+                    } else {
+                        pushNotificationMessage({
+                            kind: 'err',
+                            text: lf("Something went wrong submitting game to kiosk {0}", validKioskId),
+                            hc: false
+                        });
+                    }
                 }
+            } else {
+                pushNotificationMessage({
+                    kind: 'err',
+                    text: lf("Invalid format for Kiosk Code"),
+                    hc: false
+                });
             }
         }
     }
@@ -147,8 +171,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
     }
 
     const handleKioskHelpClick = () => {
-        pxt.log("this will lead the user to documentation");
-        const kioskDocumentationUrl = "https://arcade.makecode.com/developer/kiosk";
+        const kioskDocumentationUrl = "https://arcade.makecode.com/hardware/kiosk";
         window.open(kioskDocumentationUrl, "_blank");
     }
 


### PR DESCRIPTION
Now giving feedback to users for different submission cases. 

**Empty Input**
I left it as doing nothing if there is nothing in the input, however, because I would imagine that this case is self-explanatory. I can add something here if we think it is valuable, though.

**Correct format, but errors on the backend (not found, etc.)**
Error notification in red; text changes between `kiosk code not found` and `something went wrong...` depending on the error received.

<img width="551" alt="image" src="https://user-images.githubusercontent.com/49178322/214467435-dee9e084-2c52-4986-b8e1-0beae61c78b8.png">



**Incorrect format (too few/many characters, non-alphanumeric)**
Error notification in red. 
<img width="233" alt="image" src="https://user-images.githubusercontent.com/49178322/214467162-d9fcde9d-038d-4c33-aadb-39958ba0fe87.png">

**Successful Submission**
Info notification.

<img width="589" alt="image" src="https://user-images.githubusercontent.com/49178322/214467598-b3203296-40c4-4b63-8ba2-d1ff0303f576.png">


**Reasoning**
I know this really doesn't follow patterns for receiving feedback for input, but I don't think having text show up underneath the input field would be really appropriate for most of these cases. 
(like this) 
<img width="173" alt="image" src="https://user-images.githubusercontent.com/49178322/214469907-fcc68c99-be0c-4075-9d60-bdd5d86be74c.png">


The only case I think this design would be valuable for is the `invalid format` case, but I could be making a large assumption here. Since there is only one case where putting text under makes sense, I found that it would be more valuable to just follow the pattern of the other cases because otherwise it might be confusing to the user who is expecting to see a notification underneath.

I also think that this form of notification is really nice. It doesn't pop-up a modal and take the user completely out of the flow of what they are doing. I would probably want the modal to disappear after a certain amount of time, anyway, so I'm just taking advantage of what our notification system does for us already.

**Other thoughts**
Our `react-common` [Input component](https://github.com/microsoft/pxt/blob/srietkerk-kiosk-share-erros/react-common/components/controls/Input.tsx#L29-L30), from what I gathered, doesn't give the option to provide validation. I didn't look hard to see if the other things that use the `Input` component implement this in the `onChange` or `onEnterKey` functions, though. That being said, I can add an optional function prop like `validate` that can be used to check the format of the value and then display something below the input. I'm not sure how much this is used, but I find value in it. I think the `Input` component should have the error handling attached, so we have a common system for input issues. 

I'm still not sure if text under the input field would be good for **_this_** particular use case, but I would love to add this if we see it as something valuable. Especially if anyone thinks that the `invalid format` case should display text underneath the input. 

**Closing**
This isn't the most delightful way to receive this information as requested in the below issue. It might be more delightful to receive the information in a better designed modal, but as noted above, I don't think a modal is the best way to receive this information. 

**TL;DR:** I am using the notifications because they achieve what I need them to, but if there are better ways to communicate the below cases, I would love to hear them!

Closes https://github.com/microsoft/pxt-arcade/issues/5536