### PR TITLE
Fix autosave for tilemap assets

### DIFF
--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1158,6 +1158,26 @@ namespace pxt {
             }
         }
 
+        clone() {
+            const clone = new TilemapProject();
+            clone.committedState = cloneSnapshot(this.committedState);
+            clone.state = cloneSnapshot(this.state);
+            clone.gallery = cloneSnapshot(this.gallery);
+            clone.extensionTileSets = this.extensionTileSets?.map(t => ({
+                ...t,
+                tileSets: t.tileSets.map(ts => ({
+                    ...ts,
+                    tiles: ts.tiles.map(tl => cloneAsset(tl))
+                }))
+            }));
+            clone.needsRebuild = this.needsRebuild;
+            clone.nextID = this.nextID;
+            clone.nextInternalID = this.nextInternalID;
+            clone.undoStack = this.undoStack.map(u => cloneSnapshotDiff(u));
+            clone.redoStack = this.undoStack.map(r => cloneSnapshotDiff(r));
+            return clone;
+        }
+
         protected generateImage(entry: JRes, type: AssetType.Image): ProjectImage;
         protected generateImage(entry: JRes, type: AssetType.Tile): Tile;
         protected generateImage(entry: JRes, type: AssetType.Image | AssetType.Tile): ProjectImage | Tile {
@@ -1508,6 +1528,35 @@ namespace pxt {
         }
     }
 
+    function cloneSnapshot(toClone: AssetSnapshot) {
+        return {
+            revision: toClone.revision,
+            tilemaps: toClone.tilemaps.clone(),
+            images: toClone.images.clone(),
+            animations: toClone.animations.clone(),
+            songs: toClone.songs.clone(),
+            tiles: toClone.tiles.clone()
+        }
+    }
+
+    function cloneSnapshotDiff(toClone: AssetSnapshotDiff): AssetSnapshotDiff {
+        return {
+            ...toClone,
+            animations: cloneAssetCollectionDiff(toClone.animations),
+            tiles: cloneAssetCollectionDiff(toClone.tiles),
+            images: cloneAssetCollectionDiff(toClone.images),
+            tilemaps: cloneAssetCollectionDiff(toClone.tilemaps),
+            songs: cloneAssetCollectionDiff(toClone.songs)
+        }
+    }
+
+    function cloneAssetCollectionDiff<U extends Asset>(toClone: AssetCollectionDiff<U>): AssetCollectionDiff<U> {
+        return {
+            ...toClone,
+            before: toClone.before.map(entry => cloneAsset(entry)),
+            after: toClone.after.map(entry => cloneAsset(entry)),
+        }
+    }
 
     function addAssetToJRes(asset: Asset, allJRes: pxt.Map<Partial<JRes> | string>): void {
         // Get the last part of the fully qualified name

--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -437,7 +437,16 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
 
     protected getEmptyAsset(type: pxt.AssetType): pxt.Asset {
         const project = pxt.react.getTilemapProject();
-        const asset = { type, id: "", internalID: 0, meta: { displayName: pxt.getDefaultAssetDisplayName(type) } } as pxt.Asset;
+
+        const defaultName = pxt.getDefaultAssetDisplayName(type);
+        let newName = defaultName;
+        let index = 0;
+
+        while (project.isNameTaken(type, newName)) {
+            newName = defaultName + (index++);
+        }
+
+        const asset = { type, id: "", internalID: 0, meta: { displayName: newName } } as pxt.Asset;
         switch (type) {
             case pxt.AssetType.Image:
             case pxt.AssetType.Tile:

--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -87,16 +87,18 @@ type AssetEditorEvent = AssetEditorRequestSaveEvent | AssetEditorReadyEvent;
 
 export class AssetEditor extends React.Component<{}, AssetEditorState> {
     private editor: ImageFieldEditor<pxt.Asset>;
-    protected tilemapProject: pxt.TilemapProject;
+    protected saveProject: pxt.TilemapProject;
+    protected editorProject: pxt.TilemapProject;
     protected inflatedJres: pxt.Map<pxt.Map<pxt.JRes>>;
     protected commentAttrs: pxt.Map<pxtc.CommentAttrs>;
     protected files: pxt.Map<string>;
     protected galleryTiles: any[];
+    protected lastValue: pxt.Asset;
 
     constructor(props: {}) {
         super(props);
         this.state = {};
-        pxt.react.getTilemapProject = () => this.tilemapProject;
+        pxt.react.getTilemapProject = () => this.editorProject;
 
         setTelemetryFunction(tickAssetEditorEvent);
     }
@@ -125,7 +127,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
                 this.initTilemapProject(request.files);
                 const toOpen = this.lookupAsset(request.assetType, request.assetId);
                 if (toOpen.type === pxt.AssetType.Tilemap) {
-                    pxt.sprite.addMissingTilemapTilesAndReferences(this.tilemapProject, toOpen);
+                    pxt.sprite.addMissingTilemapTilesAndReferences(this.editorProject, toOpen);
                 }
                 this.setState({
                     editing: toOpen
@@ -140,7 +142,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
                 this.initTilemapProject(request.files);
                 const existing = this.lookupAsset(request.assetType, request.assetId);
                 this.setState({
-                    editing: this.tilemapProject.duplicateAsset(existing)
+                    editing: this.editorProject.duplicateAsset(existing)
                 });
                 this.sendResponse({
                     id: request.id,
@@ -200,13 +202,13 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
 
     componentDidUpdate(prevProps: Readonly<{}>, prevState: Readonly<AssetEditorState>, snapshot?: any): void {
         if (!!prevState?.editing && prevState.editing !== this.state.editing) {
-            this.tilemapProject.removeChangeListener(
+            this.saveProject.removeChangeListener(
                 prevState.editing.type,
                 this.sendSaveRequest
             );
         }
         if (this.state?.editing) {
-            this.tilemapProject.addChangeListener(
+            this.saveProject.addChangeListener(
                 this.state.editing,
                 this.sendSaveRequest
             );
@@ -252,43 +254,68 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
     }
 
     protected updateAsset() {
-        const currentValue = this.editor.getValue();
+        const editorAsset = this.editor.getValue();
+
+        // We have to clone the asset so that we don't break the editor
+        // by modifying it out from underneath it
+        const currentValue = pxt.cloneAsset(editorAsset);
+        if (this.lastValue && pxt.assetEquals(this.lastValue, currentValue)) {
+            return;
+        }
+        this.lastValue = pxt.cloneAsset(editorAsset);
+
+        // Clone asset doesn't clone the tilemap metadata. We need to update
+        // all of the referenced tiles, so clone it here
+        if (currentValue.type === pxt.AssetType.Tilemap && editorAsset.type === currentValue.type) {
+            currentValue.data.deletedTiles = editorAsset.data.deletedTiles?.slice();
+            currentValue.data.editedTiles = editorAsset.data.editedTiles?.slice();
+            currentValue.data.projectReferences = editorAsset.data.projectReferences?.slice();
+            currentValue.data.tileOrder = editorAsset.data.tileOrder?.slice();
+        }
+
+        // Create a clone of the tilemap project and update the asset. The clone
+        // is mostly for tilemaps; they are actually several assets (the map + tiles)
+        // and things can get weird if they are overwritten in the tilemap project
+        // while still being edited in the tilemap editor
+        this.saveProject = this.editorProject.clone();
         if (this.state.isEmptyAsset) {
             const name = currentValue.meta?.displayName;
             let newAsset: pxt.Asset;
             switch (currentValue.type) {
                 case pxt.AssetType.Image:
-                    newAsset = this.tilemapProject.createNewProjectImage(currentValue.bitmap, name); break;
+                    newAsset = this.saveProject.createNewProjectImage(currentValue.bitmap, name);
+                    break;
                 case pxt.AssetType.Tile:
-                    newAsset = this.tilemapProject.createNewTile(currentValue.bitmap, null, name); break;
+                    newAsset = this.saveProject.createNewTile(currentValue.bitmap, null, name);
+                    break;
                 case pxt.AssetType.Tilemap:
-                    const [newName, data] = this.tilemapProject.createNewTilemapFromData(currentValue.data, name);
-                    newAsset = this.tilemapProject.lookupAssetByName(pxt.AssetType.Tilemap, newName);
+                    pxt.sprite.updateTilemapReferencesFromResult(this.saveProject, currentValue);
+                    const [newName, data] = this.saveProject.createNewTilemapFromData(currentValue.data, name);
+                    newAsset = this.saveProject.lookupAssetByName(pxt.AssetType.Tilemap, newName);
                     break;
                 case pxt.AssetType.Animation:
-                    newAsset = this.tilemapProject.createNewAnimationFromData(currentValue.frames, currentValue.interval, name); break;
+                    newAsset = this.saveProject.createNewAnimationFromData(currentValue.frames, currentValue.interval, name);
+                    break;
                 case pxt.AssetType.Song:
-                    newAsset = this.tilemapProject.createNewSong(currentValue.song, name); break;
+                    newAsset = this.saveProject.createNewSong(currentValue.song, name);
+                    break;
             }
-
-            this.setState({
-                isEmptyAsset: false,
-                editing: newAsset
-            });
-            this.editor.init(this.state.editing, () => {}, {
-                galleryTiles: this.galleryTiles
-            });
         }
         else {
-            this.tilemapProject.updateAsset(currentValue);
+            if (currentValue.type === pxt.AssetType.Tilemap) {
+                pxt.sprite.updateTilemapReferencesFromResult(this.saveProject, currentValue);
+            }
+            this.saveProject.updateAsset(currentValue);
         }
+
+        this.sendSaveRequest();
     }
 
     protected saveProjectFiles() {
         this.updateAsset();
 
-        const assetJRes = pxt.inflateJRes(this.tilemapProject.getProjectAssetsJRes());
-        const tileJRes = pxt.inflateJRes(this.tilemapProject.getProjectTilesetJRes());
+        const assetJRes = pxt.inflateJRes(this.saveProject.getProjectAssetsJRes());
+        const tileJRes = pxt.inflateJRes(this.saveProject.getProjectTilesetJRes());
 
         const newFileJRes: pxt.Map<pxt.Map<pxt.JRes>> = {};
 
@@ -331,7 +358,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
         const galleryTilemaps: pxt.Map<pxt.JRes> = {};
         const projectAssets: pxt.Map<pxt.JRes> = {};
         const galleryAssets: pxt.Map<pxt.JRes> = {};
-        this.tilemapProject = new pxt.TilemapProject();
+        this.editorProject = new pxt.TilemapProject();
         this.inflatedJres = {};
         this.commentAttrs = {};
 
@@ -370,12 +397,12 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
             }
         }
 
-        this.tilemapProject.loadAssetsJRes(galleryAssets, true);
-        this.tilemapProject.loadAssetsJRes(projectAssets);
-        this.tilemapProject.loadTilemapJRes(galleryTilemaps, false, true);
-        this.tilemapProject.loadTilemapJRes(projectTilemaps);
+        this.editorProject.loadAssetsJRes(galleryAssets, true);
+        this.editorProject.loadAssetsJRes(projectAssets);
+        this.editorProject.loadTilemapJRes(galleryTilemaps, false, true);
+        this.editorProject.loadTilemapJRes(projectTilemaps);
 
-        this.galleryTiles = this.tilemapProject.getGalleryAssets(pxt.AssetType.Tile)
+        this.galleryTiles = this.editorProject.getGalleryAssets(pxt.AssetType.Tile)
             .map(tile => {
                 const comments = this.commentAttrs[tile.id];
                 if (!comments) return undefined;
@@ -395,7 +422,9 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
                     tags: splitTags
                 };
             })
-            .filter(gt => !!gt)
+            .filter(gt => !!gt);
+
+        this.saveProject = this.editorProject.clone();
     }
 
     protected locateFileForAsset(assetId: string) {
@@ -432,13 +461,13 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
     }
 
     protected lookupAsset(type: pxt.AssetType, id: string) {
-        const res = this.tilemapProject.lookupAsset(type, id);
+        const res = this.saveProject.lookupAsset(type, id);
 
         if (res) return res;
 
         const idParts = id.split(".")
 
-        return this.tilemapProject.lookupAsset(type, idParts[idParts.length - 1]);
+        return this.saveProject.lookupAsset(type, idParts[idParts.length - 1]);
     }
 }
 

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -221,7 +221,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
         const state = this.getStore().getState();
         const tilemapState = state.store.present as TilemapState;
         const { floating, overlayLayers, layerOffsetX, layerOffsetY } = tilemapState.tilemap;
-        const layers = applyBitmapData(overlayLayers[0], floating && floating.overlayLayers && floating.overlayLayers[0], layerOffsetX, layerOffsetY);
+        const layers = applyBitmapData(pxt.sprite.Bitmap.fromData(overlayLayers[0]).copy().data(), floating && floating.overlayLayers && floating.overlayLayers[0], layerOffsetX, layerOffsetY);
 
         const out = new pxt.sprite.TilemapData(imageStateToTilemap(tilemapState.tilemap), tilemapState.tileset, layers);
         out.deletedTiles = state.editor.deletedTiles;


### PR DESCRIPTION
This fixes three bugs:

1. Moving walls in the tilemap editor with the marquee tool was causing them to copy instead of move
2. When generating new empty assets the editor was always using the same default name (even if it was taken)
3. Saving tilemaps with custom tiles was *very* broken

The main issue here is number 3; tilemaps are actually collections of assets (tiles and tilemaps) and saving them all while the editor was still using them was causing the tilemap project to get into a weird state. To fix this, I made it so that we now clone the tilemap project whenever we emit files and update the assets on the clone rather than the original.