### PR TITLE
client-side auth cleanup

### DIFF
--- a/authcode/src/services/auth.ts
+++ b/authcode/src/services/auth.ts
@@ -13,13 +13,12 @@ class AuthClient extends pxt.auth.AuthClient {
     protected onSignInFailed(): Promise<void> {
         return Promise.resolve();
     }
-    protected onUserProfileChanged(): Promise<void> {
-        const state = this.getState();
-        if (state.profile) {
+    protected async onUserProfileChanged(): Promise<void> {
+        const state = await pxt.auth.getUserStateAsync();
+        if (state?.profile) {
             pxt.auth.generateUserProfilePicDataUrl(state.profile);
+            store.dispatch(authStore.setUserProfile(state.profile));
         }
-        store.dispatch(authStore.setUserProfile(state.profile));
-        return Promise.resolve();
     }
     protected onUserPreferencesChanged(diff: ts.pxtc.jsonPatch.PatchOperation[]): Promise<void> {
         return Promise.resolve();
@@ -27,7 +26,8 @@ class AuthClient extends pxt.auth.AuthClient {
     protected onStateCleared(): Promise<void> {
         return Promise.resolve();
     }
-    protected async onProfileDeleted(userId: string): Promise<void> {
+    protected onProfileDeleted(userId: string): Promise<void> {
+        return Promise.resolve();
     }
     protected onApiError(err: any): Promise<void> {
         return Promise.resolve();

--- a/multiplayer/src/services/authClient.ts
+++ b/multiplayer/src/services/authClient.ts
@@ -2,7 +2,7 @@ import { userSignedInAsync, setUserProfileAsync } from "../epics";
 
 class AuthClient extends pxt.auth.AuthClient {
     protected async onSignedIn(): Promise<void> {
-        await userSignedInAsync(this.firstName()!);
+        await userSignedInAsync((await this.firstNameAsync())!);
     }
     protected async onSignedOut(): Promise<void> {
         await setUserProfileAsync(undefined);
@@ -11,8 +11,8 @@ class AuthClient extends pxt.auth.AuthClient {
         return Promise.resolve();
     }
     protected async onUserProfileChanged(): Promise<void> {
-        const state = this.getState();
-        if (state.profile) {
+        const state = await pxt.auth.getUserStateAsync();
+        if (state?.profile) {
             pxt.auth.generateUserProfilePicDataUrl(state.profile);
         }
         await setUserProfileAsync(state.profile);
@@ -30,8 +30,8 @@ class AuthClient extends pxt.auth.AuthClient {
         return Promise.resolve();
     }
 
-    public firstName(): string | undefined {
-        const state = this.getState();
+    public async firstNameAsync(): Promise<string | undefined> {
+        const state = await pxt.auth.getUserStateAsync();
         return pxt.auth.firstName(state?.profile!);
     }
 }
@@ -89,6 +89,5 @@ export async function loginAsync(
 }
 
 export async function authTokenAsync(): Promise<string | undefined> {
-    const cli = await clientAsync();
-    return await cli?.authTokenAsync();
+    return await pxt.auth.getAuthTokenAsync();
 }

--- a/pxtlib/auth.ts
+++ b/pxtlib/auth.ts
@@ -71,7 +71,7 @@ namespace pxt.auth {
     /**
      * Cloud-synced user state.
      */
-    export type State = {
+    export type UserState = {
         profile?: UserProfile;
         preferences?: UserPreferences;
     };
@@ -84,29 +84,70 @@ namespace pxt.auth {
     let debouncePreferencesChangedTimeout = 0;
     let debouncePreferencesChangedStarted = 0;
 
-    export abstract class AuthClient {
-        /**
-         * In-memory cache of user profile state. This is persisted in local storage.
-         * DO NOT ACCESS DIRECTLY UNLESS YOU KNOW IT IS OK. Functions allowed direct
-         * access are marked as such below.
-         */
-        private state$: Readonly<State>;
+    //
+    // Local storage of auth token.
+    //
 
+    // Last known auth token state. This is provided as a convenience for legacy methods that cannot be made async.
+    // Preference hasAuthTokenAsync() over taking a dependency on this cached value.
+    export let cachedHasAuthToken = false;
+
+    export async function getAuthTokenAsync(): Promise<string> {
+        let token: string;
+        try { token = await pxt.storage.shared.getAsync(AUTH_CONTAINER, CSRF_TOKEN_KEY); } catch {}
+        cachedHasAuthToken = !!token;
+        return token;
+    }
+    async function setAuthTokenAsync(token: string): Promise<void> {
+        cachedHasAuthToken = !!token;
+        return await pxt.storage.shared.setAsync(AUTH_CONTAINER, CSRF_TOKEN_KEY, token);
+    }
+    export async function hasAuthTokenAsync(): Promise<boolean> {
+        return !!(await getAuthTokenAsync());
+    }
+    async function delAuthTokenAsync(): Promise<void> {
+        cachedHasAuthToken = false;
+        return await pxt.storage.shared.delAsync(AUTH_CONTAINER, CSRF_TOKEN_KEY);
+    }
+
+    //
+    // Local storage of user state (profile and preferences).
+    //
+
+    // Last known user state. This is provided as a convenience for legacy methods that cannot be made async.
+    // Preference getUserStateAsync() over taking a dependency on this cached value.
+    export let cachedUserState: Readonly<UserState>;
+
+    export async function getUserStateAsync(): Promise<Readonly<UserState>> {
+        let userState: UserState;
+        if (await hasAuthTokenAsync()) {
+            try { userState = await pxt.storage.shared.getAsync(AUTH_CONTAINER, AUTH_USER_STATE_KEY); } catch {}
+        }
+        cachedUserState = userState;
+        return userState;
+    }
+    async function setUserStateAsync(state: UserState): Promise<void> {
+        if (await hasAuthTokenAsync()) {
+            cachedUserState = { ...state };
+            return await pxt.storage.shared.setAsync(AUTH_CONTAINER, AUTH_USER_STATE_KEY, state);
+        }
+    }
+    async function delUserStateAsync(): Promise<void> {
+        cachedUserState = undefined;
+        return await pxt.storage.shared.delAsync(AUTH_CONTAINER, AUTH_USER_STATE_KEY);
+    }
+
+    export abstract class AuthClient {
         constructor() {
             // Set global instance.
             _client = this;
         }
 
         public async initAsync() {
-            // Load state from local storage
-            try {
-                this.state$ = await pxt.storage.shared.getAsync<State>(AUTH_CONTAINER, AUTH_USER_STATE_KEY);
-            } catch { }
-            if (!this.state$) {
-                this.state$ = {};
-            }
-            this.setUserProfileAsync(this.state$.profile);
-            this.setUserPreferencesAsync(this.state$.preferences);
+            // Initialize user state from local storage.
+            const state = await getUserStateAsync();
+            this.setUserProfileAsync(state?.profile);
+            this.setUserPreferencesAsync(state?.preferences);
         }
 
         protected abstract onSignedIn(): Promise<void>;
@@ -117,10 +158,6 @@ namespace pxt.auth {
         protected abstract onProfileDeleted(userId: string): Promise<void>;
         protected abstract onApiError(err: any): Promise<void>;
         protected abstract onStateCleared(): Promise<void>
-
-        public async authTokenAsync(): Promise<string> {
-            return await pxt.storage.shared.getAsync(AUTH_CONTAINER, CSRF_TOKEN_KEY);
-        }
 
         /**
          * Starts the process of authenticating the user against the given identity
@@ -137,20 +174,8 @@ namespace pxt.auth {
 
             callbackState = callbackState ?? NilCallbackState;
 
-            const state = this.getState();
-
-            // See if we have a valid access token already.
-            if (!state.profile) { await this.authCheckAsync(); }
-
-            const currIdp = state.profile?.idp;
-
-            // Check if we're already signed into this identity provider.
-            if (currIdp?.provider === idp) {
-                pxt.debug(`loginAsync: Already signed into ${idp}.`);
-                return;
-            }
-
-            this.clearState();
+            // Clear local auth state so we can no longer make authenticated requests.
+            this.clearAuthStateAsync();
 
             // Store some continuation state in local storage so we can return to what
             // the user was doing before signing in.
@@ -178,7 +203,7 @@ namespace pxt.auth {
                 pxt.tickEvent('auth.login.start', { 'provider': idp });
                 window.location.href = apiResult.resp.loginUrl;
             } else {
-                await this.onSignInFailed();
+                try { await this.onSignInFailed(); } catch {}
             }
         }
 
@@ -188,9 +213,12 @@ namespace pxt.auth {
         public async logoutAsync(continuationHash?: string) {
             if (!hasIdentity()) { return; }
 
-            this.clearState();
+            // Clear local auth state so we can no longer make authenticated requests.
+            await this.clearAuthStateAsync();
 
-            return await AuthClient.staticLogoutAsync(continuationHash);
+            await AuthClient.staticLogoutAsync(continuationHash);
+
+            try { await this.onSignedOut(); } catch {}
         }
 
         /**
@@ -201,18 +229,17 @@ namespace pxt.auth {
 
             pxt.tickEvent('auth.logout');
 
-            // backend will clear the cookie token and pass back the provider logout endpoint.
-            await AuthClient.staticApiAsync('/api/auth/logout');
+            // Tell backend to clear the http-only auth cookie. Ignore errors here, we want to clear local state even if the backend rejects this request.
+            try { await AuthClient.staticApiAsync('/api/auth/logout'); } catch {}
 
-            // Clear csrf token so we can no longer make authenticated requests.
-            await pxt.storage.shared.delAsync(AUTH_CONTAINER, CSRF_TOKEN_KEY);
+            // Clear local auth state so we can no longer make authenticated requests.
+            await delAuthTokenAsync();
+            await delUserStateAsync();
 
-            // Update state and UI to reflect logged out state.
-            const hash = continuationHash ? continuationHash.startsWith('#') ? continuationHash : `#${continuationHash}` : "";
-
-            // Redirect to home screen, or skillmap home screen
+            // Redirect to home screen
             if (pxt.BrowserUtils.hasWindow()) {
-                window.location.href = `${window.location.origin}${window.location.pathname}${hash}`;
+                const hash = continuationHash ? continuationHash.startsWith('#') ? continuationHash : `#${continuationHash}` : "";
+                window.location.href = `${window.location.origin}${window.location.pathname}${window.location.search}${hash}`;
                 location.reload();
             }
         }
@@ -221,24 +248,18 @@ namespace pxt.auth {
             // only if we're logged in
             if (!await this.loggedInAsync()) { return; }
 
-            const userId = this.getState().profile?.id;
+            const state = await getUserStateAsync();
+            const userId = state?.profile?.id;
 
             const res = await this.apiAsync('/api/user', null, 'DELETE');
             if (res.err) {
-                await this.onApiError((res.err));
+                try { await this.onApiError((res.err)); } catch {}
             } else {
                 try {
-                    // Clear csrf token so we can no longer make authenticated requests.
-                    await pxt.storage.shared.delAsync(AUTH_CONTAINER, CSRF_TOKEN_KEY);
+                    // Clear local auth state so we can no longer make authenticated requests.
+                    await this.clearAuthStateAsync();
 
-                    try {
-                        await this.onProfileDeleted(userId);
-                    } catch {
-                        pxt.tickEvent('auth.profile.cloudToLocalFailed');
-                    }
-
-                    // Update state and UI to reflect logged out state.
-                    this.clearState();
+                    try { await this.onProfileDeleted(userId); } catch {}
                 }
                 finally {
                     pxt.tickEvent('auth.profile.deleted');
@@ -259,13 +280,13 @@ namespace pxt.auth {
 
         public async userProfileAsync(): Promise<UserProfile | undefined> {
             if (!await this.loggedInAsync()) { return undefined; }
-            const state = this.getState();
+            const state = await getUserStateAsync();
             return { ...state.profile };
         }
 
         public async userPreferencesAsync(): Promise<UserPreferences | undefined> {
             //if (!await this.loggedInAsync()) { return undefined; } // allow even when not signed in.
-            const state = this.getState();
+            const state = await getUserStateAsync();
             return { ...state.preferences };
         }
 
@@ -276,13 +297,12 @@ namespace pxt.auth {
          */
         public async authCheckAsync(): Promise<UserProfile | undefined> {
             if (!hasIdentity()) { return undefined; }
+            if (!(await hasAuthTokenAsync())) { return undefined; }
 
-            // Fail fast if we don't have csrf token.
-            if (!(await pxt.storage.shared.getAsync(AUTH_CONTAINER, CSRF_TOKEN_KEY))) { return undefined; }
+            const state = await getUserStateAsync();
 
-            const state = this.getState();
-
-            if (state.profile?.id) {
+            if (state?.profile?.id) {
+                // If we already have a user profile, return it.
                 if (!this.initialAuthCheck_) {
                     this.initialAuthCheck_ = Promise.resolve(state.profile);
                 }
@@ -296,8 +316,9 @@ namespace pxt.auth {
         }
 
         public async loggedInAsync(): Promise<boolean> {
-            await this.authCheckAsync();
-            return this.hasUserId();
+            const profile = await this.authCheckAsync();
+            if (!profile) return false;
+            return await this.hasUserIdAsync();
         }
 
         public async updateUserProfileAsync(opts: {
@@ -305,7 +326,7 @@ namespace pxt.auth {
             avatarUrl?: string
         }): Promise<boolean> {
             if (!await this.loggedInAsync()) { return false; }
-            const state = this.getState();
+            const state = await getUserStateAsync();
             const result = await this.apiAsync<UserProfile>('/api/user/profile', {
                 id: state.profile.id,
                 username: opts.username,
@@ -411,19 +432,21 @@ namespace pxt.auth {
             }
         }
 
-        /*protected*/ hasUserId(): boolean {
+        private async hasUserIdAsync(): Promise<boolean> {
             if (!hasIdentity()) { return false; }
-            const state = this.getState();
-            return !!state.profile?.id;
+            if (!(await hasAuthTokenAsync())) { return undefined; }
+            const state = await getUserStateAsync();
+            return !!state?.profile?.id;
         }
 
         private async fetchUserAsync(): Promise<UserProfile | undefined> {
             if (!hasIdentity()) { return undefined; }
+            if (!(await hasAuthTokenAsync())) { return undefined; }
 
-            const state = this.getState();
+            const state = await getUserStateAsync();
 
             // We already have a user, no need to get it again.
-            if (state.profile?.id) {
+            if (state?.profile?.id) {
                 return state.profile;
             }
 
@@ -437,36 +460,38 @@ namespace pxt.auth {
         }
 
         private async setUserProfileAsync(profile: UserProfile) {
-            const wasLoggedIn = this.hasUserId();
-            this.transformUserProfile(profile);
-            const isLoggedIn = this.hasUserId();
-            this.onUserProfileChanged();
+            const wasLoggedIn = await this.hasUserIdAsync();
+            await this.transformUserProfileAsync(profile);
+            const isLoggedIn = await this.hasUserIdAsync();
+            try { await this.onUserProfileChanged(); } catch {}
             //pxt.data.invalidate(USER_PROFILE);
             if (isLoggedIn && !wasLoggedIn) {
-                await this.onSignedIn();
+                try { await this.onSignedIn(); } catch {}
                 //pxt.data.invalidate(LOGGED_IN);
             } else if (!isLoggedIn && wasLoggedIn) {
-                await this.onSignedOut();
+                try { await this.onSignedOut(); } catch {}
                 //pxt.data.invalidate(LOGGED_IN);
             }
         }
 
-        private async setUserPreferencesAsync(newPref: Partial<UserPreferences>) {
-            const oldPref = this.getState().preferences ?? DEFAULT_USER_PREFERENCES()
+        private async setUserPreferencesAsync(newPref: Partial<UserPreferences>): Promise<UserPreferences> {
+            const state = await getUserStateAsync();
+            const oldPref = state?.preferences ?? DEFAULT_USER_PREFERENCES()
             const diff = ts.pxtc.jsonPatch.diff(oldPref, newPref);
             // update
-            this.transformUserPreferences({
+            const finalPref = await this.transformUserPreferencesAsync({
                 ...oldPref,
                 ...newPref
             });
-            await this.onUserPreferencesChanged(diff);
+            try { await this.onUserPreferencesChanged(diff); } catch {}
+            return finalPref;
         }
 
         private async fetchUserPreferencesAsync(): Promise<UserPreferences | undefined> {
             // Wait for the initial auth
             if (!await this.loggedInAsync()) { return undefined; }
 
-            const state = this.getState();
+            const state = await getUserStateAsync();
 
             const result = await this.apiAsync<Partial<UserPreferences>>('/api/user/preferences');
             if (result.success) {
@@ -475,10 +500,10 @@ namespace pxt.auth {
                     // Note the cloud should send partial information back if it is missing
                     // a field. So e.g. if the language has never been set in the cloud, it won't
                     // overwrite the local state.
-                    this.setUserPreferencesAsync(result.resp);
+                    const prefs = this.setUserPreferencesAsync(result.resp);
 
                     // update our one-time promise for the initial load
-                    return state.preferences;
+                    return prefs;
                 }
             }
             return undefined;
@@ -486,56 +511,41 @@ namespace pxt.auth {
 
         /**
          * Updates user profile state and writes it to local storage.
-         * Direct access to state$ allowed.
          */
-        private transformUserProfile(profile: UserProfile) {
-            this.state$ = {
-                ...this.state$,
+        private async transformUserProfileAsync(profile: UserProfile): Promise<UserProfile> {
+            let state = await getUserStateAsync();
+            state = {
+                ...state,
                 profile: {
                     ...profile
                 }
             };
-            this.saveState();
+            await setUserStateAsync(state);
+            return state.profile;
         }
 
         /**
          * Updates user preference state and writes it to local storage.
-         * Direct access to state$ allowed.
          */
-        protected transformUserPreferences(preferences: UserPreferences) {
-            this.state$ = {
-                ...this.state$,
+        protected async transformUserPreferencesAsync(preferences: UserPreferences): Promise<UserPreferences> {
+            let state = await getUserStateAsync();
+            state = {
+                ...state,
                 preferences: {
                     ...preferences
                 }
             };
-            this.saveState();
+            await setUserStateAsync(state);
+            return state.preferences;
         }
 
         /**
-         * Read-only access to current state.
-         * Direct access to state$ allowed.
+         * Clear local auth state then call the onStateCleared callback.
          */
-        /*private*/ getState(): Readonly<State> {
-            return this.state$;
-        };
-
-        /**
-         * Write auth state to local storage.
-         * Direct access to state$ allowed.
-         */
-        private saveState() {
-            pxt.storage.shared.setAsync(AUTH_CONTAINER, AUTH_USER_STATE_KEY, this.state$).then(() => { });
-        }
-
-        /**
-         * Clear all auth state.
-         * Direct access to state$ allowed.
-         */
-        private clearState() {
-            this.state$ = {};
-            pxt.storage.shared.delAsync(AUTH_CONTAINER, AUTH_USER_STATE_KEY)
-                .then(() => this.onStateCleared());
+        private async clearAuthStateAsync() {
+            await delAuthTokenAsync();
+            await delUserStateAsync();
+            try { await this.onStateCleared(); } catch {}
         }
 
         /*protected*/ async apiAsync<T = any>(url: string, data?: any, method?: string, authToken?: string): Promise<ApiResult<T>> {
@@ -544,7 +554,7 @@ namespace pxt.auth {
 
         static async staticApiAsync<T = any>(url: string, data?: any, method?: string, authToken?: string): Promise<ApiResult<T>> {
             const headers: pxt.Map<string> = {};
-            authToken = authToken || (await pxt.storage.shared.getAsync<string>(AUTH_CONTAINER, CSRF_TOKEN_KEY));
+            authToken = authToken || (await getAuthTokenAsync());
             if (authToken) {
                 headers["authorization"] = `mkcd ${authToken}`;
             }
@@ -665,7 +675,7 @@ namespace pxt.auth {
             // "Remember me" wasn't selected because this token is not usable
             // without its cookie-based counterpart. When "Remember me" is false,
             // the cookie is not persisted.
-            await pxt.storage.shared.setAsync(AUTH_CONTAINER, CSRF_TOKEN_KEY, authToken);
+            await setAuthTokenAsync(authToken);
 
             pxt.tickEvent('auth.login.success', { 'provider': loginState.idp });
         } while (false);
@@ -674,7 +684,7 @@ namespace pxt.auth {
         const hash = callbackState.hash.startsWith('#') ? callbackState.hash : `#${callbackState.hash}`;
         const params = pxt.Util.stringifyQueryString('', callbackState.params);
         const pathname = loginState.callbackPathname.startsWith('/') ? loginState.callbackPathname : `/${loginState.callbackPathname}`;
-        const redirect = `${pathname}${hash}${params}`;
+        const redirect = `${pathname}${params}${hash}`;
         window.location.href = redirect;
     }
 
@@ -705,8 +715,8 @@ namespace pxt.auth {
         return user?.idp?.displayName ?? user?.idp?.username ?? EMPTY_USERNAME;
     }
 
-    export function identityProviderId(): pxt.IdentityProviderId | undefined {
-        return client()?.getState()?.profile?.idp?.provider;
+    export function identityProviderId(user: pxt.auth.UserProfile): pxt.IdentityProviderId | undefined {
+        return user?.idp?.provider;
     }
 
     export function firstName(user: pxt.auth.UserProfile): string {

--- a/react-common/components/profile/Profile.tsx
+++ b/react-common/components/profile/Profile.tsx
@@ -7,7 +7,7 @@ import { BadgeInfo } from "./BadgeInfo";
 import { CheckboxStatus } from "../util";
 
 export interface ProfileProps {
-    user: pxt.auth.State;
+    user: pxt.auth.UserState;
     signOut: () => void;
     deleteProfile: () => void;
     checkedEmail: CheckboxStatus;

--- a/skillmap/src/lib/authClient.ts
+++ b/skillmap/src/lib/authClient.ts
@@ -16,13 +16,12 @@ class AuthClient extends pxt.auth.AuthClient {
         // Show a notification?
         return Promise.resolve();
     }
-    protected onUserProfileChanged(): Promise<void> {
-        const state = this.getState();
-        if (state.profile) {
+    protected async onUserProfileChanged(): Promise<void> {
+        const state = await pxt.auth.getUserStateAsync();
+        if (state?.profile) {
             pxt.auth.generateUserProfilePicDataUrl(state.profile);
         }
         store.dispatch(dispatchSetUserProfile(state.profile));
-        return Promise.resolve();
     }
     protected onUserPreferencesChanged(diff: ts.pxtc.jsonPatch.PatchOperation[]): Promise<void> {
         // TODO: Dispatch individual preference fields individually (if changed): language, highContrast, etc.

--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -454,8 +454,9 @@ async function syncAsyncInternal(opts: SyncAsyncOptions): Promise<pxt.workspace.
         }
 
         async function syncOneDown(remote: Header): Promise<void> {
-            const projShorthand = shortName(remote);
+            if (!remote?.id) return;
             try {
+                const projShorthand = shortName(remote);
                 const local = workspace.getHeader(remote.id);
                 if (!local) {
                     if (!remote.isDeleted) {
@@ -500,7 +501,7 @@ async function syncAsyncInternal(opts: SyncAsyncOptions): Promise<pxt.workspace.
         errors = [];
 
         const elapsed = U.nowSeconds() - syncStart;
-        pxt.tickEvent(`identity.sync.finished`, { elapsed, provider: pxt.auth.identityProviderId() })
+        pxt.tickEvent(`identity.sync.finished`, { elapsed, provider: pxt.auth.identityProviderId(pxt.auth.cachedUserState?.profile) })
 
         data.invalidate("headers:");
 
@@ -527,7 +528,7 @@ export function forceReloadForCloudSync() {
 export async function convertCloudToLocal(userId: string) {
     if (userId) {
         const localCloudHeaders = workspace
-            .getHeaders(false/*withDeleted*/, false/*filterByEditorType*/)
+            .getHeaders(false/*withDeleted*/, false/*filterByEditorType*/, userId /*cloudUserIdOverride*/)
             .filter(h => h.cloudUserId && h.cloudUserId === userId);
         const tasks: Promise<void>[] = [];
         localCloudHeaders.forEach((h) => {

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -41,7 +41,8 @@ export class LoginDialog extends auth.Component<LoginDialogProps, LoginDialogSta
     private signInAsync = async (provider: pxt.AppCloudProvider, rememberMe: boolean): Promise<void> => {
         pxt.tickEvent(`identity.loginClick`, { provider: provider.name, rememberMe: rememberMe.toString() });
         await auth.loginAsync(provider.id, rememberMe, {
-            hash: this.state.continuationHash
+            hash: this.state.continuationHash,
+            params: pxt.Util.parseQueryString(window.location.search)
         });
     }
 

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -116,9 +116,9 @@ async function switchToMemoryWorkspace(reason: string): Promise<void> {
     implType = "mem";
 }
 
-export function getHeaders(withDeleted = false, filterByEditorType = true) {
+export function getHeaders(withDeleted = false, filterByEditorType = true, cloudUserIdOverride?: string) {
     maybeSyncHeadersAsync();
-    const cloudUserId = auth.userProfile()?.id;
+    const cloudUserId = cloudUserIdOverride ?? auth.userProfile()?.id;
     let r = allScripts.map(e => e.header).filter(h =>
         // Filter deleted projects
         (withDeleted || !h.isDeleted) &&


### PR DESCRIPTION
This set of changes looks big, but the bulk is contained in `pxtlib/auth.ts`. The main purpose here is twofold:
- be tidier about cleaning up local auth state when logging out.
- be more resilient against stale auth state that might have been left over from a previous session.

This change also contains several important bug fixes:
- Fixes https://github.com/microsoft/pxt-arcade/issues/3878
- Fixes an issue where if a cloud project is synced down and any error occurs while processing it, some number of other cloud projects will not be listed in My Projects.
- Fixes the infinite reload issue @srietkerk saw yesterday in microbit.

Once merged, I will bump beta and test skillmap and multiplayer in the beta channel. Skillmap + auth is especially difficult to test effectively on localhost.
