### PR TITLE
Fix monaco field editor regex and support ctrl+A

### DIFF
--- a/pxteditor/monaco-fields/field_musiceditor.ts
+++ b/pxteditor/monaco-fields/field_musiceditor.ts
@@ -104,10 +104,10 @@ namespace pxt.editor {
              *     assets.song("""name""")
              *
              * and the hex-literal syntax:
-             *     music.startSong(hex`01234`
-             *     music.start_song(hex("""01234""")
+             *     music.createSong(hex`01234`
+             *     music.create_song(hex("""01234""")
              *
-             * For the hex literal matches, it includes the call to music.startSong since
+             * For the hex literal matches, it includes the call to music.createSong since
              * hex buffers can also be used for other things
              */
             searchString: "(?:(?:assets\\s*\\.\\s*song)|(?:music\\s*\\.\\s*create(?:S|_s)ong\\s*\\(\\s*hex))\\s*(?:`|\\(\\s*\"\"\")(?:(?:[^(){}:\\[\\]\"';?/,+\\-=*&|^%!`~]|\\n)*)\\s*(?:`|\"\"\"\\s*\\))",

--- a/pxteditor/monaco-fields/field_musiceditor.ts
+++ b/pxteditor/monaco-fields/field_musiceditor.ts
@@ -110,7 +110,7 @@ namespace pxt.editor {
              * For the hex literal matches, it includes the call to music.startSong since
              * hex buffers can also be used for other things
              */
-            searchString: "(?:(?:assets\\s*\\.\\s*song)|(?:music\\s*\\.\\s*start(?:S|_s)ong\\s*\\(\\s*hex))\\s*(?:`|\\(\\s*\"\"\")(?:(?:[^(){}:\\[\\]\"';?/,+\\-=*&|^%!`~]|\\n)*)\\s*(?:`|\"\"\"\\s*\\))",
+            searchString: "(?:(?:assets\\s*\\.\\s*song)|(?:music\\s*\\.\\s*create(?:S|_s)ong\\s*\\(\\s*hex))\\s*(?:`|\\(\\s*\"\"\")(?:(?:[^(){}:\\[\\]\"';?/,+\\-=*&|^%!`~]|\\n)*)\\s*(?:`|\"\"\"\\s*\\))",
             isRegex: true,
             matchCase: true,
             matchWholeWord: false

--- a/webapp/src/components/musicEditor/keyboardNavigation.ts
+++ b/webapp/src/components/musicEditor/keyboardNavigation.ts
@@ -427,6 +427,20 @@ export function handleKeyboardEvent(song: pxt.assets.music.Song, cursor: CursorS
             }
             break;
         default:
+            if (ctrlPressed && event.key === "a" || event.key === "A") {
+                event.preventDefault();
+                if (editedCursor.selection) {
+                    clearSelection(true);
+                }
+                editedCursor.selection = {
+                    startTick: 0,
+                    endTick: maxTicks,
+                    originalSong: editedSong,
+                    transpose: 0,
+                    deltaTick: 0
+                }
+                break;
+            }
             if (/^[a-g]$/i.test(event.key)) {
                 if (ctrlPressed) break;
                 event.preventDefault();


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5653

I broke the regex when I did the playable change in pxt-common-packages and forgot to fix it!