### PR TITLE
Port to Stable8.5: Code Validation Telemetry Improvements

### DIFF
--- a/webapp/src/components/tutorial/TutorialStepCounter.tsx
+++ b/webapp/src/components/tutorial/TutorialStepCounter.tsx
@@ -32,7 +32,6 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
 
     const handleNextStep = () => {
         const step = Math.min(currentStep + 1, totalSteps - 1);
-        pxt.tickEvent("tutorial.next", { tutorial: tutorialId, step: step, isModal: 0, isStepCounter: 1 }, { interactiveConsent: true });
         setTutorialStep(step);
     }
 

--- a/webapp/src/components/tutorial/TutorialValidationErrorMessage.tsx
+++ b/webapp/src/components/tutorial/TutorialValidationErrorMessage.tsx
@@ -8,6 +8,7 @@ interface TutorialValidationErrorMessageProps {
     validationFailures: CodeValidationResult[];
     tutorialId: string;
     currentStep: number;
+    attemptsWithError: number;
 }
 
 export function TutorialValidationErrorMessage(
@@ -20,6 +21,7 @@ export function TutorialValidationErrorMessage(
             pxt.tickEvent("codevalidation.showhint", {
                 tutorial: props.tutorialId,
                 step: props.currentStep,
+                attemptsWithError: props.attemptsWithError,
             });
             setShowHint(true);
         }

--- a/webapp/src/components/tutorialValidators.tsx
+++ b/webapp/src/components/tutorialValidators.tsx
@@ -33,17 +33,7 @@ abstract class CodeValidatorBase implements CodeValidator {
     execute(options: CodeValidationExecuteOptions): Promise<CodeValidationResult> {
         if (!this.enabled) return Promise.resolve(defaultResult);
 
-        const result = this.executeInternal(options);
-
-        if (!result) {
-            pxt.tickEvent(`codevalidation.detectederror`, {
-                validator: this.name,
-                tutorial: options.tutorialOptions?.tutorial,
-                step: options.tutorialOptions?.tutorialStep,
-            });
-        }
-
-        return result;
+        return this.executeInternal(options);
     }
 
     protected abstract executeInternal(options: CodeValidationExecuteOptions): Promise<CodeValidationResult>;


### PR DESCRIPTION
Port of https://github.com/microsoft/pxt/commit/6d731ade66e4f518b091b35af498f7c0506d296f

1. Added a field to several events which records how many times the user has tried to click next and encountered an error on the step. Basically, how many failed attempts have they made. This will simplify queries and I think it will be helpful in understanding if users are actually getting the error popup and fixing things, or if they just see the popup a few times and continue anyway.

2. Remove a redundant event that wasn't firing anyway due to a bug.

3. Fix a bug where two tutorial.next events were firing when the step counter was used.