### PR TITLE
Allowing setting a theme for sim (& palette) from tutorial md

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1119,6 +1119,7 @@ declare namespace pxt.tutorial {
         tutorialValidationRules?: pxt.Map<boolean>; //a map of rules used in a tutorial and if the rules are activated
         globalBlockConfig?: TutorialBlockConfig; // concatenated `blockconfig.global` sections. Contains block configs applicable to all tutorial steps
         globalValidationConfig?: CodeValidationConfig; // concatenated 'validation.global' sections. Contains validation config applicable to all steps
+        simTheme?: Partial<pxt.PackageConfig>;
     }
 
     interface TutorialMetadata {
@@ -1238,6 +1239,7 @@ declare namespace pxt.tutorial {
         templateLoaded?: boolean; // if the template code has been loaded once, we skip
         globalBlockConfig?: TutorialBlockConfig; // concatenated `blockconfig.global` sections. Contains block configs applicable to all tutorial steps
         globalValidationConfig?: CodeValidationConfig // concatenated 'validation.global' sections. Contains validation config applicable to all steps
+        simTheme?: Partial<pxt.PackageConfig>;
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -91,6 +91,7 @@ declare namespace pxt {
         disablesVariants?: string[]; // don't build these variants, when this extension is enabled
         utf8?: boolean; // force compilation with UTF8 enabled
         disableTargetTemplateFiles?: boolean; // do not override target template files when commiting to github
+        theme?: string | pxt.Map<string>;
     }
 
     interface PackageExtension {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -118,6 +118,7 @@ namespace pxt.editor {
         preferredEditor?: string; // preferred editor to open, pxt.BLOCKS_PROJECT_NAME, ...
         extensionUnderTest?: string; // workspace id of the extension under test
         skillmapProject?: boolean;
+        simTheme?: Partial<pxt.PackageConfig>;
     }
 
     export interface ExampleImportOptions {

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -12,6 +12,7 @@ namespace pxt.gallery {
         filesOverride: pxt.Map<string>;
         dependencies: pxt.Map<string>;
         features?: string[];
+        simTheme?: Partial<pxt.PackageConfig>;
     }
 
     export function parsePackagesFromMarkdown(md: string): pxt.Map<string> {
@@ -63,6 +64,15 @@ namespace pxt.gallery {
 
         return {};
     }
+    export function parseSimThemeJSON(md: string): Partial<pxt.PackageConfig> {
+        const pm = /```simtheme\s+((.|\s)+?)\s*```/i.exec(md);
+
+        if (pm) {
+            return pxt.tutorial.parseSimThemeJson(pm[1]);
+        }
+
+        return {};
+    }
 
     export function parseExampleMarkdown(name: string, md: string): GalleryProject {
         if (!md) return undefined;
@@ -75,6 +85,7 @@ namespace pxt.gallery {
         const source = m[2];
         const features = parseFeaturesFromMarkdown(md);
         const jres = parseJResFromMarkdown(md);
+        const simTheme = parseSimThemeJSON(md);
 
         const prj: GalleryProject = {
             name,
@@ -85,7 +96,8 @@ namespace pxt.gallery {
             dependencies,
             features,
             snippetType,
-            source
+            source,
+            simTheme
         };
 
         prj.filesOverride = {
@@ -97,6 +109,7 @@ namespace pxt.gallery {
             prj.filesOverride[pxt.TILEMAP_JRES] = jres.jres;
             prj.filesOverride[pxt.TILEMAP_CODE] = jres.ts;
         }
+
         return prj;
     }
 

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -65,7 +65,7 @@ namespace pxt.gallery {
         return {};
     }
     export function parseSimThemeJSON(md: string): Partial<pxt.PackageConfig> {
-        const pm = /```simtheme\s+((.|\s)+?)\s*```/i.exec(md);
+        const pm = /```simtheme\s+([\s\S]*?)```/i.exec(md);
 
         if (pm) {
             return pxt.tutorial.parseSimThemeJson(pm[1]);

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -441,6 +441,7 @@ namespace pxt.runner {
             autofocus: simOptions.autofocus,
             queryParameters: simOptions.additionalQueryParameters,
             mpRole: simOptions.mpRole,
+            theme: mainPkg.config?.theme,
         };
         if (pxt.appTarget.simulator && !simOptions.fullScreen)
             runOptions.aspectRatio = parts.length && pxt.appTarget.simulator.partsAspectRatio

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -28,6 +28,7 @@ namespace pxsim {
         single?: boolean;
         traceDisabled?: boolean;
         activePlayer?: 1 | 2 | 3 | 4 | undefined;
+        theme?: string | pxt.Map<string>;
     }
 
     export interface SimulatorInstructionsMessage extends SimulatorMessage {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -75,6 +75,7 @@ namespace pxsim {
         queryParameters?: string;
         mpRole?: "server" | "client";
         activePlayer?: 1 | 2 | 3 | 4 | undefined;
+        theme?: string | pxt.Map<string>;
     }
 
     export interface HwDebugger {
@@ -669,6 +670,7 @@ namespace pxsim {
                 single: opts.single,
                 dependencies: opts.dependencies,
                 activePlayer: opts.activePlayer,
+                theme: opts.theme,
             }
             this.start();
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2826,6 +2826,15 @@ export class ProjectView
         if (options.preferredEditor)
             cfg.preferredEditor = options.preferredEditor;
 
+        if (options.simTheme || options.tutorial?.simTheme) {
+            const theming = options.simTheme || options.tutorial?.simTheme;
+            if (theming.theme) {
+                cfg.theme = theming.theme;
+            }
+            if (theming.palette) {
+                cfg.palette = theming.palette;
+            }
+        }
         if (options.languageRestriction) {
             let filesToDrop = /\.(blocks)$/;
             if (options.languageRestriction === pxt.editor.LanguageRestriction.JavaScriptOnly) {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -329,7 +329,8 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
         autoRun,
         ipc: isIpcRenderer,
         dependencies,
-        activePlayer: playerNumber
+        activePlayer: playerNumber,
+        theme: pkg.config.theme,
     }
     //if (pxt.options.debug)
     //    pxt.debug(JSON.stringify(opts, null, 2))


### PR DESCRIPTION
Allow setting a theme in tutorial / pxt.json, and send that to the sim: https://arcade.makecode.com/app/777ae82cacd76f735a2b99ee0ee53328ed69906c-7731d4169b

w/ tutorial loading bubblegum theme:
https://arcade.makecode.com/app/777ae82cacd76f735a2b99ee0ee53328ed69906c-7731d4169b#tutorial:44182-86552-65080-62109

loading normal project w/ theme set:
https://arcade.makecode.com/app/777ae82cacd76f735a2b99ee0ee53328ed69906c-7731d4169b#pub:_gmeV5DWmEfKf

re: https://github.com/microsoft/pxt-arcade/issues/5819, I took a look around and this should be very simple to implement, but I didn't attach anything for that in this pr / I'll take a look again for next release -- the code is easy but the ux flow / user testing will take a bit and we can't fit that in for a hotfix. I'll find some time to put in the 'glue' for it so we can put something in beta, but before release there would be lots of things to consider, e.g. ;
* making sure user understands when a skin is unlocked
* making sure user understands difference between it being unlocked & being used (e.g. a skillmap might want to use a skin while 'in' it and allow the user to unlock it at the end along with a badge)
* ui for picking skin unlocked skins -- a dropdown is easy but maybe a preview or something?
* how much we care about making sure a user is 'allowed' to share a game with an unlocked skin
    * clientside just not listing in a dropdown, if they edit into pxt.json manually then it works
    * ignore field in pxt.json if not unlocked
    * stripping it from pxt.json when sharing if not unlocked
    * stripping it in backend when sharing if not unlocked

Similarly, I left off any handling for displaying which user you are playing as in the sim when a user sets there skin & edits a multiplayer project; on the sim side I have it set that explicitly defined skin overrides the player # based one to ignore this for now. Since this is only sneaking in the feature for tutorial authors (and manual-pxt-json-editors) at the moment I'd consider this as a fine 'known future enhancement'.

one last thing, I snuck in a fix for the 'not being able to define user palette' issue from https://github.com/microsoft/pxt-arcade/issues/5804 as it wasn't any extra work / fell into the same object. So this provides a way to apply a theme for a tutorial that you've selected in the asset editor.

https://arcade.makecode.com/app/777ae82cacd76f735a2b99ee0ee53328ed69906c-7731d4169b#tutorial:46259-14675-05160-20703

````
```simtheme
{
    "theme": "bubblegum",
    "palette": [
        "#000000",
        "#ffffff",
        "#d45362",
        "#e8958b",
        "#cc8945",
        "#f5dc8c",
        "#417d53",
        "#5dd48f",
        "#5162c2",
        "#6cadeb",
        "#b56edd",
        "#8f3f29",
        "#612431",
        "#c0fac2",
        "#24325e",
        "#1b1221"
    ]
}
```
````