### PR TITLE
Make Block Errors Easier to Read

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -90,6 +90,10 @@ body.blocklyMinimalBody {
         font-style: italic;
     }
 
+    text.blocklyText.blocklyBubbleText {
+        fill: #fff;
+    }
+
     .blocklyEditableText>text.semanticIcon, .blocklyNonEditableText>text.semanticIcon {
         fill: #fff;
         font-family: "Icons";


### PR DESCRIPTION
I think white is a safe bet, since I believe the bubble's background is chosen based on the block color and it looks like we use white text for all the regular block text, too.

Before:
![image](https://user-images.githubusercontent.com/69657545/214698066-f37927bb-14e9-4af8-bf7b-ef1556cd5791.png)

After:
<img width="320" alt="image" src="https://user-images.githubusercontent.com/69657545/214697809-adcd85fd-fc6e-4ae1-8160-2b67f50b8212.png">

Fixes https://github.com/microsoft/pxt-arcade/issues/4993