### PR TITLE
Don't emit songs in the 'myImages' namespace

### DIFF
--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1602,7 +1602,8 @@ namespace pxt {
                 const songJres: Partial<JRes> = {
                     data: pxt.assets.music.encodeSongToHex(asset.song),
                     mimeType: SONG_MIME_TYPE,
-                    displayName: asset.meta.displayName
+                    displayName: asset.meta.displayName,
+                    namespace: pxt.sprite.SONG_NAMESPACE + "."
                 };
                 if (tags?.length)
                     songJres.tags = tags;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-makecode/issues/130

The issue, in a nutshell:

1, We create a song (mySongs.Song1)
2. We emit that with the wrong namespace (myImages.Song1)
3. The user creates a new song
4. Since mySongs.Song1 is not used, we use that id
5. We emit again, the new asset goes to the wrong namespace and overwrites the original