### PR TITLE
Color palette: center arrows on button

### DIFF
--- a/react-common/styles/palette/ColorPickerField.less
+++ b/react-common/styles/palette/ColorPickerField.less
@@ -3,6 +3,9 @@
     grid-template-columns: 0.5fr 8fr 1fr 1fr;
     align-items: center;
     padding: 0.1rem 0rem;
+    i.fas {
+        margin: 0;
+    }
 }
 
 .common-color-inputs {


### PR DESCRIPTION
closes https://github.com/microsoft/pxt-arcade/issues/5656
![image](https://user-images.githubusercontent.com/15070078/216711119-137b2423-eae0-4bf6-81c3-06928cea753b.png)
