### PR TITLE
support decompiling more than one tagged template for a parameter

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -2979,14 +2979,12 @@ ${output}</xml>`;
                     }
 
                     const tag = unwrapNode((e as ts.TaggedTemplateExpression).tag);
-
-                    if (tag.kind !== SK.Identifier) {
-                        return Util.lf("Tagged template literals must use an identifier as the tag");
-                    }
-
                     const tagText = tag.getText();
-                    if (tagText.trim() != tagName.trim()) {
-                        return Util.lf("Function only supports template literals with tag '{0}'", tagName);
+
+                    const possibleTags = tagName.split(";").map(t => t.trim());
+
+                    if (possibleTags.indexOf(tagText) === -1) {
+                        return Util.lf("Function only supports template literals with tag '{0}'", possibleTags.join(", "));
                     }
 
                     const template = (e as ts.TaggedTemplateExpression).template;

--- a/tests/decompile-test/baselines/tagged_template_multiple.blocks
+++ b/tests/decompile-test/baselines/tagged_template_multiple.blocks
@@ -1,0 +1,26 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="music_song_field_editor">
+<field name="song">hex&#38;&#35;96&#59;1234&#38;&#35;96&#59;</field>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">y</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="music_song_field_editor">
+<field name="song">assets.song&#38;&#35;96&#59;hello&#38;&#35;96&#59;</field>
+</block>
+</value>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/tagged_template_multiple.ts
+++ b/tests/decompile-test/cases/tagged_template_multiple.ts
@@ -1,0 +1,2 @@
+let x = music.createSong(hex`1234`);
+let y = music.createSong(assets.song`hello`);

--- a/tests/decompile-test/cases/testBlocks/templateStrings.ts
+++ b/tests/decompile-test/cases/testBlocks/templateStrings.ts
@@ -11,6 +11,8 @@ declare interface Fixed {
     whatever(): void;
 }
 
+function hex(lits: any, ...args: any[]): Buffer { return null }
+
 //% shim=@f4 helper=image::ofBuffer
 //% groups=["0.","1#","2T","3t","4N","5n","6G","7g","8","9","aAR","bBP","cCp","dDO","eEY","fFW"]
 function img(lits: any, ...args: any[]): Image { return null }
@@ -129,4 +131,22 @@ namespace template {
     export function _animationFrames(frames: Image[]) {
         return frames
     }
+}
+
+namespace music {
+    //% blockId=music_song_field_editor
+    //% block="song $song"
+    //% song.fieldEditor=musiceditor
+    //% song.fieldOptions.decompileLiterals=true
+    //% song.fieldOptions.taggedTemplate="hex;assets.song"
+    //% song.fieldOptions.decompileIndirectFixedInstances="true"
+    //% song.fieldOptions.decompileArgumentAsString="true"
+    export function createSong(song: Buffer): Buffer {
+        return song
+    }
+}
+
+namespace assets {
+    //% pyConvertToTaggedTemplate
+    export function song(lits: any, ...args: any[]): Buffer { return null }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5738

Adding support for multiple tagged templates to decompile a parameter from; the music editor supports two:

```
assets.song`name`
hex`1234`
```