### PR TITLE
add flag to skip simshims check

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3940,6 +3940,9 @@ function testForBuildTargetAsync(useNative: boolean, cachedSHA: string): Promise
 
 function simshimAsync() {
     pxt.debug("looking for shim annotations in the simulator.")
+    if (pxt.appTarget.noSimShims) {
+        return Promise.resolve();
+    }
     if (!fs.existsSync(path.join(simDir(), "tsconfig.json"))) {
         pxt.debug("no sim/tsconfig.json; skipping")
         return Promise.resolve();

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -105,6 +105,7 @@ declare namespace pxt {
         cacheusedblocksdirs?: string[]; // list of /docs subfolders for parsing and caching used block ids (for tutorial loading)
         blockIdMap?: Map<string[]>; // list of target-specific blocks that are "synonyms" (eg. "agentturnright" and "minecraftAgentTurn")
         defaultBadges?: pxt.auth.Badge[];
+        noSimShims?: boolean; // skip check for simshims and only build from cpp / user level typescript.
     }
 
     interface BrowserOptions {


### PR DESCRIPTION
It looks like we only actually create output from this in sim only targets, so add a flag to skip it -- it takes a few seconds and generates about 150 lines of output / couple dozen spurious errors in arcade (https://github.com/microsoft/pxt-arcade/actions/runs/4704080574/jobs/8343339084#step:6:27 down to where it first says 'looking for tutorial markdown')