### PR TITLE
Hide Tutorial Instructions in Fullscreen Mode and Fix CSS Specificity 

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1416,6 +1416,9 @@ p.ui.font.small {
         display: none !important;
         z-index: -10 !important;
     }
+    #tutorialWrapper {
+        display: none;
+    }
     .sandboxfooter {
         z-index: @sandboxFooterZIndex;
         bottom: 1rem;

--- a/theme/common.less
+++ b/theme/common.less
@@ -55,18 +55,18 @@ pre {
     position: relative;
 }
 
-.editor-sidebar,
+#simulator .editor-sidebar,
 #maineditor,
 #sidedocs {
   position: absolute;
   bottom: 0rem;
 }
 
-.editor-sidebar, #maineditor, #sidedocs {
+#simulator .editor-sidebar, #maineditor, #sidedocs {
     top: @mainMenuHeight;
 }
 
-.hideMenuBar:not(.headless) .editor-sidebar,
+.hideMenuBar:not(.headless) #simulator .editor-sidebar,
     .hideMenuBar #maineditor,
     .hideMenuBar #sidedocs {
     top: 0 !important;
@@ -159,7 +159,7 @@ pre {
     border: unset;
 }
 
-#blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, .editor-sidebar {
+#blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #simulator .editor-sidebar {
     bottom: @editorToolsCollapsedHeight;
 }
 
@@ -169,7 +169,7 @@ pre {
 .hideEditorToolbar #serialEditor,
 .hideEditorToolbar #githubEditor,
 .hideEditorToolbar #assetEditor,
-.hideEditorToolbar .editor-sidebar {
+.hideEditorToolbar #simulator .editor-sidebar {
     bottom: 0rem !important;
 }
 
@@ -187,13 +187,13 @@ pre {
 #simulator {
     height: 100%;
 }
-.editor-sidebar, #downloadArea {
+#simulator .editor-sidebar, #downloadArea {
     min-width: @simulatorWidth;
     max-width: @simulatorWidth;
     left: 0;
 }
 
-.editor-sidebar {
+#simulator .editor-sidebar {
     overflow-x: hidden;
     overflow-y: auto;
     margin-top: 0;
@@ -214,7 +214,7 @@ pre {
 }
 
 
-.editor-sidebar .simtoolbar {
+#simulator .editor-sidebar .simtoolbar {
     -webkit-transition: opacity 0.2s; /* Safari */
     -moz-transition: opacity 0.2s; /* Mozilla */
     -webkit-transition-timing-function: linear; /* Mozilla */
@@ -244,7 +244,7 @@ pre {
     background-color: transparent !important;
 }
 
-.editor-sidebar .filemenu {
+#simulator .editor-sidebar .filemenu {
     direction: ltr;
     width: 100% !important;
     margin: 0;
@@ -674,7 +674,7 @@ div.simframe > iframe {
     z-index: 1000;
 }
 
-.notificationBannerVisible .editor-sidebar,
+.notificationBannerVisible #simulator .editor-sidebar,
 .notificationBannerVisible #maineditor,
 .notificationBannerVisible #sidedocs {
     top: calc(@mainMenuHeight + @bannerHeight);
@@ -1210,7 +1210,7 @@ Field editors
 @sidebarSecondaryColor: @blue;
 @sidbarActiveTabIconColor: @sidebarSecondaryColor;
 
-.editor-sidebar {
+#simulator .editor-sidebar {
     border-right: 2px solid darken(desaturate(@blocklyToolboxColor, 60%), 10%);
 
     .tab-navigation {
@@ -1311,7 +1311,7 @@ p.ui.font.small {
         display:none !important; // hide desktop simulator toggle
     }
 
-    .hideEditorToolbar .editor-sidebar {
+    .hideEditorToolbar #simulator .editor-sidebar {
         display:none !important;
     }
 
@@ -1494,7 +1494,7 @@ p.ui.font.small {
 }
 
 #root.headless.collapsedEditorTools {
-    .editor-sidebar {
+    #simulator .editor-sidebar {
         position: absolute;
         width: auto;
         top: auto;
@@ -1514,7 +1514,7 @@ p.ui.font.small {
 }
 
 #root.headless:not(.collapsedEditorTools) {
-    .editor-sidebar {
+    #simulator .editor-sidebar {
         left: 0;
         z-index: 40;
     }
@@ -1877,7 +1877,7 @@ p.ui.font.small {
 
 /* >= Small Monitor (Small Monitor + Large Monitor + Wide Monitor) */
 @media only screen and (min-width: @computerBreakpoint) {
-    .collapsedEditorTools:not(.headless):not(.tabTutorial) .editor-sidebar {
+    .collapsedEditorTools:not(.headless):not(.tabTutorial) #simulator .editor-sidebar {
         min-width: 21px;
         width: 21px;
         padding: 0;
@@ -1908,7 +1908,7 @@ p.ui.font.small {
         position: relative;
     }
 
-    .topInstructions {
+    #simulator .topInstructions {
         left: @simulatorWidth;
         min-width: unset;
         max-width: unset;
@@ -1919,12 +1919,12 @@ p.ui.font.small {
 /* <= Small Monitor (Mobile + Tablet + Small Monitor) */
 @media only screen and (max-width: @largestSmallMonitor) {
     /* Layout */
-    .editor-sidebar, #downloadArea {
+    #simulator .editor-sidebar, #downloadArea {
         min-width:@simulatorWidthSmall;
         max-width:@simulatorWidthSmall;
     }
 
-    .topInstructions {
+    #simulator .topInstructions {
         left: @simulatorWidthSmall;
         min-width: unset;
         max-width: unset;
@@ -1995,7 +1995,7 @@ p.ui.font.small {
         }
     }
 
-    .editor-sidebar {
+    #simulator .editor-sidebar {
         min-width: unset;
         max-width: unset;
         width: 0;
@@ -2181,7 +2181,7 @@ p.ui.font.small {
     #maineditor {
         top: @thinMenuHeight;
     }
-    .editor-sidebar {
+    #simulator .editor-sidebar {
         top: @thinMenuHeight;
     }
 }

--- a/theme/greenscreen.less
+++ b/theme/greenscreen.less
@@ -25,9 +25,9 @@
         transform: scaleX(-1);
     }
 
-    #maineditor, .editor-sidebar, .blocklyToolboxDiv, svg.blocklySvg,
+    #maineditor, #simulator .editor-sidebar, .blocklyToolboxDiv, svg.blocklySvg,
     .monaco-editor, .monaco-editor .margin, .monaco-editor .monaco-editor-background,
-    .monacoToolboxDiv, .editor-sidebar .tutorial-container-outer.active, .tutorial-container-outer {
+    .monacoToolboxDiv, #simulator .editor-sidebar .tutorial-container-outer.active, .tutorial-container-outer {
         background-image: none !important;
         background-color: transparent !important;
         border: none !important;

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -214,7 +214,7 @@
     #root {
         background: @HCRootBackground !important;
     }
-    .editor-sidebar {
+    #simulator .editor-sidebar {
         background: @HCsimulatorBackground !important;
 
         #boardview {
@@ -877,7 +877,7 @@
         border: 1px solid @HCtextColor;
     }
 
-    .editor-sidebar .tab-navigation {
+    #simulator .editor-sidebar .tab-navigation {
         color: @HCtextColor;
         background-color: @HCbackground;
         border-bottom: 2px solid @HCtextColor;
@@ -966,7 +966,7 @@
     /* immersive reader */
     .modals .ui.button.immersive-reader-button,
     #mainmenu .immersive-reader-button.ui.item,
-    .editor-sidebar .immersive-reader-button.ui.item {
+    #simulator .editor-sidebar .immersive-reader-button.ui.item {
         border: 1px solid #fff!important;
         background-image: @immersiveReaderLightIcon !important;
         background-repeat: no-repeat !important;
@@ -978,8 +978,8 @@
     .modals .ui.button.immersive-reader-button:hover,
     #mainmenu .immersive-reader-button.ui.item:focus,
     #mainmenu .immersive-reader-button.ui.item:hover,
-    .editor-sidebar .immersive-reader-button.ui.item:focus,
-    .editor-sidebar .immersive-reader-button.ui.item:hover {
+    #simulator .editor-sidebar .immersive-reader-button.ui.item:focus,
+    #simulator .editor-sidebar .immersive-reader-button.ui.item:hover {
         background-color: white !important;
         background-image: @immersiveReaderIcon !important;
         background-repeat: no-repeat !important;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -29,12 +29,12 @@
         Tutorial Tab
 *******************************/
 
-.editor-sidebar .tutorial-container-outer.active {
+#simulator .editor-sidebar .tutorial-container-outer.active {
     background-color: @white;
 }
 
 .tutorial-container-outer {
-    background-color: @white;
+    background-color: @white !important;
 }
 
 .tutorial-content-bkg {
@@ -502,7 +502,7 @@
 *******************************/
 
 .tabTutorial.tutorial-embed {
-    .editor-sidebar, #maineditor, &.sideDocs #sidedocs, .simView #simulators {
+    #simulator .editor-sidebar, #maineditor, &.sideDocs #sidedocs, .simView #simulators {
         top: 0;
     }
     .simView #boardview {
@@ -515,7 +515,7 @@
 *******************************/
 
 #root.headless.tabTutorial {
-    .editor-sidebar {
+    #simulator .editor-sidebar {
         position: relative;
         display: block !important;
         width: @simulatorWidth;
@@ -534,7 +534,7 @@
 }
 
 #root.headless.tabTutorial.hideMenuBar {
-    .editor-sidebar {
+    #simulator .editor-sidebar {
         top: 0;
         height: 100%;
     }
@@ -659,7 +659,7 @@
             top: @defaultTutorialHeight;
         }
 
-        .editor-sidebar {
+        #simulator .editor-sidebar {
             height: @defaultTutorialHeight;
             width: 100%;
         }
@@ -669,12 +669,12 @@
         display: none;
     }
 
-    .editor-sidebar {
+    #simulator .editor-sidebar {
         border-right: 0;
         border-bottom: 2px solid darken(desaturate(@blocklyToolboxColor, 60%), 10%);
     }
 
-    .tutorial-container-outer {
+    #simulator .tutorial-container-outer {
         padding-top: 0;
     }
 
@@ -884,14 +884,14 @@
 
     #root.headless.tabTutorial.collapsedEditorTools {
         #maineditor { left: 0; }
-        .editor-sidebar { width: 100%; }
+        #simulator .editor-sidebar { width: 100%; }
 
         .tutorial-top-bar {
            right: 4rem;
         }
 
-        .editor-sidebar .immersive-reader-button.ui.item,
-        .editor-sidebar .immersive-reader-button.ui.item:focus{
+        #simulator .editor-sidebar .immersive-reader-button.ui.item,
+        #simulator .editor-sidebar .immersive-reader-button.ui.item:focus{
             background-image: @immersiveReaderIcon;
         }
         .tutorial-step-counter {
@@ -955,7 +955,7 @@
 /* Desktop Only */
 @media only screen and (min-width: @largestTabletScreen) {
     #root.tabTutorial:not(.fullscreensim, .greenscreen) {
-        .editor-sidebar:not(.topInstructions) {
+        #simulator .editor-sidebar:not(.topInstructions) {
             bottom: 0;
         }
 
@@ -963,13 +963,13 @@
             display: none;
         }
     }
-    .editor-sidebar:not(.topInstructions) .tutorial-container .tutorial-step-counter {
+    #simulator .editor-sidebar:not(.topInstructions) .tutorial-container .tutorial-step-counter {
         .tutorial-step-label {
             display: none;
         }
     }
 
-    .editor-sidebar:not(.topInstructions) .tutorial-step-label {
+    #simulator .editor-sidebar:not(.topInstructions) .tutorial-step-label {
         font-size: 1rem;
         justify-content: space-between;
         margin-bottom: 1.5rem;
@@ -1033,7 +1033,7 @@
         min-width: 25rem;
     }
 
-    .editor-sidebar {
+    #simulator .editor-sidebar {
         top: @mobileMenuHeight;
     }
 
@@ -1050,7 +1050,7 @@
 @media only screen and (min-width: @largestMobileScreen) and (max-height: @tallEditorBreakpoint) {
     #root.tabTutorial,
     #root.headless.tabTutorial {
-        .editor-sidebar {
+        #simulator .editor-sidebar {
             top: @thinMenuHeight;
         }
     }

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -522,8 +522,8 @@ code.lang-filterblocks {
 ******************************/
 // TODO (shakao) remove #mainmenu items when cleaning up
 // old tutorial code
-.editor-sidebar .immersive-reader-button.ui.item,
-.editor-sidebar .immersive-reader-button.ui.item:focus,
+#simulator .editor-sidebar .immersive-reader-button.ui.item,
+#simulator .editor-sidebar .immersive-reader-button.ui.item:focus,
 #mainmenu .immersive-reader-button.ui.item,
 #mainmenu .immersive-reader-button.ui.item:focus {
     width: 2rem;
@@ -537,8 +537,8 @@ code.lang-filterblocks {
 #mainmenu .immersive-reader-button.ui.item:focus {
     background-image: @immersiveReaderLightIcon;
 }
-.editor-sidebar .immersive-reader-button.ui.item,
-.editor-sidebar .immersive-reader-button.ui.item:focus{
+#simulator .editor-sidebar .immersive-reader-button.ui.item,
+#simulator .editor-sidebar .immersive-reader-button.ui.item:focus{
     background-image: @immersiveReaderIcon;
 }
 
@@ -701,7 +701,7 @@ code.lang-filterblocks {
  * CSS for embedded tutorial used in the skills map
  */
 .tutorial.tutorial-embed {
-    .editor-sidebar, #maineditor, &.sideDocs #sidedocs, .simView #simulators {
+    #simulator .editor-sidebar, #maineditor, &.sideDocs #sidedocs, .simView #simulators {
         top: @tutorialEmbedMenuHeight;
     }
     .simView #boardview {
@@ -843,7 +843,7 @@ code.lang-filterblocks {
     * CSS for embedded tutorial used in the skills map
     */
     .tutorial.tutorial-embed {
-        .editor-sidebar {
+        #simulator .editor-sidebar {
             top: unset;
         }
     }


### PR DESCRIPTION
This change fixes https://github.com/microsoft/pxt-microbit/issues/5003. The fix for this happens in `common.less` around line 1419.

It also goes through and adds `#simulator` to the places where I used .editor-sidebar so that the css specificity is closer to what it was before my changes in https://github.com/microsoft/pxt/pull/9430. It used to be id-level and I changed it to class level, which had layout side-effects because the priority of certain styles was now different. The hope is that this will reduce the likelihood of those bugs.