### PR TITLE
Fix Sim Layout on Page Refreshed

### DIFF
--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -44,7 +44,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     constructor(props: SidepanelProps) {
         super(props);
 
-        if(!props.tutorialSimSidebar) {
+        if(props.tutorialOptions?.tutorial && !props.tutorialSimSidebar) {
             this.props.showMiniSim(true);
         }
     }


### PR DESCRIPTION
I recently added a check in the sidepanel to display the minisim if we're not in sim-sidebar view, but I had forgotten to only do so in tutorial mode, so it was happening even in a regular projects when the user refreshed the page.

Fixes https://github.com/microsoft/pxt-arcade/issues/5814