### PR TITLE
Add music icon for song assets in asset editor

### DIFF
--- a/webapp/src/components/assetEditor/assetCard.tsx
+++ b/webapp/src/components/assetEditor/assetCard.tsx
@@ -40,6 +40,8 @@ export class AssetCardView extends React.Component<AssetCardCoreProps> {
                 return "video";
             case pxt.AssetType.Tilemap:
                 return "map";
+            case pxt.AssetType.Song:
+                return "music";
             case pxt.AssetType.Image:
             default:
                 return null;


### PR DESCRIPTION
closes https://github.com/microsoft/pxt-arcade/issues/5659
![image](https://user-images.githubusercontent.com/15070078/216724672-dabe1c1f-c4d3-4c4b-8e70-be674d2cd9c2.png)
