### PR TITLE
Fix Answer Key Causing Code Validation to Detect Error Incorrectly

### DIFF
--- a/webapp/src/components/tutorialValidators.tsx
+++ b/webapp/src/components/tutorialValidators.tsx
@@ -1,7 +1,7 @@
 import { MarkedContent } from "../marked";
+import { getBlocksEditor } from "../app";
 import TutorialOptions = pxt.tutorial.TutorialOptions;
 import TutorialStepInfo = pxt.tutorial.TutorialStepInfo;
-import CodeValidationConfig = pxt.tutorial.CodeValidationConfig;
 import CodeValidator = pxt.tutorial.CodeValidator;
 import CodeValidatorMetadata = pxt.tutorial.CodeValidatorMetadata;
 import CodeValidationResult = pxt.tutorial.CodeValidationResult;
@@ -63,9 +63,14 @@ export class BlocksExistValidator extends CodeValidatorBase {
             return defaultResult;
         }
 
-        const userBlocks = Blockly.getMainWorkspace()?.getAllBlocks(false /* ordered */);
+        const editor = getBlocksEditor()?.editor;
+        if (!editor) {
+            return defaultResult;
+        }
+
+        const userBlocks = editor.getAllBlocks(false /* ordered */);
         const userBlocksEnabledByType = new Map<string, boolean>(); // Key = type, value = enabled
-        userBlocks.forEach(b => userBlocksEnabledByType.set(b.type, userBlocksEnabledByType.get(b.type) || b.isEnabled()));
+        userBlocks?.forEach(b => userBlocksEnabledByType.set(b.type, userBlocksEnabledByType.get(b.type) || b.isEnabled()));
 
         const allHighlightedBlocks = await getTutorialHighlightedBlocks(tutorialOptions, stepInfo);
         if (!allHighlightedBlocks) {


### PR DESCRIPTION
Fix Answer Key Causing Code Validation to Detect Error Incorrectly (#9346)

Not 100% consistent, but sometimes, if the user opens the answer key and then tries to proceed to the next step, validation will flag an error, even if the user has the correct code. This happens because, in this scenario, the call to Blockly.getMainWorkspace() sometimes doesn't return the user's actual workspace. Instead, it returns a workspace with no blocks in it.

To fix this, I've gotten rid of the call to Blockly.getMainWorkspace and instead grab it directly from the ProjectView editor (using an existing getBlocksEditor() function)