### PR TITLE
Allow projects to be imported as asset packs

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -92,6 +92,7 @@ declare namespace pxt {
         utf8?: boolean; // force compilation with UTF8 enabled
         disableTargetTemplateFiles?: boolean; // do not override target template files when commiting to github
         theme?: string | pxt.Map<string>;
+        assetPack?: boolean; // if set to true, only the assets of this project will be imported when added as an extension (no code)
     }
 
     interface PackageExtension {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -269,7 +269,7 @@ namespace pxt {
         }
 
         isAssetPack() {
-            return !!this.config?.assetPack;
+            return this.level !== 0 && !!this.config?.assetPack;
         }
 
         private resolveVersionAsync() {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -63,6 +63,16 @@ namespace pxt {
                 const projId = fullVers.slice("workspace:".length);
                 // TODO: Fetch pxt.json from the workspace project
                 return null;
+            } else if (fullVers.startsWith("pub:")) {
+                const id = fullVers.slice("pub:".length);
+                try {
+                    const files = await Cloud.downloadScriptFilesAsync(id);
+                    return JSON.parse(files[CONFIG_NAME]);
+                }
+                catch (e) {
+                    pxt.log(`Unable to fetch files for published script '${fullVers}'`);
+                    return null;
+                }
             } else {
                 // If it's not from GH, assume it's a bundled package
                 // TODO: Add logic for shared packages if we enable that
@@ -86,8 +96,9 @@ namespace pxt {
         public ignoreTests = false;
         public cppOnly = false;
         public installedVersion: string; // resolve version
+        protected assetPackFiles: pxt.Map<string>;
 
-        constructor(public id: string, public _verspec: string, public parent: MainPackage, addedBy: Package) {
+        constructor(public id: string, public _verspec: string, public parent: MainPackage, addedBy: Package, public depName: string) {
             if (addedBy) {
                 this.level = addedBy.level + 1
             }
@@ -127,32 +138,74 @@ namespace pxt {
                     : undefined;
         }
 
-        commonDownloadAsync(): Promise<Map<string>> {
+        async commonDownloadAsync(): Promise<Map<string>> {
             const proto = this.verProtocol()
+            let files: Map<string>;
+
             if (proto == "pub") {
-                return Cloud.downloadScriptFilesAsync(this.verArgument())
+                files = await Cloud.downloadScriptFilesAsync(this.verArgument())
             } else if (proto == "github") {
-                return pxt.packagesConfigAsync()
-                    .then(config => pxt.github.downloadPackageAsync(this.verArgument(), config))
-                    .then(resp => resp.files)
+                const config = await pxt.packagesConfigAsync();
+                const resp = await pxt.github.downloadPackageAsync(this.verArgument(), config)
+                files = resp.files;
             } else if (proto == "embed") {
-                const resp = pxt.getEmbeddedScript(this.verArgument())
-                return Promise.resolve(resp)
+                files = pxt.getEmbeddedScript(this.verArgument())
             } else if (proto == "pkg") {
                 // the package source is serialized in a file in the package itself
                 const src = this.parent || this; // fall back to current package if no parent
                 const pkgFilesSrc = src.readFile(this.verArgument());
-                const pkgFilesJson = ts.pxtc.Util.jsonTryParse(pkgFilesSrc) as Map<string>;
+                const pkgFilesJson = U.jsonTryParse(pkgFilesSrc) as Map<string>;
                 if (!pkgFilesJson)
                     pxt.log(`unable to find ${this.verArgument()}`)
-                return Promise.resolve(pkgFilesJson)
-            } else return Promise.resolve(null as Map<string>)
+                files = pkgFilesJson
+            }
+
+            return files;
+        }
+
+        writeAssetPackFiles() {
+            const config = JSON.parse(JSON.stringify(this.config)) as pxt.PackageConfig;
+            config.files = config.files.filter(f => f.endsWith(".jres"));
+            config.files.push("gallery.ts");
+            this.config = config;
+            this.saveConfig();
+
+            let galleryTS = "";
+            for (const file of config.files) {
+                const content = this.readFile(file);
+                const parsed = U.jsonTryParse(content);
+
+                if (parsed) {
+                    const [jres, ts] = pxt.emitGalleryDeclarations(parsed, this.getNamespaceName());
+                    this.writeFile(file, JSON.stringify(jres, null, 4));
+                    galleryTS += ts;
+                }
+            }
+            this.writeFile("gallery.ts", galleryTS);
+        }
+
+        protected getNamespaceName() {
+            let child: Package = this;
+            let parent = child.addedBy[0];
+            const parts: string[] = [];
+
+            while (parent && parent !== child) {
+                if (child.depName) parts.push(child.depName);
+                child = parent;
+                parent = child.addedBy[0];
+            }
+
+            return parts.reverse().map(n => ts.pxtc.escapeIdentifier(n)).join(".");
         }
 
         host() { return this.parent._host }
 
         readFile(fn: string) {
             return this.host().readFile(this, fn)
+        }
+
+        writeFile(fn: string, content: string) {
+            this.host().writeFile(this, fn, content, true);
         }
 
         readGitJson(): pxt.github.GitJson {
@@ -215,6 +268,10 @@ namespace pxt {
             return allres
         }
 
+        isAssetPack() {
+            return !!this.config?.assetPack;
+        }
+
         private resolveVersionAsync() {
             let v = this._verspec
 
@@ -261,6 +318,10 @@ namespace pxt {
                     return this.host().downloadPackageAsync(this)
                         .then(() => {
                             this.loadConfig();
+
+                            if (this.isAssetPack()) {
+                                this.writeAssetPackFiles();
+                            }
                             pxt.debug(`installed ${this.id} /${verNo}`)
                         })
 
@@ -750,7 +811,7 @@ namespace pxt {
                             mod.addedBy.push(from)
                         }
                     } else {
-                        let mod = new Package(id, ver, from.parent, from)
+                        let mod = new Package(id, ver, from.parent, from, id)
                         if (isCpp)
                             mod.cppOnly = true
                         from.parent.deps[id] = mod
@@ -937,7 +998,7 @@ namespace pxt {
         private _jres: Map<JRes>;
 
         constructor(public _host: Host) {
-            super("this", "file:.", null, null)
+            super("this", "file:.", null, null, null)
             this.parent = this
             this.addedBy = [this]
             this.level = 0

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -167,6 +167,7 @@ namespace pxt {
             const config = JSON.parse(JSON.stringify(this.config)) as pxt.PackageConfig;
             config.files = config.files.filter(f => f.endsWith(".jres"));
             config.files.push("gallery.ts");
+            config.dependencies = {};
             this.config = config;
             this.saveConfig();
 
@@ -269,7 +270,7 @@ namespace pxt {
         }
 
         isAssetPack() {
-            return this.level !== 0 && !!this.config?.assetPack;
+            return this.level > 0 && !!this.config?.assetPack;
         }
 
         private resolveVersionAsync() {

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -248,10 +248,10 @@ namespace pxt.sprite {
         }
     }
 
-    export function encodeTilemap(t: TilemapData, fileType: "typescript" | "python"): string {
+    export function encodeTilemap(t: TilemapData, fileType: "typescript" | "python", idMap?: {[index: string]: string}): string {
         if (!t) return `null`;
 
-        return `tiles.createTilemap(${tilemapToTilemapLiteral(t.tilemap)}, ${bitmapToImageLiteral(Bitmap.fromData(t.layers), fileType)}, [${t.tileset.tiles.map(tile => encodeTile(tile, fileType))}], ${tileWidthToTileScale(t.tileset.tileWidth)})`
+        return `tiles.createTilemap(${tilemapToTilemapLiteral(t.tilemap)}, ${bitmapToImageLiteral(Bitmap.fromData(t.layers), fileType)}, [${t.tileset.tiles.map(tile => encodeTile(tile, fileType, idMap))}], ${tileWidthToTileScale(t.tileset.tileWidth)})`
     }
 
     export function decodeTilemap(literal: string, fileType: "typescript" | "python", proj: TilemapProject): TilemapData {
@@ -546,7 +546,10 @@ namespace pxt.sprite {
         return tileset ? tileset.split(",").filter(t => !!t.trim()).map(t => decodeTile(t, proj)) : [];
     }
 
-    function encodeTile(tile: Tile, fileType: "typescript" | "python") {
+    function encodeTile(tile: Tile, fileType: "typescript" | "python", idMap?: {[index: string]: string}) {
+        if (idMap && idMap[tile.id]) {
+            return idMap[tile.id];
+        }
         return tile.id;
     }
 

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1027,19 +1027,38 @@ namespace pxt {
                 }
             }
 
-            for (const tm of getTilemaps(pack.parseJRes())) {
-                this.state.tilemaps.add({
-                    internalID: this.getNewInternalId(),
-                    type: AssetType.Tilemap,
-                    id: tm.id,
-                    meta: {
-                        // For tilemaps, use the id as the display name for backwards compat
-                        displayName: tm.displayName || tm.id,
-                        package: pack.id
-                    },
-                    data: decodeTilemap(tm, id => this.resolveTile(id))
-                })
+            for (const dep of allPackages) {
+                const isProject = dep.id === "this";
+                for (const tm of getTilemaps(dep.parseJRes())) {
+                    if (isProject) {
+                        this.state.tilemaps.add({
+                            internalID: this.getNewInternalId(),
+                            type: AssetType.Tilemap,
+                            id: tm.id,
+                            meta: {
+                                // For tilemaps, use the id as the display name for backwards compat
+                                displayName: tm.displayName || tm.id,
+                                package: pack.id
+                            },
+                            data: decodeTilemap(tm, id => this.resolveTile(id))
+                        });
+                    }
+                    else {
+                        this.gallery.tilemaps.add({
+                            internalID: this.getNewInternalId(),
+                            type: AssetType.Tilemap,
+                            id: tm.id,
+                            meta: {
+                                // For tilemaps, use the id as the display name for backwards compat
+                                displayName: tm.displayName || tm.id,
+                                package: pack.id
+                            },
+                            data: decodeTilemap(tm, id => this.gallery.tiles.getByID(id))
+                        });
+                    }
+                }
             }
+
 
             this.committedState = this.cloneState();
             this.undoStack = [];
@@ -1458,6 +1477,9 @@ namespace pxt {
                     if (entry.namespace.endsWith(".")) {
                         outJRes[varName].namespace += ".";
                     }
+                }
+                if (outJRes[varName].tileset) {
+                    outJRes[varName].tileset = entry.tileset.map(t => idMapping[t] || t);
                 }
             }
         }

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -457,8 +457,6 @@ export class EditorPackage {
         let lst = Util.values(this.files)
         if (!pxt.options.debug)
             lst = lst.filter(f => f.name != pxt.github.GIT_JSON && f.name != pxt.SIMSTATE_JSON && f.name != pxt.SERIAL_EDITOR_FILE && f.name != pxt.PALETTES_FILE)
-        if (this.ksPkg?.config?.assetPack && this.ksPkg?.level !== 0)
-            lst = lst.filter(f => f.getExtension() === "jres" || f.name === "gallery.ts")
         lst.sort((a, b) => a.weight() - b.weight() || Util.strcmp(a.name, b.name))
         return lst
     }
@@ -500,8 +498,6 @@ export class EditorPackage {
     }
 
     async buildAssetsAsync() {
-        // await this.buildDependencyAssetsAsync();
-
         if (!this.tilemapProject?.needsRebuild) return;
         this.tilemapProject.needsRebuild = false;
 
@@ -550,45 +546,6 @@ export class EditorPackage {
                 compiler.refreshLanguageServiceApisInfo();
             });
     }
-
-    // async buildDependencyAssetsAsync() {
-    //     for (const dep of this.pkgAndDeps()) {
-    //         if (dep.getKsPkg()?.config?.assetPack) {
-    //             if (dep.files["gallery.ts"]) continue;
-    //             let out = "";
-    //             const jres = dep.filterFiles(f => f.getExtension() === "jres" && f.epkg === dep);
-    //             const namespaceName = dep.getNamespaceName();
-    //             for (const file of jres) {
-    //                 const parsed = JSON.parse(file.content);
-    //                 const [updatedJres, ts] = pxt.emitGalleryDeclarations(parsed, namespaceName);
-    //                 out += ts;
-    //                 await dep.setContentAsync(file.name, JSON.stringify(updatedJres, null, 4));
-    //             }
-
-    //             if (out) {
-    //                 await dep.setContentAsync("gallery.ts", out);
-    //             }
-    //         }
-    //     }
-    // }
-
-    // protected getNamespaceName() {
-    //     let child = this.getKsPkg();
-    //     let parent = child.parent;
-    //     const parts: string[] = [];
-
-    //     while (parent && parent !== child) {
-    //         for (const key of Object.keys(parent.deps)) {
-    //             if (parent.deps[key] === child) {
-    //                 parts.push(key)
-    //             }
-    //         }
-    //         child = parent;
-    //         parent = child.parent;
-    //     }
-
-    //     return parts.reverse().map(n => ts.pxtc.escapeIdentifier(n)).join(".");
-    // }
 
     cacheTranspile(fromLanguage: pxtc.CodeLang, fromText: string, toLanguage: pxtc.CodeLang, toText: string) {
         this.transpileCache.push({

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -671,7 +671,7 @@ class Host
                     epkg.files[filename] = new File(epkg, filename, contents);
                 }
                 else {
-                    throw Util.oops("trying to nonexistent write " + module + " / " + filename)
+                    throw Util.oops("trying to write file not listed in pxt.json " + module + " / " + filename)
                 }
             }
             else {


### PR DESCRIPTION
This PR adds a field to pxt.json that allows you to turn a project into an asset pack.

When the field is set, we do the following things:
1. Remove all files except for *.jres
2. Remap all of the asset ids to be under a new namespace
3. Add a gallery.ts file that declares variables for all of the assets, allowing you to reference them in TS as well

The namespace we generate is based on the key for this dependency in the project pxt.json. When referencing a package in a tutorial it is very important that you make the id in the `````` ```packages`````` block match the id field in the pxt.json of the package to avoid weird bugs.

For example, if the imported project is named "my asset pack", then the namespace for referencing the assets will be "my_asset_pack". 

