### PR TITLE
add tags field so .g.jres can have gallery tags

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -205,6 +205,7 @@ declare namespace pxt {
         displayName?: string;
         tilemapTile?: boolean;
         tileset?: string[];
+        tags?: string[];
     }
 
     type SnippetOutputType = 'blocks'

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -1345,7 +1345,8 @@ namespace pxt {
                 mimeType,
                 tilemapTile: v.tilemapTile,
                 displayName: v.displayName,
-                tileset: v.tileset
+                tileset: v.tileset,
+                tags: v.tags
             }
         }
 

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1166,7 +1166,8 @@ namespace pxt {
                 type: type,
                 id: entry.id,
                 meta: {
-                    displayName: entry.displayName
+                    displayName: entry.displayName,
+                    tags: entry.tags,
                 },
                 jresData: entry.data,
                 bitmap: pxt.sprite.getBitmapFromJResURL(`data:${IMAGE_MIME_TYPE};base64,${entry.data}`).data()
@@ -1179,7 +1180,8 @@ namespace pxt {
                 type: AssetType.Song,
                 id: entry.id,
                 meta: {
-                    displayName: entry.displayName
+                    displayName: entry.displayName,
+                    tags: entry.tags
                 },
                 song: pxt.assets.music.decodeSongFromHex(entry.data)
             }
@@ -1200,7 +1202,8 @@ namespace pxt {
                     internalID: this.getNewInternalId(),
                     type: AssetType.Animation,
                     meta: {
-                        displayName: entry.displayName
+                        displayName: entry.displayName,
+                        tags: entry.tags
                     },
                     id: entry.id,
                     frames: [],
@@ -1509,25 +1512,33 @@ namespace pxt {
     function addAssetToJRes(asset: Asset, allJRes: pxt.Map<Partial<JRes> | string>): void {
         // Get the last part of the fully qualified name
         const id = asset.id.substr(asset.id.lastIndexOf(".") + 1);
+        const tags = asset.meta.tags;
 
         switch (asset.type) {
             case AssetType.Image:
                 allJRes[id] = asset.jresData;
-                if (asset.meta.displayName) {
-                    allJRes[id] = {
+                if (asset.meta.displayName || tags?.length) {
+                    const imgJres: Partial<JRes> = {
                         data: asset.jresData,
                         mimeType: IMAGE_MIME_TYPE,
-                        displayName: asset.meta.displayName
                     }
+                    if (asset.meta.displayName)
+                        imgJres.displayName = asset.meta.displayName;
+                    if (tags?.length)
+                        imgJres.tags = tags;
+                    allJRes[id] = imgJres;
                 }
                 break;
             case AssetType.Tile:
-                allJRes[id] = {
+                const tileJres: Partial<JRes> = {
                     data: asset.jresData,
                     mimeType: IMAGE_MIME_TYPE,
                     tilemapTile: true,
                     displayName: asset.meta.displayName
                 };
+                if (tags?.length)
+                    tileJres.tags = tags;
+                allJRes[id] = tileJres;
                 break;
             case AssetType.Tilemap:
                 // we include the full ID for tilemaps
@@ -1539,13 +1550,18 @@ namespace pxt {
                 allJRes[id] = serializeAnimation(asset);
                 break;
             case AssetType.Song:
-                allJRes[id] = {
+                const songJres: Partial<JRes> = {
                     data: pxt.assets.music.encodeSongToHex(asset.song),
                     mimeType: SONG_MIME_TYPE,
                     displayName: asset.meta.displayName
                 };
+                if (tags?.length)
+                    songJres.tags = tags;
+
+                allJRes[id] = songJres;
                 break;
         }
+
     }
 
     export function assetEquals(a: Asset, b: Asset) {
@@ -1728,13 +1744,16 @@ namespace pxt {
     }
 
     function serializeAnimation(asset: Animation): JRes {
-        return {
+        const animationJres: JRes = {
             namespace: asset.id.substr(0, asset.id.lastIndexOf(".")),
             id: asset.id.substr(asset.id.lastIndexOf(".") + 1),
             mimeType: ANIMATION_MIME_TYPE,
             data: pxt.sprite.encodeAnimationString(asset.frames, asset.interval),
-            displayName: asset.meta.displayName
+            displayName: asset.meta.displayName,
         }
+        if (asset.meta.tags?.length)
+            animationJres.tags = asset.meta.tags;
+        return animationJres;
     }
 
     function decodeAnimation(jres: JRes): Animation {
@@ -1778,7 +1797,8 @@ namespace pxt {
             interval,
             frames: decodedFrames,
             meta: {
-                displayName: jres.displayName
+                displayName: jres.displayName,
+                tags: jres.tags
             }
         }
     }


### PR DESCRIPTION
@kiki-lee wanted to put some gallery images for a tutorial but they don't show up in the background image gallery; currently the only way to sneak em in without running the cli tool would be via the assetsjres but that ends up creating ~40-200k long lines which can break things.

Basically, make https://github.com/jwunderl/arrow-images/blob/master/images.g.jres#L11 work to define tags for assets (I editted this by hand (don't tell anyone >.>) but we should probably just add the option to list out tags somewhere in the arcade-sprite-pack tool)

test build https://arcade.makecode.com/app/b7117e402ed06a7aaeda7ead979300400be20fee-8a1cae52b6#pub:_F3kbef0rbhzE