### PR TITLE
Add site variables to allow teaching bubble colors to be overriden by target

### DIFF
--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -385,21 +385,21 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
                     </div>}
                     <div className="teaching-bubble-navigation">
                         {hasPrevious && <Button
-                            className="blue"
+                            className="primary"
                             onClick={onBack}
                             title={backLabel}
                             ariaLabel={backLabel}
                             label={backLabel}
                         />}
                         {hasNext && <Button
-                            className="blue inverted"
+                            className="primary inverted"
                             onClick={onNext}
                             title={nextLabel}
                             ariaLabel={nextLabel}
                             label={nextLabel}
                         />}
                         {!hasNext && <Button
-                            className="blue inverted"
+                            className="primary inverted"
                             onClick={onFinish}
                             title={finishLabel}
                             ariaLabel={finishLabel}

--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -30,8 +30,8 @@
     position: fixed;
     max-width: 25rem;
     min-width: 18.75rem;
-    background: @blue;
-    color: @white;
+    background: @teachingBubbleBackgroundColor;
+    color: @teachingBubbleTextColor;
     box-shadow: 0 0 0 0.1rem;
     border-radius: 0.5rem;
     padding: 1rem;
@@ -40,10 +40,10 @@
     .common-button {
 
         &:focus {
-            outline: .1rem solid @white;
+            outline: .1rem solid @teachingBubbleTextColor;
             filter: grayscale(.15) brightness(.85) contrast(1.3);
         }
-        &.blue:focus::after, &:focus::after {
+        &.primary:focus::after, &:focus::after {
             outline: none;
         }
     }
@@ -54,7 +54,7 @@
     width: 0;
     height: 0;
     z-index: @modalDimmerZIndex + 1;
-    color: @blue;
+    color: @teachingBubbleBackgroundColor;
 }
 
 .teaching-bubble-arrow-outline {
@@ -62,7 +62,7 @@
     width: 0;
     height: 0;
     z-index: @modalDimmerZIndex;
-    color: @white;
+    color: @teachingBubbleTextColor;
 }
 
 .teaching-bubble-content {
@@ -81,16 +81,20 @@
 
     .teaching-bubble-steps {
         font-size: .9rem;
-        color: @lightGrey
+        color: @teachingBubbleStepsColor;
     }
 
-    .common-button.blue {
+    .common-button.primary {
         padding: .25rem .5rem;
         margin: 0 .5rem 0 0;
-        border: .1rem solid @white;
+        border: .1rem solid @teachingBubbleTextColor;
+        background: @teachingBubbleBackgroundColor;
+        color: @teachingBubbleTextColor;
 
         &.inverted {
             margin-right: 0;
+            background: @teachingBubbleTextColor;
+            color: @teachingBubbleBackgroundColor;
         }
     }
 
@@ -105,7 +109,7 @@
     top: 0.5rem;
     padding: 0.5rem 0 0.25rem 0;
     background: transparent;
-    color: @white;
+    color: @teachingBubbleTextColor;
     margin: 0;
 
     i.right {

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -411,3 +411,10 @@
    Cloud Status
 ----------------------------*/
 @cloudStatusColor: @grey;
+
+/*---------------------------
+   Teaching Bubble
+----------------------------*/
+@teachingBubbleBackgroundColor: @blue;
+@teachingBubbleTextColor: @white;
+@teachingBubbleStepsColor: @lightGrey;


### PR DESCRIPTION
Using these CSS variables allows us to override the teaching bubble colors according to the target in the target repos. 
This impacts the editor tour and any future tours.