### PR TITLE
Fix Hang on Tutorial Load

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1098,7 +1098,7 @@ namespace pxt.BrowserUtils {
 
         static createAsync(): Promise<TutorialInfoIndexedDb> {
             function openAsync() {
-                const idbWrapper = new pxt.BrowserUtils.IDBWrapper(TutorialInfoIndexedDb.dbName(), 3, (ev, r) => {
+                const idbWrapper = new pxt.BrowserUtils.IDBWrapper(TutorialInfoIndexedDb.dbName(), 2, (ev, r) => {
                     const db = r.result as IDBDatabase;
                     db.createObjectStore(TutorialInfoIndexedDb.TABLE, { keyPath: TutorialInfoIndexedDb.KEYPATH });
                 }, () => {


### PR DESCRIPTION
This change puts the `TutorialInfoIndexedDb` back to version 2. I had updated it to 3 in https://github.com/microsoft/pxt/pull/9300 but that isn't really necessary since we have null checks on the new field usage anyway, and the upgrade process was sometimes causing hangs.

The hang happens when another tab already has an open connection to the db and a new tab requests to upgrade it. The upgrade request just gets put into a pending state and never finishes, even if the original tab is closed again. It then stays in this state until the entire browser is closed. Requests from new tabs will similarly get stuck in the pending state behind the upgrade request, even if they're going back to the original version.

Fixes https://github.com/microsoft/pxt-arcade/issues/5540