### PR TITLE
Add "Disconnect GitHub" button to GitHub screen

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -355,6 +355,7 @@ namespace pxt.editor {
         hideOnboarding(): void;
         showKeymap(show: boolean): void;
         toggleKeymap(): void;
+        signOutGithub(): void;
 
         showReportAbuse(): void;
         showLanguagePicker(): void;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4351,6 +4351,15 @@ export class ProjectView
         });
     }
 
+    signOutGithub() {
+        const githubProvider = cloudsync.githubProvider();
+        if (githubProvider) {
+            githubProvider.logout();
+            this.forceUpdate();
+            core.infoNotification(lf("Signed out from GitHub"))
+        }
+    }
+
     ///////////////////////////////////////////////////////////
     ////////////             Tutorials            /////////////
     ///////////////////////////////////////////////////////////

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -255,12 +255,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
     signOutGithub() {
         pxt.tickEvent("menu.github.signout");
         this.hide();
-        const githubProvider = cloudsync.githubProvider();
-        if (githubProvider) {
-            githubProvider.logout();
-            this.props.parent.forceUpdate();
-            core.infoNotification(lf("Signed out from GitHub..."))
-        }
+        this.props.parent.signOutGithub();
     }
 
     UNSAFE_componentWillReceiveProps(nextProps: SettingsMenuProps) {
@@ -335,7 +330,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
                 <div className="avatar" role="presentation">
                     <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />
                 </div>
-                {lf("Unlink GitHub")}
+                {lf("Disconnect GitHub")}
             </div> : undefined}
             {showCenterDivider && <div className="ui divider"></div>}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -784,7 +784,6 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                         {!isBlocksMode && isOwner &&
                             <sui.Link className="ui item button desktop only" icon="user plus" href={`https://github.com/${githubId.slug}/settings/collaboration`} target="_blank" title={lf("Invite others to contributes to this GitHub repository.")} />}
                         <sui.Link className="ui button" icon="external alternate" href={url} title={lf("Open repository in GitHub.")} target="_blank" onKeyDown={fireClickOnEnter} />
-                        {user && <sui.Button className="ui button" icon="fas fa-sign-out-alt" text={lf("Disconnect GitHub")} title={lf("Log out of GitHub")} onClick={this.handleSignoutGithub} onKeyDown={fireClickOnEnter} />}
                     </div>
                 </div>
                 <MessageComponent parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />
@@ -806,7 +805,9 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                     <HistoryZone parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />
                     {master && <ReleaseZone parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
                     {!isBlocksMode && <ExtensionZone parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
-                    <div></div>
+                    <div>
+                        {user && <sui.Button className="ui button" icon="fas fa-sign-out-alt" text={lf("Disconnect GitHub")} title={lf("Log out of GitHub")} textClass="landscape only" onClick={this.handleSignoutGithub} onKeyDown={fireClickOnEnter} />}
+                    </div>
                 </div>
             </div>
         )

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -805,8 +805,11 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                     <HistoryZone parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />
                     {master && <ReleaseZone parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
                     {!isBlocksMode && <ExtensionZone parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
-                    <div>
-                        {user && <sui.Button className="ui button" icon="fas fa-sign-out-alt" text={lf("Disconnect GitHub")} title={lf("Log out of GitHub")} textClass="landscape only" onClick={this.handleSignoutGithub} onKeyDown={fireClickOnEnter} />}
+                    <div></div>
+                </div>
+                <div className="ui serialHeader">
+                    <div className="rightHeader">
+                        {user && <sui.Button className="ui button" icon="fas fa-sign-out-alt" text={lf("Disconnect GitHub")} title={lf("Log out of GitHub")} onClick={this.handleSignoutGithub} onKeyDown={fireClickOnEnter} />}
                     </div>
                 </div>
             </div>

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -55,6 +55,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         this.handleBranchClick = this.handleBranchClick.bind(this);
         this.handleGithubError = this.handleGithubError.bind(this);
         this.handlePullRequest = this.handlePullRequest.bind(this);
+        this.handleSignoutGithub = this.handleSignoutGithub.bind(this);
     }
 
     clearCacheDiff(cachePrefix?: string, f?: DiffFile) {
@@ -737,6 +738,11 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         return diffFiles;
     }
 
+    private async handleSignoutGithub() {
+        pxt.tickEvent("github.signout");
+        this.props.parent.signOutGithub();
+    }
+
     renderCore(): JSX.Element {
         const gs = this.getGitJson();
         if (!gs)
@@ -778,6 +784,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                         {!isBlocksMode && isOwner &&
                             <sui.Link className="ui item button desktop only" icon="user plus" href={`https://github.com/${githubId.slug}/settings/collaboration`} target="_blank" title={lf("Invite others to contributes to this GitHub repository.")} />}
                         <sui.Link className="ui button" icon="external alternate" href={url} title={lf("Open repository in GitHub.")} target="_blank" onKeyDown={fireClickOnEnter} />
+                        {user && <sui.Button className="ui button" icon="fas fa-sign-out-alt" text={lf("Disconnect GitHub")} title={lf("Log out of GitHub")} onClick={this.handleSignoutGithub} onKeyDown={fireClickOnEnter} />}
                     </div>
                 </div>
                 <MessageComponent parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -63,6 +63,8 @@ type UserMenuState = {
 };
 
 export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
+    dropdown: sui.DropdownMenu;
+
     constructor(props: UserMenuProps) {
         super(props);
         this.state = {
@@ -94,17 +96,19 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
 
     handleUnlinkGitHubClicked = () => {
         pxt.tickEvent("menu.github.signout");
-        const githubProvider = cloudsync.githubProvider();
-        if (githubProvider) {
-            githubProvider.logout();
-            this.props.parent.forceUpdate();
-            core.infoNotification(lf("Signed out from GitHub..."))
-        }
+        this.hide();
+        this.props.parent.signOutGithub();
     }
 
     avatarPicUrl(): string {
         const user = this.getUserProfile();
         return user?.idp?.pictureUrl ?? user?.idp?.picture?.dataUrl;
+    }
+
+    hide() {
+        if (this.dropdown) {
+            this.dropdown.hide();
+        }
     }
 
     renderCore() {
@@ -144,6 +148,7 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
                 titleContent={loggedIn ? signedInElem : signedOutElem}
                 tabIndex={loggedIn ? 0 : -1}
                 onClick={this.handleDropdownClicked}
+                ref={ref => this.dropdown = ref}
             >
                 {loggedIn ? <sui.Item role="menuitem" text={lf("My Profile")} onClick={this.handleProfileClicked} /> : undefined}
                 {loggedIn ? <div className="ui divider"></div> : undefined}
@@ -152,7 +157,7 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
                         <div className="icon avatar" role="presentation">
                             <img className="circular image" src={githubUser.photo} alt={lf("User picture")} />
                         </div>
-                        <span>{lf("Unlink GitHub")}</span>
+                        <span>{lf("Disconnect GitHub")}</span>
                     </sui.Item>
                     : undefined}
                 {githubUser && <div className="ui divider"></div>}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -275,12 +275,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
 
     signOutGithub() {
         pxt.tickEvent("home.github.signout");
-        const githubProvider = cloudsync.githubProvider();
-        if (githubProvider) {
-            githubProvider.logout();
-            this.props.parent.forceUpdate();
-            core.infoNotification(lf("Signed out from GitHub"))
-        }
+        this.props.parent.signOutGithub();
     }
 
     renderCore() {
@@ -300,7 +295,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
                 <div className="avatar" role="presentation">
                     <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />
                 </div>
-                {lf("Unlink GitHub")}
+                {lf("Disconnect GitHub")}
             </div>}
             {showDivider && <div className="ui divider"></div>}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}


### PR DESCRIPTION
Add a button at the bottom of the screen to sign out of GitHub:

Arcade
![image](https://user-images.githubusercontent.com/12176807/234335692-a1f41855-e314-4e67-87e3-e1609238f09a.png)

Microbit
![image](https://user-images.githubusercontent.com/12176807/234336480-d4a986e3-fb56-4708-b6be-ea4a7ac551df.png)

I changed the wording from "Unlink" to "Disconnect" because it made more sense to me. Curious what others think.
![image](https://user-images.githubusercontent.com/12176807/234336851-eb268b18-05c9-4953-b722-e0c87dc1aa66.png)


Resolves https://github.com/microsoft/pxt-microbit/issues/4398
