### PR TITLE
Fix autosave weirdness in asset editor page

### DIFF
--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -191,10 +191,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
     }
 
     pollForUpdates = () => {
-        const currAsset = this.editor?.getValue();
-        if (!currAsset)
-            return;
-        this.tilemapProject.updateAsset(currAsset);
+        if (this.state.editing) this.updateAsset();
     }
 
     componentDidUpdate(prevProps: Readonly<{}>, prevState: Readonly<AssetEditorState>, snapshot?: any): void {
@@ -250,7 +247,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
         }
     }
 
-    protected saveProjectFiles() {
+    protected updateAsset() {
         const currentValue = this.editor.getValue();
         if (this.state.isEmptyAsset) {
             const name = currentValue.meta?.displayName;
@@ -281,6 +278,10 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
         else {
             this.tilemapProject.updateAsset(currentValue);
         }
+    }
+
+    protected saveProjectFiles() {
+        this.updateAsset();
 
         const assetJRes = pxt.inflateJRes(this.tilemapProject.getProjectAssetsJRes());
         const tileJRes = pxt.inflateJRes(this.tilemapProject.getProjectTilesetJRes());

--- a/webapp/src/components/ImageEditor/util.ts
+++ b/webapp/src/components/ImageEditor/util.ts
@@ -302,7 +302,7 @@ export interface Color { r: number, g: number, b: number, a?: number }
 
 
 export function imageStateToBitmap(state: pxt.sprite.ImageState) {
-    const base = pxt.sprite.Bitmap.fromData(state.bitmap);
+    const base = pxt.sprite.Bitmap.fromData(state.bitmap).copy();
     if (state.floating && state.floating.bitmap) {
         const floating = pxt.sprite.Bitmap.fromData(state.floating.bitmap);
         floating.x0 = state.layerOffsetX || 0;
@@ -315,7 +315,7 @@ export function imageStateToBitmap(state: pxt.sprite.ImageState) {
 }
 
 export function imageStateToTilemap(state: pxt.sprite.ImageState) {
-    const base = pxt.sprite.Tilemap.fromData(state.bitmap);
+    const base = pxt.sprite.Tilemap.fromData(state.bitmap).copy();
     if (state.floating && state.floating.bitmap) {
         const floating = pxt.sprite.Tilemap.fromData(state.floating.bitmap);
         floating.x0 = state.layerOffsetX || 0;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-makecode/issues/92
Fixes https://github.com/microsoft/vscode-makecode/issues/94

The issue was that we delay creating a real asset until we receive a save message from outside the iframe, so autosave was saving the "fake" asset and hilarity ensued.

Also fixes the issue where dragging a marquee leaves the original image behind