### PR TITLE
add default .pxt git ignore, set excludeGitIgnore setting

### DIFF
--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -80,6 +80,7 @@ node_modules
 yotta_modules
 yotta_targets
 pxt_modules
+.pxt
 _site
 *.db
 *.tgz
@@ -88,6 +89,7 @@ _site
 `,
             ".vscode/settings.json":
                 `{
+    "explorer.excludeGitIgnore": true,
     "editor.formatOnType": true,
     "files.autoSave": "afterDelay",
     "files.watcherExclude": {


### PR DESCRIPTION
ignore generated .pxt files, and default 'on' for the `explorer.excludeGitIgnore` setting which makes explorer not show built files can drop that second one if we don't like that or think it's potentially confusing? I guess the thing to note is that it'll hide pxt_modules unless you e.g. go to definition which might be controversial:

<img width="894" alt="image" src="https://user-images.githubusercontent.com/5615930/217393553-a5b3913e-8f31-442f-b65a-37e8ad856524.png">


test repo: https://github.com/jwunderl/ignore-me-testing-2
<img width="254" alt="image" src="https://user-images.githubusercontent.com/5615930/217393190-24f0fdd6-24c0-4155-acdf-0e1e15c170b1.png">
