### PR TITLE
Add a Test for Code Validation

### DIFF
--- a/tests/tutorial-test/baselines/codeValidation.json
+++ b/tests/tutorial-test/baselines/codeValidation.json
@@ -1,0 +1,66 @@
+{
+    "editor": "blocksprj",
+    "title": "Getting started",
+    "steps": [
+        {
+            "title": "Introduction",
+            "contentMd": "Let's get started!",
+            "headerContentMd": "Let's get started!",
+            "localBlockConfig": {
+                "md": "",
+                "blocks": []
+            },
+            "localValidationConfig": null,
+            "showHint": true,
+            "showDialog": true
+        },
+        {
+            "title": "Step 1",
+            "contentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.\n\n```blocks\nbasic.showString(\"Micro!\")\n```",
+            "headerContentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.",
+            "localBlockConfig": {
+                "md": "",
+                "blocks": []
+            },
+            "localValidationConfig": {
+                "validatorsMetadata": [
+                    {
+                        "validatorType": "BlocksExistValidator",
+                        "properties": {
+                            "enabled": "false"
+                        }
+                    }
+                ]
+            },
+            "showHint": true,
+            "hintContentMd": "```blocks\nbasic.showString(\"Micro!\")\n```"
+        },
+        {
+            "title": "Step 2",
+            "contentMd": "Click ``|Download|`` to transfer your code in your unknown macro!",
+            "headerContentMd": "Click ``|Download|`` to transfer your code in your unknown macro!",
+            "localBlockConfig": {
+                "md": "",
+                "blocks": []
+            },
+            "localValidationConfig": null
+        }
+    ],
+    "activities": null,
+    "code": [
+        "{\nbasic.showString(\"Micro!\")\n}"
+    ],
+    "metadata": {},
+    "globalBlockConfig": {
+        "md": "",
+        "blocks": []
+    },
+    "globalValidationConfig": {
+        "validatorsMetadata": [
+            {
+                "validatorType": "BlocksExistValidator",
+                "properties": {}
+            }
+        ]
+    }
+}

--- a/tests/tutorial-test/cases/codeValidation.md
+++ b/tests/tutorial-test/cases/codeValidation.md
@@ -1,0 +1,26 @@
+# Getting started
+
+## Introduction @showdialog
+
+Let's get started!
+
+## Step 1 @showhint
+
+Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.
+
+```blocks
+basic.showString("Micro!")
+```
+
+```validation.local
+# BlocksExistValidator
+* Enabled: false
+```
+
+## Step 2
+
+Click ``|Download|`` to transfer your code in your unknown macro!
+
+```validation.global
+# BlocksExistValidator
+```


### PR DESCRIPTION
This test has a global BlocksExistValidator specified in the tutorial markdown as well as a local disable in one step, and it ensures that both get parsed correctly into validator metadata.

I basically copied the files from the steps test and just added some validation markdown, too.

Fixes https://github.com/microsoft/pxt-arcade/issues/5542