### PR TITLE
make it so stringify minifies json for prod

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -412,6 +412,8 @@ function ciAsync() {
         fs.writeFileSync(npmrc, cfg)
     }
 
+    process.env["PXT_ENV"] = "production";
+
     const latest = branch == "master" ? "latest" : "git-" + branch
     // upload locs on build on master
     const masterOrReleaseBranchRx = /^(master|v\d+\.\d+\.\d+)$/;


### PR DESCRIPTION
we had some logic to minify json for prod environments but we must have stopped setting the 'production' env flag in our builds at some point (probably when we moved to github actions, because it's only relevant exactly for minifying js?). Anyway, this is the only place this field is actually read: https://github.com/microsoft/pxt/blob/minifyTargetJson/cli/nodeutil.ts#L619, which says to minify json produced in our build (e.g. `target.js` and `target.json`). So setting this at the beginning of ci should cut off about 3mb of arcade's target.js/json (~~ 11mb -> 8mb) (which are the same things besides target.js setting it to a variable), which brings the gzipped size down from ~2.1mb to 1.9mb when I did a quick check. 

It's worth noting target.js(on)? is super required / part of the initial loading path of (pretty much if not) every page we publish, as it's `pxt.appTarget`, so it's nice to trim as much as possible. Here's the current released sites page as an example:

https://pxt.azureedge.net/blob/5a1b7d9132662a8fa68ab262e66d6ea113fe6730/target.js