### PR TITLE
don't hide asset name in asseteditor page

### DIFF
--- a/theme/image-editor/bottomBar.less
+++ b/theme/image-editor/bottomBar.less
@@ -22,6 +22,7 @@
     height: 100%;
     line-height: 2rem;
     color: var(--sidebar-label-color);
+    width: 5rem;
 }
 
 .image-editor-undo-redo {
@@ -54,6 +55,12 @@
 .image-editor-change-name {
     position: relative;
     width: 20rem;
+}
+
+.image-editor.hide-done-button .image-editor-change-name {
+    flex-grow: 1;
+    width: unset;
+    max-width: 15rem;
 }
 
 .image-editor-change-name .image-editor-input {
@@ -99,6 +106,10 @@
     margin-top: 0.5rem;
 }
 
+.image-editor-seperator.transparent {
+    opacity: 0;
+}
+
 .image-editor-zoom-controls {
     display: flex;
     flex-direction: row;
@@ -106,7 +117,7 @@
 
 
 @media only screen and (max-width: @largestMobileScreen) {
-    .image-editor-change-name {
+    .image-editor:not(.hide-done-button) .image-editor-change-name {
         display: none;
     }
 }

--- a/webapp/src/components/ImageEditor/BottomBar.tsx
+++ b/webapp/src/components/ImageEditor/BottomBar.tsx
@@ -7,6 +7,7 @@ import { IconButton } from "./Button";
 import { fireClickOnlyOnEnter } from "./util";
 import { isNameTaken } from "../../assets";
 import { obtainShortcutLock, releaseShortcutLock } from "./keyboardShortcuts";
+import { classList } from "../../../../react-common/components/util";
 
 export interface BottomBarProps {
     dispatchChangeImageDimensions: (dimensions: [number, number]) => void;
@@ -118,7 +119,7 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
                         toggle={!onionSkinEnabled}
                     />
                 </div> }
-                { cursorLocation && !resizeDisabled && <div className="image-editor-seperator"/> }
+                { !resizeDisabled && <div className={classList("image-editor-seperator", !cursorLocation && "transparent")}/> }
                 <div className="image-editor-coordinate-preview">
                     {cursorLocation && `${cursorLocation[0]}, ${cursorLocation[1]}`}
                 </div>
@@ -249,8 +250,8 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
     protected handleAssetNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         let errorMessage = null;
 
-        const trimmedName = event.target.value.trim(); // validate using the trimmed name
-        const name = event.target.value;               // but don't trim the state otherwise they won't be able to type spaces
+        const name = event.target.value || "";      // don't trim the state otherwise they won't be able to type spaces
+        const trimmedName = name.trim();            // validate using the trimmed name
 
         if (!pxt.validateAssetName(trimmedName)) {
             errorMessage = lf("Names may only contain letters, numbers, '-', '_', and space");
@@ -265,10 +266,12 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
     protected handleAssetNameBlur = () => {
         const { dispatchChangeAssetName, assetName } = this.props;
 
-        let newName = this.state.assetName.trim();
+        if (this.state.assetName) {
+            let newName = this.state.assetName.trim();
 
-        if (newName !== assetName && pxt.validateAssetName(newName) && !isNameTaken(newName)) {
-            dispatchChangeAssetName(newName);
+            if (newName !== assetName && pxt.validateAssetName(newName) && !isNameTaken(newName)) {
+                dispatchChangeAssetName(newName);
+            }
         }
         this.setState({ assetName: null, assetNameMessage: null });
         this.setShortcutsEnabled(true);

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -18,6 +18,7 @@ import { imageStateToBitmap, imageStateToTilemap, applyBitmapData } from './util
 import { Unsubscribe, Action } from 'redux';
 import { createNewImageAsset, getNewInternalID } from '../../assets';
 import { AssetEditorCore } from '../ImageFieldEditor';
+import { classList } from '../../../../react-common/components/util';
 
 export const LIGHT_MODE_TRANSPARENT = "#dedede";
 
@@ -84,7 +85,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
 
         return <div className="image-editor-outer">
             <Provider store={instanceStore}>
-                <div className={`image-editor ${editingTile ? "editing-tile" : ""}`}>
+                <div className={classList("image-editor", editingTile && "editing-tile", hideDoneButton && "hide-done-button")}>
                     <TopBar singleFrame={singleFrame} />
                     <div className="image-editor-content">
                         <SideBar lightMode={lightMode} />


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-makecode/issues/100

checks to see if the done button is hidden and then doesn't hide the asset name

also fixed a random exception while i was in there; we weren't checking if assetname was defined before calling trim