### PR TITLE
fix blockly exception when deleting tile referenced by tileset field

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -88,6 +88,12 @@ namespace pxtblockly {
                     editorKind = "tilemap-editor";
                     const project = pxt.react.getTilemapProject();
                     pxt.sprite.addMissingTilemapTilesAndReferences(project, this.asset);
+
+                    for (const tile of getTilesReferencedByTilesets(this.sourceBlock_.workspace)) {
+                        if (this.asset.data.projectReferences.indexOf(tile.id) === -1) {
+                            this.asset.data.projectReferences.push(tile.id);
+                        }
+                    }
                     break;
                 case pxt.AssetType.Song:
                     editorKind = "music-editor";

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -95,6 +95,11 @@ namespace pxtblockly {
                 let tile = this.selectedOption_[2];
                 tile = pxt.react.getTilemapProject().lookupAsset(tile.type, tile.id);
 
+                if (!tile) {
+                    // This shouldn't happen
+                    return super.getValue();
+                }
+
                 return pxt.getTSReferenceForAsset(tile);
             }
             const v = super.getValue();

--- a/pxtblocks/fields/field_utils.ts
+++ b/pxtblocks/fields/field_utils.ts
@@ -332,6 +332,31 @@ namespace pxtblockly {
         return Object.keys(all).map(key => all[key]).filter(t => !!t);
     }
 
+    export function getTilesReferencedByTilesets(workspace: Blockly.Workspace) {
+        let all: pxt.Map<pxt.Tile> = {};
+
+        const project = pxt.react.getTilemapProject();
+
+        const allTiles = getAllBlocksWithTilesets(workspace);
+        for (const tilesetField of allTiles) {
+            const value = tilesetField.ref.getValue();
+            const match = /^\s*assets\s*\.\s*tile\s*`([^`]*)`\s*$/.exec(value);
+
+            if (match) {
+                const tile = project.lookupAssetByName(pxt.AssetType.Tile, match[1]);
+
+                if (tile && !all[tile.id]) {
+                    all[tile.id] = tile;
+                }
+            }
+            else if (!all[value]) {
+                all[value] = project.resolveTile(value);
+            }
+        }
+
+        return Object.keys(all).map(key => all[key]).filter(t => !!t);
+    }
+
     export function getTemporaryAssets(workspace: Blockly.Workspace, type: pxt.AssetType) {
         switch (type) {
             case pxt.AssetType.Image:


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5723

Not sure when this got broken, but for some reason we stopped adding the tiles referenced by tileset blocks to the projectReferences array that we use to prevent deletion.