### PR TITLE
Code Validation Telemetry Improvements

### DIFF
--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -36,6 +36,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         preferredEditor, tutorialOptions, onTutorialStepChange, onTutorialComplete,
         setParentHeight } = props;
     const [ currentStep, setCurrentStep ] = React.useState(props.currentStep || 0);
+    const [ stepErrorAttemptCount, setStepErrorAttemptCount ] = React.useState(0);
     const [ hideModal, setHideModal ] = React.useState(false);
     const [ showScrollGradient, setShowScrollGradient ] = React.useState(false);
     const [ layout, setLayout ] = React.useState<"vertical" | "horizontal">("vertical");
@@ -90,6 +91,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         contentDiv.scrollTo(0, 0);
         contentDiv.querySelector(".tutorial-step-content")?.focus();
         setShowScrollGradient(contentDiv.scrollHeight > contentDiv.offsetHeight);
+        setStepErrorAttemptCount(0);
 
         onTutorialStepChange(currentStep);
         if (showNext) setHideModal(false);
@@ -109,7 +111,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
     const markdown = steps[visibleStep].headerContentMd;
     const hintMarkdown = steps[visibleStep].hintContentMd;
 
-    const validateTutorialStep = async () => {
+    const validateTutorialStep = async (isStepCounter: boolean = false) => {
         let validators: pxt.Map<CodeValidator> = {};
 
         currentStepInfo.localValidationConfig?.validatorsMetadata?.forEach(v => validators[v.validatorType] = GetValidator(v));
@@ -132,12 +134,17 @@ export function TutorialContainer(props: TutorialContainerProps) {
 
         setValidationFailures(failedResults);
         if (failedResults.length == 0) {
-            tutorialStepNext();
+            tutorialStepNext(isStepCounter);
         } else {
+            // Use errAttempts below instead of stepErrorAttemptCount since state update is async
+            // and may not complete before the tickEvent is called.
+            let errAttempts = stepErrorAttemptCount + 1;
+            setStepErrorAttemptCount(errAttempts);
             pxt.tickEvent("codevalidation.stopnext", {
                 tutorial: tutorialId,
                 step: currentStep,
                 errorCount: failedResults.length,
+                attemptsWithError: errAttempts,
             });
         }
     };
@@ -146,6 +153,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         pxt.tickEvent("codevalidation.continueanyway", {
             tutorial: tutorialId,
             step: currentStep,
+            attemptsWithError: stepErrorAttemptCount,
         });
         tutorialStepNext();
     };
@@ -155,6 +163,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         pxt.tickEvent("codevalidation.popupclose", {
             tutorial: tutorialId,
             step: currentStep,
+            attemptsWithError: stepErrorAttemptCount,
         });
     };
 
@@ -163,15 +172,26 @@ export function TutorialContainer(props: TutorialContainerProps) {
         // If going backwards, user could be trying to fix something from a previous step and this message could be annoying/confusing.
         // If going forwards multiple steps, then the user has fully skipped entire steps, so validation doesn't make much sense.
         if (step == currentStep + 1) {
-            validateTutorialStep();
+            validateTutorialStep(true);
         } else {
             setCurrentStep(step);
         }
     }
 
-    const tutorialStepNext = () => {
+    const tutorialStepNext = (isStepCounter: boolean = false) => {
         const step = Math.min(currentStep + 1, props.steps.length - 1);
-        pxt.tickEvent("tutorial.next", { tutorial: tutorialId, step: step, isModal: isModal ? 1 : 0, validationErrors: validationFailures?.length ?? 0 }, { interactiveConsent: true });
+        pxt.tickEvent(
+            "tutorial.next",
+            {
+                tutorial: tutorialId,
+                step: step,
+                isModal: isModal ? 1 : 0,
+                validationErrors: validationFailures?.length ?? 0,
+                attemptsWithError: stepErrorAttemptCount,
+                isStepCounter: isStepCounter ? 1 : 0,
+            },
+            { interactiveConsent: true }
+        );
         if (validationFailures.length > 0) {
             setValidationFailures([]);
         }
@@ -184,7 +204,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         setCurrentStep(step);
     }
 
-    const onModalClose = showNext ? tutorialStepNext : () => setHideModal(true);
+    const onModalClose = showNext ? () => tutorialStepNext() : () => setHideModal(true);
 
     const tutorialContentScroll = () => {
         const contentDiv = contentRef?.current;
@@ -210,7 +230,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
     const nextButtonLabel = lf("Go to the next step of the tutorial.");
     const nextButton = showDone
         ? <Button icon="check circle" title={doneButtonLabel} ariaLabel={doneButtonLabel} text={lf("Done")} onClick={onTutorialComplete} />
-        : <Button icon="arrow circle right" title={nextButtonLabel} ariaLabel={nextButtonLabel} disabled={!showNext} text={lf("Next")} onClick={validateTutorialStep} />;
+        : <Button icon="arrow circle right" title={nextButtonLabel} ariaLabel={nextButtonLabel} disabled={!showNext} text={lf("Next")} onClick={() => validateTutorialStep()} />;
 
     const stepCounter = <TutorialStepCounter
         tutorialId={tutorialId}
@@ -239,7 +259,13 @@ export function TutorialContainer(props: TutorialContainerProps) {
             </div>
         </div>
         {validationFailures.length > 0 &&
-            <TutorialValidationErrorMessage onContinueClicked={handleTutorialContinueAnyway} onReturnClicked={handleTutorialClose} validationFailures={validationFailures} tutorialId={tutorialId} currentStep={currentStep} />}
+            <TutorialValidationErrorMessage
+                onContinueClicked={handleTutorialContinueAnyway}
+                onReturnClicked={handleTutorialClose}
+                validationFailures={validationFailures}
+                tutorialId={tutorialId}
+                currentStep={currentStep}
+                attemptsWithError={stepErrorAttemptCount} />}
         {hasTemplate && currentStep == firstNonModalStep && preferredEditor !== "asset" && !pxt.appTarget.appTheme.hideReplaceMyCode &&
             <TutorialResetCode tutorialId={tutorialId} currentStep={visibleStep} resetTemplateCode={parent.resetTutorialTemplateCode} />}
         {showScrollGradient && <div className="tutorial-scroll-gradient" />}

--- a/webapp/src/components/tutorial/TutorialStepCounter.tsx
+++ b/webapp/src/components/tutorial/TutorialStepCounter.tsx
@@ -32,7 +32,6 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
 
     const handleNextStep = () => {
         const step = Math.min(currentStep + 1, totalSteps - 1);
-        pxt.tickEvent("tutorial.next", { tutorial: tutorialId, step: step, isModal: 0, isStepCounter: 1 }, { interactiveConsent: true });
         setTutorialStep(step);
     }
 

--- a/webapp/src/components/tutorial/TutorialValidationErrorMessage.tsx
+++ b/webapp/src/components/tutorial/TutorialValidationErrorMessage.tsx
@@ -8,6 +8,7 @@ interface TutorialValidationErrorMessageProps {
     validationFailures: CodeValidationResult[];
     tutorialId: string;
     currentStep: number;
+    attemptsWithError: number;
 }
 
 export function TutorialValidationErrorMessage(
@@ -20,6 +21,7 @@ export function TutorialValidationErrorMessage(
             pxt.tickEvent("codevalidation.showhint", {
                 tutorial: props.tutorialId,
                 step: props.currentStep,
+                attemptsWithError: props.attemptsWithError,
             });
             setShowHint(true);
         }

--- a/webapp/src/components/tutorialValidators.tsx
+++ b/webapp/src/components/tutorialValidators.tsx
@@ -33,17 +33,7 @@ abstract class CodeValidatorBase implements CodeValidator {
     execute(options: CodeValidationExecuteOptions): Promise<CodeValidationResult> {
         if (!this.enabled) return Promise.resolve(defaultResult);
 
-        const result = this.executeInternal(options);
-
-        if (!result) {
-            pxt.tickEvent(`codevalidation.detectederror`, {
-                validator: this.name,
-                tutorial: options.tutorialOptions?.tutorial,
-                step: options.tutorialOptions?.tutorialStep,
-            });
-        }
-
-        return result;
+        return this.executeInternal(options);
     }
 
     protected abstract executeInternal(options: CodeValidationExecuteOptions): Promise<CodeValidationResult>;


### PR DESCRIPTION
1. Added a field to several events which records how many times the user has tried to click next and encountered an error on the step. Basically, how many failed attempts have they made. This will simplify queries and I think it will be helpful in understanding if users are actually getting the error popup and fixing things, or if they just see the popup a few times and continue anyway.
2. Remove a redundant event that wasn't firing anyway due to a bug.
3. Fix a bug where two tutorial.next events were firing when the step counter was used. 