### PR TITLE
Fix high contrast issues for palette editor and extensions page

### DIFF
--- a/react-common/components/controls/Modal.tsx
+++ b/react-common/components/controls/Modal.tsx
@@ -127,5 +127,5 @@ export const Modal = (props: ModalProps) => {
                 </div>
             }
         </div>
-    </FocusTrap>, parentElement || document.body)
+    </FocusTrap>, parentElement || document.getElementById("root") || document.body)
 }

--- a/react-common/styles/controls/Input.less
+++ b/react-common/styles/controls/Input.less
@@ -125,7 +125,7 @@
  *                 High Contrast                    *
  ****************************************************/
 
-.high-contrast {
+.high-contrast, .hc {
     .common-input {
         color: @highContrastTextColor;
         border-color: @highContrastTextColor;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5701
Fixes https://github.com/microsoft/pxt-microbit/issues/4997

At first glance, high contrast seemed to be working, but that was only the case if you had just turned high contrast on. If instead, you already had high contrast on from a previous session or reloaded the page, the palette editor and extensions page would not be in high contrast mode.