### PR TITLE
Prevent Mini-Playable Sim from Overlapping Scrollbars

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1721,7 +1721,7 @@ p.ui.font.small {
             width: 10rem;
         }
         .simPanel .simtoolbar {
-            margin: 0.5em 0;
+            margin: 1rem 0;
             width: 3rem;
             float: right;
         }
@@ -1755,6 +1755,7 @@ p.ui.font.small {
         display:inline-block;
         width: 10rem;
         margin-right:0.5rem;
+        margin-bottom: 1rem;
         padding-bottom: 81.96% !important;
     }
     div.simframe:not(:first-child) {
@@ -2067,6 +2068,18 @@ p.ui.font.small {
     }
     #root #editordropdown .menu .item .text {
         display: inline-block!important;
+    }
+
+    #root.miniSim:not(.fullscreensim) {
+        div.simframe {
+            margin-bottom: -0.4rem
+        }
+        
+        &:not(.headless):not(.sandbox) {
+            .simPanel .simtoolbar {
+                margin-bottom: -0.2rem;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Noticed this while touching-up layout for microbit, the mini-playable sim would overlap the scrollbar in desktop mode. Then in mobile and table mode, it was actually a bit far away from them.

## Screenshots

| Scenario | Before Fix  | After Fix |
| ------------- | ------------- | ------------- |
| Desktop Arcade | <img width="257" alt="image" src="https://user-images.githubusercontent.com/69657545/219152245-06382846-911d-4ea8-a911-206611694d8b.png"> | <img width="271" alt="image" src="https://user-images.githubusercontent.com/69657545/219146444-3c698110-be9e-4ee9-aa89-8cda73ea9bee.png">  |
| Desktop Microbit | <img width="260" alt="image" src="https://user-images.githubusercontent.com/69657545/219151428-0b0c32f5-a02c-4747-a04f-9b11d086d79f.png"> | <img width="289" alt="image" src="https://user-images.githubusercontent.com/69657545/219146401-3de07a2f-c0a9-413b-b481-c89e599b22a8.png">  |
| Mobile/Tablet Arcade | <img width="408" alt="image" src="https://user-images.githubusercontent.com/69657545/219152442-c78e6d7f-23b7-4187-b797-238ebd72d5c6.png"> |  <img width="413" alt="image" src="https://user-images.githubusercontent.com/69657545/219146769-f8c82123-54d8-4b37-9e4c-52fdd96095f2.png"> |
| Mobile/Tablet Microbit | <img width="406" alt="image" src="https://user-images.githubusercontent.com/69657545/219151605-8f3c8910-7b05-4daf-ad84-620d9fc02b38.png"> |  <img width="412" alt="image" src="https://user-images.githubusercontent.com/69657545/219146862-cec0337f-fda4-4fa5-9463-e4bde43dc896.png"> |