### PR TITLE
Music editor hot fixes

### DIFF
--- a/pxtlib/react.ts
+++ b/pxtlib/react.ts
@@ -9,6 +9,7 @@ namespace pxt.react {
         restorePersistentData(value: any): void;
     }
 
+    export let isFieldEditorViewVisible: () => boolean;
     export let getFieldEditorView: <U>(fieldEditorId: string, value: U, options: any, container?: HTMLDivElement) => FieldEditorView<U>;
     export let getTilemapProject: () => TilemapProject;
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3745,14 +3745,16 @@ export class ProjectView
                             pxt.debug(`sim: run`)
 
                             const hc = data.getData<boolean>(auth.HIGHCONTRAST)
-                            simulator.run(pkg.mainPkg, opts.debug, resp, {
-                                mute: this.state.mute,
-                                highContrast: hc,
-                                light: pxt.options.light,
-                                clickTrigger: opts.clickTrigger,
-                                storedState: pkg.mainEditorPkg().getSimState(),
-                                autoRun: this.state.autoRun
-                            }, opts.trace)
+                            if (!pxt.react.isFieldEditorViewVisible?.()) {
+                                simulator.run(pkg.mainPkg, opts.debug, resp, {
+                                    mute: this.state.mute,
+                                    highContrast: hc,
+                                    light: pxt.options.light,
+                                    clickTrigger: opts.clickTrigger,
+                                    storedState: pkg.mainEditorPkg().getSimState(),
+                                    autoRun: this.state.autoRun
+                                }, opts.trace)
+                            }
                             this.blocksEditor.setBreakpointsMap(resp.breakpoints, resp.procCallLocations);
                             this.textEditor.setBreakpointsMap(resp.breakpoints, resp.procCallLocations);
                             if (!cancellationToken.isCancelled()) {

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -265,6 +265,8 @@ export function init() {
     pxt.react.getTilemapProject = () => {
         return project;
     }
+
+    pxt.react.isFieldEditorViewVisible = () => !!current;
 }
 
 export function dismissIfVisible() {

--- a/webapp/src/components/musicEditor/MusicEditor.tsx
+++ b/webapp/src/components/musicEditor/MusicEditor.tsx
@@ -80,7 +80,7 @@ export const MusicEditor = (props: MusicEditorProps) => {
                 let newSelection: WorkspaceSelectionState;
                 if (selection) {
                     newSelection = {
-                        originalSong: deleteSelectedNotes(applySelection(selection, hideTracksActive ? selectedTrack : undefined)),
+                        originalSong: unselectAllNotes(applySelection(selection, hideTracksActive ? selectedTrack : undefined)),
                         pastedContent: pasted,
                         startTick: selection.startTick,
                         endTick: selection.startTick + (pasted.endTick - pasted.startTick),

--- a/webapp/src/components/musicEditor/keyboardNavigation.ts
+++ b/webapp/src/components/musicEditor/keyboardNavigation.ts
@@ -428,6 +428,7 @@ export function handleKeyboardEvent(song: pxt.assets.music.Song, cursor: CursorS
             break;
         default:
             if (/^[a-g]$/i.test(event.key)) {
+                if (ctrlPressed) break;
                 event.preventDefault();
                 clearSelection(true);
 


### PR DESCRIPTION
Fixes copy and paste for the music editor and also stops the simulator from starting if one of the react field editors is open.