### PR TITLE
Switch Back to Default Build Engine after Build

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,7 @@
 			"stopOnEntry": false,
 			"args": [
 				"checkdocs",
-				"--re", 
+				"--re",
 				"adafruit"
 			],
 			"cwd": "${workspaceRoot}/../pxt-maker",
@@ -137,7 +137,8 @@
 			"program": "${workspaceRoot}/built/pxt.js",
 			"stopOnEntry": false,
 			"args": [
-				"buildsprites", "space"
+				"buildsprites",
+				"space"
 			],
 			"cwd": "${workspaceRoot}/../pxt-32/libs/device",
 			"runtimeExecutable": null,
@@ -230,7 +231,7 @@
 			"console": "integratedTerminal",
 			"sourceMaps": false,
 			"outFiles": []
-		},		
+		},
 		{
 			"name": "Attach",
 			"type": "node",

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -680,7 +680,7 @@ function getBoardDrivesAsync(): Promise<string[]> {
                             res.push(m[1] + "/");
                         }
                     }
-                );
+                    );
                 return res;
             });
     }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1788,7 +1788,7 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
     if (theme.title) targetStrings[theme.title] = theme.title;
     if (theme.name) targetStrings[theme.name] = theme.name;
     if (theme.description) targetStrings[theme.description] = theme.description;
-    if (theme.homeScreenHero && typeof theme.homeScreenHero != "string" ) {
+    if (theme.homeScreenHero && typeof theme.homeScreenHero != "string") {
         const heroBannerCard = theme.homeScreenHero;
         if (heroBannerCard.title) targetStrings[heroBannerCard.title] = heroBannerCard.title;
         if (heroBannerCard.description) targetStrings[heroBannerCard.description] = heroBannerCard.description;
@@ -1972,7 +1972,7 @@ async function buildSemanticUIAsync(parsed?: commandParser.ParsedCommand) {
 
     async function generateReactCommonCss(app: string) {
         const appFile = isPxtCore ? `react-common/styles/react-common-${app}-core.less` :
-        `node_modules/pxt-core/react-common/styles/react-common-${app}.less`;
+            `node_modules/pxt-core/react-common/styles/react-common-${app}.less`;
         await nodeutil.spawnAsync({
             cmd: "node",
             args: [
@@ -2022,7 +2022,7 @@ async function buildSemanticUIAsync(parsed?: commandParser.ParsedCommand) {
     for (const cssFile of files) {
         const css = await readFileAsync(`built/web/${cssFile}`, "utf8");
         const processed = await postcss([cssnano])
-                .process(css, { from: `built/web/${cssFile}`, to: `built/web/${cssFile}` });
+            .process(css, { from: `built/web/${cssFile}`, to: `built/web/${cssFile}` });
 
         await writeFileAsync(`built/web/${cssFile}`, processed.css);
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4581,10 +4581,11 @@ async function testSnippetsAsync(snippets: CodeSnippet[], re?: string, pyStrictS
 
 function setBuildEngine() {
     const cs = pxt.appTarget.compileService
-    if (cs && cs.buildEngine) {
-        build.setThisBuild(build.buildEngines[cs.buildEngine]);
+    if (cs) {
+        const engine = cs.buildEngine || "yotta"
+        build.setThisBuild(build.buildEngines[engine]);
         if (!build.thisBuild)
-            U.userError("cannot find build engine: " + cs.buildEngine)
+            U.userError("cannot find build engine: " + engine)
     }
 }
 


### PR DESCRIPTION
### Problem
When you run the `pxt buildtarget --local --force` command in the pxt-microbit repo, you'll receive the following error:
```
building bundled libs/bluetoothprj
[run] git clone https://github.com/lancaster-university/microbit built/dockercodal
Cloning into 'built/dockercodal'...
INTERNAL ERROR: TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
    at new NodeError (node:internal/errors:371:5)
    at Hash.update (node:internal/crypto/hash:105:11)
    at Object.sha256 (/Users/microbit-carlos/workspace/tmp/pxt-microbit/node_modules/pxt-core/built/nodeutil.js:226:10)
    at Object.buildHexAsync (/Users/microbit-carlos/workspace/tmp/pxt-microbit/node_modules/pxt-core/built/buildengine.js:241:20)
    at Host.getHexInfoAsync (/Users/microbit-carlos/workspace/tmp/pxt-microbit/node_modules/pxt-core/built/pxt.js:160537:22)
    at fillExtInfoAsync (/Users/microbit-carlos/workspace/tmp/pxt-microbit/node_modules/pxt-core/built/pxt.js:112387:69)
    at MainPackage.getCompileOptionsAsync (/Users/microbit-carlos/workspace/tmp/pxt-microbit/node_modules/pxt-core/built/pxt.js:112433:39)
remote: Enumerating objects: 432, done.
remote: Counting objects: 100% (24/24), done.
remote: Compressing objects: 100% (10/10), done.
remote: Total 432 (delta 14), reused 23 (delta 14), pack-reused 408
Receiving objects: 100% (432/432), 162.65 KiB | 1.75 MiB/s, done.
Resolving deltas: 100% (223/223), done.
```

### Solution
When the `buildtarget` command is run pxt-microbit, we build all the folders in `/libs` using the variants defined in the `multiVariants` field in pxttarget.json for the target. For [micro:bit](https://github.com/microsoft/pxt-microbit/blob/master/pxtarget.json#L147), those variants are `mbdal` and `mbcodal`. The `mbcodal` variant specifies that it should be built with the `codal` build engine, which the cli obliges when it builds pxt-microbit/libs/blocksprj. Unfortunately, the `mbdal` variant does not specify a build engine, so the call to `setBuildEngine` in the cli.ts becomes a no-op:
https://github.com/microsoft/pxt/blob/c86403d0d8e93a94a05a2bc3795207deb8f6cc18/cli/cli.ts#L4582-L4589. 

What we should do is in `setBuildEngine` is the same as what we do when first setting the build engine in the cli:
https://github.com/microsoft/pxt/blob/c86403d0d8e93a94a05a2bc3795207deb8f6cc18/cli/cli.ts#L7376-L7378.

So even if a build engine is not defined by the variant, we'll go back to the default build engine. This way, variants that expect the default build engine will work correctly while variants that specify the build engine will continue to work.

### Validation
- Ran `pxt buildtarget --local --force` in the pxt-microbit repo directory and did not receive this stack trace
	- > I did run into a rate limit error, but that is a separate issue

### Notes
I also included changes that remove excess whitespace.