### PR TITLE
elide hidden and deprecated apis from ts completions

### DIFF
--- a/webapp/src/tsworker.ts
+++ b/webapp/src/tsworker.ts
@@ -91,7 +91,7 @@ const worker: monaco.languages.typescript.CustomTSWebWorkerFactory = (TSWorkerCl
                                 const parsed = parseCommentString(comments);
                                 let weight = 0;
 
-                                if (parsed.shim === "TD_ID") {
+                                if (parsed.shim === "TD_ID" || parsed.hidden || parsed.deprecated) {
                                     // These entries are filtered out below
                                     this.weightCache[qName][entry.name] = "hidden";
                                     return;


### PR DESCRIPTION
Currently, we're showing deprecated apis in ts completions; e.g. `tiles.setTilemap` is shown which was deprecated in favor of `tiles.setCurrentTilemap`: 

<img width="332" alt="image" src="https://user-images.githubusercontent.com/5615930/234958434-109171e6-28b1-4f76-8da4-c3aa6a17cfc0.png">

vs with this:

<img width="411" alt="image" src="https://user-images.githubusercontent.com/5615930/234958640-f9e1f921-fc06-4017-aab3-230d0e139bf5.png">

I think there is some race condition where we don't attach the info correctly so sometimes we don't actually apply the filters, but it seems rare / would affect this whole fn anyways (most likely just before the project is fully loaded / etc type thing)
