### PR TITLE
Editor Tour: add more telemetry

### DIFF
--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -38,6 +38,7 @@ export interface TeachingBubbleProps extends ContainerProps {
     activeTarget?: boolean; // if true, the target is clickable
     onNext: () => void;
     onBack: () => void;
+    onFinish: () => void;
 }
 
 export const TeachingBubble = (props: TeachingBubbleProps) => {
@@ -52,6 +53,7 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
         onClose,
         onNext,
         onBack,
+        onFinish,
         stepNumber,
         totalSteps,
         parentElement,
@@ -354,7 +356,7 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
                         />}
                         {!hasNext && <Button
                             className="primary-button"
-                            onClick={onClose}
+                            onClick={onFinish}
                             title={finishLabel}
                             ariaLabel={finishLabel}
                             label={finishLabel}

--- a/webapp/src/components/onboarding/EditorTour.tsx
+++ b/webapp/src/components/onboarding/EditorTour.tsx
@@ -57,14 +57,14 @@ export const EditorTour = (props: EditorTourProps) => {
 
     useEffect(() => {
         stepStartTime.current = Date.now();
-    },[currentStep]);
+    }, [currentStep]);
 
     const getTourDuration = () => {
-       return ((Date.now() - tourStartTime.current)/1000).toFixed(1) + "s"
+        return ((Date.now() - tourStartTime.current) / 1000).toFixed(1) + "s";
     }
 
     const getStepDuration = () => {
-        return ((Date.now() - stepStartTime.current)/1000).toFixed(1) + "s"
+        return ((Date.now() - stepStartTime.current) / 1000).toFixed(1) + "s";
     }
 
     const data = () => ({
@@ -96,12 +96,12 @@ export const EditorTour = (props: EditorTourProps) => {
     }
 
     return <TeachingBubble id="teachingBubble"
-            targetContent={EditorContent[currentStep]}
-            onNext={onNext}
-            onBack={onBack}
-            stepNumber={currentStep + 1}
-            totalSteps={EditorContent.length}
-            onClose={onExit}
-            onFinish={onFinish}
-        />
+        targetContent={EditorContent[currentStep]}
+        onNext={onNext}
+        onBack={onBack}
+        stepNumber={currentStep + 1}
+        totalSteps={EditorContent.length}
+        onClose={onExit}
+        onFinish={onFinish}
+    />
 };

--- a/webapp/src/components/onboarding/EditorTour.tsx
+++ b/webapp/src/components/onboarding/EditorTour.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useEffect, useRef, useState } from "react";
 import { Location, TeachingBubble, TargetContent } from "../../../../react-common/components/controls/TeachingBubble";
 
 const Simulator: TargetContent = {
@@ -50,15 +51,49 @@ export interface EditorTourProps {
 
 export const EditorTour = (props: EditorTourProps) => {
     const { onClose } = props;
-    const [currentStep, setCurrentStep] = React.useState(0);
+    const [currentStep, setCurrentStep] = useState(0);
+    const tourStartTime = useRef(Date.now());
+    const stepStartTime = useRef(Date.now());
+
+    useEffect(() => {
+        stepStartTime.current = Date.now();
+    },[currentStep]);
+
+    const getTourDuration = () => {
+       return ((Date.now() - tourStartTime.current)/1000).toFixed(1) + "s"
+    }
+
+    const getStepDuration = () => {
+        return ((Date.now() - stepStartTime.current)/1000).toFixed(1) + "s"
+    }
+
+    const data = () => ({
+        title: EditorContent[currentStep].title,
+        stepDuration: getStepDuration(),
+        tourDuration: getTourDuration(),
+        step: currentStep + 1,
+        totalSteps: EditorContent.length
+    });
 
     const onNext = () => {
+        pxt.tickEvent("tour.next", data());
         setCurrentStep(currentStep + 1);
     };
 
     const onBack = () => {
+        pxt.tickEvent("tour.back", data());
         setCurrentStep(currentStep - 1);
     };
+
+    const onExit = () => {
+        pxt.tickEvent("tour.exit", data());
+        onClose();
+    }
+
+    const onFinish = () => {
+        pxt.tickEvent("tour.finish", data());
+        onClose();
+    }
 
     return <TeachingBubble id="teachingBubble"
             targetContent={EditorContent[currentStep]}
@@ -66,6 +101,7 @@ export const EditorTour = (props: EditorTourProps) => {
             onBack={onBack}
             stepNumber={currentStep + 1}
             totalSteps={EditorContent.length}
-            onClose={onClose}
+            onClose={onExit}
+            onFinish={onFinish}
         />
 };

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -42,7 +42,7 @@ function openDocs(parent: pxt.editor.IProjectView, path: string) {
 }
 
 function startTour(parent: pxt.editor.IProjectView) {
-    pxt.tickEvent(`tour`);
+    pxt.tickEvent(`tour.start`, { origin: "help-menu" });
     parent.showOnboarding();
 }
 


### PR DESCRIPTION
This PR adds telemetry for all button clicks within the editor tour: next, back, exit, and finish.
The data passed includes:
- the title of the content
- stepDuration (time in s the user has been on this step)
- tourDuration (time in s since the user started the tour)
- [current] step
- totalSteps

Example ticks:
![image](https://user-images.githubusercontent.com/15070078/227634072-8951fbd5-b3dc-4da3-a5cf-064dbcdceabb.png)
