### PR TITLE
Editor tour: remove project area from toolbox cutout

### DIFF
--- a/webapp/src/components/onboarding/EditorTour.tsx
+++ b/webapp/src/components/onboarding/EditorTour.tsx
@@ -13,6 +13,8 @@ const Toolbox: TargetContent = {
     title: lf("Toolbox"),
     description: lf("Drag out blocks of code from the Toolbox categories into the Workspace."),
     targetQuery: "#blocksEditorToolbox",
+    sansQuery: "#projectNameArea",
+    sansLocation: Location.Below,
     location: Location.Right,
 };
 
@@ -21,6 +23,7 @@ const Workspace: TargetContent = {
     description: lf("Snap blocks of code together to build your program."),
     targetQuery: "#blocksEditor", // includes the toolbox
     sansQuery: ".blocklyToolboxDiv",
+    sansLocation: Location.Left,
     location: Location.Center,
 };
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5028
Before, when the toolbox was expanded, the cutout was including the project area directly below it. Now, I check if the cutout will collide with the project area and then adjust the cutout, if needed.
![image](https://user-images.githubusercontent.com/15070078/230231181-6e41c9cc-46b1-421f-8e3e-f05f8ea0a491.png)
