### PR TITLE
Expand bass clef for drums as well

### DIFF
--- a/webapp/src/components/musicEditor/utils.ts
+++ b/webapp/src/components/musicEditor/utils.ts
@@ -486,7 +486,7 @@ function moveNoteEvent(noteEvent: pxt.assets.music.NoteEvent, trackOctave: numbe
 
 export function doesSongUseBassClef(song: pxt.assets.music.Song) {
     return song.tracks.some(track =>
-        !track.drums && track.notes.some(noteEvent =>
+        track.notes.some(noteEvent =>
             noteEvent.notes.some(note =>
                 isBassClefNote(track.instrument.octave, note, !!track.drums)
             )


### PR DESCRIPTION
Fixing a little bug I just noticed. The bass clef wasn't automatically showing when there were notes in the bass clef for drums