### PR TITLE
Allow projects to declare dependencies to be asset packs and emit tags

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -93,6 +93,7 @@ declare namespace pxt {
         disableTargetTemplateFiles?: boolean; // do not override target template files when commiting to github
         theme?: string | pxt.Map<string>;
         assetPack?: boolean; // if set to true, only the assets of this project will be imported when added as an extension (no code)
+        assetPacks?: Map<boolean>; // a map of dependency id to boolean that indicates which dependencies should be imported as asset packs
     }
 
     interface PackageExtension {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -853,7 +853,6 @@ namespace pxt {
                             const conflictNames = conflicts.map((c) => c.pkg0.id).join(", ");
                             const settingNames = conflicts.map((c) => c.settingName).filter((s) => !!s).join(", ");
                             pxt.log(`skipping missing package ${missing} because it conflicts with the following packages: ${conflictNames} (conflicting settings: ${settingNames})`);
-                            continue;
                         } else {
                             pxt.log(`adding missing package ${missing}`);
                             didAddPackages = true;

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -649,7 +649,7 @@ namespace pxt {
                 if (!isInstall)
                     U.userError("Package not installed: " + this.id + ", did you forget to run `pxt install`?")
             } else {
-                await this.parseConfig(str);
+                this.parseConfig(str);
             }
 
             // if we are installing this script, we haven't yet downloaded the config
@@ -686,7 +686,7 @@ namespace pxt {
 
             if (appTarget.simulator && appTarget.simulator.dynamicBoardDefinition) {
                 if (this.level == 0) {
-                    await this.patchCorePackage();
+                    this.patchCorePackage();
                 }
                 if (this.config.compileServiceVariant) {
                     pxt.setAppTargetVariant(this.config.compileServiceVariant)

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1433,6 +1433,20 @@ namespace pxt {
             let blockIdentity: string;
             let value: string;
             const varName = idMapping[getId(key)].split(".").pop();
+            let tags: string[] = entry.tags;
+
+            if (!tags) {
+                tags = [];
+                if (varName.toLowerCase().indexOf("background") !== -1) {
+                    tags.push("background");
+                }
+                if (varName.toLowerCase().indexOf("dialog") !== -1) {
+                    tags.push("dialog");
+                }
+                if (entry.tilemapTile) {
+                    tags.push("tile");
+                }
+            }
 
             if (mimeType === IMAGE_MIME_TYPE) {
                 value = "image.ofBuffer(hex\`\`)"
@@ -1462,6 +1476,7 @@ namespace pxt {
 
             out += `${indent}//% fixedInstance jres whenUsed\n`
             if (blockIdentity)  out += `${indent}//% blockIdentity=${blockIdentity}\n`
+            if (tags.length) out += `${indent}//% tags="${tags.join(" ")}"\n`
             out += `${indent}export const ${varName} = ${value};\n`
 
             if (typeof entry === "string") {
@@ -1470,7 +1485,8 @@ namespace pxt {
             else {
                 outJRes[varName] = {
                     ...entry,
-                    id: idMapping[getId(key)]
+                    id: idMapping[getId(key)],
+                    tags
                 };
                 if (entry.namespace) {
                     outJRes[varName].namespace = namespaceName


### PR DESCRIPTION
This is an extension to my asset pack pr that allows for projects that import dependencies to declare those dependencies to be asset packs. it looks like this:

```
{
    "name": "Untitled",
    "description": "",
    "dependencies": {
        "device": "*",
        "tagged-assets": "pub:37366-48747-84953-13766"
    },
    "files": [
        "main.blocks",
        "main.ts",
        "README.md",
        "assets.json"
    ],
    "preferredEditor": "tsprj",
    "assetPacks": {
        "tagged-assets": true
    }
}

```

Also added tag emitting to the declaration file generated for asset packs. If tags are not specified in the jres, i check the name of the asset for "dialog" or "background" and add those tags if missing.