### PR TITLE
[Stable8.5] Cherry picking asset pack PRs

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -92,6 +92,7 @@ declare namespace pxt {
         utf8?: boolean; // force compilation with UTF8 enabled
         disableTargetTemplateFiles?: boolean; // do not override target template files when commiting to github
         theme?: string | pxt.Map<string>;
+        assetPack?: boolean; // if set to true, only the assets of this project will be imported when added as an extension (no code)
     }
 
     interface PackageExtension {

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -93,6 +93,7 @@ declare namespace pxt {
         disableTargetTemplateFiles?: boolean; // do not override target template files when commiting to github
         theme?: string | pxt.Map<string>;
         assetPack?: boolean; // if set to true, only the assets of this project will be imported when added as an extension (no code)
+        assetPacks?: Map<boolean>; // a map of dependency id to boolean that indicates which dependencies should be imported as asset packs
     }
 
     interface PackageExtension {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -168,6 +168,7 @@ namespace pxt {
             config.files = config.files.filter(f => f.endsWith(".jres"));
             config.files.push("gallery.ts");
             config.dependencies = {};
+            config.assetPack = true;
             this.config = config;
             this.saveConfig();
 
@@ -635,10 +636,9 @@ namespace pxt {
             return dependencies;
         }
 
-        loadAsync(isInstall = false, targetVersion?: string): Promise<void> {
-            if (this.isLoaded) return Promise.resolve();
+        async loadAsync(isInstall = false, targetVersion?: string): Promise<void> {
+            if (this.isLoaded) return;
 
-            let initPromise = Promise.resolve()
 
             if (this.level == 0 && !pxt.appTarget.multiVariants)
                 pxt.setAppTargetVariant(null)
@@ -649,42 +649,49 @@ namespace pxt {
                 if (!isInstall)
                     U.userError("Package not installed: " + this.id + ", did you forget to run `pxt install`?")
             } else {
-                initPromise = initPromise.then(() => this.parseConfig(str))
+                this.parseConfig(str);
             }
 
             // if we are installing this script, we haven't yet downloaded the config
             // do upgrade later
             if (this.level == 0 && !isInstall) {
-                initPromise = initPromise.then(() => this.upgradePackagesAsync().then(() => { }))
+                await this.upgradePackagesAsync();
             }
 
-            if (isInstall)
-                initPromise = initPromise.then(() => this.downloadAsync())
+            if (isInstall) {
+                await this.downloadAsync();
+                if (this.level !== 0 && !this.isAssetPack()) {
+                    for (const parent of this.addedBy) {
+                        if (parent.config.assetPacks?.[this.id]) {
+                            this.writeAssetPackFiles();
+                            break;
+                        }
+                    }
+                }
+            }
 
             // we are installing the script, and we've download the original version and we haven't upgraded it yet
             // do upgrade and reload as needed
             if (this.level == 0 && isInstall) {
-                initPromise = initPromise.then(() => this.upgradePackagesAsync())
-                    .then(fixes => {
-                        if (fixes) {
-                            // worst case scenario with double load
-                            Object.keys(fixes).forEach(key => pxt.tickEvent("package.doubleload", { "extension": key }))
-                            pxt.log(`upgraded, downloading again`);
-                            pxt.debug(fixes);
-                            return this.downloadAsync();
-                        }
-                        // nothing to do here
-                        else return Promise.resolve();
-                    })
+                const fixes = await this.upgradePackagesAsync();
+
+                if (fixes) {
+                    // worst case scenario with double load
+                    Object.keys(fixes).forEach(key => pxt.tickEvent("package.doubleload", { "extension": key }))
+                    pxt.log(`upgraded, downloading again`);
+                    pxt.debug(fixes);
+                    await this.downloadAsync();
+                }
             }
 
             if (appTarget.simulator && appTarget.simulator.dynamicBoardDefinition) {
-                if (this.level == 0)
-                    initPromise = initPromise.then(() => this.patchCorePackage());
-                initPromise = initPromise.then(() => {
-                    if (this.config.compileServiceVariant)
-                        pxt.setAppTargetVariant(this.config.compileServiceVariant)
-                    if (this.config.files.indexOf("board.json") < 0) return
+                if (this.level == 0) {
+                    this.patchCorePackage();
+                }
+                if (this.config.compileServiceVariant) {
+                    pxt.setAppTargetVariant(this.config.compileServiceVariant)
+                }
+                if (this.config.files.indexOf("board.json") >= 0) {
                     const def = appTarget.simulator.boardDefinition = JSON.parse(this.readFile("board.json")) as pxsim.BoardDefinition;
                     def.id = this.config.name;
                     appTarget.appTheme.boardName = def.boardName || lf("board");
@@ -705,7 +712,7 @@ namespace pxt {
                         vis.image = expandPkg(vis.image)
                         vis.outlineImage = expandPkg(vis.outlineImage)
                     }
-                })
+                }
             }
 
             const handleVerMismatch = (mod: Package, ver: string) => {
@@ -812,7 +819,7 @@ namespace pxt {
                             mod.addedBy.push(from)
                         }
                     } else {
-                        let mod = new Package(id, ver, from.parent, from, id)
+                        mod = new Package(id, ver, from.parent, from, id)
                         if (isCpp)
                             mod.cppOnly = true
                         from.parent.deps[id] = mod
@@ -823,63 +830,49 @@ namespace pxt {
                 }
             }
 
-            return initPromise
-                .then(() => loadDepsRecursive(null, this))
-                .then(() => {
-                    // get paletter config loading deps, so the more higher level packages take precedence
-                    if (this.config.palette && appTarget.runtime) {
-                        appTarget.runtime.palette = U.clone(this.config.palette);
-                        if (this.config.paletteNames) appTarget.runtime.paletteNames = this.config.paletteNames;
-                    }
-                    // get screen size loading deps, so the more higher level packages take precedence
-                    if (this.config.screenSize && appTarget.runtime)
-                        appTarget.runtime.screenSize = U.clone(this.config.screenSize);
+            await loadDepsRecursive(null, this);
 
-                    if (this.level === 0) {
-                        // Check for missing packages. We need to add them 1 by 1 in case they conflict with eachother.
-                        const mainTs = this.readFile(pxt.MAIN_TS);
-                        if (!mainTs) return Promise.resolve(null);
+            // get paletter config loading deps, so the more higher level packages take precedence
+            if (this.config.palette && appTarget.runtime) {
+                appTarget.runtime.palette = U.clone(this.config.palette);
+                if (this.config.paletteNames) appTarget.runtime.paletteNames = this.config.paletteNames;
+            }
+            // get screen size loading deps, so the more higher level packages take precedence
+            if (this.config.screenSize && appTarget.runtime)
+                appTarget.runtime.screenSize = U.clone(this.config.screenSize);
 
-                        const missingPackages = this.getMissingPackages(this.config, mainTs);
-                        let didAddPackages = false;
-                        return Object.keys(missingPackages).reduce((addPackagesPromise, missing) => {
-                            return addPackagesPromise
-                                .then(() => this.findConflictsAsync(missing, missingPackages[missing]))
-                                .then((conflicts) => {
-                                    if (conflicts.length) {
-                                        const conflictNames = conflicts.map((c) => c.pkg0.id).join(", ");
-                                        const settingNames = conflicts.map((c) => c.settingName).filter((s) => !!s).join(", ");
-                                        pxt.log(`skipping missing package ${missing} because it conflicts with the following packages: ${conflictNames} (conflicting settings: ${settingNames})`);
-                                        return Promise.resolve(null);
-                                    } else {
-                                        pxt.log(`adding missing package ${missing}`);
-                                        didAddPackages = true;
-                                        this.config.dependencies[missing] = "*"
-                                        const addDependency: Map<string> = {};
-                                        addDependency[missing] = missingPackages[missing];
-                                        return loadDepsRecursive(addDependency, this);
-                                    }
-                                });
-                        }, Promise.resolve(null))
-                            .then(() => {
-                                if (didAddPackages) {
-                                    this.saveConfig();
-                                    this.validateConfig();
-                                }
-                                return Promise.resolve(null);
-                            });
+            if (this.level === 0) {
+                // Check for missing packages. We need to add them 1 by 1 in case they conflict with eachother.
+                const mainTs = this.readFile(pxt.MAIN_TS);
+                if (mainTs) {
+                    const missingPackages = this.getMissingPackages(this.config, mainTs);
+                    let didAddPackages = false;
+                    for (const missing of Object.keys(missingPackages)) {
+                        const conflicts = await this.findConflictsAsync(missing, missingPackages[missing]);
+                        if (conflicts.length) {
+                            const conflictNames = conflicts.map((c) => c.pkg0.id).join(", ");
+                            const settingNames = conflicts.map((c) => c.settingName).filter((s) => !!s).join(", ");
+                            pxt.log(`skipping missing package ${missing} because it conflicts with the following packages: ${conflictNames} (conflicting settings: ${settingNames})`);
+                        } else {
+                            pxt.log(`adding missing package ${missing}`);
+                            didAddPackages = true;
+                            this.config.dependencies[missing] = "*"
+                            const addDependency: Map<string> = {};
+                            addDependency[missing] = missingPackages[missing];
+                            await loadDepsRecursive(addDependency, this);
+                        }
                     }
-                    return Promise.resolve(null);
-                })
-                .then<any>(() => {
-                    if (this.level != 0)
-                        return Promise.resolve()
-                    return Promise.all(U.values(this.parent.deps).map(pkg =>
-                        loadDepsRecursive(null, pkg, true)))
-                })
-                .then(() => {
-                    pxt.debug(`  installed ${this.id}`)
-                });
+
+                    if (didAddPackages) {
+                        this.saveConfig();
+                        this.validateConfig();
+                    }
+                }
+
+                await Promise.all(U.values(this.parent.deps).map(pkg => loadDepsRecursive(null, pkg, true)));
+            }
+
+            pxt.debug(`  installed ${this.id}`);
         }
 
         static depWarnings: Map<boolean> = {}

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -248,10 +248,10 @@ namespace pxt.sprite {
         }
     }
 
-    export function encodeTilemap(t: TilemapData, fileType: "typescript" | "python"): string {
+    export function encodeTilemap(t: TilemapData, fileType: "typescript" | "python", idMap?: {[index: string]: string}): string {
         if (!t) return `null`;
 
-        return `tiles.createTilemap(${tilemapToTilemapLiteral(t.tilemap)}, ${bitmapToImageLiteral(Bitmap.fromData(t.layers), fileType)}, [${t.tileset.tiles.map(tile => encodeTile(tile, fileType))}], ${tileWidthToTileScale(t.tileset.tileWidth)})`
+        return `tiles.createTilemap(${tilemapToTilemapLiteral(t.tilemap)}, ${bitmapToImageLiteral(Bitmap.fromData(t.layers), fileType)}, [${t.tileset.tiles.map(tile => encodeTile(tile, fileType, idMap))}], ${tileWidthToTileScale(t.tileset.tileWidth)})`
     }
 
     export function decodeTilemap(literal: string, fileType: "typescript" | "python", proj: TilemapProject): TilemapData {
@@ -546,7 +546,10 @@ namespace pxt.sprite {
         return tileset ? tileset.split(",").filter(t => !!t.trim()).map(t => decodeTile(t, proj)) : [];
     }
 
-    function encodeTile(tile: Tile, fileType: "typescript" | "python") {
+    function encodeTile(tile: Tile, fileType: "typescript" | "python", idMap?: {[index: string]: string}) {
+        if (idMap && idMap[tile.id]) {
+            return idMap[tile.id];
+        }
         return tile.id;
     }
 

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1433,6 +1433,20 @@ namespace pxt {
             let blockIdentity: string;
             let value: string;
             const varName = idMapping[getId(key)].split(".").pop();
+            let tags: string[] = entry.tags;
+
+            if (!tags) {
+                tags = [];
+                if (varName.toLowerCase().indexOf("background") !== -1) {
+                    tags.push("background");
+                }
+                if (varName.toLowerCase().indexOf("dialog") !== -1) {
+                    tags.push("dialog");
+                }
+                if (entry.tilemapTile) {
+                    tags.push("tile");
+                }
+            }
 
             if (mimeType === IMAGE_MIME_TYPE) {
                 value = "image.ofBuffer(hex\`\`)"
@@ -1462,6 +1476,7 @@ namespace pxt {
 
             out += `${indent}//% fixedInstance jres whenUsed\n`
             if (blockIdentity)  out += `${indent}//% blockIdentity=${blockIdentity}\n`
+            if (tags.length) out += `${indent}//% tags="${tags.join(" ")}"\n`
             out += `${indent}export const ${varName} = ${value};\n`
 
             if (typeof entry === "string") {
@@ -1470,7 +1485,8 @@ namespace pxt {
             else {
                 outJRes[varName] = {
                     ...entry,
-                    id: idMapping[getId(key)]
+                    id: idMapping[getId(key)],
+                    tags
                 };
                 if (entry.namespace) {
                     outJRes[varName].namespace = namespaceName

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1027,19 +1027,38 @@ namespace pxt {
                 }
             }
 
-            for (const tm of getTilemaps(pack.parseJRes())) {
-                this.state.tilemaps.add({
-                    internalID: this.getNewInternalId(),
-                    type: AssetType.Tilemap,
-                    id: tm.id,
-                    meta: {
-                        // For tilemaps, use the id as the display name for backwards compat
-                        displayName: tm.displayName || tm.id,
-                        package: pack.id
-                    },
-                    data: decodeTilemap(tm, id => this.resolveTile(id))
-                })
+            for (const dep of allPackages) {
+                const isProject = dep.id === "this";
+                for (const tm of getTilemaps(dep.parseJRes())) {
+                    if (isProject) {
+                        this.state.tilemaps.add({
+                            internalID: this.getNewInternalId(),
+                            type: AssetType.Tilemap,
+                            id: tm.id,
+                            meta: {
+                                // For tilemaps, use the id as the display name for backwards compat
+                                displayName: tm.displayName || tm.id,
+                                package: pack.id
+                            },
+                            data: decodeTilemap(tm, id => this.resolveTile(id))
+                        });
+                    }
+                    else {
+                        this.gallery.tilemaps.add({
+                            internalID: this.getNewInternalId(),
+                            type: AssetType.Tilemap,
+                            id: tm.id,
+                            meta: {
+                                // For tilemaps, use the id as the display name for backwards compat
+                                displayName: tm.displayName || tm.id,
+                                package: pack.id
+                            },
+                            data: decodeTilemap(tm, id => this.gallery.tiles.getByID(id))
+                        });
+                    }
+                }
             }
+
 
             this.committedState = this.cloneState();
             this.undoStack = [];
@@ -1348,6 +1367,126 @@ namespace pxt {
         }
 
         return res;
+    }
+
+    export function emitGalleryDeclarations(jres: pxt.Map<JRes>, namespaceName: string): [pxt.Map<JRes>, string] {
+        const entries = Object.keys(jres);
+
+        const indent = "    ";
+        let out = "";
+
+        const takenNames: {[index: string]: boolean} = {};
+        const idMapping: {[index: string]: string} = {};
+
+        const outJRes: pxt.Map<JRes> = {};
+
+        const getId = (key: string) => {
+            let ns = jres[key].namespace || jres["*"].namespace;
+            const id = jres[key].id || key;
+
+            if (ns) {
+                if (ns.endsWith(".")) {
+                    ns = ns.slice(0, ns.length - 1);
+                }
+
+                if (!id.startsWith(ns + ".")) {
+                    return ns + "." + id;
+                }
+            }
+
+            return id;
+        }
+
+        if (jres["*"]) {
+            outJRes["*"] = {
+                ...jres["*"],
+                namespace: namespaceName
+            };
+        }
+
+        // First do a pass to generate new qualified names for each asset
+        for (const key of entries) {
+            if (key === "*") continue;
+
+            const entry = jres[key];
+            const id = getId(key);
+            let varName = ts.pxtc.escapeIdentifier(entry.displayName || id.split(".").pop());
+
+            if (takenNames[varName]) {
+                const base = varName;
+                let index = 2;
+                while (takenNames[varName]) {
+                    varName = base + index;
+                    index++;
+                }
+            }
+            takenNames[varName] = true;
+            idMapping[id] = namespaceName + "." + varName
+        }
+
+        // Now actually generate the TS
+        for (const key of entries) {
+            if (key === "*") continue;
+
+            const entry = jres[key];
+            let mimeType = entry.mimeType || jres["*"]?.mimeType;
+            let blockIdentity: string;
+            let value: string;
+            const varName = idMapping[getId(key)].split(".").pop();
+
+            if (mimeType === IMAGE_MIME_TYPE) {
+                value = "image.ofBuffer(hex\`\`)"
+
+                if (entry.tilemapTile) {
+                    blockIdentity = "images._tile"
+                }
+                else {
+                    blockIdentity = "images._image"
+                }
+            }
+            else if (mimeType === ANIMATION_MIME_TYPE) {
+                const am = decodeAnimation(entry);
+                value = `[${
+                    am.frames.map(f =>
+                        pxt.sprite.bitmapToImageLiteral(pxt.sprite.Bitmap.fromData(f), "typescript")
+                    ).join(",")
+                }]`;
+            }
+            else if (mimeType === TILEMAP_MIME_TYPE) {
+                const tm = decodeTilemap(entry);
+                value = pxt.sprite.encodeTilemap(tm, "typescript", idMapping);
+            }
+            else if (mimeType === SONG_MIME_TYPE) {
+                value = `hex\`${entry.data}\``;
+            }
+
+            out += `${indent}//% fixedInstance jres whenUsed\n`
+            if (blockIdentity)  out += `${indent}//% blockIdentity=${blockIdentity}\n`
+            out += `${indent}export const ${varName} = ${value};\n`
+
+            if (typeof entry === "string") {
+                outJRes[varName] = entry;
+            }
+            else {
+                outJRes[varName] = {
+                    ...entry,
+                    id: idMapping[getId(key)]
+                };
+                if (entry.namespace) {
+                    outJRes[varName].namespace = namespaceName
+                    if (entry.namespace.endsWith(".")) {
+                        outJRes[varName].namespace += ".";
+                    }
+                }
+                if (outJRes[varName].tileset) {
+                    outJRes[varName].tileset = entry.tileset.map(t => idMapping[t] || t);
+                }
+            }
+        }
+
+        const warning = lf("Auto-generated code. Do not edit.");
+
+        return [outJRes, `// ${warning}\nnamespace ${namespaceName} {\n${out}\n}\n// ${warning}\n`]
     }
 
     export function emitTilemapsFromJRes(jres: pxt.Map<JRes>) {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -497,12 +497,12 @@ export class EditorPackage {
         return this.filterFiles(f => f.getName() == name)[0]
     }
 
-    buildAssetsAsync() {
-        if (!this.tilemapProject?.needsRebuild) return Promise.resolve();
+    async buildAssetsAsync() {
+        if (!this.tilemapProject?.needsRebuild) return;
         this.tilemapProject.needsRebuild = false;
 
-        return this.buildTilemapsAsync()
-            .then(() => this.buildImagesAsync())
+        await this.buildTilemapsAsync();
+        await this.buildImagesAsync();
     }
 
     buildTilemapsAsync() {
@@ -665,7 +665,18 @@ class Host
             // only write config writes
             let epkg = getEditorPkg(module)
             let file = epkg.files[filename];
-            file.setContentAsync(contents, force);
+
+            if (!file) {
+                if (module.config.files.indexOf(filename) !== -1) {
+                    epkg.files[filename] = new File(epkg, filename, contents);
+                }
+                else {
+                    throw Util.oops("trying to write file not listed in pxt.json " + module + " / " + filename)
+                }
+            }
+            else {
+                file.setContentAsync(contents, force);
+            }
             return;
         }
         throw Util.oops("trying to write " + module + " / " + filename)


### PR DESCRIPTION
Cherry picking https://github.com/microsoft/pxt/pull/9475 and https://github.com/microsoft/pxt/pull/9477

Together, these PRs make it so that you can import dependencies as asset packs. @kiki-lee mentioned that she would like to see if we can have this merged/released by Friday because she would like to use this feature in the skillmaps and tutorials she's publishing.