### PR TITLE
Better handling of click events on the music workspace

### DIFF
--- a/webapp/src/components/musicEditor/MusicEditor.tsx
+++ b/webapp/src/components/musicEditor/MusicEditor.tsx
@@ -181,12 +181,13 @@ export const MusicEditor = (props: MusicEditorProps) => {
         }
     }
 
-    const onRowClick = (coord: WorkspaceCoordinate, ctrlIsPressed: boolean) => {
+    const onRowClick = (coord: WorkspaceClickCoordinate, ctrlIsPressed: boolean) => {
         setCursorVisible(false);
         const track = currentSong.tracks[selectedTrack];
         const instrument = track.instrument;
 
         const existingEvent = findPreviousNoteEvent(currentSong, selectedTrack, coord.tick);
+        const closestToClickEvent = findPreviousNoteEvent(currentSong, selectedTrack, coord.exactTick);
 
         clearSelection();
         setCursorTick(coord.tick);
@@ -199,17 +200,29 @@ export const MusicEditor = (props: MusicEditorProps) => {
             return noteToRow(instrument.octave, note, isDrumTrack) === coord.row;
         }
 
-        if (existingEvent?.startTick === coord.tick && existingEvent.notes.some(isAtCoord)) {
+        let clickedTick: number;
+        let clickedEvent: pxt.assets.music.NoteEvent;
+
+        if (closestToClickEvent?.startTick === coord.exactTick && closestToClickEvent.notes.some(isAtCoord)) {
+            clickedTick = coord.exactTick;
+            clickedEvent = closestToClickEvent;
+        }
+        else if (existingEvent?.startTick === coord.tick && existingEvent.notes.some(isAtCoord)) {
+            clickedTick = coord.tick;
+            clickedEvent = existingEvent;
+        }
+
+        if (clickedEvent) {
             const unselected = unselectAllNotes(currentSong);
 
             if (ctrlIsPressed && !isDrumTrack) {
                 // Change the enharmonic spelling
-                const existingNote = existingEvent.notes.find(isAtCoord);
+                const existingNote = clickedEvent.notes.find(isAtCoord);
 
                 const minNote = instrument.octave * 12 - 20;
                 const maxNote = instrument.octave * 12 + 20;
 
-                const removed = removeNoteAtRowFromTrack(unselected, selectedTrack, coord.row, coord.isBassClef, coord.tick);
+                const removed = removeNoteAtRowFromTrack(unselected, selectedTrack, coord.row, coord.isBassClef, clickedTick);
 
                 let newSpelling: "normal" | "sharp" | "flat";
                 if (existingNote.enharmonicSpelling === "normal" && existingNote.note < maxNote) {
@@ -228,17 +241,17 @@ export const MusicEditor = (props: MusicEditorProps) => {
                         removed,
                         selectedTrack,
                         newNote,
-                        existingEvent.startTick,
-                        existingEvent.endTick
+                        clickedEvent.startTick,
+                        clickedEvent.endTick
                     ),
                     true
                 );
 
-                playNoteAsync(newNote.note, instrument, tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, gridTicks))
+                playNoteAsync(newNote.note, instrument, tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, clickedEvent.endTick - clickedEvent.startTick))
             }
             else {
                 updateSong(
-                    removeNoteAtRowFromTrack(unselected, selectedTrack, coord.row, coord.isBassClef, coord.tick),
+                    removeNoteAtRowFromTrack(unselected, selectedTrack, coord.row, coord.isBassClef, clickedTick),
                     true
                 );
             }
@@ -266,10 +279,23 @@ export const MusicEditor = (props: MusicEditorProps) => {
                 if (hideTracksActive && i !== selectedTrack) continue;
 
                 const existingEvent = findPreviousNoteEvent(currentSong, i, coord.tick);
+                const closestToClickEvent = findPreviousNoteEvent(currentSong, i, coord.exactTick);
 
-                if (existingEvent?.startTick === coord.tick || existingEvent?.endTick > coord.tick) {
-                    if (existingEvent.notes.some(isAtCoord)) {
-                        updateSong(removeNoteAtRowFromTrack(currentSong, i, coord.row, coord.isBassClef, existingEvent.startTick), false);
+                let clickedTick: number;
+                let clickedEvent: pxt.assets.music.NoteEvent;
+
+                if (closestToClickEvent?.startTick === coord.exactTick && closestToClickEvent.notes.some(isAtCoord)) {
+                    clickedTick = coord.exactTick;
+                    clickedEvent = closestToClickEvent;
+                }
+                else if (existingEvent?.startTick === coord.tick && existingEvent.notes.some(isAtCoord)) {
+                    clickedTick = coord.tick;
+                    clickedEvent = existingEvent;
+                }
+
+                if (clickedEvent?.startTick === clickedTick || clickedEvent?.endTick > clickedTick) {
+                    if (clickedEvent.notes.some(isAtCoord)) {
+                        updateSong(removeNoteAtRowFromTrack(currentSong, i, coord.row, coord.isBassClef, clickedEvent.startTick), false);
                     }
                 }
             }
@@ -335,7 +361,7 @@ export const MusicEditor = (props: MusicEditorProps) => {
         dragState.current = undefined;
     }
 
-    const onNoteDrag = (start: WorkspaceCoordinate, end: WorkspaceCoordinate) => {
+    const onNoteDrag = (start: WorkspaceClickCoordinate, end: WorkspaceClickCoordinate) => {
         setCursorTick(end.tick);
 
         // First, check if we are erasing
@@ -345,7 +371,7 @@ export const MusicEditor = (props: MusicEditorProps) => {
 
                 const track = currentSong.tracks[i];
                 const instrument = track.instrument;
-                const existingEvent = findPreviousNoteEvent(currentSong, i, end.tick);
+                const existingEvent = findPreviousNoteEvent(currentSong, i, end.exactTick);
 
                 const isAtCoord = (note: pxt.assets.music.Note) => {
                     const isBassClef = isBassClefNote(instrument.octave, note, isDrumTrack);
@@ -355,7 +381,7 @@ export const MusicEditor = (props: MusicEditorProps) => {
                     return noteToRow(instrument.octave, note, isDrumTrack) === end.row;
                 }
 
-                if (existingEvent?.startTick === end.tick || existingEvent?.endTick > end.tick) {
+                if (existingEvent?.startTick === end.exactTick || existingEvent?.endTick > end.exactTick) {
                     if (existingEvent.notes.some(isAtCoord)) {
                         updateSong(removeNoteAtRowFromTrack(currentSong, i, end.row, end.isBassClef, existingEvent.startTick), false);
                     }
@@ -400,9 +426,9 @@ export const MusicEditor = (props: MusicEditorProps) => {
 
 
         // Next, check if this is a drag to change a note length
-        const event = findPreviousNoteEvent(dragState.current.original, selectedTrack, start.tick);
+        const event = findPreviousNoteEvent(dragState.current.original, selectedTrack, start.exactTick);
 
-        if (!isDrumTrack && event && start.tick >= event.startTick && start.tick < event.endTick) {
+        if (!isDrumTrack && event && start.exactTick >= event.startTick && start.exactTick < event.endTick) {
             let isOnRow = false;
             for (const note of event.notes) {
                 if (noteToRow(currentSong.tracks[selectedTrack].instrument.octave, note, false) === start.row) {

--- a/webapp/src/components/musicEditor/Workspace.tsx
+++ b/webapp/src/components/musicEditor/Workspace.tsx
@@ -10,10 +10,10 @@ import { WorkspaceSelection } from "./WorkspaceSelection";
 
 export interface WorkspaceProps {
     song: pxt.assets.music.Song;
-    onWorkspaceClick: (coordinate: WorkspaceCoordinate, ctrlIsPressed: boolean) => void;
+    onWorkspaceClick: (coordinate: WorkspaceClickCoordinate, ctrlIsPressed: boolean) => void;
     onWorkspaceDragStart: () => void;
     onWorkspaceDragEnd: () => void;
-    onWorkspaceDrag: (startCoordinate: WorkspaceCoordinate, endCoordinate: WorkspaceCoordinate) => void;
+    onWorkspaceDrag: (startCoordinate: WorkspaceClickCoordinate, endCoordinate: WorkspaceClickCoordinate) => void;
     onKeydown: (event: React.KeyboardEvent) => void;
     cursor: CursorState;
     selectedTrack: number
@@ -27,8 +27,8 @@ export interface WorkspaceProps {
 export const Workspace = (props: WorkspaceProps) => {
     const { song, onWorkspaceClick, gridTicks, selectedTrack, onWorkspaceDrag, onWorkspaceDragStart, onWorkspaceDragEnd, onKeydown, cursor, hideUnselectedTracks, eraserActive, showBassClef, selection } = props;
 
-    const [cursorLocation, setCursorLocation] = React.useState<WorkspaceCoordinate>(null);
-    const [dragStart, setDragStart] = React.useState<WorkspaceCoordinate>(null);
+    const [cursorLocation, setCursorLocation] = React.useState<WorkspaceClickCoordinate>(null);
+    const [dragStart, setDragStart] = React.useState<WorkspaceClickCoordinate>(null);
     const [isDragging, setIsDragging] = React.useState(false);
 
     let workspaceRef: SVGSVGElement;
@@ -46,7 +46,7 @@ export const Workspace = (props: WorkspaceProps) => {
         workspaceRef.onpointermove = ev => {
             const coord = coordinateToWorkspaceCoordinate(ev, workspaceRef, song, gridTicks);
 
-            if (cursorLocation && cursorLocation.tick === coord.tick && cursorLocation.row === coord.row) return;
+            if (cursorLocation && cursorLocation.exactTick === coord.exactTick && cursorLocation.row === coord.row) return;
 
             const maxTick = song.beatsPerMeasure * song.ticksPerBeat * song.measures;
 
@@ -206,7 +206,7 @@ export const Workspace = (props: WorkspaceProps) => {
     </svg>
 }
 
-function coordinateToWorkspaceCoordinate(ev: MouseEvent | PointerEvent | TouchEvent, el: SVGSVGElement, song: pxt.assets.music.Song, gridTicks?: number): WorkspaceCoordinate {
+function coordinateToWorkspaceCoordinate(ev: MouseEvent | PointerEvent | TouchEvent, el: SVGSVGElement, song: pxt.assets.music.Song, gridTicks?: number): WorkspaceClickCoordinate {
     const coord = screenToSVGCoord(el, clientCoord(ev));
     const isBassClef = coord.y > BASS_STAFF_TOP;
 
@@ -217,6 +217,7 @@ function coordinateToWorkspaceCoordinate(ev: MouseEvent | PointerEvent | TouchEv
     return {
         isBassClef,
         row: note,
-        tick
+        tick,
+        exactTick: closestTick(song.ticksPerBeat, coord.x, 1)
     }
 }

--- a/webapp/src/components/musicEditor/types.d.ts
+++ b/webapp/src/components/musicEditor/types.d.ts
@@ -24,6 +24,10 @@ interface WorkspaceCoordinate {
     row: number;
 }
 
+interface WorkspaceClickCoordinate extends WorkspaceCoordinate {
+    exactTick: number;
+}
+
 interface WorkspaceSelectionState {
     originalSong: pxt.assets.music.Song;
     startTick: number;

--- a/webapp/src/components/musicEditor/utils.ts
+++ b/webapp/src/components/musicEditor/utils.ts
@@ -94,6 +94,7 @@ export function addNoteToTrack(song: pxt.assets.music.Song, trackIndex: number, 
         tracks: song.tracks.map((track, index) => index !== trackIndex ? track : {
             ...track,
             notes: addToNoteArray(track.notes, note, startTick, endTick, track.instrument.octave, !!track.drums)
+                .filter(ev => (ev.startTick <= startTick || ev.startTick >= endTick) && (ev.endTick >= endTick || ev.endTick <= startTick))
         })
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5596

Stop aggressively snapping the events to the grid. Now just note add and note drag are grid aligned