### PR TITLE
fix so presence bar shows up in multiplayer skillmap

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1562,8 +1562,8 @@ export class ProjectView
 
         if (this.shareEditor) {
             this.shareEditor.setThumbnailFrames(undefined);
-            this.setState({ isMultiplayerGame: false });
         }
+        this.setState({ isMultiplayerGame: false });
 
         const checkAsync = this.tryCheckTargetVersionAsync(h.targetVersion);
         if (checkAsync)
@@ -3171,13 +3171,11 @@ export class ProjectView
             try {
                 const resp = await compiler.compileAsync({ native: true, forceEmit: true });
                 this.editor.setDiagnostics(this.editorFile, state);
-                if (this.shareEditor) {
-                    if (resp.usedParts && resp.usedParts.indexOf("multiplayer") !== -1) {
-                        this.setState({ isMultiplayerGame: true });
-                    }
-                    else {
-                        this.setState({ isMultiplayerGame: false });
-                    }
+                if (resp.usedParts && resp.usedParts.indexOf("multiplayer") !== -1) {
+                    this.setState({ isMultiplayerGame: true });
+                }
+                else {
+                    this.setState({ isMultiplayerGame: false });
                 }
 
                 if (!saveOnly) {
@@ -3735,13 +3733,11 @@ export class ProjectView
                     this.clearSerial();
                     this.editor.setDiagnostics(this.editorFile, state)
 
-                    if (this.shareEditor) {
-                        if (resp.usedParts && resp.usedParts.indexOf("multiplayer") !== -1) {
-                            this.setState({ isMultiplayerGame: true });
-                        }
-                        else {
-                            this.setState({ isMultiplayerGame: false });
-                        }
+                    if (resp.usedParts && resp.usedParts.indexOf("multiplayer") !== -1) {
+                        this.setState({ isMultiplayerGame: true });
+                    }
+                    else {
+                        this.setState({ isMultiplayerGame: false });
                     }
 
                     if (resp.outfiles[pxtc.BINARY_JS]) {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/5614, we don't load `shareEditor` in this iframe. These guards were added to just not crash here https://github.com/microsoft/pxt/pull/9214 when these were calls to methods on `shareEditor` vs just `setState`

You can test on the final level of this tutorial: https://arcade.makecode.com/app/e3ee7dc5421ae4217a36fe347cc69168ff9805fa-eed2f68d38--skillmap?debugCompleted=1#docs:/test/skillmap/mole