### PR TITLE
Email checkbox on profile page now a set size

### DIFF
--- a/react-common/styles/controls/Checkbox.less
+++ b/react-common/styles/controls/Checkbox.less
@@ -1,6 +1,6 @@
 .common-checkbox {
     position: relative;
-    padding: 0.25rem;
+    // padding: 0.25rem;
 
     display: flex;
     align-items: center;
@@ -14,6 +14,10 @@
 .common-checkbox:focus-within {
     outline: @checkboxFocusOutline;
     border-radius: 0.2em;
+}
+
+#profile-email-checkbox {
+    width: 2rem;
 }
 
 /****************************************************

--- a/react-common/styles/controls/Checkbox.less
+++ b/react-common/styles/controls/Checkbox.less
@@ -1,6 +1,6 @@
 .common-checkbox {
     position: relative;
-    // padding: 0.25rem;
+    padding: 0.25rem;
 
     display: flex;
     align-items: center;


### PR DESCRIPTION
The size of the email checkbox would change based on the size of the window. A checkbox like that is so small that it doesn't need to be responsive, so I just set the size to a fixed rem. It will always look the size shown in the picture. 

<img width="305" alt="image" src="https://user-images.githubusercontent.com/49178322/218910096-c266ac74-cc5c-41d0-bc6f-016b5f2b0452.png">


Closes https://github.com/microsoft/pxt-arcade/issues/5687