### PR TITLE
auto save assets for vscode ext

### DIFF
--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -226,7 +226,9 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
                 ref={this.refHandler}
                 singleFrame={this.state.editing.type !== "animation"}
                 isMusicEditor={this.state.editing.type === "song"}
-                doneButtonCallback={this.callbackOnDoneClick} />
+                doneButtonCallback={this.callbackOnDoneClick}
+                hideDoneButton={true}
+            />
         }
 
         return <div></div>

--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -73,9 +73,9 @@ interface DuplicateAssetEditorResponse extends BaseAssetEditorResponse {
 
 type AssetEditorResponse = OpenAssetEditorResponse | CreateAssetEditorResponse | SaveAssetEditorResponse | DuplicateAssetEditorResponse;
 
-interface AssetEditorDoneClickedEvent {
+interface AssetEditorRequestSaveEvent {
     type: "event";
-    kind: "done-clicked"
+    kind: "done-clicked";
 }
 
 interface AssetEditorReadyEvent {
@@ -83,8 +83,7 @@ interface AssetEditorReadyEvent {
     kind: "ready";
 }
 
-type AssetEditorEvent = AssetEditorDoneClickedEvent | AssetEditorReadyEvent;
-
+type AssetEditorEvent = AssetEditorRequestSaveEvent | AssetEditorReadyEvent;
 
 export class AssetEditor extends React.Component<{}, AssetEditorState> {
     private editor: ImageFieldEditor<pxt.Asset>;
@@ -166,7 +165,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
 
     handleKeydown = (e: KeyboardEvent) => {
         if (e.ctrlKey && (e.key === "s" || e.key === "S")) {
-            this.callbackOnDoneClick();
+            this.sendSaveRequest();
         }
     }
 
@@ -202,18 +201,18 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
         if (!!prevState?.editing && prevState.editing !== this.state.editing) {
             this.tilemapProject.removeChangeListener(
                 prevState.editing.type,
-                this.callbackOnDoneClick
+                this.sendSaveRequest
             );
         }
         if (this.state?.editing) {
             this.tilemapProject.addChangeListener(
                 this.state.editing,
-                this.callbackOnDoneClick
+                this.sendSaveRequest
             );
         }
     }
 
-    callbackOnDoneClick = () => {
+    sendSaveRequest = () => {
         this.sendEvent({
             type: "event",
             kind: "done-clicked"
@@ -226,7 +225,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
                 ref={this.refHandler}
                 singleFrame={this.state.editing.type !== "animation"}
                 isMusicEditor={this.state.editing.type === "song"}
-                doneButtonCallback={this.callbackOnDoneClick}
+                doneButtonCallback={this.sendSaveRequest}
                 hideDoneButton={true}
             />
         }

--- a/webapp/src/components/ImageEditor/BottomBar.tsx
+++ b/webapp/src/components/ImageEditor/BottomBar.tsx
@@ -32,6 +32,7 @@ export interface BottomBarProps {
     isTilemap?: boolean;
 
     onDoneClick?: () => void;
+    hideDoneButton?: boolean;
 }
 
 export interface BottomBarState {
@@ -64,7 +65,8 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
             resizeDisabled,
             singleFrame,
             onDoneClick,
-            assetName
+            assetName,
+            hideDoneButton
         } = this.props;
 
         const { assetNameMessage } = this.state;
@@ -164,14 +166,14 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
                         toggle={true}
                     />
                 </div>
-                <div role="button"
+                {!hideDoneButton && <div role="button"
                     className={`image-editor-confirm`}
                     title={lf("Done")}
                     tabIndex={0}
                     onClick={onDoneClick}
                     onKeyDown={fireClickOnlyOnEnter}>
                         {lf("Done")}
-                </div>
+                </div>}
             </div>
         );
     }

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -35,6 +35,7 @@ export interface ImageEditorProps {
     onTileEditorOpenClose?: (open: boolean) => void;
     nested?: boolean;
     lightMode?: boolean;
+    hideDoneButton?: boolean;
 }
 
 export interface ImageEditorState {
@@ -74,7 +75,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
     }
 
     render(): JSX.Element {
-        const { singleFrame, lightMode } = this.props;
+        const { singleFrame, lightMode, hideDoneButton } = this.props;
         const instanceStore = this.getStore();
 
         const { tileToEdit, editingTile, alert } = this.state;
@@ -90,7 +91,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
                         <ImageCanvas suppressShortcuts={editingTile} lightMode={lightMode} />
                         {isAnimationEditor && !singleFrame ? <Timeline /> : undefined}
                     </div>
-                    <BottomBar singleFrame={singleFrame} onDoneClick={this.onDoneClick} />
+                    <BottomBar singleFrame={singleFrame} onDoneClick={this.onDoneClick} hideDoneButton={!!hideDoneButton} />
                     {alert && alert.title && <Alert title={alert.title} text={alert.text} options={alert.options} />}
                 </div>
             </Provider>

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -16,6 +16,7 @@ export interface ImageFieldEditorProps {
     singleFrame: boolean;
     isMusicEditor?: boolean;
     doneButtonCallback?: () => void;
+    hideDoneButton?: boolean;
 }
 
 interface ToggleOption extends BasicEditorToggleItem {
@@ -170,14 +171,16 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                     {this.props.isMusicEditor ?
                         <MusicFieldEditor
                             ref="image-editor"
-                            onDoneClicked={this.onDoneClick} /> :
+                            onDoneClicked={this.onDoneClick}
+                            hideDoneButton={this.props.hideDoneButton} /> :
                         <ImageEditor
                             ref="image-editor"
                             singleFrame={this.props.singleFrame}
                             onDoneClicked={this.onDoneClick}
                             onTileEditorOpenClose={this.onTileEditorOpenClose}
                             lightMode={this.lightMode}
-                            />
+                            hideDoneButton={this.props.hideDoneButton}
+                        />
                     }
                     <ImageEditorGallery
                         items={filteredAssets}

--- a/webapp/src/components/MusicFieldEditor.tsx
+++ b/webapp/src/components/MusicFieldEditor.tsx
@@ -6,6 +6,7 @@ import { MusicEditor } from "./musicEditor/MusicEditor";
 
 interface MusicFieldEditorProps {
     onDoneClicked: () => void;
+    hideDoneButton?: boolean;
 }
 
 interface MusicFieldEditorState {
@@ -34,7 +35,8 @@ export class MusicFieldEditor extends React.Component<MusicFieldEditorProps, Mus
                     onSongChanged={this.onSongChanged}
                     onAssetNameChanged={this.onAssetNameChanged}
                     editRef={this.state.editRef}
-                    onDoneClicked={onDoneClicked} />
+                    onDoneClicked={onDoneClicked}
+                    hideDoneButton={this.props.hideDoneButton} />
             }
         </div>
     }

--- a/webapp/src/components/musicEditor/EditControls.tsx
+++ b/webapp/src/components/musicEditor/EditControls.tsx
@@ -7,10 +7,11 @@ export interface EditControlsProps {
     assetName: string;
     onAssetNameChanged: (newName: string) => void;
     onDoneClicked: () => void;
+    hideDoneButton?: boolean;
 }
 
 export const EditControls = (props: EditControlsProps) => {
-    const { onAssetNameChanged, onDoneClicked, assetName } = props;
+    const { onAssetNameChanged, onDoneClicked, assetName, hideDoneButton } = props;
     const [editName, setEditName] = React.useState<string>();
     const [nameError, setNameError] = React.useState<string>();
 
@@ -54,10 +55,10 @@ export const EditControls = (props: EditControlsProps) => {
             initialValue={assetName || editName}
             onBlur={handleNameEdit}
             onEnterKey={handleNameEdit} />
-        <Button
+        {!hideDoneButton && <Button
             className="green"
             title={lf("Done")}
             label={lf("Done")}
-            onClick={onDoneClicked} />
+            onClick={onDoneClicked} />}
     </div>
 }

--- a/webapp/src/components/musicEditor/MusicEditor.tsx
+++ b/webapp/src/components/musicEditor/MusicEditor.tsx
@@ -14,6 +14,7 @@ export interface MusicEditorProps {
     onAssetNameChanged: (newName: string) => void;
     onDoneClicked: () => void;
     editRef: number;
+    hideDoneButton?: boolean;
 }
 
 interface DragState {
@@ -29,7 +30,7 @@ interface DragState {
 }
 
 export const MusicEditor = (props: MusicEditorProps) => {
-    const { asset, onSongChanged, savedUndoStack, onAssetNameChanged, editRef, onDoneClicked } = props;
+    const { asset, onSongChanged, savedUndoStack, onAssetNameChanged, editRef, onDoneClicked, hideDoneButton} = props;
     const [selectedTrack, setSelectedTrack] = React.useState(0);
     const [gridResolution, setGridResolution] = React.useState<GridResolution>("1/8");
     const [currentSong, setCurrentSong] = React.useState(asset.song);
@@ -592,7 +593,8 @@ export const MusicEditor = (props: MusicEditorProps) => {
         <EditControls
             assetName={asset.meta.displayName}
             onAssetNameChanged={onAssetNameChanged}
-            onDoneClicked={onDoneClicked} />
+            onDoneClicked={onDoneClicked}
+            hideDoneButton={hideDoneButton}/>
     </div>
 }
 


### PR DESCRIPTION
was this about how you'd want this to happen? Instead of a `setInterval` I suppose I add could add a field in the image editor itself to make it happen on each edit that goes in the undo/redo stack but not sure there'd be much difference there in the end.

~(I suppose might be worth renaming the `onDoneClick` now that it's gone from that to 'on done click, ctrl+s clicked, or we noticed it updated')~ cut out done, probably need to look at a throttle on the vscode ext side when saving