### PR TITLE
just ignore pxt_modules / .pxt, not /built

### DIFF
--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -89,7 +89,6 @@ _site
 `,
             ".vscode/settings.json":
                 `{
-    "explorer.excludeGitIgnore": true,
     "editor.formatOnType": true,
     "files.autoSave": "afterDelay",
     "files.watcherExclude": {
@@ -98,7 +97,8 @@ _site
         "**/node_modules/**": true,
         "**/yotta_modules/**": true,
         "**/yotta_targets": true,
-        "**/pxt_modules/**": true
+        "**/pxt_modules/**": true,
+        "**/.pxt/**": true
     },
     "files.associations": {
         "*.blocks": "html",
@@ -109,7 +109,12 @@ _site
         "**/node_modules": true,
         "**/yotta_modules": true,
         "**/yotta_targets": true,
-        "**/pxt_modules": true
+        "**/pxt_modules": true,
+        "**/.pxt": true
+    },
+    "files.exclude": {
+        "**/pxt_modules": true,
+        "**/.pxt": true
     }
 }`,
             ".vscode/extensions.json":


### PR DESCRIPTION
using files exclude instead of the gitignore setting so built will still show up. (I tried `"**/built": false` but that just got ignored)