### PR TITLE
one more small adjustment for very thin phones

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -225,6 +225,8 @@
     justify-content: space-between;
     margin-bottom: .5rem;
     font-size: 1.1rem;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 }
 
 .filter-subheading-button {
@@ -372,13 +374,6 @@
     .filter-tag {
         padding-top: .5rem;
         padding-bottom: .5rem;
-    }
-
-    .filter-subheading-row {
-        .filter-subheading-button {
-            flex-shrink: 0;
-            padding-left: .25rem;
-        }
     }
 }
 


### PR DESCRIPTION
quick follow up to https://github.com/microsoft/pxt/pull/9423 -- I was playing around on very thin views and the words got a little closer than I wanted, so just give it a wrap / some gap

build: https://arcade.makecode.com/app/3a4976d9a846afecd7a9248ba447046535e8b16b-4d237bd7dd

![image](https://user-images.githubusercontent.com/5615930/225701604-50671ff1-a22f-47c3-8002-cb17119000e2.png)

and anywhere it's wide enough display is normal: 
![image](https://user-images.githubusercontent.com/5615930/225701730-4c79f4c0-c61d-4c9a-8857-4aeaae1d5634.png)
