### PR TITLE
Add flyout labels to the translate path

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -2150,7 +2150,7 @@ namespace pxt.blocks {
                 xmlList[xmlList.length - 1].setAttribute('gap', '24');
 
                 if (Blockly.Blocks['variables_change'] || Blockly.Blocks['variables_set']) {
-                    xmlList.unshift(createFlyoutGroupLabel("Your Variables"));
+                    xmlList.unshift(createFlyoutGroupLabel(lf("Your Variables")));
                 }
 
                 if (Blockly.Blocks['variables_change']) {
@@ -2634,7 +2634,7 @@ namespace pxt.blocks {
             if (elems.length > 1) {
                 let returnBlock = mkReturnStatementBlock();
                 // Add divider
-                elems.splice(1, 0, createFlyoutGroupLabel("Your Functions"));
+                elems.splice(1, 0, createFlyoutGroupLabel(lf("Your Functions")));
                 // Insert after the "make a function" button
                 elems.splice(1, 0, returnBlock as HTMLElement);
             }


### PR DESCRIPTION
There are a couple of strings from the "Variables" and "Functions" flyouts that aren't getting to Crowdin. Hope this is the correct way to get them into strings.json.

![image](https://user-images.githubusercontent.com/27789908/229596266-c532e5bd-9fd6-48f2-a064-16779b64df2e.png)

RE: https://crowdin.com/project/makecode/discussions/119