### PR TITLE
allow local projects in dependency check

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -58,6 +58,11 @@ namespace pxt {
                 const packagesConfig = await pxt.packagesConfigAsync()
                 const gitRepo = await pxt.github.repoAsync(repoInfo.fullName, packagesConfig)    // Make sure repo exists and is whitelisted
                 return gitRepo ? await pxt.github.pkgConfigAsync(repoInfo.fullName, repoInfo.tag, packagesConfig) : null
+            } else if (fullVers.startsWith("workspace:")) {
+                // It's a local package
+                const projId = fullVers.slice("workspace:".length);
+                // TODO: Fetch pxt.json from the workspace project
+                return null;
             } else {
                 // If it's not from GH, assume it's a bundled package
                 // TODO: Add logic for shared packages if we enable that
@@ -432,7 +437,7 @@ namespace pxt {
                         });
                     }
                     // Also check for conflicts for all the specified package's dependencies (recursively)
-                    return Object.keys(pkgCfg.dependencies).reduce((soFar, pkgDep) => {
+                    return Object.keys(pkgCfg?.dependencies ?? {}).reduce((soFar, pkgDep) => {
                         return soFar
                             .then(() => this.findConflictsAsync(pkgDep, pkgCfg.dependencies[pkgDep]))
                             .then((childConflicts) => conflicts.push.apply(conflicts, childConflicts));


### PR DESCRIPTION
This bug was making it impossible for me to test multiple local extensions together, so here is a partial fix. It addresses a gap in the logic to check a project's dependencies for conflicts. We need to consider that a dependency might be a local project reference.

This fix is "just enough" to get it working. A more complete solution would require some refactoring to allow for the loading of the local project's dependencies and walking those.

Fixes https://github.com/microsoft/pxt-arcade/issues/5509
