### PR TITLE
Fix Tutorial Layout Bugs

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -669,6 +669,13 @@
         display: none;
     }
 
+    .tutorial-hint.ui.button,
+    .tutorial-hint .ui.button {
+        height: 2.5rem;
+        width: 2.5rem;
+        font-size: 1.1em;
+    }
+
     #simulator .editor-sidebar {
         border-right: 0;
         border-bottom: 2px solid darken(desaturate(@blocklyToolboxColor, 60%), 10%);
@@ -724,9 +731,8 @@
         align-items: center;
         justify-content: space-between;
         flex-wrap: wrap;
-        padding: 1rem 0 0 0;
+        padding: 0 0;
         column-gap: 1rem;
-        margin-bottom: .5rem;
         border-bottom: unset;
         margin-left: auto;
 
@@ -764,6 +770,7 @@
         align-items: center;
         margin: 0;
         margin-top: 0.5rem;
+        padding: 1rem 0 0 0;
 
         > .ui.button {
             width: unset;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -669,8 +669,7 @@
         display: none;
     }
 
-    .tutorial-hint.ui.button,
-    .tutorial-hint .ui.button {
+    .tutorial-callout-button.ui.button {
         height: 2.5rem;
         width: 2.5rem;
         font-size: 1.1em;
@@ -1022,7 +1021,7 @@
         
         .tutorial-callout {
             right: unset;
-            top: 20rem;
+            top: 15rem;
             bottom: unset;
             left: unset;
         }
@@ -1046,10 +1045,6 @@
 
     #simulator .editor-sidebar {
         top: @mobileMenuHeight;
-    }
-
-    .tutorial-hint .tutorial-callout-button.ui.button {
-        margin: 1rem;
     }
 
     .tutorial-container > .ui.button i.icon {

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -734,9 +734,13 @@
             margin: 0;
             padding: 0.65rem;
 
-            .right {
+            .icon {
                 margin-left: 0;
             }
+        }
+        
+        .counter-previous-button .icon {
+            margin: 0;
         }
     }
 

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -788,9 +788,9 @@
     // Overrides
     .tutorial-container-outer:not(.topInstructions) {
         .tutorial-callout {
-            right: 1.6rem;
             bottom: unset;
             left: unset;
+            top: 15rem;
             max-width: 80%;
             transform: translateY(15px);
         }

--- a/webapp/src/components/tutorial/TutorialStepCounter.tsx
+++ b/webapp/src/components/tutorial/TutorialStepCounter.tsx
@@ -44,6 +44,24 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
     const nextButtonTitle = lastStep ? lf("Finish the tutorial.") : lf("Go to the next step of the tutorial.");
     const nextButtonAction = lastStep ? props.onDone : handleNextStep;
 
+    const previousButton = props.isHorizontal ? (
+        <Button
+            disabled={currentStep == 0}
+            className="ui button counter-previous-button"
+            leftIcon="icon arrow circle left"
+            onClick={handlePreviousStep}
+            aria-label={backButtonLabel}
+            title={backButtonLabel} />
+    ) : (
+        <Button
+            disabled={currentStep == 0}
+            className="square-button"
+            leftIcon="left chevron"
+            onClick={handlePreviousStep}
+            aria-label={backButtonLabel}
+            title={backButtonLabel} />
+    );
+
     const nextButton = props.isHorizontal ? (
         <Button
             className="ui button counter-next-button"
@@ -67,14 +85,7 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
             <span className="tutorial-step-number">{lf("Step {0} of {1}", currentStep + 1, totalSteps)}</span>
         </div>
         <div className="tutorial-step-bubbles">
-            <Button
-                disabled={currentStep == 0}
-                className="square-button"
-                leftIcon={`icon ${props.isHorizontal ? "arrow circle left" : "left chevron"}`}
-                onClick={handlePreviousStep}
-                aria-label={backButtonLabel}
-                title={backButtonLabel}
-            />
+            {previousButton}
             {stepsToShow.map(stepNum => {
                 const isCurrentStep = stepNum === currentStep;
                 return <Button

--- a/webapp/src/components/tutorial/TutorialStepCounter.tsx
+++ b/webapp/src/components/tutorial/TutorialStepCounter.tsx
@@ -56,7 +56,7 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
         <Button
             disabled={currentStep == 0}
             className="square-button"
-            leftIcon="left chevron"
+            leftIcon="icon left chevron"
             onClick={handlePreviousStep}
             aria-label={backButtonLabel}
             title={backButtonLabel} />

--- a/webapp/src/components/tutorial/TutorialStepCounter.tsx
+++ b/webapp/src/components/tutorial/TutorialStepCounter.tsx
@@ -42,42 +42,6 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
 
     const lastStep = currentStep == totalSteps - 1;
     const nextButtonTitle = lastStep ? lf("Finish the tutorial.") : lf("Go to the next step of the tutorial.");
-    const nextButtonAction = lastStep ? props.onDone : handleNextStep;
-
-    const previousButton = props.isHorizontal ? (
-        <Button
-            disabled={currentStep == 0}
-            className="ui button counter-previous-button"
-            leftIcon="icon arrow circle left"
-            onClick={handlePreviousStep}
-            aria-label={backButtonLabel}
-            title={backButtonLabel} />
-    ) : (
-        <Button
-            disabled={currentStep == 0}
-            className="square-button"
-            leftIcon="icon left chevron"
-            onClick={handlePreviousStep}
-            aria-label={backButtonLabel}
-            title={backButtonLabel} />
-    );
-
-    const nextButton = props.isHorizontal ? (
-        <Button
-            className="ui button counter-next-button"
-            leftIcon={`icon ${lastStep ? "check" : "arrow circle right"}`}
-            onClick={nextButtonAction}
-            aria-label={nextButtonTitle}
-            title={nextButtonTitle}
-            label={lastStep ? lf("Done") : lf("Next")} />
-    ) : (
-        <Button
-            className="square-button"
-            leftIcon={`icon ${lastStep ? "check" : "right chevron"}`}
-            onClick={nextButtonAction}
-            aria-label={nextButtonTitle}
-            title={nextButtonTitle} />
-    );
 
     return <div className="tutorial-step-counter">
         <div className="tutorial-step-label">
@@ -85,7 +49,13 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
             <span className="tutorial-step-number">{lf("Step {0} of {1}", currentStep + 1, totalSteps)}</span>
         </div>
         <div className="tutorial-step-bubbles">
-            {previousButton}
+            <Button
+                disabled={currentStep == 0}
+                className={props.isHorizontal ? "ui button counter-previous-button" : "square-button"}
+                leftIcon={`icon ${props.isHorizontal ? "arrow circle left" : "left chevron"}`}
+                onClick={handlePreviousStep}
+                aria-label={backButtonLabel}
+                title={backButtonLabel} />
             {stepsToShow.map(stepNum => {
                 const isCurrentStep = stepNum === currentStep;
                 return <Button
@@ -98,7 +68,13 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
                     label={stepNum === currentStep ? `${stepNum + 1}` : undefined}
                 />
             })}
-            {nextButton}
+            <Button
+                className={props.isHorizontal ? "ui button counter-next-button" : "square-button"}
+                leftIcon={`icon ${lastStep ? "check" : props.isHorizontal ? "arrow circle right" : "right chevron"}`}
+                onClick={lastStep ? props.onDone : handleNextStep}
+                aria-label={nextButtonTitle}
+                title={nextButtonTitle}
+                label={props.isHorizontal ? lastStep ? lf("Done") : lf("Next") : ""} />
         </div>
     </div>
 }


### PR DESCRIPTION
This addresses the following tutorial layout issues:

1. Makes Next and Back buttons the same height (fixes https://github.com/microsoft/pxt-microbit/issues/5029).
2. Aligns top of hint and next/back buttons, and shrinks hint button to be the same size as the next/back buttons (fixes https://github.com/microsoft/pxt-microbit/issues/5030).
3. Reduce space between hint button and popup (fixes https://github.com/microsoft/pxt-microbit/issues/5031).

Try it here on Micro:bit: https://makecode.microbit.org/app/1b7457b8c6c200710558a2c93bb057d5a46513fc-e3db915f82

And here on Arcade: https://arcade.makecode.com/app/1cff0a1e2c5efd69dd0811a54ec7ccb282cbfb0e-24044b6328