### PR TITLE
Add open in vscode flag

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -474,6 +474,7 @@ declare namespace pxt {
             editor?: string // path to markdown file for the editor tour steps
         }
         tutorialSimSidebarLayout?: boolean; // Enable tutorial layout with the sim in the sidebar (desktop only)
+        showOpenInVscode?: boolean; // show the open in VS Code button
     }
 
     interface DownloadDialogTheme {

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -138,7 +138,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         const { height } = this.state;
 
         const hasSimulator = !pxt.appTarget.simulator?.headless;
-        const showOpenInVscodeButton = parent.isJavaScriptActive();
+        const showOpenInVscodeButton = parent.isJavaScriptActive() && pxt.appTarget?.appTheme?.showOpenInVscode;
 
         const simContainerClassName = `simulator-container ${this.props.tutorialSimSidebar ? "" : " hidden"}`;
         const outerTutorialContainerClassName = `editor-sidebar tutorial-container-outer${this.props.tutorialSimSidebar ? " topInstructions" : ""}`


### PR DESCRIPTION
Adding the `showOpenInVscode` flag so that we can avoid showing this button in microbit.
closes https://github.com/microsoft/pxt-microbit/issues/4979

I'll have another PR shortly to add the flag and set to true for Arcade.