### PR TITLE
Multiplayer quick UI updates

### DIFF
--- a/multiplayer/src/components/BetaTag.tsx
+++ b/multiplayer/src/components/BetaTag.tsx
@@ -1,7 +1,0 @@
-export default function Render() {
-    return (
-        <div className="tw-text-sm">
-            <span className="tw-text-white">{lf("Multiplayer")}</span>
-        </div>
-    );
-}

--- a/multiplayer/src/components/BetaTag.tsx
+++ b/multiplayer/src/components/BetaTag.tsx
@@ -1,9 +1,6 @@
 export default function Render() {
     return (
         <div className="tw-text-sm">
-            <span className="tw-bg-white tw-shadow-sm tw-uppercase tw-text-primary-color tw-rounded-md tw-font-bold tw-px-1 tw-pt-[0.05rem] tw-pb-[0.15rem] tw-mr-1">
-                {lf("Beta")}
-            </span>
             <span className="tw-text-white">{lf("Multiplayer")}</span>
         </div>
     );

--- a/multiplayer/src/components/EditGameButton.tsx
+++ b/multiplayer/src/components/EditGameButton.tsx
@@ -10,7 +10,7 @@ export default function Render() {
         ? `${pxt.webConfig.relprefix.replace(/-+$/, "")}#pub:${gameId}`
         : undefined;
 
-    function handleRemixGameClick() {
+    function handleEditGameClick() {
         if (remixUrl) {
             window.open(remixUrl);
         }
@@ -19,13 +19,13 @@ export default function Render() {
     return remixUrl ? (
         <Button
             leftIcon={"fas fa-bolt"}
-            title={lf("Remix Game")}
+            title={lf("Edit Game")}
             label={
                 <div className="tw-hidden sm:tw-inline tw-m-0 tw-p-0">
-                    {lf("Remix Game")}
+                    {lf("Edit Game")}
                 </div>
             }
-            onClick={handleRemixGameClick}
+            onClick={handleEditGameClick}
             className="tw-border-2 tw-border-slate-400 tw-border-solid tw-p-2 tw-bg-slate-100 hover:tw-bg-slate-200 active:tw-bg-slate-300 tw-ease-linear tw-duration-[50ms] tw-pr-1 sm:tw-pr-3"
         />
     ) : null;

--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -1,7 +1,6 @@
 import { useContext } from "react";
 import { AppStateContext } from "../state/AppStateContext";
 import ArcadeSimulator from "./ArcadeSimulator";
-import BetaTag from "./BetaTag";
 import HostLobby from "./HostLobby";
 import JoinCodeLabel from "./JoinCodeLabel";
 import JoinLobby from "./JoinLobby";
@@ -23,11 +22,6 @@ export default function Render(props: GamePageProps) {
                 <div className="tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-full tw-h-full">
                     {clientRole === "host" && <HostLobby />}
                     {clientRole === "guest" && <JoinLobby />}
-                </div>
-            )}
-            {state.gameState?.gameMode === "playing" && (
-                <div className="tw-mx-2 tw-self-start tw-mb-1">
-                    <BetaTag />
                 </div>
             )}
             <div

--- a/multiplayer/src/components/GamePage.tsx
+++ b/multiplayer/src/components/GamePage.tsx
@@ -7,7 +7,7 @@ import JoinCodeLabel from "./JoinCodeLabel";
 import JoinLobby from "./JoinLobby";
 import KeyboardControlsButton from "./KeyboardControlsButton";
 import PresenceBar from "./PresenceBar";
-import RemixGameButton from "./RemixGameButton";
+import EditGameButton from "./EditGameButton";
 import ToggleMuteButton from "./ToggleMuteButton";
 
 export interface GamePageProps {}
@@ -43,7 +43,7 @@ export default function Render(props: GamePageProps) {
                     <div>
                         <ToggleMuteButton />
                         <div className="tw-hidden sm:tw-inline-block">
-                            <RemixGameButton />
+                            <EditGameButton />
                         </div>
                     </div>
                     <div className="tw-mr-1 sm:tw-mr-0">
@@ -53,7 +53,7 @@ export default function Render(props: GamePageProps) {
                         <KeyboardControlsButton />
                     </div>
                     <div className="tw-inline-block sm:tw-hidden">
-                        <RemixGameButton />
+                        <EditGameButton />
                     </div>
                 </div>
                 <div className="tw-mt-3">

--- a/multiplayer/src/components/HostLobby.tsx
+++ b/multiplayer/src/components/HostLobby.tsx
@@ -5,7 +5,6 @@ import { startGameAsync } from "../epics";
 import { clearModal } from "../state/actions";
 import { AppStateContext } from "../state/AppStateContext";
 import { QRCodeSVG } from "qrcode.react";
-import BetaTag from "./BetaTag";
 import CopyButton from "./CopyButton";
 import PresenceBar from "./PresenceBar";
 
@@ -34,9 +33,6 @@ export default function Render() {
 
     return (
         <div className="tw-bg-white tw-shadow-lg tw-rounded-lg tw-m-1 tw-min-w-[17rem]">
-            <div className="tw-absolute tw-translate-y-[-130%]">
-                <BetaTag />
-            </div>
             <div className="tw-flex tw-flex-col tw-gap-1 tw-items-center tw-justify-between tw-py-[3rem] tw-px-3 sm:tw-px-14 md:tw-px-[7rem]">
                 <div className="tw-mt-3 tw-text-lg tw-text-center tw-text-neutral-700">
                     {inviteStringSegments[0]}

--- a/multiplayer/src/components/JoinLobby.tsx
+++ b/multiplayer/src/components/JoinLobby.tsx
@@ -1,12 +1,8 @@
-import BetaTag from "./BetaTag";
 import PresenceBar from "./PresenceBar";
 
 export default function Render() {
     return (
         <div className="tw-bg-white tw-shadow-lg tw-rounded-lg tw-m-1">
-            <div className="tw-absolute tw-translate-y-[-130%]">
-                <BetaTag />
-            </div>
             <div className="tw-flex tw-flex-col tw-items-center tw-py-[2rem] tw-px-[1.5rem] sm:tw-px-[3.5rem] md:tw-px-[6rem]">
                 <div className="tw-font-bold tw-text-2xl tw-text-neutral-800">
                     {lf("Waiting for players")}

--- a/multiplayer/src/components/JoinOrHost.tsx
+++ b/multiplayer/src/components/JoinOrHost.tsx
@@ -9,7 +9,6 @@ import { Link } from "react-common/components/controls/Link";
 import { hostGameAsync, joinGameAsync } from "../epics";
 import TabButton from "./TabButton";
 import HostGameButton from "./HostGameButton";
-import BetaTag from "./BetaTag";
 
 export default function Render() {
     const { state } = useContext(AppStateContext);
@@ -46,9 +45,6 @@ export default function Render() {
     return (
         <div className="tw-flex tw-flex-col tw-w-screen tw-h-screen tw-justify-center tw-items-center">
             <div className="tw-bg-white tw-rounded-lg tw-drop-shadow-xl tw-min-h-[17rem] tw-min-w-[17rem] md:tw-min-w-[25rem]">
-                <div className="tw-absolute tw-translate-y-[-130%]">
-                    <BetaTag />
-                </div>
                 <div className="tw-py-5 tw-px-10 ">
                     <div className="tw-pt-2">
                         <div className="tw-flex tw-justify-center">


### PR DESCRIPTION
Remove `[beta] multiplayer` label, remix game -> edit game

One more quick thing I just remembered we had talked about but didn't make it into the release was potentially giving a light border around the join code on the host page, so that it looks more like a button / less temptation to manually copy & paste to send it to friend; should I sneak that in as well or just leave it alone for this release?

<img width="958" alt="image" src="https://user-images.githubusercontent.com/5615930/215575512-7c02bc93-2315-460a-92ae-cb0fb1f3b733.png">

<img width="651" alt="image" src="https://user-images.githubusercontent.com/5615930/215575605-3729f487-8c37-419f-b41b-0fab8cc399ab.png">
<img width="624" alt="image" src="https://user-images.githubusercontent.com/5615930/215575675-939ece20-0e0a-4672-b8e9-ae52e8d52600.png">

<img width="633" alt="image" src="https://user-images.githubusercontent.com/5615930/215575726-4033e0ba-3ffe-40f7-b8e6-de4e7e20d0f6.png">
