### PR TITLE
Move "Share to Kiosk" Button in Share Popup

### DIFF
--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -358,13 +358,6 @@ export const ShareInfo = (props: ShareInfoProps) => {
                             </div>
                             <div className="project-share-actions">
                                 <div className="project-share-social">
-                                    {
-                                        pxt.appTarget?.appTheme?.shareToKiosk &&
-                                            <Button className="square-button gray mobile-portrait-hidden"
-                                            title={lf("Share to MakeCode Arcade Kiosk")}
-                                            leftIcon={"xicon kiosk"}
-                                            onClick={handleKioskClick} />
-                                    }
                                     <Button className="square-button gray embed mobile-portrait-hidden"
                                         title={lf("Show embed code")}
                                         leftIcon="fas fa-code"
@@ -389,12 +382,20 @@ export const ShareInfo = (props: ShareInfoProps) => {
                                         url={shareData?.url}
                                         type='whatsapp'
                                         heading={lf("Share on WhatsApp")} />
-                                    {navigator.share && <Button className="square-button device-share"
-                                        title={lf("Show device share options")}
-                                        ariaLabel={lf("Show device share options")}
-                                        leftIcon={"icon share"}
-                                        onClick={handleDeviceShareClick}
-                                    />}
+                                    {
+                                        pxt.appTarget?.appTheme?.shareToKiosk &&
+                                            <Button className="square-button gray mobile-portrait-hidden"
+                                            title={lf("Share to MakeCode Arcade Kiosk")}
+                                            leftIcon={"xicon kiosk"}
+                                            onClick={handleKioskClick} />
+                                    }
+                                    {
+                                        navigator.share && <Button className="square-button device-share"
+                                            title={lf("Show device share options")}
+                                            ariaLabel={lf("Show device share options")}
+                                            leftIcon={"icon share"}
+                                            onClick={handleDeviceShareClick} />
+                                    }
                                 </div>
                                 <Button
                                     className="menu-button project-qrcode"


### PR DESCRIPTION
This partially addresses https://github.com/microsoft/pxt-arcade/issues/5447. I don't have an svg for the new icon yet, so I'll either add that in a future iteration or follow up with a separate PR once we get that.

Before:
<img width="729" alt="image" src="https://user-images.githubusercontent.com/69657545/214974201-d81ff3f1-1984-4a25-a084-a899e803f40d.png">

After:
<img width="732" alt="image" src="https://user-images.githubusercontent.com/69657545/214974803-78ff83c8-73b9-42a7-8aae-5647089d6a59.png">
