### PR TITLE
Editor tour: add congrats with confetti

### DIFF
--- a/react-common/components/animations/Confetti.tsx
+++ b/react-common/components/animations/Confetti.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+
+export const Confetti = () => {
+    const density = 100;
+    return <div className="confetti-container">
+        {Array(density).fill(0).map((el, i) => {
+            const style = {
+                animationDelay: `${0.1 * (i % density)}s`,
+                left: `${1 * (Math.floor(Math.random() * density))}%`
+            }
+            return <div key={i} style={style} className={`confetti ${Math.random() > 0.5 ? "reverse" : ""} color-${Math.floor(Math.random() * 9)}`} />
+        })}
+    </div>
+}

--- a/react-common/components/animations/Confetti.tsx
+++ b/react-common/components/animations/Confetti.tsx
@@ -1,8 +1,14 @@
 import * as React from "react";
 
-export const Confetti = () => {
+export interface ConfettiProps {
+    children?: React.ReactNode;
+}
+
+export const Confetti = (props: ConfettiProps) => {
+    const { children } = props;
     const density = 100;
     return <div className="confetti-container">
+        {children}
         {Array(density).fill(0).map((el, i) => {
             const style = {
                 animationDelay: `${0.1 * (i % density)}s`,

--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -348,12 +348,12 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
     }
 
     const hasPrevious = stepNumber > 1;
-    const hasNext = stepNumber < totalSteps;
+    const hasNext = stepNumber < totalSteps + 1;
     const hasSteps = totalSteps > 1;
     const closeLabel = lf("Close");
     const backLabel = lf("Back");
     const nextLabel = lf("Next");
-    const finishLabel = hasSteps ? stepNumber > totalSteps ? lf("Done") : lf("Finish") : lf("Got it");
+    const finishLabel = hasSteps ? lf("Finish") : lf("Got it");
 
     const classes = classList(
         "teaching-bubble-container",

--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Button } from "./Button";
+import { Confetti } from "../animations/Confetti";
 import { ContainerProps, classList } from "../util";
 import { FocusTrap } from "./FocusTrap";
 import { useEffect } from "react";
@@ -350,6 +351,7 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
     );
 
     return ReactDOM.createPortal(<FocusTrap className={classes} onEscape={onClose}>
+        {stepNumber === totalSteps && <Confetti />}
         <div className="teaching-bubble-cutout" />
         <div className="teaching-bubble-arrow" />
         <div className="teaching-bubble-arrow-outline" />

--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -73,11 +73,21 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
 
     useEffect(() => {
         positionBubbleAndCutout();
+        setStepsVisibility();
         window.addEventListener("resize", positionBubbleAndCutout);
         return () => {
             window.removeEventListener("resize", positionBubbleAndCutout);
         }
     }, [stepNumber]);
+
+    const setStepsVisibility = () => {
+        const steps = document.querySelector(".teaching-bubble-steps") as HTMLElement;
+        if (stepNumber > totalSteps || totalSteps === 1) {
+            steps.style.visibility = "hidden";
+        } else {
+            steps.style.visibility = "visible";
+        }
+    }
 
     const positionBubbleAndCutout = () => {
         const bubble = document.getElementById(id);
@@ -343,7 +353,7 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
     const closeLabel = lf("Close");
     const backLabel = lf("Back");
     const nextLabel = lf("Next");
-    const finishLabel = hasSteps ? lf("Finish") : lf("Got it");
+    const finishLabel = hasSteps ? stepNumber > totalSteps ? lf("Done") : lf("Finish") : lf("Got it");
 
     const classes = classList(
         "teaching-bubble-container",
@@ -351,7 +361,7 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
     );
 
     return ReactDOM.createPortal(<FocusTrap className={classes} onEscape={onClose}>
-        {stepNumber === totalSteps && <Confetti />}
+        {stepNumber === totalSteps + 1 && <Confetti />}
         <div className="teaching-bubble-cutout" />
         <div className="teaching-bubble-arrow" />
         <div className="teaching-bubble-arrow-outline" />

--- a/react-common/styles/animations/Confetti.less
+++ b/react-common/styles/animations/Confetti.less
@@ -1,0 +1,49 @@
+.confetti-container {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    z-index: 100;
+}
+
+.confetti {
+    width: 10px;
+    height: 10px;
+    background-color: #249ca3;
+    position: absolute;
+    left: 50%;
+    top: -15px;
+    animation: confetti 2.5s linear -2s infinite;
+    transform-origin: left top;
+    z-index: 110;
+}
+
+.confetti.reverse {
+    animation: confetti-reverse 2.5s linear -2s infinite;
+}
+
+.color-0 { background-color: #ff2121; }
+.color-1 { background-color: #ff93c4; }
+.color-2 { background-color: #ff8135; }
+.color-3 { background-color: #fff609; }
+.color-4 { background-color: #249ca3; }
+.color-5 { background-color: #78dc52; }
+.color-6 { background-color: #003fad; }
+.color-7 { background-color: #87f2ff; }
+.color-8 { background-color: #8e2ec4; }
+
+@keyframes confetti {
+    0% { transform: rotateZ(15deg) rotateY(0deg) translate(0,0); }
+    25% { transform: rotateZ(5deg) rotateY(360deg) translate(-1vw,20vh); }
+    50% { transform: rotateZ(15deg) rotateY(720deg) translate(1vw,50vh); }
+    75% { transform: rotateZ(5deg) rotateY(1080deg) translate(-1vw,80vh); }
+    100% { transform: rotateZ(15deg) rotateY(1440deg) translate(1vw,110vh); }
+}
+
+@keyframes confetti-reverse {
+    0% { transform: rotateZ(5deg) rotateY(0deg) translate(0,0); }
+    25% { transform: rotateZ(15deg) rotateY(360deg) translate(1vw,20vh); }
+    50% { transform: rotateZ(5deg) rotateY(720deg) translate(-1vw,50vh); }
+    75% { transform: rotateZ(15deg) rotateY(1080deg) translate(1vw,80vh); }
+    100% { transform: rotateZ(5deg) rotateY(1440deg) translate(-1vw,110vh); }
+}

--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -7,19 +7,23 @@
     z-index: @modalDimmerZIndex;
 }
 
+.teaching-bubble-cutout {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: @modalDimmerZIndex;
+    box-shadow: 0 0 0 99999px @modalOverlayColor;
+    border-radius: 0.5rem;
+}
+
 .teaching-bubble-cutout,
 .teaching-bubble,
 .teaching-bubble-arrow,
 .teaching-bubble-arrow-outline {
     transition-property: top, left, width, height;
     transition-duration: 0.5s;
-}
-
-.teaching-bubble-cutout {
-    position: fixed;
-    z-index: @modalDimmerZIndex;
-    box-shadow: 0 0 0 99999px @modalOverlayColor;
-    border-radius: 0.5rem;
 }
 
 .teaching-bubble {

--- a/react-common/styles/react-common.less
+++ b/react-common/styles/react-common.less
@@ -4,7 +4,7 @@
 @import "extensions/ExtensionCard.less";
 @import "language/language.less";
 @import "onboarding/TeachingBubble.less";
-@import "animations/confetti.less";
+@import "animations/Confetti.less";
 @import "controls/Button.less";
 @import "controls/Card.less";
 @import "controls/Checkbox.less";

--- a/react-common/styles/react-common.less
+++ b/react-common/styles/react-common.less
@@ -4,6 +4,7 @@
 @import "extensions/ExtensionCard.less";
 @import "language/language.less";
 @import "onboarding/TeachingBubble.less";
+@import "animations/confetti.less";
 @import "controls/Button.less";
 @import "controls/Card.less";
 @import "controls/Checkbox.less";

--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -16,6 +16,7 @@ import { Modal, ModalAction } from 'react-common/components/controls/Modal';
 import { jsxLF } from "react-common/components/util";
 import { Badge } from "react-common/components/profile/Badge";
 import { Button } from "react-common/components/controls/Button";
+import { Confetti } from "react-common/components/animations/Confetti";
 import { SignInModal } from "react-common/components/profile/SignInModal";
 import { Share, ShareData } from "react-common/components/share/Share";
 import { Input } from 'react-common/components/controls/Input';
@@ -194,17 +195,6 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
         return modalActions;
     }
 
-    renderConfetti() {
-        const density = 100;
-        return Array(density).fill(0).map((el, i) => {
-            const style = {
-                animationDelay: `${0.1 * (i % density)}s`,
-                left: `${1 * (Math.floor(Math.random() * density))}%`
-            }
-            return <div key={i} style={style} className={`confetti ${Math.random() > 0.5 ? "reverse" : ""} color-${Math.floor(Math.random() * 9)}`} />
-        })
-    }
-
     renderCompletionModal() {
         const  { skillMap, type, activity, userState, pageSourceUrl, dispatchNextModal, reward, mapId } = this.props;
         if (!type || !skillMap) return <div />
@@ -228,7 +218,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
         const shouldShowShare = previousState && previousState.headerId;
         const showMultiplayerShare = shouldShowShare && (activity as MapCompletionNode).showMultiplayerShare;
 
-        return <div className="confetti-container">
+        return <Confetti>
             <Modal title={completionModalTitle} actions={this.getCompletionActions(node.actions)} className="completion" onClose={this.handleOnClose}>
                 {completionModalTextSegments[0]}{<strong>{skillMap.displayName}</strong>}{completionModalTextSegments[1]}
                 <Button
@@ -254,8 +244,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
                         onClick={this.handleMultiplayerShareClick} />
                 }
             </Modal>
-            {this.renderConfetti()}
-        </div>
+        </Confetti>
     }
 
     renderRestartWarning() {
@@ -451,10 +440,9 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
         if (reward?.type === "certificate") modal = this.renderCertificateModal(reward);
         else if (reward?.type === "completion-badge") modal = this.renderBadgeModal(reward);
 
-        return <div className="confetti-container">
+        return <Confetti>
             {modal}
-            {this.renderConfetti()}
-        </div>
+        </Confetti>
     }
 
     renderCertificateModal(reward: MapRewardCertificate) {

--- a/skillmap/src/styles/modal.css
+++ b/skillmap/src/styles/modal.css
@@ -132,41 +132,6 @@
     width: 100%;
 }
 
-/* COMPLETION CONFETTI */
-.confetti-container {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-    z-index: 100;
-}
-
-.confetti {
-    width: 10px;
-    height: 10px;
-    background-color: #249ca3;
-    position: absolute;
-    left: 50%;
-    top: -15px;
-    animation: confetti 2.5s linear -2s infinite;
-    transform-origin: left top;
-    z-index: 110;
-}
-
-.confetti.reverse {
-    animation: confetti-reverse 2.5s linear -2s infinite;
-}
-
-.color-0 { background-color: #ff2121; }
-.color-1 { background-color: #ff93c4; }
-.color-2 { background-color: #ff8135; }
-.color-3 { background-color: #fff609; }
-.color-4 { background-color: #249ca3; }
-.color-5 { background-color: #78dc52; }
-.color-6 { background-color: #003fad; }
-.color-7 { background-color: #87f2ff; }
-.color-8 { background-color: #8e2ec4; }
-
 /*******************************/
 /*****   HIGH CONTRAST     *****/
 /*******************************/

--- a/webapp/src/components/onboarding/EditorTour.tsx
+++ b/webapp/src/components/onboarding/EditorTour.tsx
@@ -38,12 +38,20 @@ const Download: TargetContent = {
     location: Location.Above,
 };
 
+const Congrats: TargetContent = {
+    title: lf("Congratulations!"),
+    description: lf("You've completed the editor tour! {0} Happy coding!", "🤩🏆🤩"),
+    targetQuery: "#root",
+    location: Location.Center,
+};
+
 const EditorContent: TargetContent[] = [
     Toolbox,
     Workspace,
     Simulator,
     Share,
     Download,
+    Congrats
 ];
 
 export interface EditorTourProps {
@@ -92,8 +100,13 @@ export const EditorTour = (props: EditorTourProps) => {
     }
 
     const onFinish = () => {
-        pxt.tickEvent("tour.finish", data());
-        onClose();
+        if (currentStep < EditorContent.length - 1) {
+            pxt.tickEvent("tour.finish", data());
+            setCurrentStep(currentStep + 1);
+        } else { // Congrats modal
+            pxt.tickEvent("tour.congrats", data());
+            onClose();
+        }
     }
 
     return <TeachingBubble id="teachingBubble"
@@ -101,7 +114,7 @@ export const EditorTour = (props: EditorTourProps) => {
         onNext={onNext}
         onBack={onBack}
         stepNumber={currentStep + 1}
-        totalSteps={EditorContent.length}
+        totalSteps={EditorContent.length - 1}
         onClose={onExit}
         onFinish={onFinish}
     />

--- a/webapp/src/components/onboarding/EditorTour.tsx
+++ b/webapp/src/components/onboarding/EditorTour.tsx
@@ -100,13 +100,8 @@ export const EditorTour = (props: EditorTourProps) => {
     }
 
     const onFinish = () => {
-        if (currentStep < EditorContent.length - 1) {
-            pxt.tickEvent("tour.finish", data());
-            setCurrentStep(currentStep + 1);
-        } else { // Congrats modal
-            pxt.tickEvent("tour.congrats", data());
-            onClose();
-        }
+        pxt.tickEvent("tour.finish", data());
+        onClose();
     }
 
     return <TeachingBubble id="teachingBubble"


### PR DESCRIPTION
This PR adds:
- Confetti as a react common component (this code comes from Shannon's implementation within skillmaps)
- Final congrats step in tour with confetti
- Initial transition animation for cutout (full screen to toolbox)

Try it out: https://makecode.microbit.org/app/7ce1ca36335e9776ca7ab2161f3747d9689808da-3c95e373c1
![editorTourCongrats](https://user-images.githubusercontent.com/15070078/229903083-82735c4f-e175-4473-8826-943e990dfdcd.gif)