### PR TITLE
propagate presence on host resuming pause game

### DIFF
--- a/multiplayer/src/components/ArcadeSimulator.tsx
+++ b/multiplayer/src/components/ArcadeSimulator.tsx
@@ -49,7 +49,7 @@ export default function Render() {
     };
     const postIconMsg = async (msg: SimMultiplayer.MultiplayerIconMessage) => {
         const { iconType, palette, icon, slot } = msg;
-        const { data } = icon;
+        const { data } = icon || {};
         await gameClient.sendIconAsync(iconType, slot, palette, data);
     };
 

--- a/multiplayer/src/epics/resumeGameAsync.ts
+++ b/multiplayer/src/epics/resumeGameAsync.ts
@@ -2,9 +2,10 @@ import { state, dispatch } from "../state";
 import * as gameClient from "../services/gameClient";
 import { setGamePaused } from "../state/actions";
 import { simDriver } from "../services/simHost";
+import { SimMultiplayer } from "../types";
 
 export async function resumeGameAsync() {
-    const { clientRole } = state;
+    const { clientRole, presence } = state;
 
     try {
         if (clientRole === "host") {
@@ -13,6 +14,18 @@ export async function resumeGameAsync() {
         }
         simDriver()?.resume(pxsim.SimulatorDebuggerCommand.Resume);
         dispatch(setGamePaused(false));
+        if (clientRole === "host") {
+            for (let i = 1; i <= 4; i++) {
+                const nowConnected = !!presence.users.find(el => el.slot === i);
+                simDriver()?.postMessage({
+                    type: "multiplayer",
+                    content: "Connection",
+                    slot: i,
+                    connected: nowConnected,
+                } as SimMultiplayer.MultiplayerConnectionMessage);
+            }
+            await gameClient.sendCurrentScreenAsync();
+        }
     } catch (e) {
     } finally {
     }

--- a/multiplayer/src/services/gameClient.ts
+++ b/multiplayer/src/services/gameClient.ts
@@ -562,7 +562,7 @@ class GameClient {
         }
     }
 
-    private async sendCurrentScreenAsync() {
+    public async sendCurrentScreenAsync() {
         if (this.screen) {
             const zippedData = await gzipAsync(this.screen);
             const buffer = Protocol.Binary.packCompressedScreenMessage(
@@ -703,6 +703,10 @@ export async function sendScreenUpdateAsync(
     palette: Uint8Array
 ) {
     await gameClient?.sendScreenUpdateAsync(img, palette);
+}
+
+export async function sendCurrentScreenAsync() {
+    await gameClient?.sendCurrentScreenAsync();
 }
 
 export function kickPlayer(clientId: string) {


### PR DESCRIPTION
since messages can be dropped while sim is paused, propagate current user state.

(we only fire events when connected state changes https://github.com/microsoft/pxt-common-packages/blob/sendConnectionEventsOnScreenPop/libs/game/controller.ts#L257 so no worries on the event coming in twice)