### PR TITLE
fix arrays inline snippets

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -431,7 +431,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                         color = pxt.toolbox.getNamespaceColor(ns);
                     } else if (/^arrays?$/i.test(ns)) {
                         ns = "arrays";
-                        color = pxt.toolbox.getNamespaceColor(ns)
+                        color = pxt.toolbox.getNamespaceColor(ns);
                     } else if (bi?.kind !== pxtc.SymbolKind.Module){
                         continue;
                     }

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -436,7 +436,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                         continue;
                     }
 
-                    const isAdvanced = bi?.attributes?.advanced;
+                    const isAdvanced = bi?.attributes?.advanced || ns === "arrays";
                     inlineBlock.classList.add("clickable");
                     inlineBlock.tabIndex = 0;
                     inlineBlock.ariaLabel = lf("Toggle the {0} category", ns);

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -429,6 +429,9 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     } else if (/^variables?$/i.test(ns)) {
                         ns = "variables";
                         color = pxt.toolbox.getNamespaceColor(ns);
+                    } else if (/^arrays?$/i.test(ns)) {
+                        ns = "arrays";
+                        color = pxt.toolbox.getNamespaceColor(ns)
                     } else if (bi?.kind !== pxtc.SymbolKind.Module){
                         continue;
                     }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/5671

For reference, the issue is that the namespace in ts is `Array` but in blocks we've always used `Arrays` -- so it's one of the special cased ones in the first place so the namespace opening logic didn't work with either (if you did array it'd get wrong color & wouldn't be able to open the category as the name didn't match, if you did arrays you'd get right color but we wouldn't see it as a namespace)

probably should port this. I put up an uploadtrg to test it real quick https://arcade.makecode.com/app/78fa5169e463d537c5233eda10a1bcf8597ee579-09f260dd5e--skillmap?debugCompleted=1#space