### PR TITLE
Prioritize webusb downloads when available

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -440,6 +440,7 @@ declare namespace pxt {
         experimentalHw?: boolean; // enable experimental hardware
         // recipes?: boolean; // inlined tutorials - deprecated
         checkForHwVariantWebUSB?: boolean; // check for hardware variant using webusb before compiling
+        preferWebUSBDownload?: boolean; // default to webusb over normal browser download when available
         shareFinishedTutorials?: boolean; // always pop a share dialog once the tutorial is finished
         leanShare?: boolean; // use leanscript.html instead of script.html for sharing pages
         nameProjectFirst?: boolean; // prompt user to name project when creating new one

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -1,4 +1,10 @@
 namespace pxt.commands {
+    export enum WebUSBPairResult {
+        Failed = 0,
+        Success = 1,
+        UserRejected = 2,
+    }
+
     export interface RecompileOptions {
         recompile: boolean;
         useVariants: string[];
@@ -29,7 +35,7 @@ namespace pxt.commands {
     export let showProgramTooLargeErrorAsync: (variants: string[], confirmAsync: (options: any) => Promise<number>) => Promise<RecompileOptions>;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts
-    export let webUsbPairDialogAsync: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<number>) => Promise<number> = undefined;
+    export let webUsbPairDialogAsync: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<WebUSBPairResult>, implicitlyCalled?: boolean) => Promise<WebUSBPairResult> = undefined;
     export let onTutorialCompleted: () => void = undefined;
     export let workspaceLoadedAsync: () => Promise<void> = undefined;
 }

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -1,5 +1,14 @@
 namespace pxt.usb {
 
+    /**
+     * For local testing of WebUSB, be sure to (temporarily)
+     * enable the browser command line flag `--disable-webusb-security`
+     * to allow localhost (non-https) access to the APIs.
+     * If possible it might be easiest to download a separate canary build
+     * for chrome / edge to run.
+     * https://chromium.googlesource.com/playground/chromium-org-site/+/refs/heads/main/for-testers/command-line-flags.md
+     */
+
     export class USBError extends Error {
         constructor(msg: string) {
             super(msg)

--- a/theme/common.less
+++ b/theme/common.less
@@ -1595,7 +1595,7 @@ p.ui.font.small {
 
     .ui.purple.ribbon.label {
         position: absolute;
-        left: -1.2rem;
+        left: -1rem;
         top: -1rem;
         padding-left: 1.5rem;
     }

--- a/theme/common.less
+++ b/theme/common.less
@@ -1593,15 +1593,19 @@ p.ui.font.small {
     position: relative;
     margin-top: 1.5rem;
 
-    .ui.purple.ribbon.large.label {
+    .ui.purple.ribbon.label {
         position: absolute;
         left: -1.2rem;
         top: -1rem;
+        padding-left: 1.5rem;
     }
 
-    a {
-        color: #4C309D;
-        cursor: pointer;
+    > .content {
+        padding-top: .25rem;
+    }
+
+    a.ui.button {
+        margin-top: .5rem;
     }
 }
 
@@ -2091,7 +2095,7 @@ p.ui.font.small {
         div.simframe {
             margin-bottom: -0.4rem
         }
-        
+
         &:not(.headless):not(.sandbox) {
             .simPanel .simtoolbar {
                 margin-bottom: -0.2rem;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4272,6 +4272,7 @@ export class ProjectView
         dialogs.showResetDialogAsync().then(r => {
             if (!r) return Promise.resolve();
             dialogs.clearDontShowDownloadDialogFlag();
+            webusb.clearUserPrefersDownloadFlag();
             return this.resetWorkspace();
         });
     }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -447,12 +447,19 @@ export function maybeReconnectAsync(pairIfDeviceNotFound = false, skipIfConnecte
     return reconnectPromise;
 }
 
-export function pairAsync(): Promise<void> {
+export function pairAsync(implicitlyCalled?: boolean): Promise<void> {
     pxt.tickEvent("cmds.pair")
-    return pxt.commands.webUsbPairDialogAsync(pxt.usb.pairAsync, core.confirmAsync)
+    return pxt.commands.webUsbPairDialogAsync(pxt.usb.pairAsync, core.confirmAsync, implicitlyCalled)
         .then(res => {
-            if (res) return maybeReconnectAsync();
-            else return core.infoNotification("Oops, no device was paired.")
+            switch (res) {
+                case pxt.commands.WebUSBPairResult.Success:
+                    return maybeReconnectAsync();
+                case pxt.commands.WebUSBPairResult.Failed:
+                    return core.infoNotification("Oops, no device was paired.")
+                case pxt.commands.WebUSBPairResult.UserRejected:
+                    // User exited pair flow intentionally
+                    return;
+            }
         });
 }
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -14,10 +14,6 @@ function log(msg: string) {
 }
 
 let extensionResult: pxt.editor.ExtensionResult;
-// This can be overidden by the extension result
-pxt.commands.renderBrowserDownloadInstructions = dialogs.renderBrowserDownloadInstructions;
-pxt.commands.renderIncompatibleHardwareDialog = dialogs.renderIncompatibleHardwareDialog;
-
 
 function browserDownloadAsync(text: string, name: string, contentType: string): Promise<void> {
     pxt.BrowserUtils.browserDownloadBinText(
@@ -314,6 +310,9 @@ function applyExtensionResult() {
     if (res.renderBrowserDownloadInstructions) {
         log(`extension upload renderBrowserDownloadInstructions`);
         pxt.commands.renderBrowserDownloadInstructions = res.renderBrowserDownloadInstructions;
+    } else {
+        // default
+        pxt.commands.renderBrowserDownloadInstructions = dialogs.renderBrowserDownloadInstructions;
     }
     if (res.renderUsbPairDialog) {
         log(`extension renderUsbPairDialog`)
@@ -322,6 +321,9 @@ function applyExtensionResult() {
     if (res.renderIncompatibleHardwareDialog) {
         log(`extension renderIncompatibleHardwareDialog`)
         pxt.commands.renderIncompatibleHardwareDialog = res.renderIncompatibleHardwareDialog;
+    } else {
+        // default
+        pxt.commands.renderIncompatibleHardwareDialog = dialogs.renderIncompatibleHardwareDialog;
     }
     if (res.showUploadInstructionsAsync) {
         log(`extension upload instructions async`);

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -771,8 +771,8 @@ export function renderBrowserDownloadInstructions(saveonly?: boolean) {
                                         </div>
                                         {webUSBSupported &&
                                             <div className="download-callout">
-                                                <label className="ui purple ribbon large label">{lf("New!")}</label>
-                                                <div className="ui two column grid">
+                                                <label className="ui purple ribbon label">{lf("Want faster downloads?")}</label>
+                                                <div className="ui two column grid content">
                                                     <div className="icon-align three wide column">
                                                         <div />
                                                         <i className="icon big usb" />
@@ -780,8 +780,7 @@ export function renderBrowserDownloadInstructions(saveonly?: boolean) {
                                                     </div>
                                                     <div className="thirteen wide column">
                                                         {lf("Download your code faster by pairing with web usb!")}
-                                                        <br />
-                                                        <strong><a onClick={onPairClicked}>{lf("Pair now")}</a></strong>
+                                                        <a className="ui button purple" onClick={onPairClicked}>{lf("Pair now")}</a>
                                                     </div>
                                                 </div>
                                             </div>

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -10,6 +10,7 @@ import * as cloudsync from "./cloudsync";
 import Cloud = pxt.Cloud;
 import Util = pxt.Util;
 import { fireClickOnEnter } from "./util";
+import { pairAsync } from "./cmds";
 
 let dontShowDownloadFlag = false;
 
@@ -744,7 +745,7 @@ export function renderBrowserDownloadInstructions(saveonly?: boolean) {
 
     const onPairClicked = () => {
         core.hideDialog();
-        pxt.commands.webUsbPairDialogAsync(pxt.usb.pairAsync, core.confirmAsync);
+        pairAsync();
     }
 
     const onCheckboxClicked = (value: boolean) => {

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -10,6 +10,7 @@ import * as auth from "./auth";
 import * as identity from "./identity";
 import { ProjectView } from "./app";
 import { clearDontShowDownloadDialogFlag } from "./dialogs";
+import { userPrefersDownloadFlagSet } from "./webusb";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -184,8 +185,16 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     }
 
-    protected onDownloadButtonClick = () => {
+    protected onDownloadButtonClick = async () => {
         pxt.tickEvent("editortools.downloadbutton", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
+        if (pxt.appTarget.appTheme?.preferWebUSBDownload
+            && pxt.usb.isEnabled
+            && !userPrefersDownloadFlagSet()
+            && !pxt.packetio.isConnected()
+            && !pxt.packetio.isConnecting()
+        ) {
+            await cmds.pairAsync(true);
+        }
         this.compile();
     }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -188,6 +188,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
     protected onDownloadButtonClick = async () => {
         pxt.tickEvent("editortools.downloadbutton", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
         if (pxt.appTarget.appTheme?.preferWebUSBDownload
+            && pxt.appTarget?.compile?.webUSB
             && pxt.usb.isEnabled
             && !userPrefersDownloadFlagSet()
             && !pxt.packetio.isConnected()

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -65,7 +65,7 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
     else {
         const tryAgain = await showConnectionFailureAsync(confirmAsync, implicitlyCalled);
 
-        if (tryAgain) await webUsbPairThemedDialogAsync(pairAsync, confirmAsync);
+        if (tryAgain) await webUsbPairThemedDialogAsync(pairAsync, confirmAsync, implicitlyCalled);
     }
 
     if (paired) {

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -336,7 +336,7 @@ function showPairStepAsync(
                     tryAgain = true;
                 }
             }
-        ]
+        ].filter(el => !!el)
     })
     .then(() => tryAgain)
 }


### PR DESCRIPTION
When pressing download, show pairing flow first to encourage webusb use.

* if they exit the flow (click outside, x) it will bail out and generate a hex file
* if they go through the pairing flow as normal and end up not connecting, there is a secondary option for 'download as file' which will generate the hex file && not show pairing prompt automatically again (in memory) (similar to a "don't show this again" toggle, but in this case we have to give an indication that clicking it will still download as well)
![image](https://user-images.githubusercontent.com/5615930/231835999-21f536f5-24e1-442d-91bd-e222a8b59acf.png)

    * Above two points will probably be fiddled with after testing in beta to get something that feels right without making it too easy to accidentally not pair
* Minor tweaking of the download completed dialog to ideally make webusb pairing a bit more appealing
![image](https://user-images.githubusercontent.com/5615930/231835039-1b699f9c-44e0-404e-aeaa-3f972018f767.png)
    * label from new to describing why you'd want it -- it's not really "new" anymore and new might make people think it's less stable / in testing / etc
    * plain anchor to button styling for pair to make it obvious it's an action you take
* pushing webusb first is enabled by target flag
*  `...`  menu next to download button has same options (connect device, download as file)

build https://makecode.microbit.org/app/ce711df396e087f68c1a6b552ca1c2c7a20f9fd5-088b06d19f