### PR TITLE
Select active player in multiplayer mode

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1043,6 +1043,7 @@ declare namespace ts.pxtc {
         fnArgs?: pxt.Map<String[]>;
         parts?: string[];
         usedBuiltinParts?: string[];
+        allParts?: string[];
         breakpoints?: number[];
     }
 
@@ -1163,7 +1164,7 @@ declare namespace pxt.tutorial {
         enabled: boolean;
         execute(options: CodeValidationExecuteOptions): Promise<CodeValidationResult>;
     }
-    
+
     interface CodeValidatorMetadata {
         validatorType: string;
         properties: pxt.Map<string>;
@@ -1172,7 +1173,7 @@ declare namespace pxt.tutorial {
     interface CodeValidationConfig {
         validatorsMetadata: CodeValidatorMetadata[];
     }
-    
+
     interface TutorialStepInfo {
         // Step metadata
         showHint?: boolean; // automatically displays hint

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -447,30 +447,12 @@ class GameClient {
 
         if (iconBuffer) {
             const unzipped = await gunzipAsync(iconBuffer);
-            const imgConv = new pxt.ImageConverter();
             const iconPalette = unzipped.slice(0, PALETTE_BUFFER_SIZE);
             const iconImage = unzipped.slice(PALETTE_BUFFER_SIZE);
-            const paletteAsTripletArray: number[][] = [];
-
-            for (let i = 0; i < 16; i++) {
-                paletteAsTripletArray.push([
-                    iconPalette[i * 3 + 2],
-                    iconPalette[i * 3 + 1],
-                    iconPalette[i * 3 + 0],
-                    255,
-                ]);
-            }
-            imgConv.setPalette(paletteAsTripletArray);
-            const stringifiedRefBuffer = String.fromCharCode.apply(
-                null,
-                iconImage as any as number[]
+            const iconPngDataUri = pxt.convertUint8BufferToPngUri(
+                iconPalette,
+                iconImage
             );
-
-            const jresFormattedIconBuffer = `data:image/x-mkcd-f4;base64,${btoa(
-                stringifiedRefBuffer
-            )}`;
-
-            const iconPngDataUri = imgConv.convert(jresFormattedIconBuffer);
 
             setCustomIconAsync(iconType, iconSlot, iconPngDataUri);
         } else {

--- a/pxtlib/imageConverter.ts
+++ b/pxtlib/imageConverter.ts
@@ -185,4 +185,31 @@ namespace pxt {
             return "data:image/bmp;base64," + btoa(U.uint8ArrayToString(bmp))
         }
     }
+
+    export function convertUint8BufferToPngUri(palette: Uint8Array, icon: Uint8Array) {
+        const imgConv = new pxt.ImageConverter();
+        const paletteAsTripletArray: number[][] = [];
+
+        for (let i = 0; i < 16; i++) {
+            paletteAsTripletArray.push([
+                palette[i * 3 + 2],
+                palette[i * 3 + 1],
+                palette[i * 3 + 0],
+                255,
+            ]);
+        }
+
+        imgConv.setPalette(paletteAsTripletArray);
+        const stringifiedRefBuffer = String.fromCharCode.apply(
+            null,
+            icon as any as number[]
+        );
+
+        const jresFormattedIconBuffer = `data:image/x-mkcd-f4;base64,${btoa(
+            stringifiedRefBuffer
+        )}`;
+
+        const iconPngDataUri = imgConv.convert(jresFormattedIconBuffer);
+        return iconPngDataUri;
+    }
 }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -389,6 +389,7 @@ namespace ts.pxtc {
             fnArgs: compileResult.usedArguments,
             parts: pxtc.computeUsedParts(compileResult, "ignorebuiltin"),
             usedBuiltinParts: pxtc.computeUsedParts(compileResult, "onlybuiltin"),
+            allParts: pxtc.computeUsedParts(compileResult, undefined, true),
             breakpoints: compileResult.breakpoints?.map(bp => bp.id),
         };
     }

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -27,6 +27,7 @@ namespace pxsim {
         dependencies?: Map<string>;
         single?: boolean;
         traceDisabled?: boolean;
+        activePlayer?: 1 | 2 | 3 | 4 | undefined;
     }
 
     export interface SimulatorInstructionsMessage extends SimulatorMessage {
@@ -255,6 +256,22 @@ namespace pxsim {
         css?: string;
         uri?: string;
         error?: string;
+    }
+
+    export interface SetActivePlayerMessage extends SimulatorMessage {
+        type: "setactiveplayer";
+        playerNumber: 1 | 2 | 3 | 4 | undefined;
+    }
+
+    export interface SetSimThemeMessage extends SimulatorMessage {
+        type: "setsimthemecolor";
+        part:
+            | "background-color"
+            | "button-stroke"
+            | "text-color"
+            | "button-fill"
+            | "dpad-fill";
+        color: string;
     }
 
     export function print(delay: number = 0) {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -74,6 +74,7 @@ namespace pxsim {
         autofocus?: boolean;
         queryParameters?: string;
         mpRole?: "server" | "client";
+        activePlayer?: 1 | 2 | 3 | 4 | undefined;
     }
 
     export interface HwDebugger {
@@ -666,7 +667,8 @@ namespace pxsim {
                 storedState: opts.storedState,
                 ipc: opts.ipc,
                 single: opts.single,
-                dependencies: opts.dependencies
+                dependencies: opts.dependencies,
+                activePlayer: opts.activePlayer,
             }
             this.start();
         }

--- a/theme/common.less
+++ b/theme/common.less
@@ -1429,6 +1429,13 @@ p.ui.font.small {
         right: auto;
         display: block !important;
     }
+    .simPanel .multiplayer-presence {
+        position: fixed;
+        bottom: 4rem;
+    }
+    .simPanel.multiplayer-preview #simulators {
+        height: calc(100% - 2rem);
+    }
     #simulators {
         position: relative;
         padding: 3rem 1rem 3rem;
@@ -2322,6 +2329,86 @@ button.ui.button.hostmultiplayergame-button {
     .icon.xicon.multiplayer {
         font-size: 24px;
         margin-top: 0.25rem !important;
+    }
+}
+
+#root {
+    --multiplayer-presence-icon-1: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='25' height='29' fill='%23FF0000'%3E%3Cpath d='M12.754 14.686a7 7 0 100-14 7 7 0 000 14zm-8.5 2a3.5 3.5 0 00-3.5 3.5v.5c0 2.393 1.523 4.417 3.685 5.793 2.174 1.384 5.117 2.207 8.315 2.207 3.199 0 6.141-.823 8.315-2.206 2.163-1.377 3.685-3.4 3.685-5.794v-.5a3.5 3.5 0 00-3.5-3.5h-17z'/%3E%3C/svg%3E");
+    --multiplayer-presence-icon-2: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='25' height='29' fill='%230038FF'%3E%3Cpath d='M12.754 14.686a7 7 0 100-14 7 7 0 000 14zm-8.5 2a3.5 3.5 0 00-3.5 3.5v.5c0 2.393 1.523 4.417 3.685 5.793 2.174 1.384 5.117 2.207 8.315 2.207 3.199 0 6.141-.823 8.315-2.206 2.163-1.377 3.685-3.4 3.685-5.794v-.5a3.5 3.5 0 00-3.5-3.5h-17z'/%3E%3C/svg%3E");
+    --multiplayer-presence-icon-3: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='25' height='29' fill='%23FF9A14'%3E%3Cpath d='M12.754 14.686a7 7 0 100-14 7 7 0 000 14zm-8.5 2a3.5 3.5 0 00-3.5 3.5v.5c0 2.393 1.523 4.417 3.685 5.793 2.174 1.384 5.117 2.207 8.315 2.207 3.199 0 6.141-.823 8.315-2.206 2.163-1.377 3.685-3.4 3.685-5.794v-.5a3.5 3.5 0 00-3.5-3.5h-17z'/%3E%3C/svg%3E");
+    --multiplayer-presence-icon-4: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='25' height='29' fill='%234DA64D'%3E%3Cpath d='M12.754 14.686a7 7 0 100-14 7 7 0 000 14zm-8.5 2a3.5 3.5 0 00-3.5 3.5v.5c0 2.393 1.523 4.417 3.685 5.793 2.174 1.384 5.117 2.207 8.315 2.207 3.199 0 6.141-.823 8.315-2.206 2.163-1.377 3.685-3.4 3.685-5.794v-.5a3.5 3.5 0 00-3.5-3.5h-17z'/%3E%3C/svg%3E");
+}
+
+#root:not(.fullscreensim) .multiplayer-presence {
+    margin: 0;
+    margin-bottom: -.5rem;
+}
+
+.sim-presence-bar {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding: 0.5rem;
+    gap: 1rem;
+    padding: 0;
+
+    .sim-presence-bar-player {
+        border-radius: 3rem;
+        height: 3rem;
+        width: 3rem;
+        padding: 0.2rem;
+        border: 2px solid;
+
+        // img {
+            image-rendering: optimizeSpeed;
+            image-rendering: -moz-crisp-edges;
+            image-rendering: -webkit-optimize-contrast;
+            image-rendering: optimize-contrast;
+            image-rendering: pixelated;
+            -ms-interpolation-mode: nearest-neighbor;
+            background-repeat: no-repeat;
+            background-position: center;
+            background-size: 75%;
+        //     width: 2rem;
+        //     height: 2rem;
+
+        //     object-fit: contain;
+        //     height: auto;
+        // }
+        &.player-1 {
+            border-color: #FF0000;
+            // TODO: what to use for background color? just leave as default white?
+            // background-color: #FF00001A;
+            // img {
+            //     content: var(--multiplayer-presence-icon-1);
+            // }
+            background-image: var(--multiplayer-presence-icon-1);
+        }
+        &.player-2 {
+            border-color: #0038FF;
+            // background-color: #0038FF1A;
+            // img {
+            //     content: var(--multiplayer-presence-icon-2);
+            // }
+            background-image: var(--multiplayer-presence-icon-2);
+        }
+        &.player-3 {
+            border-color: #FF9A14;
+            // background-color: #FF9A141A;
+            // img {
+            //     content: var(--multiplayer-presence-icon-3);
+            // }
+            background-image: var(--multiplayer-presence-icon-3);
+        }
+        &.player-4 {
+            border-color: #4DA64D;
+            // background-color: #4DA64D1A;
+            // img {
+            //     content: var(--multiplayer-presence-icon-4);
+            // }
+            background-image: var(--multiplayer-presence-icon-4);
+        }
     }
 }
 

--- a/theme/common.less
+++ b/theme/common.less
@@ -2360,53 +2360,35 @@ button.ui.button.hostmultiplayergame-button {
         padding: 0.2rem;
         border: 2px solid;
 
-        // img {
-            image-rendering: optimizeSpeed;
-            image-rendering: -moz-crisp-edges;
-            image-rendering: -webkit-optimize-contrast;
-            image-rendering: optimize-contrast;
-            image-rendering: pixelated;
-            -ms-interpolation-mode: nearest-neighbor;
-            background-repeat: no-repeat;
-            background-position: center;
-            background-size: 75%;
-        //     width: 2rem;
-        //     height: 2rem;
+        image-rendering: optimizeSpeed;
+        image-rendering: -moz-crisp-edges;
+        image-rendering: -webkit-optimize-contrast;
+        image-rendering: optimize-contrast;
+        image-rendering: pixelated;
+        -ms-interpolation-mode: nearest-neighbor;
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: 75%;
 
-        //     object-fit: contain;
-        //     height: auto;
-        // }
         &.player-1 {
             border-color: #FF0000;
             // TODO: what to use for background color? just leave as default white?
             // background-color: #FF00001A;
-            // img {
-            //     content: var(--multiplayer-presence-icon-1);
-            // }
             background-image: var(--multiplayer-presence-icon-1);
         }
         &.player-2 {
             border-color: #0038FF;
             // background-color: #0038FF1A;
-            // img {
-            //     content: var(--multiplayer-presence-icon-2);
-            // }
             background-image: var(--multiplayer-presence-icon-2);
         }
         &.player-3 {
             border-color: #FF9A14;
             // background-color: #FF9A141A;
-            // img {
-            //     content: var(--multiplayer-presence-icon-3);
-            // }
             background-image: var(--multiplayer-presence-icon-3);
         }
         &.player-4 {
             border-color: #4DA64D;
             // background-color: #4DA64D1A;
-            // img {
-            //     content: var(--multiplayer-presence-icon-4);
-            // }
             background-image: var(--multiplayer-presence-icon-4);
         }
     }

--- a/theme/common.less
+++ b/theme/common.less
@@ -2355,8 +2355,8 @@ button.ui.button.hostmultiplayergame-button {
 
     .sim-presence-bar-player {
         border-radius: 3rem;
-        height: 3rem;
-        width: 3rem;
+        height: 2.5rem;
+        width: 2.5rem;
         padding: 0.2rem;
         border: 2px solid;
 

--- a/theme/common.less
+++ b/theme/common.less
@@ -2374,24 +2374,32 @@ button.ui.button.hostmultiplayergame-button {
             border-color: #FF0000;
             // TODO: what to use for background color? just leave as default white?
             // background-color: #FF00001A;
-            background-image: var(--multiplayer-presence-icon-1);
+            // !importants here as we have to override hc nulling background properties
+            background-image: var(--multiplayer-presence-icon-1) !important;
         }
         &.player-2 {
             border-color: #0038FF;
             // background-color: #0038FF1A;
-            background-image: var(--multiplayer-presence-icon-2);
+            background-image: var(--multiplayer-presence-icon-2) !important;
         }
         &.player-3 {
             border-color: #FF9A14;
             // background-color: #FF9A141A;
-            background-image: var(--multiplayer-presence-icon-3);
+            background-image: var(--multiplayer-presence-icon-3) !important;
         }
         &.player-4 {
             border-color: #4DA64D;
             // background-color: #4DA64D1A;
-            background-image: var(--multiplayer-presence-icon-4);
+            background-image: var(--multiplayer-presence-icon-4) !important;
         }
     }
+}
+
+// win the specificity fight with hc mode
+#root.hc .sim-presence-bar .sim-presence-bar-player {
+    background-repeat: no-repeat !important;
+    background-position: center !important;
+    background-size: 75% !important;
 }
 
 /* Profile dialog */

--- a/theme/common.less
+++ b/theme/common.less
@@ -1434,7 +1434,7 @@ p.ui.font.small {
         bottom: 4rem;
     }
     .simPanel.multiplayer-preview #simulators {
-        height: calc(100% - 2rem);
+        height: calc(100% - 1.5rem);
     }
     #simulators {
         position: relative;
@@ -2342,6 +2342,22 @@ button.ui.button.hostmultiplayergame-button {
 #root:not(.fullscreensim) .multiplayer-presence {
     margin: 0;
     margin-bottom: -.5rem;
+}
+
+.miniSim:not(.fullscreensim):not(.tabTutorial) .multiplayer-presence {
+    display: none;
+}
+
+#root.tabTutorial:not(.fullscreensim):not(.collapsedEditorTools) .tab-content.tab-simulator.hidden .simPanel > .multiplayer-presence {
+    display: block;
+    position: fixed;
+    bottom: 7rem;
+    right: 16.5rem;
+    width: 4rem;
+
+    .sim-presence-bar {
+        flex-direction: column;
+    }
 }
 
 .sim-presence-bar {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -251,6 +251,15 @@ export class ProjectView
             }
             else if (msg.type === "thumbnail") {
                 if (this.shareEditor) this.shareEditor.setThumbnailFrames((msg as pxsim.SimulatorAutomaticThumbnailMessage).frames);
+            } else if (msg.type === "multiplayer") {
+                // todo move over types from multiplayer app to pxsim/embed.ts
+                const multiplayerMessage = msg as any;
+                if (multiplayerMessage.content === "Icon"
+                    && multiplayerMessage.iconType === 0 /** IconType.Player **/
+                ) {
+                    const { palette, icon, slot } = multiplayerMessage;
+                    this.handleSetPresenceIcon(slot, palette, icon.data);
+                }
             }
         }, false);
     }
@@ -314,6 +323,36 @@ export class ProjectView
             core.handleNetworkError(e);
         } finally {
             core.hideLoading("addextensions")
+        }
+    }
+
+    handleSetPresenceIcon = (slot: number, palette?: Uint8Array, icon?: Uint8Array) => {
+        slot = slot | 0;
+        if (slot < 1 || slot > 4)
+            return;
+
+        const root = document.getElementById("root");
+
+        const slotCssVarName = `--multiplayer-presence-icon-${slot}`;
+
+        if (!palette || !icon) {
+            root.style.removeProperty(slotCssVarName);
+            return;
+        } else {
+            const iconPngDataUri = pxt.convertUint8BufferToPngUri(
+                palette,
+                icon,
+            );
+            if (!iconPngDataUri) {
+                // failed to parse icon, bail out
+                return;
+            }
+            const asUrl = `url("${iconPngDataUri}")`;
+            root.style.setProperty(
+                slotCssVarName,
+                asUrl
+            );
+            // TODO: set with `content: url(var(--multiplayer-presence-icon-1))` in css later
         }
     }
 
@@ -4887,7 +4926,8 @@ export class ProjectView
             this.editor != this.blocksEditor ? "editorlang-text" : "",
             this.editor == this.textEditor && this.state.errorListState,
             'full-abs',
-            pxt.appTarget.appTheme.embeddedTutorial ? "tutorial-embed" : ""
+            pxt.appTarget.appTheme.embeddedTutorial ? "tutorial-embed" : "",
+            // isMultiplayerGame ? "multiplayer-preview" : "",
         ];
         this.rootClasses = rootClassList;
         const rootClasses = sui.cx(rootClassList);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -352,7 +352,6 @@ export class ProjectView
                 slotCssVarName,
                 asUrl
             );
-            // TODO: set with `content: url(var(--multiplayer-presence-icon-1))` in css later
         }
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4926,7 +4926,6 @@ export class ProjectView
             this.editor == this.textEditor && this.state.errorListState,
             'full-abs',
             pxt.appTarget.appTheme.embeddedTutorial ? "tutorial-embed" : "",
-            // isMultiplayerGame ? "multiplayer-preview" : "",
         ];
         this.rootClasses = rootClassList;
         const rootClasses = sui.cx(rootClassList);

--- a/webapp/src/components/SimulatorPresenceBar.tsx
+++ b/webapp/src/components/SimulatorPresenceBar.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { Button } from "../../../react-common/components/controls/Button";
+import * as simulator from "../simulator";
+
+export function SimulatorPresenceBar() {
+    return (<div className="sim-presence-bar">
+        <PlayerPresenceIcon slot={1} />
+        <PlayerPresenceIcon slot={2} />
+        <PlayerPresenceIcon slot={3} />
+        <PlayerPresenceIcon slot={4} />
+    </div>);
+}
+
+function PlayerPresenceIcon(props: React.PropsWithoutRef<{slot: 1 | 2 | 3 | 4}>) {
+    const { slot } = props;
+
+    const onClick = () => {
+        const setSlotMsg: pxsim.SetActivePlayerMessage = {
+            type: "setactiveplayer",
+            playerNumber: slot,
+        };
+        simulator.driver.postMessage(setSlotMsg);
+    }
+    return (<Button
+        className={`sim-presence-bar-player player-${slot}`}
+        title={lf("Player {0}", slot)}
+        onClick={onClick}
+        // label={(
+        //     <img
+        //         className={"player-icon"}
+        //         alt={lf("User set icon for player {0}", slot)}
+        //         src="" // set in css as content:
+        //     />
+        // )}
+    />);
+}

--- a/webapp/src/components/SimulatorPresenceBar.tsx
+++ b/webapp/src/components/SimulatorPresenceBar.tsx
@@ -25,12 +25,5 @@ function PlayerPresenceIcon(props: React.PropsWithoutRef<{slot: 1 | 2 | 3 | 4}>)
         className={`sim-presence-bar-player player-${slot}`}
         title={lf("Player {0}", slot)}
         onClick={onClick}
-        // label={(
-        //     <img
-        //         className={"player-icon"}
-        //         alt={lf("User set icon for player {0}", slot)}
-        //         src="" // set in css as content:
-        //     />
-        // )}
     />);
 }

--- a/webapp/src/components/SimulatorPresenceBar.tsx
+++ b/webapp/src/components/SimulatorPresenceBar.tsx
@@ -20,6 +20,7 @@ function PlayerPresenceIcon(props: React.PropsWithoutRef<{slot: 1 | 2 | 3 | 4}>)
             playerNumber: slot,
         };
         simulator.driver.postMessage(setSlotMsg);
+        simulator.driver.focus();
     }
     return (<Button
         className={`sim-presence-bar-player player-${slot}`}

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -11,6 +11,7 @@ import * as simulator from "./simulator";
 import { Button } from "./sui";
 import { TabContent } from "./components/core/TabContent";
 import { TabPane } from "./components/core/TabPane";
+import { SimulatorPresenceBar } from "./components/SimulatorPresenceBar"
 import { TutorialContainer } from "./components/tutorial/TutorialContainer";
 import { fireClickOnEnter } from "./util";
 
@@ -155,8 +156,11 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
             {!hasSimulator && <div id="boardview" className="headless-sim" role="region" aria-label={lf("Simulator")} tabIndex={-1} />}
             <TabPane id="editorSidebar" activeTabName={activeTab} style={height ? { height: `calc(${height}px + ${marginHeight})` } : undefined}>
                 <TabContent disabled={!includeSimulatorTab} name={SIMULATOR_TAB} icon="xicon gamepad" onSelected={this.tryShowSimulatorTab} ariaLabel={lf("Open the simulator tab")}>
-                    <div className="ui items simPanel" ref={this.handleSimPanelRef}>
+                    <div className={`ui items simPanel ${showHostMultiplayerGameButton ? "multiplayer-preview" : ""}`} ref={this.handleSimPanelRef}>
                         <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
+                        {showHostMultiplayerGameButton && <div className="ui item grid centered portrait multiplayer-presence">
+                            <SimulatorPresenceBar />
+                        </div>}
                         <simtoolbar.SimulatorToolbar parent={parent} collapsed={collapseEditorTools} simSerialActive={simSerialActive} devSerialActive={deviceSerialActive} showSimulatorSidebar={this.tryShowSimulatorTab} />
                         {showKeymap && <keymap.Keymap parent={parent} />}
                         <div className="ui item portrait hide hidefullscreen">

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -289,6 +289,7 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
         fnArgs,
         parts,
         usedBuiltinParts,
+        allParts
     } = pxtc.buildSimJsInfo(res);
     lastCompileResult = res;
     const { mute, highContrast, light, clickTrigger, storedState, autoRun } = options;
@@ -296,6 +297,15 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
     const dependencies: pxt.Map<string> = {}
     for(const dep of pkg.sortedDeps())
         dependencies[dep.id] = dep.version()
+
+    const playerNumber = allParts && allParts.indexOf("multiplayer") >= 0 ? 1 : undefined;
+    if (playerNumber) {
+        const root = document.getElementById("root");
+        for (let i = 1; i < 4; i++) {
+            const cssVar = `--multiplayer-presence-icon-${i}`;
+            root?.style?.removeProperty(cssVar);
+        }
+    }
 
     const opts: pxsim.SimulatorRunOptions = {
         boardDefinition: boardDefinition,
@@ -318,7 +328,8 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
         storedState: storedState,
         autoRun,
         ipc: isIpcRenderer,
-        dependencies
+        dependencies,
+        activePlayer: playerNumber
     }
     //if (pxt.options.debug)
     //    pxt.debug(JSON.stringify(opts, null, 2))


### PR DESCRIPTION
Close https://github.com/microsoft/pxt-arcade/issues/5469

Adds a multiplayer bar underneath simulator when you're writing a multiplayer game so you can pretend to be someone else / preview what presence icons look like

<img width="343" alt="image" src="https://user-images.githubusercontent.com/5615930/214907345-6328ddff-f247-4b8c-afdb-c1013d7322d7.png">

Because there is lacking space in tutorials, I made a quick decision for now to just show it to the left

<img width="938" alt="image" src="https://user-images.githubusercontent.com/5615930/214907609-822c155b-99da-453a-b5a7-12e1f08f2e06.png">

There was a little bit that I'm gonna try and rearrange, but I already rewrote where it was rendered (out of iframe to accommodate tutorials better) & where the data was stored (treating it similar to console logs / etc ends up way too clunky just to propagate a few images, and don't want to send out significant, root of react tree updates up to 120s and second and slow full editor perf). The current semi hacky version of latching it as a style var on root ends up feeling okay to me, but I'm gonna see about adding a few message listeners in `SimulatorPresenceBar.tsx` to keep track of the images there nicely. (I'll see how that turns out and fix the typings todo I mentioned at the same time)

relies on https://github.com/microsoft/pxt-arcade-sim/pull/85 (well, not strictly relies on, but the buttons won't do anything if it's not there)

build: https://arcade.makecode.com/app/0c63e39b191ab5a18f69ed9bef12099bde2e8db7-ebce63eee6#pub:_cmhaDMf2XHX6