### PR TITLE
Add a few missing features to the asset editor page

### DIFF
--- a/webapp/public/asseteditor.html
+++ b/webapp/public/asseteditor.html
@@ -13,9 +13,6 @@
         .image-editor-wrapper {
             border-radius: 0;
         }
-        .gallery-editor-header, .image-editor-pivot-outer {
-            display: none;
-        }
         .image-editor-confirm {
             background-color: darkgreen;
         }

--- a/webapp/public/asseteditor.html
+++ b/webapp/public/asseteditor.html
@@ -34,6 +34,56 @@
         pxt.setAppTarget(pxtTargetBundle);
         // TO DO: get palette info from message from vs code extension
         pxt.appTarget.runtime.palette = ["#000000","#ffffff","#ff2121","#ff93c4","#ff8135","#fff609","#249ca3","#78dc52","#003fad","#87f2ff","#8e2ec4","#a4839f","#5c406c","#e5cdc4","#91463d","#000000"];
+
+        // this get rewritten to blob URLs with SHAs while uploading to the cloud
+        // keep in sync with index.html
+        window.MonacoPaths = {
+            "vs/loader": "/blb/vs/loader.js",
+            "vs/base/worker/workerMain": "/blb/vs/base/worker/workerMain.js",
+            "vs/basic-languages/bat/bat": "/blb/vs/basic-languages/bat/bat.js",
+            "vs/basic-languages/cpp/cpp": "/blb/vs/basic-languages/cpp/cpp.js",
+            "vs/basic-languages/markdown/markdown": "/blb/vs/basic-languages/markdown/markdown.js",
+            "vs/basic-languages/python/python": "/blb/vs/basic-languages/python/python.js",
+            "vs/basic-languages/typescript/typescript": "/blb/vs/basic-languages/typescript/typescript.js",
+            "vs/editor/editor.main.css": "/blb/vs/editor/editor.main.css",
+            "vs/editor/editor.main": "/blb/vs/editor/editor.main.js",
+            "vs/editor/editor.main.nls": "/blb/vs/editor/editor.main.nls.js",
+            "vs/language/json/jsonMode": "/blb/vs/language/json/jsonMode.js",
+            "vs/language/json/jsonWorker": "/blb/vs/language/json/jsonWorker.js",
+            "vs/language/typescript/tsMode": "/blb/vs/language/typescript/tsMode.js",
+            "vs/language/typescript/tsWorker": "/blb/vs/language/typescript/tsWorker.js",
+            "lzma/lzma_worker-min.js": "/blb/lzma/lzma_worker-min.js",
+            "smoothie/smoothie_compressed.js": "/blb/smoothie/smoothie_compressed.js",
+            "pxtblockly.js": "/blb/pxtblockly.js",
+            "blockly.css": "/blb/blockly.css",
+            "rtlblockly.css": "/blb/rtlblockly.css",
+            "gifjs/gif.js": "/blb/gifjs/gif.js",
+            "qrcode/qrcode.min.js": "/blb/qrcode/qrcode.min.js",
+            "zip.js/zip.min.js": "/blb/zip.js/zip.min.js",
+            "pdf-lib/pdf-lib.min.js": "/blb/pdf-lib/pdf-lib.min.js",
+            "music-editor/apple.png": "/blb/music-editor/apple.png",
+            "music-editor/burger.png": "/blb/music-editor/burger.png",
+            "music-editor/cake.png": "/blb/music-editor/cake.png",
+            "music-editor/car.png": "/blb/music-editor/car.png",
+            "music-editor/cat.png": "/blb/music-editor/cat.png",
+            "music-editor/cherry.png": "/blb/music-editor/cherry.png",
+            "music-editor/clam.png": "/blb/music-editor/clam.png",
+            "music-editor/computer.png": "/blb/music-editor/computer.png",
+            "music-editor/crab.png": "/blb/music-editor/crab.png",
+            "music-editor/dog.png": "/blb/music-editor/dog.png",
+            "music-editor/duck.png": "/blb/music-editor/duck.png",
+            "music-editor/egg.png": "/blb/music-editor/egg.png",
+            "music-editor/explosion.png": "/blb/music-editor/explosion.png",
+            "music-editor/fish.png": "/blb/music-editor/fish.png",
+            "music-editor/ice-cream.png": "/blb/music-editor/ice-cream.png",
+            "music-editor/lemon.png": "/blb/music-editor/lemon.png",
+            "music-editor/snake.png": "/blb/music-editor/snake.png",
+            "music-editor/star.png": "/blb/music-editor/star.png",
+            "music-editor/strawberry.png": "/blb/music-editor/strawberry.png",
+            "music-editor/taco.png": "/blb/music-editor/taco.png",
+            "music-editor/bass-clef.svg": "/blb/music-editor/bass-clef.svg",
+            "music-editor/treble-clef.svg": "/blb/music-editor/treble-clef.svg",
+        }
     </script>
     <script type="text/javascript" src="/blb/pxtasseteditor.js"></script>
     <div id="asset-editor-field-div">

--- a/webapp/public/asseteditor.html
+++ b/webapp/public/asseteditor.html
@@ -29,7 +29,7 @@
     <script type="text/javascript" src="/blb/pxtapp.js"></script>
     <script>
         pxt.setAppTarget(pxtTargetBundle);
-        // TO DO: get palette info from message from vs code extension
+        // This can be overridden via the messages sent to the page
         pxt.appTarget.runtime.palette = ["#000000","#ffffff","#ff2121","#ff93c4","#ff8135","#fff609","#249ca3","#78dc52","#003fad","#87f2ff","#8e2ec4","#a4839f","#5c406c","#e5cdc4","#91463d","#000000"];
 
         // this get rewritten to blob URLs with SHAs while uploading to the cloud

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -84,7 +84,7 @@
         };
 
         // this get rewritten to blob URLs with SHAs while uploading to the cloud
-        // keep in sync with release.manifest
+        // keep in sync with release.manifest and asseteditor.html
         window.MonacoPaths = {
             "vs/loader": "/blb/vs/loader.js",
             "vs/base/worker/workerMain": "/blb/vs/base/worker/workerMain.js",

--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -158,7 +158,9 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
         if (!e) return;
         this.editor = e;
         this.editor.init(this.state.editing, () => {}, {
-            galleryTiles: this.galleryTiles
+            galleryTiles: this.galleryTiles,
+            hideMyAssets: true,
+            hideCloseButton: true
         })
     }
 

--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -24,6 +24,7 @@ interface AssetEditorState {
 interface BaseAssetEditorRequest {
     id?: number;
     files: pxt.Map<string>;
+    palette?: string[];
 }
 
 interface OpenAssetEditorRequest extends BaseAssetEditorRequest {
@@ -106,6 +107,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
 
         switch (request.type) {
             case "create":
+                this.setPalette(request.palette);
                 this.initTilemapProject(request.files);
                 const asset = this.getEmptyAsset(request.assetType);
 
@@ -120,6 +122,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
                 });
                 break;
             case "open":
+                this.setPalette(request.palette);
                 this.initTilemapProject(request.files);
                 this.setState({
                     editing: this.lookupAsset(request.assetType, request.assetId)
@@ -130,6 +133,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
                 });
                 break;
             case "duplicate":
+                this.setPalette(request.palette);
                 this.initTilemapProject(request.files);
                 const existing = this.lookupAsset(request.assetType, request.assetId);
                 this.setState({
@@ -271,6 +275,11 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
         }
 
         return outFiles;
+    }
+
+    protected setPalette(palette: string[]) {
+        if (!palette || !Array.isArray(palette) || !palette.length) return;
+        pxt.appTarget.runtime.palette = palette.slice();
     }
 
     protected initTilemapProject(files: pxt.Map<string>) {

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -31,6 +31,7 @@ export interface ImageFieldEditorState {
     hideMyAssets?: boolean;
     galleryFilter: string;
     editingTile?: boolean;
+    hideCloseButton?: boolean;
 }
 
 interface ProjectGalleryItem extends pxt.sprite.GalleryItem {
@@ -79,7 +80,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
     }
 
     render() {
-        const { currentView, headerVisible, editingTile, hideMyAssets, filterOpen } = this.state;
+        const { currentView, headerVisible, editingTile, hideMyAssets, filterOpen, hideCloseButton } = this.state;
         const filterPanelVisible = this.state.currentView === "gallery" && filterOpen;
 
         let showHeader = headerVisible;
@@ -159,7 +160,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                         </div>
                         <div className="gallery-filter-button-label">{lf("Filter")}</div>
                     </div>
-                    {!editingTile && <div className="image-editor-close-button" role="button" onClick={this.onDoneClick}>
+                    {!editingTile && !hideCloseButton && <div className="image-editor-close-button" role="button" onClick={this.onDoneClick}>
                         <i className="ui icon close"/>
                     </div>}
                 </div>
@@ -247,6 +248,11 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
 
             if (options.hideMyAssets != undefined) {
                 this.setState({ hideMyAssets: options.hideMyAssets });
+                didUpdate = true;
+            }
+
+            if (options.hideCloseButton != undefined) {
+                this.setState({ hideCloseButton: options.hideCloseButton });
                 didUpdate = true;
             }
         }
@@ -394,7 +400,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
         if (useTags) {
             assets.forEach(a => {
                 if (!a.meta.tags && this.options) {
-                    a.meta.tags = this.blocksInfo.apis.byQName[a.id]?.attributes.tags?.split(" ") || [];
+                    a.meta.tags = this.blocksInfo?.apis.byQName[a.id]?.attributes.tags?.split(" ") || [];
                 }})
 
         // Keep tag filtering unified with pxtlib/spriteutils:filterItems


### PR DESCRIPTION
This PR includes the following changes for the asset editor page:

1. Enables the gallery (but not "my assets")
2. Fixes the icons not showing up in music editor
3. Adds support for custom palettes