### PR TITLE
Editor tour / onboarding feature: styling and animation

### DIFF
--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -96,7 +96,6 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
         const cutoutBounds = getCutoutBounds(targetBounds, targetElement);
         setCutout(cutoutBounds);
         setPosition(cutoutBounds, bubble, bubbleBounds, bubbleArrow, bubbleArrowOutline);
-
     }
 
     const getCutoutBounds = (targetBounds: DOMRect, targetElement: HTMLElement): CutoutBounds => {
@@ -172,6 +171,8 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
     }
 
     const setPosition = (cutoutBounds: CutoutBounds, bubble: HTMLElement, bubbleBounds: DOMRect, bubbleArrow: HTMLElement, bubbleArrowOutline: HTMLElement) => {
+        bubbleArrowOutline.style.opacity = "1";
+        bubbleArrow.style.opacity = "1";
         resetTryFit();
         const transparentBorder = `${margin}px solid transparent`;
         const opaqueBorder = `${margin}px solid`;
@@ -250,6 +251,11 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
             const top = (cutoutBounds.height - bubbleBounds.height) / 2 + cutoutBounds.top;
             const left = (cutoutBounds.width - bubbleBounds.width) / 2 + cutoutBounds.left;
             updatedBubblePosition(top, left);
+            // update arrow position to be centered and then transparent to improve animation appearance
+            updatePosition(bubbleArrow, top + bubbleBounds.height / 2, left + bubbleBounds.width / 2);
+            updatePosition(bubbleArrowOutline, top + bubbleBounds.height / 2, left + bubbleBounds.width / 2);
+            bubbleArrowOutline.style.opacity = "0";
+            bubbleArrow.style.opacity = "0";
         }
 
         const updatedBubblePosition = (top: number, left: number): boolean => {

--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -62,6 +62,7 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
     } = props;
 
     const margin = 10;
+    const outlineOffset = 2.5;
     const tryFit = {
         above: false,
         below: false,
@@ -81,6 +82,8 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
         const bubble = document.getElementById(id);
         const bubbleArrow = document.querySelector(".teaching-bubble-arrow") as HTMLElement;
         bubbleArrow.style.border = "none";
+        const bubbleArrowOutline = document.querySelector(".teaching-bubble-arrow-outline") as HTMLElement;
+        bubbleArrowOutline.style.border = "none";
         const bubbleBounds = bubble.getBoundingClientRect();
         // To Do: check that targetContent.targetQuery is a valid selector
         const targetElement = document.querySelector(targetContent.targetQuery) as HTMLElement;
@@ -92,7 +95,7 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
         const targetBounds = targetElement.getBoundingClientRect();
         const cutoutBounds = getCutoutBounds(targetBounds, targetElement);
         setCutout(cutoutBounds);
-        setPosition(cutoutBounds, bubble, bubbleBounds, bubbleArrow);
+        setPosition(cutoutBounds, bubble, bubbleBounds, bubbleArrow, bubbleArrowOutline);
 
     }
 
@@ -168,10 +171,12 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
         tryFit.right = false;
     }
 
-    const setPosition = (cutoutBounds: CutoutBounds, bubble: HTMLElement, bubbleBounds: DOMRect, bubbleArrow: HTMLElement) => {
+    const setPosition = (cutoutBounds: CutoutBounds, bubble: HTMLElement, bubbleBounds: DOMRect, bubbleArrow: HTMLElement, bubbleArrowOutline: HTMLElement) => {
         resetTryFit();
         const transparentBorder = `${margin}px solid transparent`;
         const opaqueBorder = `${margin}px solid`;
+        const transparentOutline = `${margin + outlineOffset}px solid transparent`;
+        const opaqueOutline = `${margin + outlineOffset}px solid`;
 
         const positionAbove = () => {
             const top = cutoutBounds.top - bubbleBounds.height - margin;
@@ -184,6 +189,10 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
             bubbleArrow.style.borderRight = transparentBorder;
             bubbleArrow.style.borderTop = opaqueBorder;
             updatePosition(bubbleArrow, arrowTop, arrowLeft);
+            bubbleArrowOutline.style.borderLeft = transparentOutline;
+            bubbleArrowOutline.style.borderRight = transparentOutline;
+            bubbleArrowOutline.style.borderTop = opaqueOutline;
+            updatePosition(bubbleArrowOutline, arrowTop, arrowLeft - outlineOffset);
         }
 
         const positionBelow = () => {
@@ -197,6 +206,10 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
             bubbleArrow.style.borderRight = transparentBorder;
             bubbleArrow.style.borderBottom = opaqueBorder;
             updatePosition(bubbleArrow, arrowTop, arrowLeft);
+            bubbleArrowOutline.style.borderLeft = transparentOutline;
+            bubbleArrowOutline.style.borderRight = transparentOutline;
+            bubbleArrowOutline.style.borderBottom = opaqueOutline;
+            updatePosition(bubbleArrowOutline, arrowTop - outlineOffset, arrowLeft - outlineOffset);
         }
 
         const positionLeft = () => {
@@ -210,6 +223,10 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
             bubbleArrow.style.borderTop = transparentBorder;
             bubbleArrow.style.borderBottom = transparentBorder;
             updatePosition(bubbleArrow, arrowTop, arrowLeft);
+            bubbleArrowOutline.style.borderLeft = opaqueOutline;
+            bubbleArrowOutline.style.borderTop = transparentOutline;
+            bubbleArrowOutline.style.borderBottom = transparentOutline;
+            updatePosition(bubbleArrowOutline, arrowTop - outlineOffset, arrowLeft);
         }
 
         const positionRight = () => {
@@ -223,6 +240,10 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
             bubbleArrow.style.borderTop = transparentBorder;
             bubbleArrow.style.borderBottom = transparentBorder;
             updatePosition(bubbleArrow, arrowTop, arrowLeft);
+            bubbleArrowOutline.style.borderRight = opaqueOutline;
+            bubbleArrowOutline.style.borderTop = transparentOutline;
+            bubbleArrowOutline.style.borderBottom = transparentOutline;
+            updatePosition(bubbleArrowOutline, arrowTop - outlineOffset, arrowLeft - outlineOffset);
         }
 
         const positionCenter = () => {
@@ -325,6 +346,7 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
     return ReactDOM.createPortal(<FocusTrap className={classes} onEscape={onClose}>
         <div className="teaching-bubble-cutout" />
         <div className="teaching-bubble-arrow" />
+        <div className="teaching-bubble-arrow-outline" />
         <div id={id}
             className="teaching-bubble"
             role={role || "dialog"}

--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -27,6 +27,7 @@ export interface TargetContent {
     description: string;
     targetQuery: string;
     location: Location;
+    sansQuery?: string; // Use this to exclude an element from the cutout
 }
 
 export interface TeachingBubbleProps extends ContainerProps {
@@ -100,6 +101,12 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
         let cutoutLeft = targetBounds.left;
         let cutoutWidth = targetBounds.width;
         let cutoutHeight = targetBounds.height;
+        if (targetContent.sansQuery) { // TO DO - take care of cases when sansElement is not to the left of targetElement
+            const sansElement = document.querySelector(targetContent.sansQuery) as HTMLElement;
+            const sansBounds = sansElement.getBoundingClientRect();
+            cutoutLeft = targetBounds.left + sansBounds.width;
+            cutoutWidth = targetBounds.width - sansBounds.width;
+        }
         // make cutout bigger if no padding and not centered
         if (targetContent.location !== Location.Center) {
             const paddingTop = parseFloat(window.getComputedStyle(targetElement).paddingTop);
@@ -137,9 +144,9 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
     const setCutout = (cutoutBounds: CutoutBounds) => {
         const cutout = document.querySelector(".teaching-bubble-cutout") as HTMLElement;
         cutout.style.top = `${cutoutBounds.top}px`;
+        cutout.style.height = `${cutoutBounds.height}px`;
         cutout.style.left = `${cutoutBounds.left}px`;
         cutout.style.width = `${cutoutBounds.width}px`;
-        cutout.style.height = `${cutoutBounds.height}px`;
 
         if (activeTarget) {
             cutout.style.pointerEvents = "none";

--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -61,12 +61,12 @@
 .teaching-bubble-footer {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: flex-end;
     justify-content: space-between;
 
     .teaching-bubble-steps {
         font-size: .9rem;
-        padding-top: .25rem;
+        color: @lightGrey
     }
 
     .common-button {

--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -9,8 +9,10 @@
 
 .teaching-bubble-cutout,
 .teaching-bubble,
-.teaching-bubble-arrow {
-    transition: all 0.75s ease 0s;
+.teaching-bubble-arrow,
+.teaching-bubble-arrow-outline {
+    transition-property: top, left;
+    transition-duration: 0.75s;
 }
 
 .teaching-bubble-cutout {
@@ -26,7 +28,7 @@
     min-width: 18.75rem;
     background: @blue;
     color: @white;
-    box-shadow: 0 0rem 0.5rem;
+    box-shadow: 0 0 0 0.1rem;
     border-radius: 0.5rem;
     padding: 1rem 1rem 0.5rem;
     z-index: @modalDimmerZIndex;
@@ -38,6 +40,14 @@
     height: 0;
     z-index: @modalDimmerZIndex + 1;
     color: @blue;
+}
+
+.teaching-bubble-arrow-outline {
+    position: fixed;
+    width: 0;
+    height: 0;
+    z-index: @modalDimmerZIndex;
+    color: @white;
 }
 
 .teaching-bubble-content {

--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -7,6 +7,10 @@
     z-index: @modalDimmerZIndex;
 }
 
+.teaching-bubble-cutout, .teaching-bubble, .teaching-bubble-arrow {
+    transition: all 0.5s ease 0s;
+}
+
 .teaching-bubble-cutout {
     position: fixed;
     z-index: @modalDimmerZIndex;

--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -30,7 +30,7 @@
     color: @white;
     box-shadow: 0 0 0 0.1rem;
     border-radius: 0.5rem;
-    padding: 1rem 1rem 0.5rem;
+    padding: 1rem;
     z-index: @modalDimmerZIndex;
 }
 
@@ -54,7 +54,7 @@
     font-size: 1.1rem;
 
     p {
-        margin: .25rem 0;
+        margin: .25rem 0 .5rem;
     }
 }
 
@@ -66,6 +66,7 @@
 
     .teaching-bubble-steps {
         font-size: .9rem;
+        padding-top: .25rem;
     }
 
     .common-button {

--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -8,7 +8,7 @@
 }
 
 .teaching-bubble-cutout, .teaching-bubble, .teaching-bubble-arrow {
-    transition: all 0.5s ease 0s;
+    transition: all 0.75s ease 0s;
 }
 
 .teaching-bubble-cutout {

--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -7,7 +7,9 @@
     z-index: @modalDimmerZIndex;
 }
 
-.teaching-bubble-cutout, .teaching-bubble, .teaching-bubble-arrow {
+.teaching-bubble-cutout,
+.teaching-bubble,
+.teaching-bubble-arrow {
     transition: all 0.75s ease 0s;
 }
 
@@ -38,8 +40,12 @@
     color: @blue;
 }
 
-.teaching-bubble-content > p {
-    margin: .25rem 0;
+.teaching-bubble-content {
+    font-size: 1.1rem;
+
+    p {
+        margin: .25rem 0;
+    }
 }
 
 .teaching-bubble-footer {
@@ -47,20 +53,24 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
+
     .teaching-bubble-steps {
         font-size: .9rem;
     }
+
     .common-button {
         color: @blue;
         padding: .25rem .5rem;
         margin: 0;
         border: .1rem solid @white;
+
         &.secondary-button {
             margin-right: .5rem;
             color: @white;
             background: @blue;
         }
     }
+
     &.no-steps {
         flex-direction: row-reverse;
     }
@@ -74,6 +84,7 @@
     background: transparent;
     color: @white;
     margin: 0;
+
     i.right {
         opacity: 1;
         font-size: 1.3rem;
@@ -85,20 +96,24 @@
  *                 High Contrast                    *
  ****************************************************/
 
- .high-contrast, .hc {
+.high-contrast,
+.hc {
     .teaching-bubble {
         background: @highContrastBackgroundColor;
         color: @highContrastTextColor;
         border: solid @highContrastTextColor;
-        .teaching-bubble-navigation > .common-button {
+
+        .teaching-bubble-navigation>.common-button {
             color: @highContrastTextColor;
             border: solid @highContrastTextColor;
         }
     }
+
     .teaching-bubble-arrow {
         color: @highContrastTextColor;
     }
+
     .teaching-bubble-cutout {
         border: 0.25rem solid @highContrastHighlightColor;
     }
- }
+}

--- a/webapp/src/components/onboarding/EditorTour.tsx
+++ b/webapp/src/components/onboarding/EditorTour.tsx
@@ -38,9 +38,9 @@ const Download: TargetContent = {
 };
 
 const EditorContent: TargetContent[] = [
-    Simulator,
     Toolbox,
     Workspace,
+    Simulator,
     Share,
     Download,
 ];

--- a/webapp/src/components/onboarding/EditorTour.tsx
+++ b/webapp/src/components/onboarding/EditorTour.tsx
@@ -4,21 +4,21 @@ import { Location, TeachingBubble, TargetContent } from "../../../../react-commo
 
 const Simulator: TargetContent = {
     title: lf("Micro:bit Simulator"),
-    description: lf("The simulator shows what your program will look like running on a micro:bit."),
+    description: lf("See what your code looks like running on a micro:bit!"),
     targetQuery: "#boardview",
     location: Location.Right,
 };
 
 const Toolbox: TargetContent = {
     title: lf("Toolbox"),
-    description: lf("The toolbox is organized into different categories with blocks of code you can drag out and use in your program. You can search for specific blocks, open the extensions gallery for more blocks, or click Advanced to expand the toolbox categories shown."),
+    description: lf("Drag out blocks of code from the Toolbox categories into the Workspace."),
     targetQuery: "#blocksEditorToolbox",
     location: Location.Right,
 };
 
 const Workspace: TargetContent = {
     title: lf("Workspace"),
-    description: lf("The workspace is where you will build your micro:bit program by dragging blocks from the toolbox and snapping them together."),
+    description: lf("Snap blocks of code together to build your program."),
     targetQuery: "#blocksEditor", // includes the toolbox
     sansQuery: ".blocklyToolboxDiv",
     location: Location.Center,
@@ -33,7 +33,7 @@ const Share: TargetContent = {
 
 const Download: TargetContent = {
     title: lf("Download"),
-    description: lf("Download your program to your micro:bit."),
+    description: lf("Download your program to the micro:bit."),
     targetQuery: "#downloadArea",
     location: Location.Above,
 };

--- a/webapp/src/components/onboarding/EditorTour.tsx
+++ b/webapp/src/components/onboarding/EditorTour.tsx
@@ -20,6 +20,7 @@ const Workspace: TargetContent = {
     title: lf("Workspace"),
     description: lf("The workspace is where you will build your micro:bit program by dragging blocks from the toolbox and snapping them together."),
     targetQuery: "#blocksEditor", // includes the toolbox
+    sansQuery: ".blocklyToolboxDiv",
     location: Location.Center,
 };
 

--- a/webapp/src/components/onboarding/EditorTour.tsx
+++ b/webapp/src/components/onboarding/EditorTour.tsx
@@ -33,7 +33,7 @@ const Share: TargetContent = {
 
 const Download: TargetContent = {
     title: lf("Download"),
-    description: lf("Download your program to the micro:bit."),
+    description: lf("Download your program onto the micro:bit."),
     targetQuery: "#downloadArea",
     location: Location.Above,
 };


### PR DESCRIPTION
This PR introduces the following changes:
- transition animation for teaching bubbles
- larger font size
- border around bubble instead of drop shadow
- removed toolbox from being highlighted in the workspace callout
- made tour in order of anticipated use (toolbox -> workspace -> simulator -> share -> download)
- (Jacqueline) updated content to be more concise
- increased padding/margin for readability
- aligned lower edge of button and progress indicator / step count
- lighter font color for steps

Closes https://github.com/microsoft/pxt-microbit/issues/5009, closes https://github.com/microsoft/pxt-microbit/issues/5013

Try it out here: https://makecode.microbit.org/app/145250d33320d7b8b2a9b197a224a222bdeda9b2-8b591e28cd

**Still need to do some refactoring to clean up the teaching bubble component and possibly move out the arrow and cutout logic into their own components.**

![EditorTour](https://user-images.githubusercontent.com/15070078/228896444-6175b3b5-b0ba-4b98-8234-1f2410640b3f.gif)
