### PR TITLE
Support relative links in multiplayer urls

### DIFF
--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -30,7 +30,7 @@ export default function Render() {
 
     // Insert a space to make the join code easier to read.
     const displayJoinCode = joinCode?.slice(0, 3) + " " + joinCode?.slice(3);
-    const joinDeepLink = pxt.multiplayer.makeJoinLink(joinCode);
+    const joinDeepLink = pxt.multiplayer.makeJoinLink(joinCode, true);
 
     return (
         <div className="tw-bg-white tw-shadow-lg tw-rounded-lg tw-m-1 tw-min-w-[17rem]">

--- a/multiplayer/src/components/JoinCodeLabel.tsx
+++ b/multiplayer/src/components/JoinCodeLabel.tsx
@@ -6,7 +6,7 @@ export default function Render() {
     const { state } = useContext(AppStateContext);
 
     const joinCode = state.gameState?.joinCode;
-    const joinDeepLink = joinCode ? pxt.multiplayer.makeJoinLink(joinCode) : "";
+    const joinDeepLink = joinCode ? pxt.multiplayer.makeJoinLink(joinCode, true) : "";
     return (
         <div>
             {joinCode && (

--- a/pxtlib/multiplayerUtils.ts
+++ b/pxtlib/multiplayerUtils.ts
@@ -6,12 +6,41 @@ namespace pxt.multiplayer {
     }
     let MULTIPLAYER_DEV_BACKEND_TYPE = MultiplayerDevBackendType.STAGING;
 
+    export const ABSOLUTE_LINKS = {
+        PROD_BETA: "https://arcade.makecode.com/beta--multiplayer",
+        STAGING_BETA: "https://arcade.staging.pxt.io/beta--multiplayer",
+        LOCAL: "http://localhost:3000",
+    };
+
+    export const RELATIVE_LINKS = {
+        PROD: "/--multiplayer",
+        BETA: "/beta--multiplayer",
+    };
+
     export const SHORT_LINKS = {
         PROD: "https://aka.ms/a9",
         PROD_BETA: "https://aka.ms/a9b",
         STAGING: "https://aka.ms/a9s",
         STAGING_BETA: "https://aka.ms/a9sb",
-        LOCAL: "http://localhost:3000"
+    };
+
+    export const RELATIVE_LINK = () => {
+        if (pxt.BrowserUtils.isLocalHostDev()) {
+            switch (MULTIPLAYER_DEV_BACKEND_TYPE) {
+                case MultiplayerDevBackendType.PROD:
+                    return ABSOLUTE_LINKS.PROD_BETA;
+                case MultiplayerDevBackendType.STAGING:
+                    return ABSOLUTE_LINKS.STAGING_BETA;
+                case MultiplayerDevBackendType.LOCAL:
+                    return ABSOLUTE_LINKS.LOCAL;
+            }
+        }
+
+        if (window.location.pathname.startsWith("/beta")) {
+            return RELATIVE_LINKS.BETA;
+        } else {
+            return RELATIVE_LINKS.PROD;
+        }
     };
 
     export const SHORT_LINK = () => {
@@ -22,7 +51,7 @@ namespace pxt.multiplayer {
                 case MultiplayerDevBackendType.STAGING:
                     return SHORT_LINKS.STAGING_BETA;
                 case MultiplayerDevBackendType.LOCAL:
-                    return SHORT_LINKS.LOCAL;
+                    return ABSOLUTE_LINKS.LOCAL;
             }
         }
 
@@ -41,11 +70,11 @@ namespace pxt.multiplayer {
         }
     };
 
-    export function makeHostLink(shareUrlOrCode: string) {
-        return `${SHORT_LINK()}?host=${encodeURIComponent(shareUrlOrCode)}`;
+    export function makeHostLink(shareUrlOrCode: string, shortLink: boolean) {
+        return `${shortLink ? SHORT_LINK() : RELATIVE_LINK()}?host=${encodeURIComponent(shareUrlOrCode)}`;
     }
 
-    export function makeJoinLink(joinCode: string) {
-        return `${SHORT_LINK()}?join=${encodeURIComponent(joinCode)}`;
+    export function makeJoinLink(joinCode: string, shortLink: boolean) {
+        return `${shortLink ? SHORT_LINK() : RELATIVE_LINK()}?join=${encodeURIComponent(joinCode)}`;
     }
 }

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -192,7 +192,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
             return;
         }
 
-        const multiplayerHostUrl = pxt.multiplayer.makeHostLink(shareId);
+        const multiplayerHostUrl = pxt.multiplayer.makeHostLink(shareId, false);
 
         // NOTE: It is allowable to log the shareId here because this is within the multiplayer context.
         // In this context, the user has consented to allowing the shareId being made public.


### PR DESCRIPTION
This was an attempt to fix https://github.com/microsoft/pxt-arcade/issues/5500. It doesn't fix it, but seems like a change worth keeping. No need to use short links everywhere.