### PR TITLE
Enable Logging Tick Events to Console with URL Parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "8.6.12",
+  "version": "8.6.13",
   "description": "Microsoft MakeCode provides Blocks / JavaScript / Python tools and editors",
   "keywords": [
     "TypeScript",

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -89,17 +89,12 @@ namespace pxt.analytics {
 
     function consoleLogTick(id: string, data: Map<string | number>, opts: TelemetryEventOptions) {
         const query = Util.parseQueryString(window.location.href);
-
-        // Optionally specify consoletickfilter to limit which ticks get printed.
-        if (!query["consoletickfilter"] || id.startsWith(query["consoletickfilter"])) {
-            const tickInfo = `${id} ${data ? JSON.stringify(data) : "<no data>"} ${opts ? JSON.stringify(opts) : "<no opts>"}`;
-
-            if (query["consoleticks"] == "1" || query["consoleticks"] == "full") {
-                const timestamp = new Date().toLocaleTimeString(undefined, { hour12: false });
-                console.log(`${timestamp} - Tick - ${tickInfo}`);
-            } else if (query["consoleticks"] == "2" || query["consoleticks"] == "short") {
-                console.log(tickInfo);
-            }
+        const tickInfo = `${id} ${data ? JSON.stringify(data) : "<no data>"} ${opts ? JSON.stringify(opts) : "<no opts>"}`;
+        if (query["consoleticks"] == "1" || query["consoleticks"] == "full") {
+            const timestamp = new Date().toLocaleTimeString(undefined, { hour12: false });
+            console.log(`${timestamp} - Tick - ${tickInfo}`);
+        } else if (query["consoleticks"] == "2" || query["consoleticks"] == "short") {
+            console.log(tickInfo);
         }
     }
 }

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -40,8 +40,6 @@ namespace pxt.analytics {
 
         const te = pxt.tickEvent;
         pxt.tickEvent = function (id: string, data?: Map<string | number>, opts?: TelemetryEventOptions): void {
-            // Log tick to console if "consoleticks" url param is present.
-            // We do this simple check first (rather than the full parse) to minimize overhead when it's not present, which is most of the time.
             if (consoleTicks != ConsoleTickOptions.Off)
             {
                 const prefix = consoleTicks == ConsoleTickOptions.Short ? "" : `${new Date().toLocaleTimeString(undefined, { hour12: false })} - Tick - `;

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -42,7 +42,7 @@ namespace pxt.analytics {
         pxt.tickEvent = function (id: string, data?: Map<string | number>, opts?: TelemetryEventOptions): void {
             // Log tick to console if "consoleticks" url param is present.
             // We do this simple check first (rather than the full parse) to minimize overhead when it's not present, which is most of the time.
-            if(consoleTicks != ConsoleTickOptions.Off)
+            if (consoleTicks != ConsoleTickOptions.Off)
             {
                 const prefix = consoleTicks == ConsoleTickOptions.Short ? "" : `${new Date().toLocaleTimeString(undefined, { hour12: false })} - Tick - `;
                 const tickInfo = `${id} ${data ? JSON.stringify(data) : "<no data>"} ${opts ? JSON.stringify(opts) : "<no opts>"}`;

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -10,6 +10,13 @@ namespace pxt.analytics {
     const defaultMeasures: Map<number> = {};
     let enabled = false;
 
+    export enum ConsoleTickOptions {
+        Off,
+        Short,
+        Verbose
+    };
+    export var consoleTicks: ConsoleTickOptions = ConsoleTickOptions.Off;
+
     export function addDefaultProperties(props: Map<string | number>) {
         Object.keys(props).forEach(k => {
             if (typeof props[k] == "string") {
@@ -35,9 +42,11 @@ namespace pxt.analytics {
         pxt.tickEvent = function (id: string, data?: Map<string | number>, opts?: TelemetryEventOptions): void {
             // Log tick to console if "consoleticks" url param is present.
             // We do this simple check first (rather than the full parse) to minimize overhead when it's not present, which is most of the time.
-            if(window && /consoleticks=/.test(window.location.href))
+            if(consoleTicks != ConsoleTickOptions.Off)
             {
-                consoleLogTick(id, data, opts);
+                const prefix = consoleTicks == ConsoleTickOptions.Short ? "" : `${new Date().toLocaleTimeString(undefined, { hour12: false })} - Tick - `;
+                const tickInfo = `${id} ${data ? JSON.stringify(data) : "<no data>"} ${opts ? JSON.stringify(opts) : "<no opts>"}`;
+                console.log(prefix + tickInfo);
             }
 
             if (te) te(id, data, opts);
@@ -85,16 +94,5 @@ namespace pxt.analytics {
                 pxt.aiTrackException(err, 'error', props);
             }
         };
-    }
-
-    function consoleLogTick(id: string, data: Map<string | number>, opts: TelemetryEventOptions) {
-        const query = Util.parseQueryString(window.location.href);
-        const tickInfo = `${id} ${data ? JSON.stringify(data) : "<no data>"} ${opts ? JSON.stringify(opts) : "<no opts>"}`;
-        if (query["consoleticks"] == "1" || query["consoleticks"] == "full") {
-            const timestamp = new Date().toLocaleTimeString(undefined, { hour12: false });
-            console.log(`${timestamp} - Tick - ${tickInfo}`);
-        } else if (query["consoleticks"] == "2" || query["consoleticks"] == "short") {
-            console.log(tickInfo);
-        }
     }
 }

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -15,7 +15,7 @@ namespace pxt.analytics {
         Short,
         Verbose
     };
-    export var consoleTicks: ConsoleTickOptions = ConsoleTickOptions.Off;
+    export let consoleTicks: ConsoleTickOptions = ConsoleTickOptions.Off;
 
     export function addDefaultProperties(props: Map<string | number>) {
         Object.keys(props).forEach(k => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5554,20 +5554,26 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     pxt.setupWebConfig((window as any).pxtConfig);
     const config = pxt.webConfig
-    pxt.options.debug = /dbg=1/i.test(window.location.href);
-    if (pxt.options.debug)
+
+    const optsQuery = Util.parseQueryString(window.location.href.toLowerCase());
+    if (optsQuery["dbg"] == "1")
         pxt.debug = console.debug;
-    pxt.options.light = /light=1/i.test(window.location.href) || pxt.BrowserUtils.isARM() || pxt.BrowserUtils.isIE();
+    pxt.options.light = optsQuery["light"] == "1" || pxt.BrowserUtils.isARM() || pxt.BrowserUtils.isIE();
     if (pxt.options.light) {
         pxsim.U.addClass(document.body, 'light');
     }
-    const wsPortMatch = /wsport=(\d+)/i.exec(window.location.href);
-    if (wsPortMatch) {
-        pxt.options.wsPort = parseInt(wsPortMatch[1]) || 3233;
-        pxt.BrowserUtils.changeHash(window.location.hash.replace(wsPortMatch[0], ""));
+    if (optsQuery["wsport"]) {
+        pxt.options.wsPort = parseInt(optsQuery["wsport"]) || 3233;
+        pxt.BrowserUtils.changeHash(window.location.hash.replace(`wsport=${optsQuery["wsport"]}`, ""));
     } else {
         pxt.options.wsPort = 3233;
     }
+    if (optsQuery["consoleticks"] == "1" || optsQuery["consoleticks"] == "verbose") {
+        pxt.analytics.consoleTicks = pxt.analytics.ConsoleTickOptions.Verbose;
+    } else if (optsQuery["consoleticks"] == "2" || optsQuery["consoleticks"] == "short") {
+        pxt.analytics.consoleTicks = pxt.analytics.ConsoleTickOptions.Short;
+    }
+
     pxt.perf.measureStart("setAppTarget");
     pkg.setupAppTarget((window as any).pxtTargetBundle);
 


### PR DESCRIPTION
Add a url parameter (`consoleticks`), which will send all tick events to the console. I find this makes it much easier to test and debug telemetry events.

It comes with a two "modes". By default (`consoleticks=1` or `consoleticks=verbose`), it will print output like so:
```15:34:29 - Tick - activity.autorun {"editor":"blocksArea"} <no opts>```

You can also specify `consoleticks=2` or `consoleticks=short` to get a more abbreviated output:
```activity.autorun {"editor":"blocksArea"} <no opts>```