### PR TITLE
[stable8.5] send connection message when user selects presence icon

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -274,6 +274,60 @@ namespace pxsim {
         color: string;
     }
 
+    export namespace multiplayer {
+        type MessageBase = {
+            type: "multiplayer";
+            origin?: "server" | "client";
+            broadcast?: boolean;
+        };
+
+        export enum IconType {
+            Player = 0,
+            Reaction = 1,
+        }
+
+        export type ImageMessage = MessageBase & {
+            content: "Image";
+            image?: pxsim.RefBuffer; // pxsim.RefBuffer
+            palette: Uint8Array;
+        };
+
+        export type InputMessage = MessageBase & {
+            content: "Button";
+            button: number;
+            clientNumber: number;
+            state: "Pressed" | "Released" | "Held";
+        };
+
+        export type AudioMessage = MessageBase & {
+            content: "Audio";
+            instruction: "playinstructions" | "muteallchannels";
+            soundbuf?: Uint8Array;
+        };
+
+        export type IconMessage = MessageBase & {
+            content: "Icon";
+            icon?: pxsim.RefBuffer; // pxsim.RefBuffer
+            slot: number;
+            iconType: IconType;
+            // 48bytes, [r0,g0,b0,r1,g1,b1,...]
+            palette: Uint8Array;
+        };
+
+        export type ConnectionMessage = MessageBase & {
+            content: "Connection";
+            slot: number;
+            connected: boolean;
+        }
+
+        export type Message =
+            | ImageMessage
+            | AudioMessage
+            | InputMessage
+            | IconMessage
+            | ConnectionMessage;
+    }
+
     export function print(delay: number = 0) {
         function p() {
             try {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -252,13 +252,22 @@ export class ProjectView
             else if (msg.type === "thumbnail") {
                 if (this.shareEditor) this.shareEditor.setThumbnailFrames((msg as pxsim.SimulatorAutomaticThumbnailMessage).frames);
             } else if (msg.type === "multiplayer") {
-                // todo move over types from multiplayer app to pxsim/embed.ts
-                const multiplayerMessage = msg as any;
+                const multiplayerMessage = msg as pxsim.multiplayer.Message;
                 if (multiplayerMessage.content === "Icon"
-                    && multiplayerMessage.iconType === 0 /** IconType.Player **/
+                    && multiplayerMessage.iconType === pxsim.multiplayer.IconType.Player
                 ) {
                     const { palette, icon, slot } = multiplayerMessage;
-                    this.handleSetPresenceIcon(slot, palette, icon.data);
+                    this.handleSetPresenceIcon(slot, palette, icon?.data);
+                }
+            } else if (msg.type === "toplevelcodefinished") {
+                if (pxt.appTarget?.appTheme?.multiplayer) {
+                    const playerOneConnectedMsg: pxsim.multiplayer.ConnectionMessage = {
+                        type: "multiplayer",
+                        content: "Connection",
+                        slot: 1,
+                        connected: true,
+                    };
+                    simulator.driver.postMessage(playerOneConnectedMsg);
                 }
             }
         }, false);

--- a/webapp/src/components/SimulatorPresenceBar.tsx
+++ b/webapp/src/components/SimulatorPresenceBar.tsx
@@ -19,7 +19,14 @@ function PlayerPresenceIcon(props: React.PropsWithoutRef<{slot: 1 | 2 | 3 | 4}>)
             type: "setactiveplayer",
             playerNumber: slot,
         };
+        const connectionMsg: pxsim.multiplayer.ConnectionMessage = {
+            type: "multiplayer",
+            content: "Connection",
+            slot: slot,
+            connected: true,
+        };
         simulator.driver.postMessage(setSlotMsg);
+        simulator.driver.postMessage(connectionMsg);
         simulator.driver.focus();
     }
     return (<Button


### PR DESCRIPTION
cherry-pick https://github.com/microsoft/pxt/pull/9351 to send user presence in editor more similarly to how it is handled in webapp. the diff in pxsim/embed.ts is just mirroring over existing types for multiplayer