### PR TITLE
send connection message when user selects presence icon

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -274,6 +274,60 @@ namespace pxsim {
         color: string;
     }
 
+    export namespace multiplayer {
+        type MessageBase = {
+            type: "multiplayer";
+            origin?: "server" | "client";
+            broadcast?: boolean;
+        };
+
+        export enum IconType {
+            Player = 0,
+            Reaction = 1,
+        }
+
+        export type ImageMessage = MessageBase & {
+            content: "Image";
+            image?: pxsim.RefBuffer; // pxsim.RefBuffer
+            palette: Uint8Array;
+        };
+
+        export type InputMessage = MessageBase & {
+            content: "Button";
+            button: number;
+            clientNumber: number;
+            state: "Pressed" | "Released" | "Held";
+        };
+
+        export type AudioMessage = MessageBase & {
+            content: "Audio";
+            instruction: "playinstructions" | "muteallchannels";
+            soundbuf?: Uint8Array;
+        };
+
+        export type IconMessage = MessageBase & {
+            content: "Icon";
+            icon?: pxsim.RefBuffer; // pxsim.RefBuffer
+            slot: number;
+            iconType: IconType;
+            // 48bytes, [r0,g0,b0,r1,g1,b1,...]
+            palette: Uint8Array;
+        };
+
+        export type ConnectionMessage = MessageBase & {
+            content: "Connection";
+            slot: number;
+            connected: boolean;
+        }
+
+        export type Message =
+            | ImageMessage
+            | AudioMessage
+            | InputMessage
+            | IconMessage
+            | ConnectionMessage;
+    }
+
     export function print(delay: number = 0) {
         function p() {
             try {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -252,13 +252,22 @@ export class ProjectView
             else if (msg.type === "thumbnail") {
                 if (this.shareEditor) this.shareEditor.setThumbnailFrames((msg as pxsim.SimulatorAutomaticThumbnailMessage).frames);
             } else if (msg.type === "multiplayer") {
-                // todo move over types from multiplayer app to pxsim/embed.ts
-                const multiplayerMessage = msg as any;
+                const multiplayerMessage = msg as pxsim.multiplayer.Message;
                 if (multiplayerMessage.content === "Icon"
-                    && multiplayerMessage.iconType === 0 /** IconType.Player **/
+                    && multiplayerMessage.iconType === pxsim.multiplayer.IconType.Player
                 ) {
                     const { palette, icon, slot } = multiplayerMessage;
-                    this.handleSetPresenceIcon(slot, palette, icon.data);
+                    this.handleSetPresenceIcon(slot, palette, icon?.data);
+                }
+            } else if (msg.type === "toplevelcodefinished") {
+                if (pxt.appTarget?.appTheme?.multiplayer) {
+                    const playerOneConnectedMsg: pxsim.multiplayer.ConnectionMessage = {
+                        type: "multiplayer",
+                        content: "Connection",
+                        slot: 1,
+                        connected: true,
+                    };
+                    simulator.driver.postMessage(playerOneConnectedMsg);
                 }
             }
         }, false);

--- a/webapp/src/components/SimulatorPresenceBar.tsx
+++ b/webapp/src/components/SimulatorPresenceBar.tsx
@@ -19,7 +19,14 @@ function PlayerPresenceIcon(props: React.PropsWithoutRef<{slot: 1 | 2 | 3 | 4}>)
             type: "setactiveplayer",
             playerNumber: slot,
         };
+        const connectionMsg: pxsim.multiplayer.ConnectionMessage = {
+            type: "multiplayer",
+            content: "Connection",
+            slot: slot,
+            connected: true,
+        };
         simulator.driver.postMessage(setSlotMsg);
+        simulator.driver.postMessage(connectionMsg);
         simulator.driver.focus();
     }
     return (<Button


### PR DESCRIPTION
requires https://github.com/microsoft/pxt-arcade-sim/pull/87, https://github.com/microsoft/pxt-common-packages/pull/1422

sends connected state re: https://github.com/microsoft/pxt-arcade/issues/5625. Also got the types for multiplayer messages in pxsim itself -- I'll dedup them with multiplayer app and pxt-common-packages separately as there are some slightly tedious null / undefined differences that will take up a lot more swaps.

This one just adds the connect message sending, as I think we still need to talk more on how to handle testing disconnection -- but implementing it in a way that makes it hard to test player 2 interacting with player 3 feels wrong / kindly handling disconnection & reconnection are much more 'advanced' scenarios than typical multiplayer stuff

quick test https://arcade.makecode.com/app/06c407421e523ff12f8d7cfeb171a147bd3dc9fb-fc9250afff#pub:_9KpLiMCxoFmP