### PR TITLE
Fixes for filters in asset editor page (mobile view, read out tags from ts file)

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -354,15 +354,15 @@
 // Tablet + Mobile
 @media only screen and (max-width: @largestTabletScreen) {
     .filter-panel-container {
-        margin: 0 0 0 0.5rem !important;
-        padding: 0 0.5rem !important;
+        margin: 0 0 0 0.5rem;
+        padding: 0 0.5rem;
     }
     .filter-panel {
-        margin: 0 !important;
-        padding: 0 !important;
+        margin: 0;
+        padding: 0;
     }
     .image-editor-gallery-content {
-        flex: 4!important;
+        flex: 4;
     }
 
     .filter-title {
@@ -370,14 +370,14 @@
     }
 
     .filter-tag {
-        padding-top: .5rem!important;
-        padding-bottom: .5rem!important;
+        padding-top: .5rem;
+        padding-bottom: .5rem;
     }
 
     .filter-subheading-row {
         .filter-subheading-button {
-            flex-shrink: 0 !important;
-            padding-left: .25rem !important;
+            flex-shrink: 0;
+            padding-left: .25rem;
         }
     }
 }
@@ -386,11 +386,11 @@
 // Mobile Only
 @media only screen and (max-width: @largestMobileScreen) {
     .image-editor-gallery-content {
-        flex: 3!important;
+        flex: 3;
     }
 
     .gallery-editor-toggle {
-        margin-left: .25rem!important;
+        margin-left: .25rem;
         flex-shrink: 1;
     }
 
@@ -400,18 +400,18 @@
 
     .gallery-filter-button {
         .gallery-filter-button-label {
-            display: none !important;
+            display: none;
         }
         display: flex;
         flex-shrink: 1;
-        width: 2em!important;
-        right: .9em!important;
-        justify-content: center!important;
-        padding: 0!important;
+        width: 2em;
+        right: .9em;
+        justify-content: center;
+        padding: 0;
     }
 
 
     .filter-title {
-        font-size: 1.5rem!important;
+        font-size: 1.5rem;
     }
 }

--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -135,67 +135,6 @@
     cursor: pointer;
 }
 
-// Tablet + Mobile
-@media only screen and (max-width: @largestTabletScreen) {
-    .filter-panel-container {
-        margin: 0 0 0 0.5rem !important;
-        padding: 0 0.5rem !important;
-    }
-    .filter-panel {
-        margin: 0 !important;
-        padding: 0 !important;
-    }
-    .image-editor-gallery-content {
-        flex: 4!important;
-    }
-
-    .filter-tag {
-        padding-top: .5rem!important;
-        padding-bottom: .5rem!important;
-    }
-
-    .filter-subheading-row {
-        .filter-subheading-button {
-            flex-shrink: 0 !important;
-            padding-left: .25rem !important;
-        }
-    }
-}
-
-
-// Mobile Only
-@media only screen and (max-width: @largestMobileScreen) {
-    .image-editor-gallery-content {
-        flex: 3!important;
-    }
-
-    .gallery-editor-toggle {
-        margin-left: .25rem!important;
-        flex-shrink: 1;
-    }
-
-    .gallery-editor-toggle-label > span {
-        display: none;
-    }
-
-    .gallery-filter-button {
-        .gallery-filter-button-label {
-            display: none !important;
-        }
-        display: flex;
-        flex-shrink: 1;
-        width: 2em!important;
-        right: .9em!important;
-        justify-content: center!important;
-        padding: 0!important;
-    }
-
-
-    .filter-title {
-        font-size: 1.5rem!important;
-    }
-}
-
 .gallery-editor-show-tiles {
     position: absolute;
     height: 2.3rem;
@@ -408,5 +347,67 @@
         .gallery-editor-toggle-handle {
             transform: translateX(3.25rem);
         }
+    }
+}
+
+// filter panel
+// Tablet + Mobile
+@media only screen and (max-width: @largestTabletScreen) {
+    .filter-panel-container {
+        margin: 0 0 0 0.5rem !important;
+        padding: 0 0.5rem !important;
+    }
+    .filter-panel {
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+    .image-editor-gallery-content {
+        flex: 4!important;
+    }
+
+    .filter-tag {
+        padding-top: .5rem!important;
+        padding-bottom: .5rem!important;
+    }
+
+    .filter-subheading-row {
+        .filter-subheading-button {
+            flex-shrink: 0 !important;
+            padding-left: .25rem !important;
+        }
+    }
+}
+
+
+// Mobile Only
+@media only screen and (max-width: @largestMobileScreen) {
+    .image-editor-gallery-content {
+        flex: 3!important;
+    }
+
+    .gallery-editor-toggle {
+        margin-left: .25rem!important;
+        flex-shrink: 1;
+    }
+
+    .gallery-editor-toggle-label > span {
+        display: none;
+    }
+
+    .gallery-filter-button {
+        .gallery-filter-button-label {
+            display: none !important;
+        }
+        display: flex;
+        flex-shrink: 1;
+        width: 2em!important;
+        right: .9em!important;
+        justify-content: center!important;
+        padding: 0!important;
+    }
+
+
+    .filter-title {
+        font-size: 1.5rem!important;
     }
 }

--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -365,6 +365,10 @@
         flex: 4!important;
     }
 
+    .filter-title {
+        margin-bottom: 0.5rem;
+    }
+
     .filter-tag {
         padding-top: .5rem!important;
         padding-bottom: .5rem!important;

--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -125,7 +125,7 @@
     flex-grow: 1;
     overflow: hidden;
     position: relative;
-    flex: 9;
+    flex: 6;
 }
 
 .image-editor-close-button {
@@ -137,13 +137,28 @@
 
 // Tablet + Mobile
 @media only screen and (max-width: @largestTabletScreen) {
+    .filter-panel-container {
+        margin: 0 0 0 0.5rem !important;
+        padding: 0 0.5rem !important;
+    }
+    .filter-panel {
+        margin: 0 !important;
+        padding: 0 !important;
+    }
     .image-editor-gallery-content {
         flex: 4!important;
     }
 
     .filter-tag {
-        padding-top: .7rem!important;
-        padding-bottom: .7rem!important;
+        padding-top: .5rem!important;
+        padding-bottom: .5rem!important;
+    }
+
+    .filter-subheading-row {
+        .filter-subheading-button {
+            flex-shrink: 0 !important;
+            padding-left: .25rem !important;
+        }
     }
 }
 
@@ -179,15 +194,6 @@
     .filter-title {
         font-size: 1.5rem!important;
     }
-
-    .filter-subheading-row {
-        flex-direction: column!important;
-    }
-
-    .filter-panel-container {
-        margin-left: 10px!important;
-    }
-
 }
 
 .gallery-editor-show-tiles {
@@ -244,6 +250,7 @@
 
 .filter-panel-gutter {
     flex: 2;
+    max-width: 22rem;
     background-color: var(--editor-bg-color);
 }
 
@@ -254,6 +261,7 @@
     margin-left: 20px;
     padding: .5rem;
     height: 100%;
+    overflow: auto;
 }
 
 .filter-panel {

--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -230,6 +230,7 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
                 isMusicEditor={this.state.editing.type === "song"}
                 doneButtonCallback={this.sendSaveRequest}
                 hideDoneButton={true}
+                includeSpecialTagsInFilter={true}
             />
         }
 

--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -362,22 +362,27 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
         this.inflatedJres = {};
         this.commentAttrs = {};
 
-        for (const filename of Object.keys(files)) {
-            if (!filename.endsWith(".jres")) {
-                const comments = parseCommentAttrsFromTs(files[filename]);
+        for (const fileName of Object.keys(files).filter(file => !file.endsWith(".jres"))) {
+            const comments = parseCommentAttrsFromTs(files[fileName]);
 
-                for (const id of Object.keys(comments)) {
-                    this.commentAttrs[id] = comments[id];
-                }
-                continue;
+            for (const id of Object.keys(comments)) {
+                this.commentAttrs[id] = comments[id];
             }
+        }
 
+        for (const filename of Object.keys(files).filter(file => file.endsWith(".jres"))) {
             const isGallery = filename.indexOf("pxt_modules") !== -1 || filename.indexOf("node_modules") !== -1;
 
             const inflated = pxt.inflateJRes(JSON.parse(files[filename]));
             this.inflatedJres[filename] = inflated;
 
             for (const id of Object.keys(inflated)) {
+                if (this.commentAttrs[id]?.tags) {
+                    const tags = this.commentAttrs[id].tags.split(" ").filter(el => !!el);
+                    if (tags.length) {
+                        inflated[id].tags = tags;
+                    }
+                }
                 if (inflated[id].mimeType === pxt.TILEMAP_MIME_TYPE || inflated[id].tilemapTile) {
                     if (isGallery) {
                         galleryTilemaps[id] = inflated[id];
@@ -407,12 +412,10 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
                 const comments = this.commentAttrs[tile.id];
                 if (!comments) return undefined;
 
-                const splitTags = (comments.tags || "")
-                    .split(" ")
-                    .filter(el => !!el)
-                    .map(tag => pxt.Util.startsWith(tag, "category-") ? tag : tag.toLowerCase());
+                const splitTags = tile.meta.tags
+                    ?.map(tag => pxt.Util.startsWith(tag, "category-") ? tag : tag.toLowerCase());
 
-                if (splitTags.indexOf("tile") === -1) return undefined;
+                if (!splitTags || splitTags.indexOf("tile") === -1) return undefined;
 
 
                 return {

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -17,6 +17,7 @@ export interface ImageFieldEditorProps {
     isMusicEditor?: boolean;
     doneButtonCallback?: () => void;
     hideDoneButton?: boolean;
+    includeSpecialTagsInFilter?: boolean;
 }
 
 interface ToggleOption extends BasicEditorToggleItem {
@@ -93,7 +94,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
             this.updateGalleryAssets();
         }
 
-        const specialTags = ["tile", "dialog", "background"];
+        const specialTags = this.props.includeSpecialTagsInFilter ? [] : ["tile", "dialog", "background"];
         let allTags: string[] = [];
         let filteredAssets: pxt.Asset[] = [];
         switch (currentView) {
@@ -319,6 +320,9 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
         // lf("Transportation")
         // lf("Swamp")
         // lf("Sports")
+        // lf("Background")
+        // lf("tile")
+        // lf("dialog")
 
         if (this.galleryAssets) {
             filterAssets.forEach( (asset) => {


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-makecode/issues/119

Also fixes some mobile view / thin desktop view sizing issues in gallery filter as it didn't look good in the thin webciew, and makes the section scrollable when it doesn't fit so it's still possible to select things when you have  a lot of categories. Probably looking at pr as separate commits is easiest as two of them were just moving some css rules below the ones they're overriding / removing unneeded importants now that the cascading order was correct

and adds a flag to the image field editor that makes it so background / tile / dialog will show up as options in the filter for vscode extension. Was just thinking again and might be worth throwing that flag on when it's loading the monacofieldeditor as well?

here's a build https://arcade.makecode.com/app/140dc9f3eb2d99ae039ee07fd466af633a638491-a23c652e99 (I was thinking maybe vscode extension should use mkc.json to set the --asseteditor page we point at, but that's probably not worth it when we just update the const locally anyway)