### PR TITLE
Webusb pairing simplification

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -482,7 +482,6 @@ declare namespace pxt {
         deviceSuccessIcon?: string;
         downloadMenuHelpURL?: string;
         downloadHelpURL?: string;
-        firmwareHelpURL?: string;
         troubleshootWebUSBHelpURL?: string;
         incompatibleHardwareHelpURL?: string;
 
@@ -490,9 +489,14 @@ declare namespace pxt {
         connectDeviceImage?: string;
         selectDeviceImage?: string;
         connectionSuccessImage?: string;
-        checkFirmwareVersionImage?: string;
-        checkUSBCableImage?: string;
         incompatibleHardwareImage?: string;
+
+        // The following fields used to be displayed, but students
+        // found the dialog confusing / hard to use; now we redirect
+        // them to help docs instead if pairing fails for step by step instructions.
+        // checkFirmwareVersionImage?: string;
+        // checkUSBCableImage?: string;
+        // firmwareHelpURL?: string;
     }
 
     interface SocialOptions {

--- a/theme/common.less
+++ b/theme/common.less
@@ -236,7 +236,7 @@ pre {
     margin-left: auto;
 }
 
-#editortools .download-button.icon-and-text {
+#editortools .download-button {
     text-align: center;
 }
 

--- a/theme/common.less
+++ b/theme/common.less
@@ -1626,6 +1626,11 @@ p.ui.font.small {
     display: inline;
 }
 
+.downloaddialog .content .webusb-connect-image {
+    padding: 0 !important;
+    margin: 0 auto;
+}
+
 .download-dialog-image img {
     max-height: 200px;
     object-fit: contain;
@@ -1636,6 +1641,14 @@ p.ui.font.small {
     display: flex;
     height: 100%;
     align-items: center;
+}
+
+.download-dialog .content .description > div {
+    padding-bottom: 1em;
+}
+
+.downloaddialog .actions .approve.secondary {
+    float: left;
 }
 
 #downloadArea button .icon.xicon {

--- a/theme/common.less
+++ b/theme/common.less
@@ -1583,7 +1583,7 @@ p.ui.font.small {
 }
 
 .downloaddialog.ui.modal .actions .icon-and-text.icon~.ui.text {
-    margin-left: 0 !important;
+    margin-left: -0.5em !important;
 }
 
 .ui.modal .actions .left-action {

--- a/theme/common.less
+++ b/theme/common.less
@@ -1576,9 +1576,14 @@ p.ui.font.small {
         Download dialogs
 *******************************/
 
-.ui.modal .actions .dialog-help-large {
+.ui.modal .actions .dialog-help-large,
+.downloaddialog.ui.modal .actions .icon.help {
     float: left;
     margin-left: 4px;
+}
+
+.downloaddialog.ui.modal .actions .icon-and-text.icon~.ui.text {
+    margin-left: 0 !important;
 }
 
 .ui.modal .actions .left-action {

--- a/theme/common.less
+++ b/theme/common.less
@@ -1643,10 +1643,6 @@ p.ui.font.small {
     align-items: center;
 }
 
-.download-dialog .content .description > div {
-    padding-bottom: 1em;
-}
-
 .downloaddialog .actions .approve.secondary {
     float: left;
 }

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -187,10 +187,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     protected onDownloadButtonClick = async () => {
         pxt.tickEvent("editortools.downloadbutton", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
-        if (pxt.appTarget.appTheme?.preferWebUSBDownload
-            && pxt.appTarget?.compile?.webUSB
-            && pxt.usb.isEnabled
-            && !userPrefersDownloadFlagSet()
+        if (this.shouldShowPairingDialogOnDownload()
             && !pxt.packetio.isConnected()
             && !pxt.packetio.isConnecting()
         ) {
@@ -220,6 +217,13 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         window.open(pxt.appTarget.appTheme.downloadDialogTheme?.downloadMenuHelpURL);
     }
 
+    protected shouldShowPairingDialogOnDownload = () => {
+        return pxt.appTarget.appTheme.preferWebUSBDownload
+            && pxt.appTarget?.compile?.webUSB
+            && pxt.usb.isEnabled
+            && !userPrefersDownloadFlagSet();
+    }
+
     protected getCompileButton(view: View): JSX.Element[] {
         const collapsed = true; // TODO: Cleanup this
         const targetTheme = pxt.appTarget.appTheme;
@@ -241,14 +245,15 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         const packetioConnected = !!this.getData("packetio:connected");
         const packetioConnecting = !!this.getData("packetio:connecting");
         const packetioIcon = this.getData("packetio:icon") as string;
+        const hideFileDownloadIcon = view === View.Computer && this.shouldShowPairingDialogOnDownload();
+        const fileDownloadIcon = targetTheme.downloadIcon || "xicon file-download";
 
         const successIcon = (packetioConnected && pxt.appTarget.appTheme.downloadDialogTheme?.deviceSuccessIcon)
             || "xicon file-download-check";
         const downloadIcon = (!!packetioConnecting && "ping " + packetioIcon)
             || (compileState === "success" && successIcon)
             || (!!packetioConnected && packetioIcon)
-            || targetTheme.downloadIcon
-            || "xicon file-download";
+            || (!hideFileDownloadIcon && fileDownloadIcon);
 
         let downloadButtonClasses = "left attached ";
         const downloadButtonIcon = "ellipsis";

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -60,7 +60,7 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
     }
 
     if (paired) {
-        await showConnectionSuccessAsync(confirmAsync);
+        await showConnectionSuccessAsync(confirmAsync, implicitlyCalled);
     }
     else {
         const tryAgain = await showConnectionFailureAsync(confirmAsync, implicitlyCalled);
@@ -121,12 +121,10 @@ function showPickWebUSBDeviceDialogAsync(confirmAsync: ConfirmAsync, showDownloa
                 <div className="ui">
                     <div className="content">
                         <div className="description">
-                            <div>
-                                {lf("We recommend pairing for easy downloads.")}
-                            </div>
-                            <div>
-                                {lf("Press 'Pair' below and select your device from the browser pop-up.")}
-                            </div>
+                            {lf("We recommend pairing for easy downloads.")}
+                            <br/>
+                            <br/>
+                            {lf("Press 'Pair' below and select your device from the browser pop-up.")}
                         </div>
                     </div>
                 </div>
@@ -153,7 +151,7 @@ function showPickWebUSBDeviceDialogAsync(confirmAsync: ConfirmAsync, showDownloa
     });
 }
 
-function showConnectionSuccessAsync(confirmAsync: ConfirmAsync) {
+function showConnectionSuccessAsync(confirmAsync: ConfirmAsync, willTriggerDownloadOnClose: boolean) {
     const boardName = getBoardName();
     const connectionImage = theme().connectionSuccessImage;
     const columns = connectionImage ? "two" : "one";
@@ -187,7 +185,7 @@ function showConnectionSuccessAsync(confirmAsync: ConfirmAsync) {
     return showPairStepAsync({
         confirmAsync,
         jsxd,
-        buttonLabel: lf("Done"),
+        buttonLabel: willTriggerDownloadOnClose ? lf("Download") : lf("Done"),
         header: lf("Connected to {0}", boardName),
         tick: "downloaddialog.button.webusbsuccess",
         help: undefined,

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -201,46 +201,10 @@ function showConnectionSuccessAsync(confirmAsync: ConfirmAsync, willTriggerDownl
 function showConnectionFailureAsync(confirmAsync: ConfirmAsync, showDownloadAsFileButton?: boolean) {
     const boardName = getBoardName();
 
-    let firmwareText: string;
-
-    if (theme().minimumFirmwareVersion) {
-        firmwareText = lf("Make sure your {0} firmware is version {1} or above.", boardName, theme().minimumFirmwareVersion);
-    }
-    else {
-        firmwareText = lf("Make sure your {0} has the latest firmware.", boardName);
-    }
-
-    const checkCableImage = theme().checkUSBCableImage || theme().connectDeviceImage;
-    const firmwareImage = theme().checkFirmwareVersionImage;
-
     const jsxd = () => (
         <div>
             <div className="ui content download-troubleshoot-header">
                 {lf("We couldn't find your {0}. Here's a few ways to fix that:", boardName)}
-            </div>
-            <div className="download-troubleshoot">
-                <div className="download-column">
-                    {checkCableImage &&
-                        <div className="download-row image-row">
-                            <img alt={lf("Image connecting {0} to a computer", boardName)} src={checkCableImage} />
-                        </div>
-                    }
-                    <div className="download-row">
-                    {lf("Check the USB cable connecting your {0} to your computer.", boardName)}
-                    </div>
-                </div>
-                <div className="download-column">
-                    { firmwareImage &&
-                        <div className="download-row image-row">
-                            <img alt={lf("Image depicting the firmware of {0}", boardName)} src={firmwareImage} />
-                        </div>
-                    }
-                    <div className="download-row">
-                        {firmwareText}
-                        <br/>
-                        <a target="_blank" href={theme().firmwareHelpURL} rel="noopener noreferrer">{lf("Learn more about firmware.", boardName)}</a>
-                    </div>
-                </div>
             </div>
         </div>
     );
@@ -251,7 +215,7 @@ function showConnectionFailureAsync(confirmAsync: ConfirmAsync, showDownloadAsFi
         jsxd,
         buttonLabel: lf("Try Again"),
         buttonIcon: pxt.appTarget?.appTheme?.downloadDialogTheme?.deviceIcon,
-        header: lf("Connect failed"),
+        header: lf("Failed to connect"),
         tick: "downloaddialog.button.webusbfailed",
         help: theme().troubleshootWebUSBHelpURL,
         headerIcon: "exclamation triangle purple",

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as core from "./core";
 import * as cmds from "./cmds";
+import { ModalButton } from "./sui";
 
 function resolveFirmwareUrl(): string {
     const boardid = pxt.appTarget?.simulator?.boardDefinition?.id;
@@ -104,6 +105,7 @@ function showConnectDeviceDialogAsync(confirmAsync: ConfirmAsync) {
         confirmAsync,
         jsxd,
         buttonLabel: lf("Next"),
+        buttonIcon: pxt.appTarget?.appTheme?.downloadDialogTheme?.deviceIcon,
         header: lf("1. Connect your {0} to your computer", boardName),
         tick: "downloaddialog.button.connectusb",
     });
@@ -145,6 +147,7 @@ function showPickWebUSBDeviceDialogAsync(confirmAsync: ConfirmAsync, showDownloa
         confirmAsync,
         jsxd,
         buttonLabel: lf("Pair"),
+        buttonIcon: pxt.appTarget?.appTheme?.downloadDialogTheme?.deviceIcon,
         showDownloadAsFileButton,
         header: lf("2. Pair your {0} to your browser", boardName),
         tick: "downloaddialog.button.pickusbdevice",
@@ -186,6 +189,7 @@ function showConnectionSuccessAsync(confirmAsync: ConfirmAsync, willTriggerDownl
         confirmAsync,
         jsxd,
         buttonLabel: willTriggerDownloadOnClose ? lf("Download") : lf("Done"),
+        buttonIcon: pxt.appTarget.appTheme.downloadDialogTheme?.deviceSuccessIcon,
         header: lf("Connected to {0}", boardName),
         tick: "downloaddialog.button.webusbsuccess",
         help: undefined,
@@ -246,6 +250,7 @@ function showConnectionFailureAsync(confirmAsync: ConfirmAsync, showDownloadAsFi
         confirmAsync,
         jsxd,
         buttonLabel: lf("Try Again"),
+        buttonIcon: pxt.appTarget?.appTheme?.downloadDialogTheme?.deviceIcon,
         header: lf("Connect failed"),
         tick: "downloaddialog.button.webusbfailed",
         help: theme().troubleshootWebUSBHelpURL,
@@ -258,6 +263,7 @@ interface PairStepOptions {
     confirmAsync: ConfirmAsync;
     jsxd: () => JSX.Element;
     buttonLabel: string;
+    buttonIcon?: string;
     header: string;
     tick: string;
     help?: string;
@@ -270,6 +276,7 @@ async function showPairStepAsync({
     confirmAsync,
     jsxd,
     buttonLabel,
+    buttonIcon,
     header,
     tick,
     help,
@@ -279,10 +286,12 @@ async function showPairStepAsync({
 }: PairStepOptions) {
     let tryAgain = false;
 
-    const buttons = [
+    const buttons: ModalButton[] = [
         {
             label: buttonLabel,
             className: "primary",
+            icon: buttonIcon,
+            labelPosition: "left",
             onclick: () => {
                 pxt.tickEvent(tick);
                 core.hideDialog();
@@ -290,10 +299,13 @@ async function showPairStepAsync({
             },
         }
     ];
+
     if (showDownloadAsFileButton) {
         buttons.unshift({
             label: lf("Download as file"),
             className: "secondary",
+            icon: pxt.appTarget.appTheme.downloadIcon || "xicon file-download",
+            labelPosition: "left",
             onclick: () => {
                 pxt.tickEvent("downloaddialog.button.webusb.preferdownload");
                 userPrefersDownloadFlag = true;


### PR DESCRIPTION
Simplifying webusb pair flow -- starting from discussion from https://github.com/microsoft/pxt/pull/9464#issuecomment-1511822423 down. image changes are in an associated pxt-microbit pr~

No build because images have to be checked in, so extra details on flow below

![microbit-pairing-success-path](https://user-images.githubusercontent.com/5615930/234723012-9c5809b5-70b7-48aa-9012-c9db458bde0d.gif)

* when the download button will started you into the pairing flow, don't show any icon; icon will fill in when the user either successfully pairs or selects to download file in pairing flow
<img width="226" alt="image" src="https://user-images.githubusercontent.com/5615930/234721872-bda46d24-bba9-4db2-ace5-5dd77d44a8b1.png">
* remove text from first modal, expand title, large gif front and center. Also makes this one **not** have an escape button, as first reaction a lot of users have is accidentally clicking out and getting lost / missing things; they have to click 'next'
<img width="762" alt="image" src="https://user-images.githubusercontent.com/5615930/234721973-26a225d0-6a97-4167-9288-401fd58196df.png">
* pairing step: simplify text, make image focus only on computer where action is happening. Download as file option offset in bottom left. Do not mention exact board names, there will only be valid things in the list as we filter on it / students get rabbit-holed trying to understand the jargon when really they just need. Change 'next' to 'pair' 
<img width="494" alt="image" src="https://user-images.githubusercontent.com/5615930/234722798-a93c38fe-e256-44c1-a873-211ad431316e.png">
* success case: text was fine, change button to 'download' in the implicit pairing flow (though exiting will still trigger download, just acts as a hint), changed image to what was previously the 'firmware update needed' image as it actually serves as a pretty good "you're all set and ready to go" -- paintbucket pouring in a rainbow is basically just pouring in the multi-colored blocks :)
<img width="521" alt="image" src="https://user-images.githubusercontent.com/5615930/234723368-cfd1920b-9700-4295-b336-df4f21134033.png">
* failure case: students focus too much on the images as they're pretty / not text, and the suggestions aren't super needed ("try connecting again" suggestion is what will show up when they press try again and start over in step 1, "update firmware" is not actionable for many users (hard flow to go through / needs instructions)) -- just give the three options:
<img width="471" alt="image" src="https://user-images.githubusercontent.com/5615930/234722754-210aae0c-cf98-4703-9c64-e3e908d35946.png">
* for failure case we might add back in an image, though keeping as just text is somewhat nice as there's nothing drawing away their attention when they need to make a choice.
* most of the buttons in the webusb pairing flow get icons to make them a little more appealing / hint what they do