### PR TITLE
Make Tutorial Background Change with Green Screen Mode

### DIFF
--- a/theme/greenscreen.less
+++ b/theme/greenscreen.less
@@ -34,6 +34,10 @@
         box-shadow: none !important;
     }
 
+    .toolbox-title {
+        background-color: @white;
+    }
+
     .monaco-editor .lines-content, .monaco-editor .view-line, .monaco-editor .view-lines {
 
         > span {

--- a/theme/greenscreen.less
+++ b/theme/greenscreen.less
@@ -17,8 +17,9 @@
         background-color: @greenScreenColor !important;
     }
     .videoContainer video {
-        min-width:100%;
-        min-height:100%;
+        max-width:100%;
+        max-height:100%;
+        object-fit: cover;
     }
     .videoContainer video.flipx {
         transform: scaleX(-1);
@@ -26,7 +27,7 @@
 
     #maineditor, #editorSidebar, .blocklyToolboxDiv, svg.blocklySvg,
     .monaco-editor, .monaco-editor .margin, .monaco-editor .monaco-editor-background,
-    .monacoToolboxDiv {
+    .monacoToolboxDiv, #editorSidebar .tab-tutorial.active, .tab-tutorial.tab-content {
         background-image: none !important;
         background-color: transparent !important;
         border: none !important;

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -137,6 +137,11 @@
         }
     }
 
+    .toolbox-title {
+        background-color: @HCbackground;
+        color: @HCtextColor;
+    }
+
     #monacoEditor .monacoDraggableBlock {
         background: none !important;
 
@@ -854,6 +859,8 @@
     /* Tabbed tutorial */
 
     .tab-tutorial.tab-content { background-color: @HCbackground; }
+    .tutorial-content-bkg { background-color: @HCbackground; }
+    .tutorial-step-counter { background-color: @HCbackground; }
     .tutorial-scroll-gradient { display: none; }
     .tutorial-title { color: @HCtextColor; }
 

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -136,6 +136,7 @@ span.blocklyTreeLabel, text.blocklyText {
     padding: .5rem 1rem;
     border-bottom: 2px solid darken(desaturate(@editorToolsBackground, 60%), 10%);
     user-select: none;
+    background-color: @white;
 }
 
 @media only screen and (max-width: @largestMobileScreen) {

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -136,7 +136,6 @@ span.blocklyTreeLabel, text.blocklyText {
     padding: .5rem 1rem;
     border-bottom: 2px solid darken(desaturate(@editorToolsBackground, 60%), 10%);
     user-select: none;
-    background-color: @white;
 }
 
 @media only screen and (max-width: @largestMobileScreen) {

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -636,7 +636,7 @@
 
 /* Desktop Only */
 @media only screen and (min-width: @largestTabletScreen) {
-    #root.tabTutorial:not(.fullscreensim) {
+    #root.tabTutorial:not(.fullscreensim, .greenscreen) {
         #editortools {
             width: calc(100% - @simulatorWidth);
             left: unset;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -34,8 +34,12 @@
 }
 
 .tab-tutorial.tab-content {
-    padding-top: 0.5rem;
     background-color: @white;
+}
+
+.tutorial-content-bkg {
+    background-color: @white;
+    padding: 0.5rem 1rem;
 }
 
 .tutorial-container {
@@ -46,8 +50,7 @@
 
 .tutorial-content {
     flex: 1;
-    padding: 0 1rem;
-    margin-top: .5rem;
+    padding: 0;
     margin-bottom: 0;
     overflow-x: hidden;
     overflow-y: auto;
@@ -141,9 +144,9 @@
 *******************************/
 
 .tutorial-step-counter {
-    padding: 0 1rem;
-    padding-bottom: 0.5rem;
+    padding: 0.5rem 1rem;
     border-bottom: 2px solid @tutorialGrayOffset;
+    background: @white;
 }
 
 .tutorial-step-label {
@@ -712,10 +715,6 @@
             border-right: 0;
             border-bottom: 2px solid darken(desaturate(@blocklyToolboxColor, 60%), 10%);
         }
-
-        .tutorial-content {
-            padding-top: .5rem;
-        }
     }
 
     .tab-tutorial.tab-content {
@@ -728,8 +727,11 @@
 
     .tutorial-content {
         margin: 0;
-        padding: 1rem;
         padding-bottom: 0;
+    }
+
+    .tutorial-content-bkg {
+        padding: 0 1rem;
     }
 
     .tutorial-replace-code + .tutorial-scroll-gradient,

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -224,16 +224,18 @@ export function TutorialContainer(props: TutorialContainerProps) {
     return <div className="tutorial-container">
         {!isHorizontal && stepCounter}
         <div className={classList("tutorial-content", hasHint && "has-hint")} ref={contentRef} onScroll={tutorialContentScroll}>
-            {isHorizontal ? stepCounter : <div className="tutorial-step-label">
-                {name && <span className="tutorial-step-title">{name}</span>}
-                <span className="tutorial-step-number">{lf("Step {0} of {1}", visibleStep + 1, steps.length)}</span>
-            </div>}
-            {showImmersiveReader && <ImmersiveReaderButton ref={immReaderRef} content={markdown} tutorialOptions={tutorialOptions} />}
-            {title && <div className="tutorial-title">{title}</div>}
-            <MarkedContent className="no-select tutorial-step-content" tabIndex={0} markdown={markdown} parent={parent}/>
-            <div className="tutorial-controls">
-                {hasHint && <TutorialHint tutorialId={tutorialId} currentStep={visibleStep} markdown={hintMarkdown} parent={parent} />}
-                { nextButton }
+            <div className={"tutorial-content-bkg"}>
+                {isHorizontal ? stepCounter : <div className="tutorial-step-label">
+                    {name && <span className="tutorial-step-title">{name}</span>}
+                    <span className="tutorial-step-number">{lf("Step {0} of {1}", visibleStep + 1, steps.length)}</span>
+                </div>}
+                {showImmersiveReader && <ImmersiveReaderButton ref={immReaderRef} content={markdown} tutorialOptions={tutorialOptions} />}
+                {title && <div className="tutorial-title">{title}</div>}
+                <MarkedContent className="no-select tutorial-step-content" tabIndex={0} markdown={markdown} parent={parent}/>
+                <div className="tutorial-controls">
+                    {hasHint && <TutorialHint tutorialId={tutorialId} currentStep={visibleStep} markdown={hintMarkdown} parent={parent} />}
+                    { nextButton }
+                </div>
             </div>
         </div>
         {validationFailures.length > 0 &&

--- a/webapp/src/greenscreen.tsx
+++ b/webapp/src/greenscreen.tsx
@@ -126,7 +126,7 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
         const { hasPrompt, devices, userFacing } = this.state;
 
         return <div className="videoContainer">
-            <video className={userFacing ? "flipx" : ""} autoPlay playsInline ref={this.handleVideoRef} />
+            <video className={userFacing ? "flipx" : ""} autoPlay playsInline ref={this.handleVideoRef} width="100%" />
             {hasPrompt ?
                 <sui.Modal isOpen={hasPrompt} onClose={this.handleClose} closeIcon={true}
                     dimmer={true} header={lf("Choose a camera")}>


### PR DESCRIPTION
The new tutorial backgrounds weren't being set to transparent when in greenscreen mode.

When I made the switch, I also noticed green screen mode was adding a scroll bar that allowed the user to scroll the entire site horizontally. This was happening because the video element that gets created was larger than the site itself (it gets scaled up to fill the screen, but this usually means `width` becomes larger than 100% so `height` can be 100% while maintaining the correct aspect ratio). To avoid this behavior, I set 100% `width` in the `video` element itself rather than the css, then cap the `width` to 100% in css and set `object-fit` to crop the `video` element appropriately, so it doesn't shrink down again when css limits its size.

I also noticed that, since the tutorial pane extends 100% vertically on desktop and the editor tools pane (with the download button) is pushed to the right, it looked weird to have the green background on the tutorial pane but not the editor tools bar. In non-tutorial layouts, however, the editor tools bar keeps its white background, and I didn't want to change that. Instead, I decided to leave the editor tools bar at 100% width when green screen is enabled. I'm not sure that this is the best way to do it, but it's relatively cheap and I think a reasonable trade off. Could revisit if we get user feedback, or if any team members feel strongly that another approach would be preferable.

Fixes https://github.com/microsoft/pxt-arcade/issues/5699

<img width="892" alt="image" src="https://user-images.githubusercontent.com/69657545/221683823-b9f77e39-e24a-4037-97ed-c72fc892adfd.png">

<img width="676" alt="image" src="https://user-images.githubusercontent.com/69657545/221683993-7c864dae-575e-4b68-a40e-246670887cdf.png">

<img width="862" alt="image" src="https://user-images.githubusercontent.com/69657545/221684181-116e866c-b758-489d-998f-f2061f8b1113.png">

