### PR TITLE
Onboarding tour accessibility fixes, animation improvement

### DIFF
--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -72,8 +72,10 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
 
     useEffect(() => {
         positionBubbleAndCutout();
-        (document.querySelector(".teaching-bubble-container") as HTMLElement).focus();
         window.addEventListener("resize", positionBubbleAndCutout);
+        if (stepNumber === totalSteps) {
+            (document.querySelector(".primary-button") as HTMLElement).focus();
+        }
         return () => {
             window.removeEventListener("resize", positionBubbleAndCutout);
         }
@@ -369,10 +371,10 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
                 rightIcon="fas fa-times-circle"
             />
             <div className="teaching-bubble-content">
-                <strong>{targetContent.title}</strong>
-                <p>{targetContent.description}</p>
+                <strong aria-live="polite">{targetContent.title}</strong>
+                <p aria-live="polite">{targetContent.description}</p>
                 <div className={`teaching-bubble-footer ${!hasSteps ? "no-steps" : ""}`}>
-                    {hasSteps && <div className="teaching-bubble-steps">
+                    {hasSteps && <div className="teaching-bubble-steps" aria-live="polite">
                         {stepNumber} of {totalSteps}
                     </div>}
                     <div className="teaching-bubble-navigation">

--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -73,9 +73,6 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
     useEffect(() => {
         positionBubbleAndCutout();
         window.addEventListener("resize", positionBubbleAndCutout);
-        if (stepNumber === totalSteps) {
-            (document.querySelector(".primary-button") as HTMLElement).focus();
-        }
         return () => {
             window.removeEventListener("resize", positionBubbleAndCutout);
         }

--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -72,6 +72,7 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
 
     useEffect(() => {
         positionBubbleAndCutout();
+        (document.querySelector(".teaching-bubble-container") as HTMLElement).focus();
         window.addEventListener("resize", positionBubbleAndCutout);
         return () => {
             window.removeEventListener("resize", positionBubbleAndCutout);

--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -376,21 +376,21 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
                     </div>}
                     <div className="teaching-bubble-navigation">
                         {hasPrevious && <Button
-                            className="secondary-button"
+                            className="blue"
                             onClick={onBack}
                             title={backLabel}
                             ariaLabel={backLabel}
                             label={backLabel}
                         />}
                         {hasNext && <Button
-                            className="primary-button"
+                            className="blue inverted"
                             onClick={onNext}
                             title={nextLabel}
                             ariaLabel={nextLabel}
                             label={nextLabel}
                         />}
                         {!hasNext && <Button
-                            className="primary-button"
+                            className="blue inverted"
                             onClick={onFinish}
                             title={finishLabel}
                             ariaLabel={finishLabel}

--- a/react-common/styles/controls/Button.less
+++ b/react-common/styles/controls/Button.less
@@ -59,6 +59,12 @@
     border: 1px solid @teal;
 }
 
+.common-button.blue {
+    background: @blue;
+    color: @buttonTextColorDarkBackground;
+    border: 1px solid @blue;
+}
+
 .common-button.orange {
     background: @orange;
     color: @buttonTextColorDarkBackground;
@@ -91,6 +97,11 @@
 .common-button.teal.inverted {
     background: @buttonTextColorDarkBackground;
     color: @teal;
+}
+
+.common-button.blue.inverted {
+    background: @buttonTextColorDarkBackground;
+    color: @blue;
 }
 
 .common-button.orange.inverted {

--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -32,6 +32,16 @@
     border-radius: 0.5rem;
     padding: 1rem;
     z-index: @modalDimmerZIndex;
+
+    .common-button {
+
+        &:focus {
+            outline: .1rem solid @white;
+        }
+        &:focus::after {
+            outline: none;
+        }
+    }
 }
 
 .teaching-bubble-arrow {

--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -37,8 +37,9 @@
 
         &:focus {
             outline: .1rem solid @white;
+            filter: grayscale(.15) brightness(.85) contrast(1.3);
         }
-        &:focus::after {
+        &.blue:focus::after, &:focus::after {
             outline: none;
         }
     }
@@ -79,16 +80,13 @@
         color: @lightGrey
     }
 
-    .common-button {
-        color: @blue;
+    .common-button.blue {
         padding: .25rem .5rem;
-        margin: 0;
+        margin: 0 .5rem 0 0;
         border: .1rem solid @white;
 
-        &.secondary-button {
-            margin-right: .5rem;
-            color: @white;
-            background: @blue;
+        &.inverted {
+            margin-right: 0;
         }
     }
 

--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -11,8 +11,8 @@
 .teaching-bubble,
 .teaching-bubble-arrow,
 .teaching-bubble-arrow-outline {
-    transition-property: top, left;
-    transition-duration: 0.75s;
+    transition-property: top, left, width, height;
+    transition-duration: 0.5s;
 }
 
 .teaching-bubble-cutout {


### PR DESCRIPTION
This PR improves:
- animation by making it faster and including width and height in transitions
- visibility of tabbing / focus on buttons (closes https://github.com/microsoft/pxt-microbit/issues/5012)
- screen reading (closes https://github.com/microsoft/pxt-microbit/issues/5014)
  - tested with Narrator and NVDA
  - it's not perfect, but it should read all the content now

Try it out: https://makecode.microbit.org/app/ad2675c5dac61c2bed8b9b8816708b290fda6d92-5997b1ced2

![tabButton](https://user-images.githubusercontent.com/15070078/229623263-b648ab62-7e9a-4d2e-94a5-ca170b1475f2.gif)
