### PR TITLE
Focus image canvas and support ctrl-s in asset page

### DIFF
--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -164,8 +164,15 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
         })
     }
 
+    handleKeydown = (e: KeyboardEvent) => {
+        if (e.ctrlKey && (e.key === "s" || e.key === "S")) {
+            this.callbackOnDoneClick();
+        }
+    }
+
     componentDidMount() {
         window.addEventListener("message", this.handleMessage, null);
+        window.addEventListener("keydown", this.handleKeydown, null);
         this.sendEvent({
             type: "event",
             kind: "ready"
@@ -175,6 +182,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
 
     componentWillUnmount() {
         window.removeEventListener("message", this.handleMessage, null);
+        window.removeEventListener("keydown", this.handleKeydown, null);
     }
 
     callbackOnDoneClick = () => {

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -94,7 +94,7 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
         const isPortrait = !imageState || (imageState.bitmap.height > imageState.bitmap.width);
         const showResizeHandles = !this.props.isTilemap && this.props.tool == ImageEditorTool.Marquee;
 
-        return <div ref="canvas-bounds" className={`image-editor-canvas ${isPortrait ? "portrait" : "landscape"}`} onContextMenu={this.preventContextMenu}>
+        return <div ref="canvas-bounds" className={`image-editor-canvas ${isPortrait ? "portrait" : "landscape"}`} onContextMenu={this.preventContextMenu} tabIndex={0}>
             <div className="paint-container">
                 {!this.props.lightMode && <canvas ref="paint-surface-bg" className="paint-surface" />}
                 <canvas ref="paint-surface" className="paint-surface main" />
@@ -201,9 +201,10 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
         this.hasInteracted = true
         if (this.isPanning()) return;
 
-        if (document.activeElement instanceof HTMLElement) {
+        if (document.activeElement instanceof HTMLElement && document.activeElement !== this.refs["canvas-bounds"]) {
             document.activeElement.blur();
         }
+        (this.refs["canvas-bounds"] as HTMLDivElement).focus();
 
         if (this.isColorSelect()) {
             this.selectCanvasColor(coord, isRightClick);


### PR DESCRIPTION
I would not be surprised if this change fixes all of our "blockly is swallowing our keyboard events" bugs for the image/tilemap/animation editor.

This PR does 2 things:
1. Makes the image canvas focusable
2. In the --asseteditor page, map ctrl+s to the same callback as the done button