### PR TITLE
Categorize builtin extensions in the extension browser

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -40,6 +40,7 @@ declare namespace pxt {
         bannedRepos?: string[];
         allowUnapproved?: boolean;
         approvedRepoLib?: pxt.Map<RepoData>;
+        builtinExtensionsLib?: pxt.Map<RepoData>;
         // list of trusted custom editor extension urls
         // that can bypass consent and send/receive messages
         approvedEditorExtensionUrls?: string[];
@@ -1163,7 +1164,7 @@ declare namespace pxt.tutorial {
         enabled: boolean;
         execute(options: CodeValidationExecuteOptions): Promise<CodeValidationResult>;
     }
-    
+
     interface CodeValidatorMetadata {
         validatorType: string;
         properties: pxt.Map<string>;
@@ -1172,7 +1173,7 @@ declare namespace pxt.tutorial {
     interface CodeValidationConfig {
         validatorsMetadata: CodeValidatorMetadata[];
     }
-    
+
     interface TutorialStepInfo {
         // Step metadata
         showHint?: boolean; // automatically displays hint

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -139,10 +139,16 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         if (extensionTags.size > 0)
             return
         let trgConfig = await data.getAsync<pxt.TargetConfig>("target-config:")
-        if (!trgConfig?.packages?.approvedRepoLib && !trgConfig?.packages?.builtinExtensionsLib)
-            return;
+        const approvedRepos = trgConfig?.packages?.approvedRepoLib;
+        const builtinExtensions = trgConfig?.packages?.builtinExtensionsLib;
+        let allExtensions: string[] = [];
         const newMap = extensionTags;
-        const allExtensions = Object.keys(trgConfig.packages.approvedRepoLib).concat(Object.keys(trgConfig.packages.builtinExtensionsLib));
+        if (!approvedRepos && !builtinExtensions)
+            return;
+        if (approvedRepos)
+            allExtensions = allExtensions.concat(Object.keys(approvedRepos));
+        if (builtinExtensions)
+            allExtensions = allExtensions.concat(Object.keys(builtinExtensions));
         allExtensions.forEach(repoSlug => {
             const repoData = trgConfig.packages.approvedRepoLib[repoSlug] || trgConfig.packages.builtinExtensionsLib[repoSlug];
             repoData.tags?.forEach(tag => {

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -150,7 +150,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         if (builtinExtensions)
             allExtensions = allExtensions.concat(Object.keys(builtinExtensions));
         allExtensions.forEach(repoSlug => {
-            const repoData = trgConfig.packages.approvedRepoLib[repoSlug] || trgConfig.packages.builtinExtensionsLib[repoSlug];
+            const repoData = approvedRepos?.[repoSlug] || builtinExtensions?.[repoSlug];
             repoData.tags?.forEach(tag => {
                 if (!newMap.has(tag)) {
                     newMap.set(tag, [])

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -139,11 +139,12 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         if (extensionTags.size > 0)
             return
         let trgConfig = await data.getAsync<pxt.TargetConfig>("target-config:")
-        if (!trgConfig?.packages?.approvedRepoLib)
+        if (!trgConfig?.packages?.approvedRepoLib && !trgConfig?.packages?.builtinExtensionsLib)
             return;
         const newMap = extensionTags;
-        Object.keys(trgConfig.packages.approvedRepoLib).forEach(repoSlug => {
-            const repoData = trgConfig.packages.approvedRepoLib[repoSlug];
+        const allExtensions = Object.keys(trgConfig.packages.approvedRepoLib).concat(Object.keys(trgConfig.packages.builtinExtensionsLib));
+        allExtensions.forEach(repoSlug => {
+            const repoData = trgConfig.packages.approvedRepoLib[repoSlug] || trgConfig.packages.builtinExtensionsLib[repoSlug];
             repoData.tags?.forEach(tag => {
                 if (!newMap.has(tag)) {
                     newMap.set(tag, [])


### PR DESCRIPTION
- Adds a `builtinExtensionsLib` to the `PackagesConfig`
- Includes tags from builtin extensions to establish the categories/tags in the extension browser

Necessary to close https://github.com/microsoft/pxt-arcade/issues/4992