### PR TITLE
Shift + Enter Searches Backwards in Blockly

### DIFF
--- a/localtypings/pxtblockly.d.ts
+++ b/localtypings/pxtblockly.d.ts
@@ -130,4 +130,6 @@ declare class WorkspaceSearch {
     protected addEvent_(node: Element, name: string, thisObject: Object, func: Function): void;
     open(): void;
     close(): void;
+    previous(): void;
+    next(): void;
 }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -3157,6 +3157,22 @@ namespace pxt.blocks {
             });
         }
 
+        /**
+         * onKeyDown_ is a private method in WorkspaceSearch, overwrite it to allow searching backwards.
+         * https://github.com/microsoft/pxt-arcade/issues/5716
+         */
+        onKeyDown_(e: KeyboardEvent) {
+            if (e.key === 'Escape') {
+                this.close();
+            } else if (e.key === 'Enter') {
+                if (e.shiftKey) {
+                    this.previous();
+                } else {
+                    this.next();
+                }
+            }
+        }
+
         protected highlightSearchGroup_(blocks: Blockly.BlockSvg[]) {
             blocks.forEach((block) => {
                 const blockPath = block.pathObject.svgPath;


### PR DESCRIPTION
Fixes microsoft/pxt-arcade#5716

### Context
Today, we can only search forward in our blockly editor:
![before](https://user-images.githubusercontent.com/4691428/220733680-371cb9ac-6626-49a4-a423-440e750a99d3.gif)

Updating this means diverging slightly from the library we use, [blockly-workspace-search](https://github.com/google/blockly-samples/tree/master/plugins/workspace-search).

### Changes Made
Overwrite the `onKeyDown_` method in `PxtWorkspaceSearch`, use _almost_ the exact same code as the source, call `previous()` when you press enter while holding shift.

Original code:

https://github.com/google/blockly-samples/blob/c190eca57865090d9b6027ae4af7eecf425396e8/plugins/workspace-search/src/WorkspaceSearch.js#L376-L389

**Note:** I did get rid of some code from the original method, but that code path was never hit because `searchOnInput` defaults to true and we never change the value.

# Result
![after](https://user-images.githubusercontent.com/4691428/220733732-6c9fd032-b311-428f-8a4a-922b724d80a7.gif)
