### PR TITLE
Refactor song sequencer/playback into pxsim

### DIFF
--- a/localtypings/pxtmusic.d.ts
+++ b/localtypings/pxtmusic.d.ts
@@ -1,0 +1,67 @@
+declare namespace pxt.assets.music {
+    export interface Instrument {
+        waveform: number;
+        ampEnvelope: Envelope;
+        pitchEnvelope?: Envelope;
+        ampLFO?: LFO;
+        pitchLFO?: LFO;
+        octave?: number;
+    }
+
+    export interface Envelope {
+        attack: number;
+        decay: number;
+        sustain: number;
+        release: number;
+        amplitude: number;
+    }
+
+    export interface LFO {
+        frequency: number;
+        amplitude: number;
+    }
+
+    export interface SongInfo {
+        measures: number;
+        beatsPerMeasure: number;
+        beatsPerMinute: number;
+        ticksPerBeat: number;
+    }
+
+    export interface Song extends SongInfo {
+        tracks: Track[];
+    }
+
+    export interface Track {
+        instrument: Instrument;
+        id: number;
+        name?: string;
+        iconURI?: string;
+        drums?: DrumInstrument[];
+        notes: NoteEvent[];
+    }
+
+    export interface NoteEvent {
+        notes: Note[];
+        startTick: number;
+        endTick: number;
+    }
+
+    export interface Note {
+        note: number;
+        enharmonicSpelling: "normal" | "flat" | "sharp";
+    }
+
+    export interface DrumSoundStep {
+        waveform: number;
+        frequency: number;
+        volume: number;
+        duration: number;
+    }
+
+    export interface DrumInstrument {
+        startFrequency: number;
+        startVolume: number;
+        steps: DrumSoundStep[];
+    }
+}

--- a/pxtlib/music.ts
+++ b/pxtlib/music.ts
@@ -1,302 +1,5 @@
+/// <reference path="../localtypings/pxtmusic.d.ts" />
 namespace pxt.assets.music {
-    export interface Instrument {
-        waveform: number;
-        ampEnvelope: Envelope;
-        pitchEnvelope?: Envelope;
-        ampLFO?: LFO;
-        pitchLFO?: LFO;
-        octave?: number;
-    }
-
-    export interface Envelope {
-        attack: number;
-        decay: number;
-        sustain: number;
-        release: number;
-        amplitude: number;
-    }
-
-    export interface LFO {
-        frequency: number;
-        amplitude: number;
-    }
-
-    export interface SongInfo {
-        measures: number;
-        beatsPerMeasure: number;
-        beatsPerMinute: number;
-        ticksPerBeat: number;
-    }
-
-    export interface Song extends SongInfo {
-        tracks: Track[];
-    }
-
-    export interface Track {
-        instrument: Instrument;
-        id: number;
-        name?: string;
-        iconURI?: string;
-        drums?: DrumInstrument[];
-        notes: NoteEvent[];
-    }
-
-    export interface NoteEvent {
-        notes: Note[];
-        startTick: number;
-        endTick: number;
-    }
-
-    export interface Note {
-        note: number;
-        enharmonicSpelling: "normal" | "flat" | "sharp";
-    }
-
-    export interface DrumSoundStep {
-        waveform: number;
-        frequency: number;
-        volume: number;
-        duration: number;
-    }
-
-    export interface DrumInstrument {
-        startFrequency: number;
-        startVolume: number;
-        steps: DrumSoundStep[];
-    }
-
-    const BUFFER_SIZE = 12;
-
-    export function renderInstrument(instrument: Instrument, noteFrequency: number, gateLength: number, volume: number) {
-        const totalDuration = gateLength + instrument.ampEnvelope.release;
-
-        const ampLFOInterval = instrument.ampLFO?.amplitude ? Math.max(500 / instrument.ampLFO.frequency, 50) : 50;
-        const pitchLFOInterval = instrument.pitchLFO?.amplitude ? Math.max(500 / instrument.pitchLFO.frequency, 50) : 50;
-
-        let timePoints = [0];
-
-        let nextAETime = instrument.ampEnvelope.attack;
-        let nextPETime = instrument.pitchEnvelope?.amplitude ? instrument.pitchEnvelope.attack : totalDuration;
-        let nextPLTime = instrument.pitchLFO?.amplitude ? pitchLFOInterval : totalDuration;
-        let nextALTime = instrument.ampLFO?.amplitude ? ampLFOInterval : totalDuration;
-
-        let time = 0;
-        while (time < totalDuration) {
-            if (nextAETime <= nextPETime && nextAETime <= nextPLTime && nextAETime <= nextALTime) {
-                time = nextAETime;
-                timePoints.push(nextAETime);
-
-                if (time < instrument.ampEnvelope.attack + instrument.ampEnvelope.decay && instrument.ampEnvelope.attack + instrument.ampEnvelope.decay < gateLength) {
-                    nextAETime = instrument.ampEnvelope.attack + instrument.ampEnvelope.decay;
-                }
-                else if (time < gateLength) {
-                    nextAETime = gateLength;
-                }
-                else {
-                    nextAETime = totalDuration;
-                }
-            }
-            else if (nextPETime <= nextPLTime && nextPETime <= nextALTime && nextPETime < totalDuration) {
-                time = nextPETime;
-                timePoints.push(nextPETime);
-                if (time < instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay && instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay < gateLength) {
-                    nextPETime = instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay;
-                }
-                else if (time < gateLength) {
-                    nextPETime = gateLength;
-                }
-                else if (time < gateLength + instrument.pitchEnvelope.release) {
-                    nextPETime = Math.min(totalDuration, gateLength + instrument.pitchEnvelope.release);
-                }
-                else {
-                    nextPETime = totalDuration
-                }
-            }
-            else if (nextPLTime <= nextALTime && nextPLTime < totalDuration) {
-                time = nextPLTime;
-                timePoints.push(nextPLTime);
-                nextPLTime += pitchLFOInterval;
-            }
-            else if (nextALTime < totalDuration) {
-                time = nextALTime;
-                timePoints.push(nextALTime);
-                nextALTime += ampLFOInterval;
-            }
-
-
-            if (time >= totalDuration) {
-                break;
-            }
-
-            if (nextAETime <= time) {
-                if (time < instrument.ampEnvelope.attack + instrument.ampEnvelope.decay && instrument.ampEnvelope.attack + instrument.ampEnvelope.decay < gateLength) {
-                    nextAETime = instrument.ampEnvelope.attack + instrument.ampEnvelope.decay;
-                }
-                else if (time < gateLength) {
-                    nextAETime = gateLength;
-                }
-                else {
-                    nextAETime = totalDuration;
-                }
-            }
-            if (nextPETime <= time) {
-                if (time < instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay && instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay < gateLength) {
-                    nextPETime = instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay;
-                }
-                else if (time < gateLength) {
-                    nextPETime = gateLength;
-                }
-                else if (time < gateLength + instrument.pitchEnvelope.release) {
-                    nextPETime = Math.min(totalDuration, gateLength + instrument.pitchEnvelope.release);
-                }
-                else {
-                    nextPETime = totalDuration
-                }
-            }
-            while (nextALTime <= time) {
-                nextALTime += ampLFOInterval;
-            }
-            while (nextPLTime <= time) {
-                nextPLTime += pitchLFOInterval;
-            }
-        }
-
-
-        let prevAmp = instrumentVolumeAtTime(instrument, gateLength, 0, volume) | 0;
-        let prevPitch = instrumentPitchAtTime(instrument, noteFrequency, gateLength, 0) | 0;
-        let prevTime = 0;
-
-        let nextAmp: number;
-        let nextPitch: number;
-        const out = new Uint8Array(BUFFER_SIZE * (timePoints.length + 1));
-        for (let i = 1; i < timePoints.length; i++) {
-            if (timePoints[i] - prevTime < 5) {
-                prevTime = timePoints[i];
-                continue;
-            }
-
-            nextAmp = instrumentVolumeAtTime(instrument, gateLength, timePoints[i], volume) | 0;
-            nextPitch = instrumentPitchAtTime(instrument, noteFrequency, gateLength, timePoints[i]) | 0
-            addNote(
-                out,
-                (i - 1) * 12,
-                (timePoints[i] - prevTime) | 0,
-                prevAmp,
-                nextAmp,
-                instrument.waveform,
-                prevPitch,
-                nextPitch
-            )
-
-            prevAmp = nextAmp;
-            prevPitch = nextPitch;
-            prevTime = timePoints[i];
-        }
-        addNote(
-            out,
-            timePoints.length * 12,
-            10,
-            prevAmp,
-            0,
-            instrument.waveform,
-            prevPitch,
-            prevPitch
-        )
-        return out;
-    }
-
-    export function renderDrumInstrument(sound: DrumInstrument, volume: number) {
-        let prevAmp = sound.startVolume;
-        let prevFreq = sound.startFrequency;
-
-        const scaleVolume = (value: number) => (value / 1024) * volume;
-
-        let out = new Uint8Array((sound.steps.length + 1) * BUFFER_SIZE);
-
-        for (let i = 0; i < sound.steps.length; i++) {
-            addNote(
-                out,
-                i * BUFFER_SIZE,
-                sound.steps[i].duration,
-                scaleVolume(prevAmp),
-                scaleVolume(sound.steps[i].volume),
-                sound.steps[i].waveform,
-                prevFreq,
-                sound.steps[i].frequency
-            );
-            prevAmp = sound.steps[i].volume;
-            prevFreq = sound.steps[i].frequency
-        }
-
-        addNote(
-            out,
-            sound.steps.length * BUFFER_SIZE,
-            10,
-            scaleVolume(prevAmp),
-            0,
-            sound.steps[sound.steps.length - 1].waveform,
-            prevFreq,
-            prevFreq
-        );
-
-        return out;
-    }
-
-    function instrumentPitchAtTime(instrument: Instrument, noteFrequency: number, gateLength: number, time: number) {
-        let mod = 0;
-        if (instrument.pitchEnvelope?.amplitude) {
-            mod += envelopeValueAtTime(instrument.pitchEnvelope, time, gateLength)
-        }
-        if (instrument.pitchLFO?.amplitude) {
-            mod += lfoValueAtTime(instrument.pitchLFO, time)
-        }
-        return Math.max(noteFrequency + mod, 0);
-    }
-
-    function instrumentVolumeAtTime(instrument: Instrument, gateLength: number, time: number, maxVolume: number) {
-        let mod = 0;
-        if (instrument.ampEnvelope.amplitude) {
-            mod += envelopeValueAtTime(instrument.ampEnvelope, time, gateLength)
-        }
-        if (instrument.ampLFO?.amplitude) {
-            mod += lfoValueAtTime(instrument.ampLFO, time)
-        }
-        return ((Math.max(Math.min(mod, instrument.ampEnvelope.amplitude), 0) / 1024) * maxVolume) | 0;
-    }
-
-    function envelopeValueAtTime(envelope: Envelope, time: number, gateLength: number) {
-        const adjustedSustain = (envelope.sustain / 1024) * envelope.amplitude;
-
-        if (time > gateLength) {
-            if (time - gateLength > envelope.release) return 0;
-
-            else if (time < envelope.attack) {
-                const height = (envelope.amplitude / envelope.attack) * gateLength;
-                return height - ((height / envelope.release) * (time - gateLength))
-            }
-            else if (time < envelope.attack + envelope.decay) {
-                const height2 = envelope.amplitude - ((envelope.amplitude - adjustedSustain) / envelope.decay) * (gateLength - envelope.attack);
-                return height2 - ((height2 / envelope.release) * (time - gateLength))
-            }
-            else {
-                return adjustedSustain - (adjustedSustain / envelope.release) * (time - gateLength)
-            }
-        }
-        else if (time < envelope.attack) {
-            return (envelope.amplitude / envelope.attack) * time
-        }
-        else if (time < envelope.attack + envelope.decay) {
-            return envelope.amplitude - ((envelope.amplitude - adjustedSustain) / envelope.decay) * (time - envelope.attack)
-        }
-        else {
-            return adjustedSustain;
-        }
-    }
-
-    function lfoValueAtTime(lfo: LFO, time: number) {
-        return Math.cos(((time / 1000) * lfo.frequency) * 2 * Math.PI) * lfo.amplitude
-    }
-
     function set16BitNumber(buf: Uint8Array, offset: number, value: number) {
         const temp = new Uint8Array(2);
         new Uint16Array(temp.buffer)[0] = value | 0;
@@ -312,30 +15,9 @@ namespace pxt.assets.music {
         return new Uint16Array(temp.buffer)[0];
     }
 
-    function addNote(sndInstr: Uint8Array, sndInstrPtr: number, ms: number, beg: number, end: number, soundWave: number, hz: number, endHz: number) {
-        if (ms > 0) {
-            sndInstr[sndInstrPtr] = soundWave;
-            sndInstr[sndInstrPtr + 1] = 0;
-            set16BitNumber(sndInstr, sndInstrPtr + 2, hz)
-            set16BitNumber(sndInstr, sndInstrPtr + 4, ms)
-            set16BitNumber(sndInstr, sndInstrPtr + 6, (beg * 255) >> 6)
-            set16BitNumber(sndInstr, sndInstrPtr + 8, (end * 255) >> 6)
-            set16BitNumber(sndInstr, sndInstrPtr + 10, endHz);
-            sndInstrPtr += BUFFER_SIZE;
-        }
-        sndInstr[sndInstrPtr] = 0;
-        return sndInstrPtr
-    }
-
     export function encodeSongToHex(song: Song) {
         const encoded = encodeSong(song);
         return U.toHex(encoded);
-    }
-
-    export function decodeSongFromHex(hex: string) {
-        const bytes = pxt.U.fromHex(hex);
-
-        return decodeSong(bytes);
     }
 
     /**
@@ -426,26 +108,6 @@ namespace pxt.assets.music {
         return out;
     }
 
-    function decodeSong(buf: Uint8Array) {
-        const res: Song = {
-            beatsPerMinute: get16BitNumber(buf, 1),
-            beatsPerMeasure: buf[3],
-            ticksPerBeat: buf[4],
-            measures: buf[5],
-            tracks: []
-        };
-
-        let current = 7;
-
-        while (current < buf.length) {
-            const [track, pointer] = decodeTrack(buf, current);
-            current = pointer;
-            res.tracks.push(track);
-        }
-
-        return res;
-    }
-
     function encodeInstrument(instrument: Instrument) {
         const out = new Uint8Array(28);
         out[0] = instrument.waveform;
@@ -466,6 +128,135 @@ namespace pxt.assets.music {
         out[27] = instrument.octave;
 
         return out;
+    }
+
+    function encodeDrumInstrument(drum: DrumInstrument) {
+        const out = new Uint8Array(5 + 7 * drum.steps.length);
+        out[0] = drum.steps.length;
+        set16BitNumber(out, 1, drum.startFrequency);
+        set16BitNumber(out, 3, drum.startVolume);
+
+        for (let i = 0; i < drum.steps.length; i++) {
+            const start = 5 + i * 7;
+            out[start] = drum.steps[i].waveform;
+            set16BitNumber(out, start + 1, drum.steps[i].frequency);
+            set16BitNumber(out, start + 3, drum.steps[i].volume);
+            set16BitNumber(out, start + 5, drum.steps[i].duration);
+        }
+
+        return out;
+    }
+
+    function encodeNoteEvent(event: NoteEvent, instrumentOctave: number, isDrumTrack: boolean) {
+        const out = new Uint8Array(5 + event.notes.length);
+        set16BitNumber(out, 0, event.startTick);
+        set16BitNumber(out, 2, event.endTick);
+        out[4] = event.notes.length;
+
+        for (let i = 0; i < event.notes.length; i++) {
+            out[5 + i] = encodeNote(event.notes[i], instrumentOctave, isDrumTrack);
+        }
+
+        return out;
+    }
+
+    function encodeNote(note: Note, instrumentOctave: number, isDrumTrack: boolean) {
+        if (isDrumTrack) {
+            return note.note;
+        }
+
+        let flags = 0;
+        if (note.enharmonicSpelling === "flat") {
+            flags = 1;
+        }
+        else if (note.enharmonicSpelling === "sharp") {
+            flags = 2;
+        }
+
+        return (note.note - (instrumentOctave - 2) * 12) | (flags << 6)
+    }
+
+    function encodeTrack(track: Track) {
+        if (track.drums) return encodeDrumTrack(track);
+        return encodeMelodicTrack(track);
+    }
+
+    function encodeMelodicTrack(track: Track) {
+        const encodedInstrument = encodeInstrument(track.instrument);
+        const encodedNotes = track.notes.map(note => encodeNoteEvent(note, track.instrument.octave, false));
+        const noteLength = encodedNotes.reduce((d, c) => c.length + d, 0);
+
+        const out = new Uint8Array(6 + encodedInstrument.length + noteLength);
+        out[0] = track.id;
+        out[1] = 0;
+
+        set16BitNumber(out, 2, encodedInstrument.length);
+        let current = 4;
+        out.set(encodedInstrument, current);
+        current += encodedInstrument.length;
+
+        set16BitNumber(out, current, noteLength);
+        current += 2;
+        for (const note of encodedNotes) {
+            out.set(note, current);
+            current += note.length
+        }
+
+        return out;
+    }
+
+    function encodeDrumTrack(track: Track) {
+        const encodedDrums = track.drums.map(encodeDrumInstrument);
+        const drumLength = encodedDrums.reduce((d, c) => c.length + d, 0);
+
+        const encodedNotes = track.notes.map(note => encodeNoteEvent(note, 0, true));
+        const noteLength = encodedNotes.reduce((d, c) => c.length + d, 0);
+
+        const out = new Uint8Array(6 + drumLength + noteLength);
+        out[0] = track.id;
+        out[1] = 1;
+        set16BitNumber(out, 2, drumLength);
+        let current = 4;
+
+        for (const drum of encodedDrums) {
+            out.set(drum, current);
+            current += drum.length
+        }
+
+        set16BitNumber(out, current, noteLength);
+        current += 2;
+        for (const note of encodedNotes) {
+            out.set(note, current);
+            current += note.length
+        }
+
+        return out;
+    }
+
+    export function decodeSongFromHex(hex: string) {
+        const bytes = pxt.U.fromHex(hex);
+
+        return decodeSong(bytes);
+    }
+
+    function decodeSong(buf: Uint8Array) {
+        const res: Song = {
+            beatsPerMinute: get16BitNumber(buf, 1),
+            beatsPerMeasure: buf[3],
+            ticksPerBeat: buf[4],
+            measures: buf[5],
+            tracks: []
+        };
+
+        let current = 7;
+
+        while (current < buf.length) {
+            const [track, pointer] = decodeTrack(buf, current);
+            current = pointer;
+            res.tracks.push(track);
+        }
+
+        return res;
     }
 
     function decodeInstrument(buf: Uint8Array, offset: number): Instrument {
@@ -505,23 +296,6 @@ namespace pxt.assets.music {
         return decodeMelodicTrack(buf, offset);
     }
 
-    function encodeDrumInstrument(drum: DrumInstrument) {
-        const out = new Uint8Array(5 + 7 * drum.steps.length);
-        out[0] = drum.steps.length;
-        set16BitNumber(out, 1, drum.startFrequency);
-        set16BitNumber(out, 3, drum.startVolume);
-
-        for (let i = 0; i < drum.steps.length; i++) {
-            const start = 5 + i * 7;
-            out[start] = drum.steps[i].waveform;
-            set16BitNumber(out, start + 1, drum.steps[i].frequency);
-            set16BitNumber(out, start + 3, drum.steps[i].volume);
-            set16BitNumber(out, start + 5, drum.steps[i].duration);
-        }
-
-        return out;
-    }
-
     function decodeDrumInstrument(buf: Uint8Array, offset: number): DrumInstrument {
         const res: DrumInstrument = {
             startFrequency: get16BitNumber(buf, offset + 1),
@@ -542,19 +316,6 @@ namespace pxt.assets.music {
         return res;
     }
 
-    function encodeNoteEvent(event: NoteEvent, instrumentOctave: number, isDrumTrack: boolean) {
-        const out = new Uint8Array(5 + event.notes.length);
-        set16BitNumber(out, 0, event.startTick);
-        set16BitNumber(out, 2, event.endTick);
-        out[4] = event.notes.length;
-
-        for (let i = 0; i < event.notes.length; i++) {
-            out[5 + i] = encodeNote(event.notes[i], instrumentOctave, isDrumTrack);
-        }
-
-        return out;
-    }
-
     function decodeNoteEvent(buf: Uint8Array, offset: number, instrumentOctave: number, isDrumTrack: boolean): NoteEvent {
         const res: NoteEvent = {
             startTick: get16BitNumber(buf, offset),
@@ -566,22 +327,6 @@ namespace pxt.assets.music {
             res.notes.push(decodeNote(buf[offset + 5 + i], instrumentOctave, isDrumTrack));
         }
         return res;
-    }
-
-    function encodeNote(note: Note, instrumentOctave: number, isDrumTrack: boolean) {
-        if (isDrumTrack) {
-            return note.note;
-        }
-
-        let flags = 0;
-        if (note.enharmonicSpelling === "flat") {
-            flags = 1;
-        }
-        else if (note.enharmonicSpelling === "sharp") {
-            flags = 2;
-        }
-
-        return (note.note - (instrumentOctave - 2) * 12) | (flags << 6)
     }
 
     function decodeNote(note: number, instrumentOctave: number, isDrumTrack: boolean) {
@@ -602,35 +347,6 @@ namespace pxt.assets.music {
         return result;
     }
 
-    function encodeTrack(track: Track) {
-        if (track.drums) return encodeDrumTrack(track);
-        return encodeMelodicTrack(track);
-    }
-
-    function encodeMelodicTrack(track: Track) {
-        const encodedInstrument = encodeInstrument(track.instrument);
-        const encodedNotes = track.notes.map(note => encodeNoteEvent(note, track.instrument.octave, false));
-        const noteLength = encodedNotes.reduce((d, c) => c.length + d, 0);
-
-        const out = new Uint8Array(6 + encodedInstrument.length + noteLength);
-        out[0] = track.id;
-        out[1] = 0;
-
-        set16BitNumber(out, 2, encodedInstrument.length);
-        let current = 4;
-        out.set(encodedInstrument, current);
-        current += encodedInstrument.length;
-
-        set16BitNumber(out, current, noteLength);
-        current += 2;
-        for (const note of encodedNotes) {
-            out.set(note, current);
-            current += note.length
-        }
-
-        return out;
-    }
-
     function decodeMelodicTrack(buf: Uint8Array, offset: number): [Track, number] {
         const res: Track = {
             id: buf[offset],
@@ -649,34 +365,6 @@ namespace pxt.assets.music {
         }
 
         return [res, currentOffset];
-    }
-
-    function encodeDrumTrack(track: Track) {
-        const encodedDrums = track.drums.map(encodeDrumInstrument);
-        const drumLength = encodedDrums.reduce((d, c) => c.length + d, 0);
-
-        const encodedNotes = track.notes.map(note => encodeNoteEvent(note, 0, true));
-        const noteLength = encodedNotes.reduce((d, c) => c.length + d, 0);
-
-        const out = new Uint8Array(6 + drumLength + noteLength);
-        out[0] = track.id;
-        out[1] = 1;
-        set16BitNumber(out, 2, drumLength);
-        let current = 4;
-
-        for (const drum of encodedDrums) {
-            out.set(drum, current);
-            current += drum.length
-        }
-
-        set16BitNumber(out, current, noteLength);
-        current += 2;
-        for (const note of encodedNotes) {
-            out.set(note, current);
-            current += note.length
-        }
-
-        return out;
     }
 
     function decodeDrumTrack(buf: Uint8Array, offset: number): [Track, number] {

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -227,6 +227,7 @@ namespace pxsim {
         let audio: HTMLAudioElement;
 
         const channels: Channel[] = []
+        let stopAllListeners: (() => void)[] = [];
 
         // All other nodes get connected to this node which is connected to the actual
         // destination. Used for muting
@@ -284,12 +285,21 @@ namespace pxsim {
         export function stopAll() {
             stopTone();
             muteAllChannels();
+
+            for (const handler of stopAllListeners) {
+                handler();
+            }
         }
 
         export function stop() {
             stopTone();
             clearVca();
         }
+
+        export function onStopAll(handler: () => void) {
+            stopAllListeners.push(handler);
+        }
+
         function clearVca() {
             if (_vca) {
                 try {

--- a/pxtsim/sound/metronome.ts
+++ b/pxtsim/sound/metronome.ts
@@ -1,0 +1,133 @@
+namespace pxsim.music {
+    interface MetronomeMessage {
+        type: "start" | "stop" | "set-interval";
+        interval?: number;
+    }
+
+    export class Metronome {
+        protected metronomeLoadPromise: Promise<Worker>;
+        protected metronomeWorker: Worker;
+        protected tickListeners: (() => void)[] = [];
+        protected currentInterval: number;
+
+        initAsync() {
+            if (this.metronomeLoadPromise) return this.metronomeLoadPromise;
+            if (this.metronomeWorker) return this.metronomeWorker;
+
+            this.metronomeLoadPromise = new Promise(resolve => {
+                this.metronomeWorker = new Worker("data:application/javascript," + encodeURIComponent(metronomeWorkerJS));
+
+                const readyHandler = (ev: MessageEvent) => {
+                    if (ev.data === "ready") {
+                        resolve(this.metronomeWorker);
+                        this.metronomeWorker.removeEventListener("message", readyHandler);
+                        this.metronomeWorker.addEventListener("message", this.onTick)
+                    }
+                }
+
+                this.metronomeWorker.addEventListener("message", readyHandler);
+            })
+
+            return this.metronomeLoadPromise;
+        }
+
+        stop() {
+            this.postMessage({
+                type: "stop"
+            });
+        }
+
+        setInterval(interval: number) {
+            this.currentInterval = interval;
+            this.postMessage({
+                type: "set-interval",
+                interval
+            });
+        }
+
+        start(interval: number) {
+            this.currentInterval = interval;
+            this.postMessage({
+                type: "start",
+                interval
+            });
+        }
+
+        addTickListener(listener: () => void) {
+            this.tickListeners.push(listener);
+        }
+
+        removeTickListener(listener: () => void) {
+            this.tickListeners = this.tickListeners.filter(l => l !== listener)
+        }
+
+        interval() {
+            return this.currentInterval;
+        }
+
+        dispose() {
+            if (this.metronomeWorker) {
+                this.metronomeWorker.terminate();
+                this.metronomeWorker = undefined;
+                this.metronomeLoadPromise = undefined;
+                this.tickListeners = [];
+                this.interval = undefined;
+            }
+            else if (this.metronomeLoadPromise) {
+                this.metronomeLoadPromise.then(() => this.dispose());
+                return;
+            }
+        }
+
+        protected onTick = () => {
+            for (const listener of this.tickListeners) {
+                listener();
+            }
+        }
+
+        protected postMessage(message: MetronomeMessage) {
+            if (!this.metronomeWorker) {
+                throw new Error("initAsync not called on metronome");
+            }
+            this.metronomeWorker.postMessage(message);
+        }
+    }
+
+    const metronomeWorkerJS = `
+/**
+ * Adpated from https://github.com/cwilso/metronome/
+ */
+
+let timerRef;
+let interval;
+
+addEventListener("message", ev => {
+    const message = ev.data;
+
+    if (message.type === "start") {
+        updateInterval(message.interval, true);
+    }
+    else if (message.type === "stop") {
+        clearInterval(timerRef);
+        timerRef = undefined;
+    }
+    else if (message.type === "set-interval") {
+        updateInterval(message.interval, false);
+    }
+})
+
+postMessage("ready");
+
+function updateInterval(interval, startIfStopped) {
+    if (timerRef) {
+        clearInterval(timerRef);
+        startIfStopped = true;
+    }
+    interval = interval;
+
+    if (startIfStopped) {
+        timerRef = setInterval(() => postMessage("tick"), interval);
+    }
+}
+`;
+}

--- a/pxtsim/sound/sequencer.ts
+++ b/pxtsim/sound/sequencer.ts
@@ -1,0 +1,186 @@
+/// <reference path="../../localtypings/pxtmusic.d.ts" />
+
+namespace pxsim.music {
+    const frequencies = [31, 33, 35, 37, 39, 41, 44, 46, 49, 52, 55, 58, 62, 65, 69, 73,
+        78, 82, 87, 92, 98, 104, 110, 117, 123, 131, 139, 147, 156, 165, 175, 185, 196, 208,
+        220, 233, 247, 262, 277, 294, 311, 330, 349, 370, 392, 415, 440, 466, 494, 523, 554,
+        587, 622, 659, 698, 740, 784, 831, 880, 932, 988, 1047, 1109, 1175, 1245, 1319, 1397,
+        1480, 1568, 1661, 1760, 1865, 1976, 2093, 2217, 2349, 2489, 2637, 2794, 2960, 3136,
+        3322, 3520, 3729, 3951, 4186, 4435, 4699, 4978, 5274, 5588, 5920, 6272, 6645, 7040,
+        7459, 7902];
+
+    export type SequencerState = "play" | "loop" | "stop";
+    export type SequencerEvent = "tick" | "play" | "stop" | "loop" | "state-change" | "looped";
+
+    export class Sequencer {
+        protected metronome: Metronome;
+        protected _currentTick = 0;
+        protected _state: SequencerState = "stop";
+        protected currentlyPlaying: pxt.assets.music.Song;
+        protected listeners: {[index: string]: (() => void)[]} = {};
+        protected shouldLoop: boolean;
+
+        protected currentCancelToken = { cancelled: false };
+
+        constructor() {
+        }
+
+        async initAsync() {
+            if (this.metronome) {
+                await this.metronome.initAsync();
+                return;
+            }
+
+            this.metronome = new Metronome();
+            await this.metronome.initAsync();
+            this.metronome.addTickListener(this.onTick);
+        }
+
+        dispose() {
+            if (this.metronome) this.metronome.dispose();
+            this.currentlyPlaying = undefined;
+            this.listeners = {};
+        }
+
+        state() {
+            return this._state
+        }
+
+        currentTick() {
+            return this._currentTick;
+        }
+
+        currentTime() {
+            return tickToMs(this.currentlyPlaying.beatsPerMinute, this.currentlyPlaying.ticksPerBeat, this.currentTick());
+        }
+
+        maxTick() {
+            if (!this.currentlyPlaying) return 0;
+            return this.currentlyPlaying.measures * this.currentlyPlaying.beatsPerMeasure * this.currentlyPlaying.ticksPerBeat
+        }
+
+        duration() {
+            return tickToMs(this.currentlyPlaying.beatsPerMinute, this.currentlyPlaying.ticksPerBeat, this.maxTick());
+        }
+
+        start(song: pxt.assets.music.Song, loop?: boolean) {
+            if (this._state !== "stop") this.stop();
+
+            if (loop !== undefined) {
+                this.shouldLoop = loop;
+            }
+
+            this._currentTick = 0;
+            this.currentlyPlaying = song;
+            this.metronome.start(tickToMs(song.beatsPerMinute, song.ticksPerBeat, 1));
+            this._state = this.shouldLoop ? "loop" : "play";
+            this.fireStateChange();
+        }
+
+        stop(sustainCurrentSounds = false) {
+            if (this._state === "stop") return;
+            this._state = "stop";
+            this.metronome.stop();
+            this.fireStateChange();
+
+            if (!sustainCurrentSounds) this.currentCancelToken.cancelled = true;
+            this.currentCancelToken = { cancelled: false };
+        }
+
+        updateSong(song: pxt.assets.music.Song) {
+            this.currentlyPlaying = song;
+
+            if (this._state !== "stop") {
+                this.metronome.setInterval(tickToMs(song.beatsPerMinute, song.ticksPerBeat, 1))
+            }
+        }
+
+        setLooping(looping: boolean) {
+            if (looping && this._state === "play") {
+                this._state = "loop";
+                this.fireStateChange();
+            }
+            else if (!looping && this._state === "loop") {
+                this._state = "play";
+                this.fireStateChange();
+            }
+            this.shouldLoop = looping;
+        }
+
+        addEventListener(event: SequencerEvent, listener: () => void) {
+            if (!this.listeners[event]) this.listeners[event] = [];
+            this.listeners[event].push(listener);
+        }
+
+        removeEventListener(event: SequencerEvent, listener: () => void) {
+            if (!this.listeners[event]) return;
+            this.listeners[event] = this.listeners[event].filter(l => l !== listener);
+        }
+
+        protected fireStateChange() {
+            this.fireEvent(this._state);
+            this.fireEvent("state-change");
+        }
+
+        protected fireEvent(event: SequencerEvent) {
+            if (this.listeners[event]) {
+                for (const listener of this.listeners[event]) {
+                    listener();
+                }
+            }
+        }
+
+        protected onTick = () => {
+            const currentToken = this.currentCancelToken;
+            for (const track of this.currentlyPlaying.tracks) {
+                for (const noteEvent of track.notes) {
+                    if (noteEvent.startTick === this._currentTick) {
+                        for (const note of noteEvent.notes) {
+                            if (track.drums) {
+                                playDrumAsync(track.drums[note.note], () => currentToken.cancelled);
+                            }
+                            else {
+                                playNoteAsync(note.note, track.instrument, tickToMs(this.currentlyPlaying.beatsPerMinute, this.currentlyPlaying.ticksPerBeat, noteEvent.endTick - noteEvent.startTick), () => currentToken.cancelled);
+                            }
+                        }
+                    }
+                    else if (noteEvent.startTick > this._currentTick) {
+                        break;
+                    }
+                }
+            }
+
+            this.fireEvent("tick");
+
+            this._currentTick ++;
+
+            if (this._currentTick >= this.maxTick()) {
+                if (this._state === "loop") {
+                    this._currentTick = 0;
+                    this.fireEvent("looped");
+                }
+                else {
+                    this.stop(true);
+                }
+            }
+        }
+    }
+
+    export async function playNoteAsync(note: number, instrument: pxt.assets.music.Instrument, time: number, isCancelled?: () => boolean) {
+        await pxsim.AudioContextManager.playInstructionsAsync(
+            pxsim.music.renderInstrument(instrument, frequencies[note], time, 100),
+            isCancelled
+        )
+    }
+
+    export async function playDrumAsync(drum: pxt.assets.music.DrumInstrument, isCancelled?: () => boolean) {
+        await pxsim.AudioContextManager.playInstructionsAsync(
+            pxsim.music.renderDrumInstrument(drum, 100),
+            isCancelled
+        )
+    }
+
+    export function tickToMs(beatsPerMinute: number, ticksPerBeat: number, ticks: number) {
+        return ((60000 / beatsPerMinute) / ticksPerBeat) * ticks;
+    }
+}

--- a/pxtsim/sound/sequencer.ts
+++ b/pxtsim/sound/sequencer.ts
@@ -19,6 +19,9 @@ namespace pxsim.music {
         protected currentlyPlaying: pxt.assets.music.Song;
         protected listeners: {[index: string]: (() => void)[]} = {};
         protected shouldLoop: boolean;
+        protected globalVolume: number = 1024;
+        protected trackVolumes: number[] = [];
+        protected drumTrackVolumes: number[][] = [];
 
         protected currentCancelToken = { cancelled: false };
 
@@ -38,6 +41,7 @@ namespace pxsim.music {
 
         dispose() {
             if (this.metronome) this.metronome.dispose();
+            this.stop();
             this.currentlyPlaying = undefined;
             this.listeners = {};
         }
@@ -117,6 +121,54 @@ namespace pxsim.music {
             this.listeners[event] = this.listeners[event].filter(l => l !== listener);
         }
 
+        setVolume(volume: number) {
+            this.globalVolume = Math.min(Math.max(volume, 0), 1024);
+        }
+
+        setTrackVolume(trackIndex: number, volume: number) {
+            volume = Math.min(Math.max(volume, 0), 1024);
+
+            while (this.trackVolumes.length < trackIndex) {
+                this.trackVolumes.push(1024);
+            }
+
+            this.trackVolumes[trackIndex] = volume;
+        }
+
+        setDrumTrackVolume(trackIndex: number, drumIndex: number, volume: number) {
+            volume = Math.min(Math.max(volume, 0), 1024);
+
+            while (this.drumTrackVolumes.length < trackIndex) {
+                this.drumTrackVolumes.push([]);
+            }
+
+            while (this.drumTrackVolumes[trackIndex].length < drumIndex) {
+                this.drumTrackVolumes[trackIndex].push(1024)
+            }
+
+            this.drumTrackVolumes[trackIndex][drumIndex] = volume;
+        }
+
+        protected getMelodicTrackVolume(trackIndex: number) {
+            let trackVolume = 1024;
+            if (trackIndex < this.trackVolumes.length) {
+                trackVolume = this.trackVolumes[trackIndex];
+            }
+
+            return this.globalVolume * (trackVolume / 1024);
+        }
+
+        protected getDrumTrackVolume(trackIndex: number, drumIndex: number) {
+            const trackVolume = this.getMelodicTrackVolume(trackIndex);
+            let drumVolume = 1024;
+
+            if (trackIndex < this.drumTrackVolumes.length && drumIndex < this.drumTrackVolumes[trackIndex].length) {
+                drumVolume = this.drumTrackVolumes[trackIndex][drumIndex]
+            }
+
+            return trackVolume * (drumVolume / 1024);
+        }
+
         protected fireStateChange() {
             this.fireEvent(this._state);
             this.fireEvent("state-change");
@@ -132,15 +184,16 @@ namespace pxsim.music {
 
         protected onTick = () => {
             const currentToken = this.currentCancelToken;
-            for (const track of this.currentlyPlaying.tracks) {
+            for (let i = 0; i < this.currentlyPlaying.tracks.length; i++) {
+                const track = this.currentlyPlaying.tracks[i];
                 for (const noteEvent of track.notes) {
                     if (noteEvent.startTick === this._currentTick) {
                         for (const note of noteEvent.notes) {
                             if (track.drums) {
-                                playDrumAsync(track.drums[note.note], () => currentToken.cancelled);
+                                playDrumAsync(track.drums[note.note], () => currentToken.cancelled, this.getDrumTrackVolume(i, note.note));
                             }
                             else {
-                                playNoteAsync(note.note, track.instrument, tickToMs(this.currentlyPlaying.beatsPerMinute, this.currentlyPlaying.ticksPerBeat, noteEvent.endTick - noteEvent.startTick), () => currentToken.cancelled);
+                                playNoteAsync(note.note, track.instrument, tickToMs(this.currentlyPlaying.beatsPerMinute, this.currentlyPlaying.ticksPerBeat, noteEvent.endTick - noteEvent.startTick), () => currentToken.cancelled, this.getMelodicTrackVolume(i));
                             }
                         }
                     }
@@ -166,16 +219,16 @@ namespace pxsim.music {
         }
     }
 
-    export async function playNoteAsync(note: number, instrument: pxt.assets.music.Instrument, time: number, isCancelled?: () => boolean) {
+    export async function playNoteAsync(note: number, instrument: pxt.assets.music.Instrument, time: number, isCancelled?: () => boolean, volume = 100) {
         await pxsim.AudioContextManager.playInstructionsAsync(
-            pxsim.music.renderInstrument(instrument, frequencies[note], time, 100),
+            pxsim.music.renderInstrument(instrument, frequencies[note], time, volume),
             isCancelled
         )
     }
 
-    export async function playDrumAsync(drum: pxt.assets.music.DrumInstrument, isCancelled?: () => boolean) {
+    export async function playDrumAsync(drum: pxt.assets.music.DrumInstrument, isCancelled?: () => boolean, volume = 100) {
         await pxsim.AudioContextManager.playInstructionsAsync(
-            pxsim.music.renderDrumInstrument(drum, 100),
+            pxsim.music.renderDrumInstrument(drum, volume),
             isCancelled
         )
     }

--- a/pxtsim/sound/song.ts
+++ b/pxtsim/sound/song.ts
@@ -1,0 +1,420 @@
+/// <reference path="../../localtypings/pxtmusic.d.ts" />
+
+namespace pxsim.music {
+    const BUFFER_SIZE = 12;
+
+    export function renderInstrument(instrument: pxt.assets.music.Instrument, noteFrequency: number, gateLength: number, volume: number) {
+        const totalDuration = gateLength + instrument.ampEnvelope.release;
+
+        const ampLFOInterval = instrument.ampLFO?.amplitude ? Math.max(500 / instrument.ampLFO.frequency, 50) : 50;
+        const pitchLFOInterval = instrument.pitchLFO?.amplitude ? Math.max(500 / instrument.pitchLFO.frequency, 50) : 50;
+
+        let timePoints = [0];
+
+        let nextAETime = instrument.ampEnvelope.attack;
+        let nextPETime = instrument.pitchEnvelope?.amplitude ? instrument.pitchEnvelope.attack : totalDuration;
+        let nextPLTime = instrument.pitchLFO?.amplitude ? pitchLFOInterval : totalDuration;
+        let nextALTime = instrument.ampLFO?.amplitude ? ampLFOInterval : totalDuration;
+
+        let time = 0;
+        while (time < totalDuration) {
+            if (nextAETime <= nextPETime && nextAETime <= nextPLTime && nextAETime <= nextALTime) {
+                time = nextAETime;
+                timePoints.push(nextAETime);
+
+                if (time < instrument.ampEnvelope.attack + instrument.ampEnvelope.decay && instrument.ampEnvelope.attack + instrument.ampEnvelope.decay < gateLength) {
+                    nextAETime = instrument.ampEnvelope.attack + instrument.ampEnvelope.decay;
+                }
+                else if (time < gateLength) {
+                    nextAETime = gateLength;
+                }
+                else {
+                    nextAETime = totalDuration;
+                }
+            }
+            else if (nextPETime <= nextPLTime && nextPETime <= nextALTime && nextPETime < totalDuration) {
+                time = nextPETime;
+                timePoints.push(nextPETime);
+                if (time < instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay && instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay < gateLength) {
+                    nextPETime = instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay;
+                }
+                else if (time < gateLength) {
+                    nextPETime = gateLength;
+                }
+                else if (time < gateLength + instrument.pitchEnvelope.release) {
+                    nextPETime = Math.min(totalDuration, gateLength + instrument.pitchEnvelope.release);
+                }
+                else {
+                    nextPETime = totalDuration
+                }
+            }
+            else if (nextPLTime <= nextALTime && nextPLTime < totalDuration) {
+                time = nextPLTime;
+                timePoints.push(nextPLTime);
+                nextPLTime += pitchLFOInterval;
+            }
+            else if (nextALTime < totalDuration) {
+                time = nextALTime;
+                timePoints.push(nextALTime);
+                nextALTime += ampLFOInterval;
+            }
+
+
+            if (time >= totalDuration) {
+                break;
+            }
+
+            if (nextAETime <= time) {
+                if (time < instrument.ampEnvelope.attack + instrument.ampEnvelope.decay && instrument.ampEnvelope.attack + instrument.ampEnvelope.decay < gateLength) {
+                    nextAETime = instrument.ampEnvelope.attack + instrument.ampEnvelope.decay;
+                }
+                else if (time < gateLength) {
+                    nextAETime = gateLength;
+                }
+                else {
+                    nextAETime = totalDuration;
+                }
+            }
+            if (nextPETime <= time) {
+                if (time < instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay && instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay < gateLength) {
+                    nextPETime = instrument.pitchEnvelope.attack + instrument.pitchEnvelope.decay;
+                }
+                else if (time < gateLength) {
+                    nextPETime = gateLength;
+                }
+                else if (time < gateLength + instrument.pitchEnvelope.release) {
+                    nextPETime = Math.min(totalDuration, gateLength + instrument.pitchEnvelope.release);
+                }
+                else {
+                    nextPETime = totalDuration
+                }
+            }
+            while (nextALTime <= time) {
+                nextALTime += ampLFOInterval;
+            }
+            while (nextPLTime <= time) {
+                nextPLTime += pitchLFOInterval;
+            }
+        }
+
+
+        let prevAmp = instrumentVolumeAtTime(instrument, gateLength, 0, volume) | 0;
+        let prevPitch = instrumentPitchAtTime(instrument, noteFrequency, gateLength, 0) | 0;
+        let prevTime = 0;
+
+        let nextAmp: number;
+        let nextPitch: number;
+        const out = new Uint8Array(BUFFER_SIZE * (timePoints.length + 1));
+        for (let i = 1; i < timePoints.length; i++) {
+            if (timePoints[i] - prevTime < 5) {
+                prevTime = timePoints[i];
+                continue;
+            }
+
+            nextAmp = instrumentVolumeAtTime(instrument, gateLength, timePoints[i], volume) | 0;
+            nextPitch = instrumentPitchAtTime(instrument, noteFrequency, gateLength, timePoints[i]) | 0
+            addNote(
+                out,
+                (i - 1) * 12,
+                (timePoints[i] - prevTime) | 0,
+                prevAmp,
+                nextAmp,
+                instrument.waveform,
+                prevPitch,
+                nextPitch
+            )
+
+            prevAmp = nextAmp;
+            prevPitch = nextPitch;
+            prevTime = timePoints[i];
+        }
+        addNote(
+            out,
+            timePoints.length * 12,
+            10,
+            prevAmp,
+            0,
+            instrument.waveform,
+            prevPitch,
+            prevPitch
+        )
+        return out;
+    }
+
+    export function renderDrumInstrument(sound: pxt.assets.music.DrumInstrument, volume: number) {
+        let prevAmp = sound.startVolume;
+        let prevFreq = sound.startFrequency;
+
+        const scaleVolume = (value: number) => (value / 1024) * volume;
+
+        let out = new Uint8Array((sound.steps.length + 1) * BUFFER_SIZE);
+
+        for (let i = 0; i < sound.steps.length; i++) {
+            addNote(
+                out,
+                i * BUFFER_SIZE,
+                sound.steps[i].duration,
+                scaleVolume(prevAmp),
+                scaleVolume(sound.steps[i].volume),
+                sound.steps[i].waveform,
+                prevFreq,
+                sound.steps[i].frequency
+            );
+            prevAmp = sound.steps[i].volume;
+            prevFreq = sound.steps[i].frequency
+        }
+
+        addNote(
+            out,
+            sound.steps.length * BUFFER_SIZE,
+            10,
+            scaleVolume(prevAmp),
+            0,
+            sound.steps[sound.steps.length - 1].waveform,
+            prevFreq,
+            prevFreq
+        );
+
+        return out;
+    }
+
+    function instrumentPitchAtTime(instrument: pxt.assets.music.Instrument, noteFrequency: number, gateLength: number, time: number) {
+        let mod = 0;
+        if (instrument.pitchEnvelope?.amplitude) {
+            mod += envelopeValueAtTime(instrument.pitchEnvelope, time, gateLength)
+        }
+        if (instrument.pitchLFO?.amplitude) {
+            mod += lfoValueAtTime(instrument.pitchLFO, time)
+        }
+        return Math.max(noteFrequency + mod, 0);
+    }
+
+    function instrumentVolumeAtTime(instrument: pxt.assets.music.Instrument, gateLength: number, time: number, maxVolume: number) {
+        let mod = 0;
+        if (instrument.ampEnvelope.amplitude) {
+            mod += envelopeValueAtTime(instrument.ampEnvelope, time, gateLength)
+        }
+        if (instrument.ampLFO?.amplitude) {
+            mod += lfoValueAtTime(instrument.ampLFO, time)
+        }
+        return ((Math.max(Math.min(mod, instrument.ampEnvelope.amplitude), 0) / 1024) * maxVolume) | 0;
+    }
+
+    function envelopeValueAtTime(envelope: pxt.assets.music.Envelope, time: number, gateLength: number) {
+        const adjustedSustain = (envelope.sustain / 1024) * envelope.amplitude;
+
+        if (time > gateLength) {
+            if (time - gateLength > envelope.release) return 0;
+
+            else if (time < envelope.attack) {
+                const height = (envelope.amplitude / envelope.attack) * gateLength;
+                return height - ((height / envelope.release) * (time - gateLength))
+            }
+            else if (time < envelope.attack + envelope.decay) {
+                const height2 = envelope.amplitude - ((envelope.amplitude - adjustedSustain) / envelope.decay) * (gateLength - envelope.attack);
+                return height2 - ((height2 / envelope.release) * (time - gateLength))
+            }
+            else {
+                return adjustedSustain - (adjustedSustain / envelope.release) * (time - gateLength)
+            }
+        }
+        else if (time < envelope.attack) {
+            return (envelope.amplitude / envelope.attack) * time
+        }
+        else if (time < envelope.attack + envelope.decay) {
+            return envelope.amplitude - ((envelope.amplitude - adjustedSustain) / envelope.decay) * (time - envelope.attack)
+        }
+        else {
+            return adjustedSustain;
+        }
+    }
+
+    function lfoValueAtTime(lfo: pxt.assets.music.LFO, time: number) {
+        return Math.cos(((time / 1000) * lfo.frequency) * 2 * Math.PI) * lfo.amplitude
+    }
+
+    function addNote(sndInstr: Uint8Array, sndInstrPtr: number, ms: number, beg: number, end: number, soundWave: number, hz: number, endHz: number) {
+        if (ms > 0) {
+            sndInstr[sndInstrPtr] = soundWave;
+            sndInstr[sndInstrPtr + 1] = 0;
+            set16BitNumber(sndInstr, sndInstrPtr + 2, hz)
+            set16BitNumber(sndInstr, sndInstrPtr + 4, ms)
+            set16BitNumber(sndInstr, sndInstrPtr + 6, (beg * 255) >> 6)
+            set16BitNumber(sndInstr, sndInstrPtr + 8, (end * 255) >> 6)
+            set16BitNumber(sndInstr, sndInstrPtr + 10, endHz);
+            sndInstrPtr += BUFFER_SIZE;
+        }
+        sndInstr[sndInstrPtr] = 0;
+        return sndInstrPtr
+    }
+
+    function set16BitNumber(buf: Uint8Array, offset: number, value: number) {
+        const temp = new Uint8Array(2);
+        new Uint16Array(temp.buffer)[0] = value | 0;
+        buf[offset] = temp[0];
+        buf[offset + 1] = temp[1];
+    }
+
+    function get16BitNumber(buf: Uint8Array, offset: number) {
+        const temp = new Uint8Array(2);
+        temp[0] = buf[offset];
+        temp[1] = buf[offset + 1];
+
+        return new Uint16Array(temp.buffer)[0];
+    }
+
+    export function decodeSong(buf: Uint8Array) {
+        const res: pxt.assets.music.Song = {
+            beatsPerMinute: get16BitNumber(buf, 1),
+            beatsPerMeasure: buf[3],
+            ticksPerBeat: buf[4],
+            measures: buf[5],
+            tracks: []
+        };
+
+        let current = 7;
+
+        while (current < buf.length) {
+            const [track, pointer] = decodeTrack(buf, current);
+            current = pointer;
+            res.tracks.push(track);
+        }
+
+        return res;
+    }
+
+    function decodeInstrument(buf: Uint8Array, offset: number): pxt.assets.music.Instrument {
+        return {
+            waveform: buf[offset],
+            ampEnvelope: {
+                attack: get16BitNumber(buf, offset + 1),
+                decay: get16BitNumber(buf, offset + 3),
+                sustain: get16BitNumber(buf, offset + 5),
+                release: get16BitNumber(buf, offset + 7),
+                amplitude: get16BitNumber(buf, offset + 9),
+            },
+            pitchEnvelope: {
+                attack: get16BitNumber(buf, offset + 11),
+                decay: get16BitNumber(buf, offset + 13),
+                sustain: get16BitNumber(buf, offset + 15),
+                release: get16BitNumber(buf, offset + 17),
+                amplitude: get16BitNumber(buf, offset + 19),
+            },
+            ampLFO: {
+                frequency: buf[offset + 21],
+                amplitude: get16BitNumber(buf, 22)
+            },
+            pitchLFO: {
+                frequency: buf[offset + 24],
+                amplitude: get16BitNumber(buf, 25)
+            },
+            octave: buf[offset + 27]
+        }
+    }
+
+    function decodeTrack(buf: Uint8Array, offset: number): [pxt.assets.music.Track, number] {
+        if (buf[offset + 1]) {
+            return decodeDrumTrack(buf, offset);
+        }
+
+        return decodeMelodicTrack(buf, offset);
+    }
+
+    function decodeDrumInstrument(buf: Uint8Array, offset: number): pxt.assets.music.DrumInstrument {
+        const res: pxt.assets.music.DrumInstrument = {
+            startFrequency: get16BitNumber(buf, offset + 1),
+            startVolume: get16BitNumber(buf, offset + 3),
+            steps: []
+        };
+
+        for (let i = 0; i < buf[offset]; i++) {
+            const start = offset + 5 + i * 7;
+            res.steps.push({
+                waveform: buf[start],
+                frequency: get16BitNumber(buf, start + 1),
+                volume: get16BitNumber(buf, start + 3),
+                duration: get16BitNumber(buf, start + 5)
+            })
+        }
+
+        return res;
+    }
+
+    function decodeNoteEvent(buf: Uint8Array, offset: number, instrumentOctave: number, isDrumTrack: boolean): pxt.assets.music.NoteEvent {
+        const res: pxt.assets.music.NoteEvent = {
+            startTick: get16BitNumber(buf, offset),
+            endTick: get16BitNumber(buf, offset + 2),
+            notes: []
+        };
+
+        for (let i = 0; i < buf[offset + 4]; i++) {
+            res.notes.push(decodeNote(buf[offset + 5 + i], instrumentOctave, isDrumTrack));
+        }
+        return res;
+    }
+
+    function decodeNote(note: number, instrumentOctave: number, isDrumTrack: boolean) {
+        const flags = note >> 6;
+
+        const result: pxt.assets.music.Note = {
+            note: isDrumTrack ? note : ((note & 0x3f) + (instrumentOctave - 2) * 12),
+            enharmonicSpelling: "normal"
+        }
+
+        if (flags === 1) {
+            result.enharmonicSpelling = "flat";
+        }
+        else if (flags === 2) {
+            result.enharmonicSpelling = "sharp";
+        }
+
+        return result;
+    }
+
+    function decodeMelodicTrack(buf: Uint8Array, offset: number): [pxt.assets.music.Track, number] {
+        const res: pxt.assets.music.Track = {
+            id: buf[offset],
+            instrument: decodeInstrument(buf, offset + 4),
+            notes: []
+        };
+
+        const noteStart = offset + 4 + get16BitNumber(buf, offset + 2);
+        const noteLength = get16BitNumber(buf, noteStart);
+
+        let currentOffset = noteStart + 2;
+
+        while (currentOffset < noteStart + 2 + noteLength) {
+            res.notes.push(decodeNoteEvent(buf, currentOffset, res.instrument.octave, false));
+            currentOffset += 5 + res.notes[res.notes.length - 1].notes.length
+        }
+
+        return [res, currentOffset];
+    }
+
+    function decodeDrumTrack(buf: Uint8Array, offset: number): [pxt.assets.music.Track, number] {
+        const res: pxt.assets.music.Track = {
+            id: buf[offset],
+            instrument: { ampEnvelope: { attack: 0, decay: 0, sustain: 0, release: 0, amplitude: 0 }, waveform: 0 },
+            notes: [],
+            drums: []
+        };
+
+        const drumByteLength = get16BitNumber(buf, offset + 2);
+        let currentOffset = offset + 4;
+
+        while (currentOffset < offset + 4 + drumByteLength) {
+            res.drums.push(decodeDrumInstrument(buf, currentOffset));
+            currentOffset += 5 + 7 * res.drums[res.drums.length - 1].steps.length;
+        }
+
+        const noteLength = get16BitNumber(buf, currentOffset);
+        currentOffset += 2;
+
+        while (currentOffset < offset + 4 + drumByteLength + noteLength) {
+            res.notes.push(decodeNoteEvent(buf, currentOffset, 0, true));
+            currentOffset += 5 + res.notes[res.notes.length - 1].notes.length
+        }
+
+        return [res, currentOffset];
+    }
+}

--- a/webapp/src/components/musicEditor/MusicEditor.tsx
+++ b/webapp/src/components/musicEditor/MusicEditor.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { EditControls } from "./EditControls";
 import { CursorState, handleKeyboardEvent } from "./keyboardNavigation";
-import { isPlaying, playDrumAsync, playNoteAsync, tickToMs, updatePlaybackSongAsync, stopPlayback } from "./playback";
+import { isPlaying, updatePlaybackSongAsync, stopPlayback } from "./playback";
 import { PlaybackControls } from "./PlaybackControls";
 import { ScrollableWorkspace } from "./ScrollableWorkspace";
 import { GridResolution, TrackSelector } from "./TrackSelector";
@@ -247,7 +247,7 @@ export const MusicEditor = (props: MusicEditorProps) => {
                     true
                 );
 
-                playNoteAsync(newNote.note, instrument, tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, clickedEvent.endTick - clickedEvent.startTick))
+                pxsim.music.playNoteAsync(newNote.note, instrument, pxsim.music.tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, clickedEvent.endTick - clickedEvent.startTick))
             }
             else {
                 updateSong(
@@ -268,10 +268,10 @@ export const MusicEditor = (props: MusicEditorProps) => {
             updateSong(unselectAllNotes(addNoteToTrack(currentSong, selectedTrack, note, coord.tick, coord.tick + noteLength)), true)
 
             if (isDrumTrack) {
-                playDrumAsync(track.drums[note.note]);
+                pxsim.music.playDrumAsync(track.drums[note.note]);
             }
             else {
-                playNoteAsync(note.note, instrument, tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, gridTicks))
+                pxsim.music.playNoteAsync(note.note, instrument, pxsim.music.tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, gridTicks))
             }
         }
         else {
@@ -481,10 +481,10 @@ export const MusicEditor = (props: MusicEditorProps) => {
         const t = currentSong.tracks[newTrack];
 
         if (t.drums) {
-            playDrumAsync(t.drums[0]);
+            pxsim.music.playDrumAsync(t.drums[0]);
         }
         else {
-            playNoteAsync(rowToNote(t.instrument.octave, 6, false, !!t.drums).note, t.instrument, tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, currentSong.ticksPerBeat / 2));
+            pxsim.music.playNoteAsync(rowToNote(t.instrument.octave, 6, false, !!t.drums).note, t.instrument, pxsim.music.tickToMs(currentSong.beatsPerMinute, currentSong.ticksPerBeat, currentSong.ticksPerBeat / 2));
         }
         setSelectedTrack(newTrack);
         if (cursor) setCursor({ ...cursor, track: newTrack });

--- a/webapp/src/components/musicEditor/Staff.tsx
+++ b/webapp/src/components/musicEditor/Staff.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { classList } from "../../../../react-common/components/util";
-import { addPlaybackStateListener, addTickListener, removePlaybackStateListener, removeTickListener, tickToMs } from "./playback";
+import { addPlaybackStateListener, addTickListener, removePlaybackStateListener, removeTickListener } from "./playback";
 import { BASS_CLEF_HEIGHT, BASS_CLEF_TOP, beatToX, CLEF_HEIGHT, CLEF_WIDTH, rowY, STAFF_END_WIDTH, STAFF_GRID_TICK_HEIGHT, STAFF_HEADER_FONT_SIZE, STAFF_HEADER_HEIGHT, STAFF_HEADER_OFFSET, tickToX, workspaceWidth, WORKSPACE_HEIGHT } from "./svgConstants";
 import { resolveImageURL } from "./utils";
 
@@ -16,7 +16,7 @@ export const Staff = (props: StaffProps) => {
     let playbackHead: SVGGElement;
 
     React.useEffect(() => {
-        const tickTime = tickToMs(beatsPerMinute, ticksPerBeat, 1);
+        const tickTime = pxsim.music.tickToMs(beatsPerMinute, ticksPerBeat, 1);
         const tickDistance = tickToX(ticksPerBeat, 2) - tickToX(ticksPerBeat, 1);
         let playbackHeadPosition = 0;
         let isPlaying = false;

--- a/webapp/src/components/musicEditor/keyboardNavigation.ts
+++ b/webapp/src/components/musicEditor/keyboardNavigation.ts
@@ -1,4 +1,4 @@
-import { isPlaying, playNoteAsync, startPlaybackAsync, stopPlayback, tickToMs } from "./playback";
+import { isPlaying, startPlaybackAsync, stopPlayback } from "./playback";
 import { addNoteToTrack, applySelection, deleteSelectedNotes, editNoteEventLength, findNextNoteEvent, findNoteEventAtTick, findPreviousNoteEvent, findSelectedRange, isBassClefNote, moveSelectedNotes, noteToRow, removeNoteAtRowFromTrack, removeNoteEventFromTrack, removeNoteFromTrack, rowToNote, selectNoteEventsInRange, unselectAllNotes } from "./utils";
 
 /**
@@ -121,7 +121,7 @@ export function handleKeyboardEvent(song: pxt.assets.music.Song, cursor: CursorS
 
     const playNoteEvent = (ev: pxt.assets.music.NoteEvent) => {
         for (const note of ev.notes) {
-            playNoteAsync(note.note, instrument, tickToMs(editedSong.beatsPerMinute, song.ticksPerBeat, ev.endTick - ev.startTick));
+            pxsim.music.playNoteAsync(note.note, instrument, pxsim.music.tickToMs(editedSong.beatsPerMinute, song.ticksPerBeat, ev.endTick - ev.startTick));
         }
     }
 
@@ -184,7 +184,7 @@ export function handleKeyboardEvent(song: pxt.assets.music.Song, cursor: CursorS
                 const newEvent = findNoteEventAtTick(editedSong, cursor.track, cursor.tick);
                 editedCursor.noteGroupIndex = newEvent.notes.findIndex(n => n.note === newNote.note);
 
-                playNoteAsync(newNote.note, instrument, tickToMs(editedSong.beatsPerMinute, song.ticksPerBeat, newEvent.endTick - newEvent.startTick));
+                pxsim.music.playNoteAsync(newNote.note, instrument, pxsim.music.tickToMs(editedSong.beatsPerMinute, song.ticksPerBeat, newEvent.endTick - newEvent.startTick));
             }
             break;
 
@@ -248,7 +248,7 @@ export function handleKeyboardEvent(song: pxt.assets.music.Song, cursor: CursorS
                 const newEvent = findNoteEventAtTick(editedSong, cursor.track, cursor.tick);
                 editedCursor.noteGroupIndex = newEvent.notes.findIndex(n => n.note === newNote.note);
 
-                playNoteAsync(newNote.note, instrument, tickToMs(editedSong.beatsPerMinute, song.ticksPerBeat, newEvent.endTick - newEvent.startTick));            }
+                pxsim.music.playNoteAsync(newNote.note, instrument, pxsim.music.tickToMs(editedSong.beatsPerMinute, song.ticksPerBeat, newEvent.endTick - newEvent.startTick));            }
             break;
 
         case "ArrowLeft":
@@ -423,7 +423,7 @@ export function handleKeyboardEvent(song: pxt.assets.music.Song, cursor: CursorS
                     noteEventAtCursor.endTick
                 );
 
-                playNoteAsync(newNote.note, instrument, tickToMs(editedSong.beatsPerMinute, editedSong.ticksPerBeat, cursor.gridTicks));
+                pxsim.music.playNoteAsync(newNote.note, instrument, pxsim.music.tickToMs(editedSong.beatsPerMinute, editedSong.ticksPerBeat, cursor.gridTicks));
             }
             break;
         default:

--- a/webapp/src/components/musicEditor/playback.ts
+++ b/webapp/src/components/musicEditor/playback.ts
@@ -1,186 +1,46 @@
-import { CancellationToken } from "../soundEffectEditor/SoundEffectEditor";
-
-let metronomeWorker: Worker;
-let metronomeLoadPromise: Promise<Worker>;
-
-let currentPlaybackState: PlaybackState;
-
-interface PlaybackState {
-    song: pxt.assets.music.Song;
-    tick: number;
-    cancellationToken: CancellationToken;
-    looping: boolean;
-}
-
+let sequencer: pxsim.music.Sequencer;
 let playbackStateListeners: ((state: "play" | "loop" | "stop") => void)[] = [];
 let onTickListeners: ((tick: number) => void)[] = [];
 
-
-const frequencies = [31, 33, 35, 37, 39, 41, 44, 46, 49, 52, 55, 58, 62, 65, 69, 73,
-    78, 82, 87, 92, 98, 104, 110, 117, 123, 131, 139, 147, 156, 165, 175, 185, 196, 208,
-    220, 233, 247, 262, 277, 294, 311, 330, 349, 370, 392, 415, 440, 466, 494, 523, 554,
-    587, 622, 659, 698, 740, 784, 831, 880, 932, 988, 1047, 1109, 1175, 1245, 1319, 1397,
-    1480, 1568, 1661, 1760, 1865, 1976, 2093, 2217, 2349, 2489, 2637, 2794, 2960, 3136,
-    3322, 3520, 3729, 3951, 4186, 4435, 4699, 4978, 5274, 5588, 5920, 6272, 6645, 7040,
-    7459, 7902];
-
-
-export async function playNoteAsync(note: number, instrument: pxt.assets.music.Instrument, time: number, isCancelled?: () => boolean) {
-    await pxsim.AudioContextManager.playInstructionsAsync(
-        pxt.assets.music.renderInstrument(instrument, frequencies[note], time, 100),
-        isCancelled
-    )
-}
-
-export async function playDrumAsync(drum: pxt.assets.music.DrumInstrument, isCancelled?: () => boolean) {
-    await pxsim.AudioContextManager.playInstructionsAsync(
-        pxt.assets.music.renderDrumInstrument(drum, 100),
-        isCancelled
-    )
-}
-
-async function loadMetronomeAsync() {
-    if (metronomeLoadPromise) return metronomeLoadPromise;
-    if (metronomeWorker) return metronomeWorker;
-
-    metronomeLoadPromise = new Promise(resolve => {
-        metronomeWorker = new Worker("data:application/javascript," + encodeURIComponent(workerJS));
-
-        const readyHandler = (ev: MessageEvent) => {
-            if (ev.data === "ready") {
-                resolve(metronomeWorker);
-                metronomeWorker.removeEventListener("message", readyHandler);
-            }
-        }
-
-        metronomeWorker.addEventListener("message", readyHandler);
-    })
-
-    return metronomeLoadPromise;
-}
-
 export async function startPlaybackAsync(song: pxt.assets.music.Song, loop: boolean) {
-    const playbackState: PlaybackState = {
-        song,
-        looping: loop,
-        cancellationToken: {
-            cancelled: false
-        },
-        tick: 0
-    }
+    if (!sequencer) {
+        sequencer = new pxsim.music.Sequencer();
+        await sequencer.initAsync();
 
-    if (currentPlaybackState) currentPlaybackState.cancellationToken.cancelled = true;
-    currentPlaybackState = playbackState;
-
-    const metronome = await loadMetronomeAsync();
-
-    let currentTick = 0;
-
-    const isCancelled = () => playbackState.cancellationToken.cancelled;
-
-    const postMessage = (message: MetronomeMessage) => {
-        metronome.postMessage(message);
-    }
-
-    const onStop = () => {
-        metronome.removeEventListener("message", onTick);
-        playbackState.cancellationToken.cancelled = true;
-
-        if (!isPlaying()) {
-            postMessage({
-                type: "stop"
-            });
-
+        sequencer.addEventListener("state-change", () => {
             for (const listener of playbackStateListeners) {
-                listener("stop");
+                listener(sequencer.state());
             }
-        }
+        });
+
+        sequencer.addEventListener("tick", () => {
+            for (const listener of onTickListeners) {
+                listener(sequencer.currentTick());
+            }
+        });
     }
 
-    const onTick = (ev: MessageEvent) => {
-        if (ev.data !== "tick") return;
-
-        if (isCancelled()) {
-            onStop();
-            return;
-        }
-
-        for (const track of playbackState.song.tracks) {
-            for (const noteEvent of track.notes) {
-                if (noteEvent.startTick === currentTick) {
-                    for (const note of noteEvent.notes) {
-                        if (track.drums) {
-                            playDrumAsync(track.drums[note.note], isCancelled);
-                        }
-                        else {
-                            playNoteAsync(note.note, track.instrument, tickToMs(playbackState.song.beatsPerMinute, playbackState.song.ticksPerBeat, noteEvent.endTick - noteEvent.startTick), isCancelled);
-                        }
-                    }
-                }
-                else if (noteEvent.startTick > currentTick) {
-                    break;
-                }
-            }
-        }
-
-        for (const listener of onTickListeners) {
-            listener(currentTick);
-        }
-
-        currentTick ++;
-
-        if (currentTick >= playbackState.song.ticksPerBeat * playbackState.song.beatsPerMeasure * playbackState.song.measures) {
-            if (!playbackState.looping) {
-                onStop();
-            }
-            else {
-                currentTick = 0;
-            }
-        }
-    }
-
-    postMessage({
-        type: "start",
-        interval: tickToMs(playbackState.song.beatsPerMinute, playbackState.song.ticksPerBeat, 1)
-    })
-    metronome.addEventListener("message", onTick);
-
-    for (const listener of playbackStateListeners) {
-        listener(loop ? "loop" : "play");
-    }
-}
-
-export function tickToMs(beatsPerMinute: number, ticksPerBeat: number, ticks: number) {
-    return ((60000 / beatsPerMinute) / ticksPerBeat) * ticks;
+    sequencer.start(song, loop);
 }
 
 export function isPlaying() {
-    return currentPlaybackState ? !currentPlaybackState.cancellationToken.cancelled : false;
+    return sequencer ? sequencer.state() !== "stop" : false;
 }
 
 export function isLooping() {
-    return isPlaying() && currentPlaybackState.looping;
+    return isPlaying() && sequencer.state() === "loop";
 }
 
 export function setLooping(loop: boolean) {
-    if (currentPlaybackState) currentPlaybackState.looping = loop;
+    if (sequencer) sequencer.setLooping(loop);
 }
 
 export async function updatePlaybackSongAsync(song: pxt.assets.music.Song) {
-    if (!isPlaying()) return;
-
-    if (currentPlaybackState.song.beatsPerMinute !== song.beatsPerMinute) {
-        const metronome = await loadMetronomeAsync();
-        metronome.postMessage({
-            type: "set-interval",
-            interval: tickToMs(song.beatsPerMinute, song.ticksPerBeat, 1)
-        })
-    }
-    currentPlaybackState.song = song;
+    if (sequencer) sequencer.updateSong(song);
 }
 
 export function stopPlayback() {
-    if (currentPlaybackState) currentPlaybackState.cancellationToken.cancelled = true;
+    if (sequencer) sequencer.stop();
 }
 
 export function addTickListener(listener: (tick: number) => void) {
@@ -198,41 +58,3 @@ export function addPlaybackStateListener(listener: (state: "play" | "stop" | "lo
 export function removePlaybackStateListener(listener: (state: "play" | "stop" | "loop") => void) {
     playbackStateListeners = playbackStateListeners.filter(l => listener !== l);
 }
-
-const workerJS = `
-/**
- * Adpated from https://github.com/cwilso/metronome/
- */
-
-let timerRef;
-let interval;
-
-addEventListener("message", ev => {
-    const message = ev.data;
-
-    if (message.type === "start") {
-        updateInterval(message.interval, true);
-    }
-    else if (message.type === "stop") {
-        clearInterval(timerRef);
-        timerRef = undefined;
-    }
-    else if (message.type === "set-interval") {
-        updateInterval(message.interval, false);
-    }
-})
-
-postMessage("ready");
-
-function updateInterval(interval, startIfStopped) {
-    if (timerRef) {
-        clearInterval(timerRef);
-        startIfStopped = true;
-    }
-    interval = interval;
-
-    if (startIfStopped) {
-        timerRef = setInterval(() => postMessage("tick"), interval);
-    }
-}
-`;

--- a/webapp/src/components/musicEditor/playback.ts
+++ b/webapp/src/components/musicEditor/playback.ts
@@ -18,6 +18,7 @@ export async function startPlaybackAsync(song: pxt.assets.music.Song, loop: bool
                 listener(sequencer.currentTick());
             }
         });
+        sequencer.setVolume(100);
     }
 
     sequencer.start(song, loop);


### PR DESCRIPTION
This moves the song sequencer into pxsim and cleans up the code a bit. I'm doing this so that I can improve playback in the sim; right now the timing in the game is *not great*. I will have a corresponding pr in pxt-common-packages that supports this in the browser sim.

As a bonus, I also added support for setting the volume for each track/drum sound. I haven't surfaced this anywhere yet but I have nefarious plans.

This PR looks scarier than it is; it is mostly just moving code around.