### PR TITLE
Fix serviceworker race condition

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5545,6 +5545,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
     pxt.perf.measureStart("setAppTarget");
     pkg.setupAppTarget((window as any).pxtTargetBundle);
+
+    // DO NOT put any async code before this line! The serviceworker must be initialized before
+    // the window load event fires
     appcache.init(() => theEditor.reloadEditor());
     pxt.setBundledApiInfo((window as any).pxtTargetBundle.apiInfo);
     pxt.perf.measureEnd("setAppTarget");

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5545,6 +5545,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
     pxt.perf.measureStart("setAppTarget");
     pkg.setupAppTarget((window as any).pxtTargetBundle);
+    appcache.init(() => theEditor.reloadEditor());
     pxt.setBundledApiInfo((window as any).pxtTargetBundle.apiInfo);
     pxt.perf.measureEnd("setAppTarget");
 
@@ -5574,7 +5575,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     cloudsync.loginCheck()
     parseLocalToken();
     hash = parseHash();
-    appcache.init(() => theEditor.reloadEditor());
     blocklyFieldView.init();
 
     pxt.react.getTilemapProject = () => {


### PR DESCRIPTION
Finally fixes the problem where the serviceworker isn't reloading; I think at some point the initialization of the load event was moved below the auth code initialization, which was causing it to miss the window's load event

This puts us in a bit of a pickle.... Since the old "bad" payload was released in the last release there is no way I know of to force all of the existing clients to unregister the old serviceworker. As a result, nobody will get the updated payload from this release. That means everyone will be stuck on an old version of arcade unless they clear their browser storage (bad idea) or manually unregister the serviceworker (multi-step-process that involves the devtools). Not sure what to do here.

@abchatra it is ABSOLUTELY CRITICAL that this gets merged before release