### PR TITLE
Kiosk share: input strings converted to upper case

### DIFF
--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -113,8 +113,9 @@ export const ShareInfo = (props: ShareInfoProps) => {
         pxt.tickEvent("share.kiosk.submitClicked");
         const gameId = pxt.Cloud.parseScriptId(shareData.url);
         if (kioskInputRef?.value) {
-            const validKioskId = /^[a-zA-Z0-9]{6}$/.exec(kioskInputRef.value)?.[0];
+            let validKioskId = /^[a-zA-Z0-9]{6}$/.exec(kioskInputRef.value)?.[0];
             if (validKioskId) {
+                validKioskId = validKioskId.toUpperCase();
                 setKioskSubmitSuccessful(true);
                 try {
                     await addGameToKioskAsync(validKioskId, gameId);


### PR DESCRIPTION
I noticed that if I tried to type in a kiosk id not in upper case, I would get a "Kiosk code not found" error. If I typed the same code in with upper case, it would successfully submit. It shouldn't matter if the user types in upper or lowercase, if it is the right sequence of characters, it should be a successful submit. 

![image](https://user-images.githubusercontent.com/49178322/215235497-b0fa0231-95ab-4c03-94e7-aa6d7eb7c8ae.png)
