### PR TITLE
Move Immersive Reader Button to Avoid Scrollbar Overlap

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -677,13 +677,13 @@
         padding: .5rem 1rem 0.7rem 1rem;
 
         .tutorial-step-content {
-            margin-right: 1rem;
+            margin-right: 1.5rem;
         }
 
         .immersive-reader-button {
             position: absolute;
             top: 0.3rem;
-            right: 0.3rem;
+            right: 1rem;
         }
     }
 


### PR DESCRIPTION
Moves the immersive reader button a little to the left so it doesn't overlap with the scrollbar. Also had to adjust the margin on the tutorial content text so it doesn't overlap with the reader button.

Fixes: https://github.com/microsoft/pxt-microbit/issues/5040

With fix:
![image](https://user-images.githubusercontent.com/69657545/233453221-44807878-6b8b-4fe6-8a2b-f21daf7550ee.png)
