### PR TITLE
Adjust code validation popup position based on sidebar

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -688,6 +688,15 @@
     }
 }
 
+
+/* <= Small Monitor (Mobile + Tablet + Small Monitor) */
+@media only screen and (max-width: @largestSmallMonitor) {
+    .tutorial-validation-error-container {
+        left: @simulatorWidthSmall + 1rem;
+    }
+}
+
+
 /* <= Tablet (Mobile + Tablet) */
 @media only screen and (max-width: @largestTabletScreen) {
     #root.tabTutorial,

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -563,7 +563,7 @@
     top: unset;
     right: unset;
     bottom: 5.5rem;
-    left: 23rem;
+    left: @simulatorWidth + 1rem;
     max-width: 60%;
     min-width: 18.75rem;
     max-height: 70%;


### PR DESCRIPTION
The sidebar for microbit is larger than the sidebar for arcade. TBD if it should stay that way, but regardless, I think it's better to make the code validation popup position reactive to changes in the sidebar width.

Without change:
<img width="757" alt="image" src="https://user-images.githubusercontent.com/69657545/219462636-b85bca3e-5536-46b2-8ab9-e7030b26de72.png">

With change:
<img width="739" alt="image" src="https://user-images.githubusercontent.com/69657545/219461980-a021a1c4-7767-490a-95a1-ddb7fca223df.png">

