### PR TITLE
fix tiny width explorer

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -245,7 +245,7 @@ pre {
 
 .editor-sidebar .filemenu {
     direction: ltr;
-    width: 100%;
+    width: 100% !important;
     margin: 0;
     margin-top: 1rem;
 }


### PR DESCRIPTION
changing the selector from `#editorSidebar` to `.editor-sidebar` made this one have less specificity then a few other rules / become tiny. Might want to check on the rules that were changed by this as I think some others slipped through too (e.g. the section was scrollable before too, so there's probably a selector that got overridden making https://github.com/microsoft/pxt/pull/9437/commits/08cd330479b23a05d5ba7fc4e3ff85980af6977b necessary)
![image](https://user-images.githubusercontent.com/5615930/227273609-1220057c-b993-4ae7-a60e-def4599e09c0.png)
