### PR TITLE
Tighten Up Sim-Sidebar & Tablet Tutorial Layout

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -194,7 +194,8 @@ pre {
 }
 
 .editor-sidebar {
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
     margin-top: 0;
     margin-bottom: 0;
     right: 0;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -140,6 +140,20 @@
 }
 
 /*******************************
+        Header Bar
+*******************************/
+
+.tutorial-header-label {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    .ui.item {
+        padding: 0.2rem !important;
+    }
+}
+
+/*******************************
          Step Counter
 *******************************/
 
@@ -1104,6 +1118,10 @@
         .counter-next-button .common-button-label {
             display: none;
         }
+    }
+
+    .tutorial-header-label .tutorial-header-step-label {
+        display: none !important;
     }
 
     /*******************************

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -257,8 +257,8 @@
 
 .tutorial-hint.ui.button,
 .tutorial-hint .ui.button {
-    height: 3.2rem;
-    width: 3.2rem;
+    height: 3rem;
+    width: 3rem;
     margin: 0;
     border-radius: 50%;
     font-size: @tutorialTitleFontSize;
@@ -639,7 +639,7 @@
         (tablet & sim-sidebar views)
 *************************************/
 
-.topInstructionsSettings {
+.topInstructionsSettings() {
     #root.tabTutorial,
     #root.headless.tabTutorial {
         #maineditor > .full-abs {
@@ -650,6 +650,10 @@
             height: @defaultTutorialHeight;
             width: 100%;
         }
+    }
+
+    .tutorial-step-label {
+        display: none;
     }
 
     .editor-sidebar {
@@ -668,10 +672,6 @@
     .tutorial-content {
         margin: 0;
         padding-bottom: 0;
-    }
-
-    .tutorial-content-bkg {
-        padding: 0 1rem;
     }
 
     .tutorial-replace-code + .tutorial-scroll-gradient,
@@ -705,7 +705,6 @@
     /*******************************
             Step Counter
     *******************************/
-
     .tutorial-step-counter {
         display: flex;
         flex-direction: row;
@@ -716,12 +715,25 @@
         padding-right: 0;
         column-gap: 1rem;
         margin-bottom: .5rem;
+        border-bottom: unset;
+        padding: unset;
+        margin-left: auto;
+
+        .ui.button {
+            margin: 0;
+            padding: 0.75rem;
+        }
     }
 
     .tutorial-step-bubbles {
-        flex: 1;
-        max-width: 20rem;
-        min-width: 13rem;
+        min-width: 30rem;
+    }
+
+    .common-button.square-button {
+        margin: 0;
+        border: unset;
+        color: @tutorialSecondaryColor !important;
+        background: @tutorialPrimaryColor;
     }
 
     /*******************************
@@ -996,6 +1008,10 @@
 @media only screen and (max-width: @largestTabletScreen) {
     .topInstructionsSettings();
 
+    .tutorial-step-bubbles {
+        min-width: 25rem;
+    }
+
     .editor-sidebar {
         top: @mobileMenuHeight;
     }
@@ -1068,6 +1084,14 @@
     }
     .tutorial-title {
         max-width: 100%;
+    }
+
+    .tutorial-step-bubbles {
+        min-width: 20rem;
+
+        .ui.button > .ui.text {
+            display: none;
+        }
     }
 
     /*******************************

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -732,7 +732,7 @@
     .common-button.square-button {
         margin: 0;
         border: unset;
-        color: @tutorialSecondaryColor !important;
+        color: @white !important;
         background: @tutorialPrimaryColor;
     }
 
@@ -752,7 +752,7 @@
     }
 
     .tutorial-hint .tutorial-callout-button.ui.button {
-        color: @tutorialSecondaryColor;
+        color: @white;
         background: @tutorialPrimaryColor;
 
         &.disabled {

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -229,7 +229,6 @@
     justify-content: space-between;
     flex-wrap: wrap;
     margin-bottom: 1rem;
-    padding-top: 1rem;
 
     .ui.button {
         margin: 0 1rem;
@@ -711,17 +710,19 @@
         align-items: center;
         justify-content: space-between;
         flex-wrap: wrap;
-        padding-left: 0;
-        padding-right: 0;
+        padding: 1rem 0 0 0;
         column-gap: 1rem;
         margin-bottom: .5rem;
         border-bottom: unset;
-        padding: unset;
         margin-left: auto;
 
         .ui.button {
             margin: 0;
-            padding: 0.75rem;
+            padding: 0.65rem;
+
+            .right {
+                margin-left: 0;
+            }
         }
     }
 
@@ -960,6 +961,12 @@
         margin-bottom: 1.5rem;
     }
 
+    .tutorial-container-outer:not(.topInstructions) {
+        .tutorial-controls {
+            padding-top: 1rem;
+        }
+    }
+    
     /* Short Deskstop Only */
     @media (max-height: @tallEditorBreakpoint) {
         #root.tabTutorial:not(.fullscreensim) {
@@ -1018,10 +1025,6 @@
 
     .tutorial-hint .tutorial-callout-button.ui.button {
         margin: 1rem;
-    }
-
-    .tutorial-controls {
-        padding-top: 0;
     }
 
     .tutorial-container > .ui.button i.icon {
@@ -1089,7 +1092,16 @@
     .tutorial-step-bubbles {
         min-width: 20rem;
 
-        .ui.button > .ui.text {
+        .ui.button {
+            padding: 0.5rem;
+
+            .right {
+                padding: 0;
+                margin: 0;
+            }
+        }
+
+        .counter-next-button .common-button-label {
             display: none;
         }
     }

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -238,6 +238,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         currentStep={visibleStep}
         totalSteps={steps.length}
         title={name}
+        customNext={isHorizontal ? nextButton : undefined}
         setTutorialStep={handleStepCounterSetStep} />;
     const hasHint = !!hintMarkdown;
 
@@ -246,7 +247,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         {!isHorizontal && stepCounter}
         <div className={classList("tutorial-content", hasHint && "has-hint")} ref={contentRef} onScroll={tutorialContentScroll}>
             <div className={"tutorial-content-bkg"}>
-                {isHorizontal ? stepCounter : <div className="tutorial-step-label">
+                {!isHorizontal && <div className="tutorial-step-label">
                     {name && <span className="tutorial-step-title">{name}</span>}
                     <span className="tutorial-step-number">{lf("Step {0} of {1}", visibleStep + 1, steps.length)}</span>
                 </div>}
@@ -255,7 +256,8 @@ export function TutorialContainer(props: TutorialContainerProps) {
                 <MarkedContent className="no-select tutorial-step-content" tabIndex={0} markdown={markdown} parent={parent}/>
                 <div className="tutorial-controls">
                     {hasHint && <TutorialHint tutorialId={tutorialId} currentStep={visibleStep} markdown={hintMarkdown} parent={parent} />}
-                    { nextButton }
+                    {isHorizontal && stepCounter}
+                    {!isHorizontal && nextButton}
                 </div>
             </div>
         </div>

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -238,8 +238,9 @@ export function TutorialContainer(props: TutorialContainerProps) {
         currentStep={visibleStep}
         totalSteps={steps.length}
         title={name}
-        customNext={isHorizontal ? nextButton : undefined}
-        setTutorialStep={handleStepCounterSetStep} />;
+        isHorizontal={isHorizontal}
+        setTutorialStep={handleStepCounterSetStep}
+        onDone={onTutorialComplete} />;
     const hasHint = !!hintMarkdown;
 
 

--- a/webapp/src/components/tutorial/TutorialStepCounter.tsx
+++ b/webapp/src/components/tutorial/TutorialStepCounter.tsx
@@ -5,6 +5,8 @@ interface TutorialStepCounterProps {
     currentStep: number;
     totalSteps: number;
     title?: string;
+    customNext?: JSX.Element; // TODO thsparks : This feels weird, but alternative (I can think of) is to duplicate a bunch of next/done logic from TutorialContainer, so maybe this is preferable?
+    isHorizontal?: boolean;
     setTutorialStep: (step: number) => void;
 }
 
@@ -65,14 +67,16 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
                     label={stepNum === currentStep ? `${stepNum + 1}` : undefined}
                 />
             })}
-            <Button
-                disabled={currentStep == totalSteps - 1}
-                className="square-button"
-                leftIcon="icon right chevron"
-                onClick={handleNextStep}
-                aria-label={nextButtonLabel}
-                title={nextButtonLabel}
-            />
+            {
+                props.customNext ??
+                <Button
+                    disabled={currentStep == totalSteps - 1}
+                    className="square-button"
+                    leftIcon="icon right chevron"
+                    onClick={handleNextStep}
+                    aria-label={nextButtonLabel}
+                    title={nextButtonLabel} />
+            }
         </div>
     </div>
 }

--- a/webapp/src/components/tutorial/TutorialStepCounter.tsx
+++ b/webapp/src/components/tutorial/TutorialStepCounter.tsx
@@ -5,9 +5,9 @@ interface TutorialStepCounterProps {
     currentStep: number;
     totalSteps: number;
     title?: string;
-    customNext?: JSX.Element; // TODO thsparks : This feels weird, but alternative (I can think of) is to duplicate a bunch of next/done logic from TutorialContainer, so maybe this is preferable?
     isHorizontal?: boolean;
     setTutorialStep: (step: number) => void;
+    onDone: () => void;
 }
 
 export function TutorialStepCounter(props: TutorialStepCounterProps) {
@@ -39,7 +39,27 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
 
     const stepButtonLabelText = (step: number) => lf("Go to step {0} of {1}", step + 1, totalSteps);
     const backButtonLabel = lf("Go to the previous step of the tutorial.");
-    const nextButtonLabel = lf("Go to the next step of the tutorial.");
+
+    const lastStep = currentStep == totalSteps - 1;
+    const nextButtonTitle = lastStep ? lf("Finish the tutorial.") : lf("Go to the next step of the tutorial.");
+    const nextButtonAction = lastStep ? props.onDone : handleNextStep;
+
+    const nextButton = props.isHorizontal ? (
+        <Button
+            className="ui button counter-next-button"
+            leftIcon={`icon ${lastStep ? "check" : "arrow circle right"}`}
+            onClick={nextButtonAction}
+            aria-label={nextButtonTitle}
+            title={nextButtonTitle}
+            label={lf("Next")} />
+    ) : (
+        <Button
+            className="square-button"
+            leftIcon={`icon ${lastStep ? "check" : "right chevron"}`}
+            onClick={nextButtonAction}
+            aria-label={nextButtonTitle}
+            title={nextButtonTitle} />
+    );
 
     return <div className="tutorial-step-counter">
         <div className="tutorial-step-label">
@@ -50,7 +70,7 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
             <Button
                 disabled={currentStep == 0}
                 className="square-button"
-                leftIcon="icon left chevron"
+                leftIcon={`icon ${props.isHorizontal ? "arrow circle left" : "left chevron"}`}
                 onClick={handlePreviousStep}
                 aria-label={backButtonLabel}
                 title={backButtonLabel}
@@ -67,16 +87,7 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
                     label={stepNum === currentStep ? `${stepNum + 1}` : undefined}
                 />
             })}
-            {
-                props.customNext ??
-                <Button
-                    disabled={currentStep == totalSteps - 1}
-                    className="square-button"
-                    leftIcon="icon right chevron"
-                    onClick={handleNextStep}
-                    aria-label={nextButtonLabel}
-                    title={nextButtonLabel} />
-            }
+            {nextButton}
         </div>
     </div>
 }

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -90,7 +90,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
         } else if (debugging) {
             return "debugging";
         } else if (!pxt.BrowserUtils.useOldTutorialLayout() && !!tutorialOptions?.tutorial) {
-            return "tutorial-tab"
+            return "tutorial-tab";
         } else if (!!tutorialOptions?.tutorial) {
             return "tutorial";
         } else {
@@ -137,7 +137,22 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
                 if (!hideIteration) return <tutorial.TutorialMenu parent={this.props.parent} />
                 break;
             case "tutorial-tab":
-                return <div />
+                if (tutorialOptions && (pxt.appTarget?.appTheme?.tutorialSimSidebarLayout || pxt.BrowserUtils.isTabletSize())) {
+                    const currentStep = tutorialOptions.tutorialStep ? tutorialOptions.tutorialStep + 1 : undefined;
+                    const totalSteps = tutorialOptions.tutorialStepInfo ? tutorialOptions.tutorialStepInfo?.length : undefined;
+                    return (
+                        <div className="tutorial-header-label">
+                            <div className="ui item tutorial-header-name-label">{tutorialOptions.tutorialName}</div>
+                            {currentStep && totalSteps && (
+                                <>
+                                    <div className="ui item tutorial-header-step-label">{" - "}</div> { /* Keeping this separate helps simplify spacing */ }
+                                    <div className="ui item tutorial-header-step-label">{lf("Step {0} of {1}", currentStep, totalSteps, totalSteps)}</div>
+                                </>
+                            )}
+                        </div>
+                    );
+                }
+                return <div />;
             case "debugging":
                 return  <sui.MenuItem className="centered" icon="large bug" name="Debug Mode" />
             case "sandbox":

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -141,7 +141,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
 
         const simContainerClassName = `simulator-container ${this.props.tutorialSimSidebar ? "" : " hidden"}`;
         const outerTutorialContainerClassName = `editor-sidebar tutorial-container-outer${this.props.tutorialSimSidebar ? " topInstructions" : ""}`
-        const editorSidebarHeight = height ? { height: `calc(${height}px + 3rem)` } : undefined;
+        const editorSidebarHeight = height ? { height: `calc(${height}px + 0.5rem)` } : undefined;
 
         return <div id="simulator" className="simulator">
             {!hasSimulator && <div id="boardview" className="headless-sim" role="region" aria-label={lf("Simulator")} tabIndex={-1} />}


### PR DESCRIPTION
## Overview
This change makes some adjustments to try and reduce empty space in our sim-sidebar and tablet tutorial layouts. Notabel adjustments include:
1. Moving the tutorial name and step to the header bar
2. Moving the step counter to the bottom and combining it with the next button
3. Reduce some of the padding
4. Scroll-bar if the sim is taller than the screen

This change affects the desktop view when sim-sidebar is enabled and the tablet and mobile views, even when the sim-sidebar flag is disabled.

Try it here: https://makecode.microbit.org/app/9da527050b955d5e99842495ee9bbb28752bb8a5-fc35b1c6da

## Screenshots

### Desktop, sim-sidebar view
<img width="688" alt="image" src="https://user-images.githubusercontent.com/69657545/227065088-a7f32d3b-f658-4e3b-9b24-4f0aa1dc01d6.png">

### Desktop, No Sim-Sidebar View
<img width="688" alt="image" src="https://user-images.githubusercontent.com/69657545/227066432-22a9684f-9577-4359-ae47-0a34880cfc37.png">

### Tablet
|  Microbit | Arcade |
| ----------- | ----------- |
| <img width="431" alt="image" src="https://user-images.githubusercontent.com/69657545/227065172-d4c13133-c6b5-49b9-8b4c-67aab463b55b.png"> | <img width="459" alt="image" src="https://user-images.githubusercontent.com/69657545/227066472-f21380a4-fc77-4657-9b22-fc1fcf71af71.png"> |

### Mobile
|  Microbit | Arcade |
| ----------- | ----------- |
| <img width="323" alt="image" src="https://user-images.githubusercontent.com/69657545/227065235-4d0ea1d6-ccd6-4a1c-a31b-2ba30f96471c.png"> | <img width="361" alt="image" src="https://user-images.githubusercontent.com/69657545/227066519-8553c0cd-eeb2-4ca1-840d-c3d8c8455cd1.png"> |