### PR TITLE
Update URL Scrubbing in Telemetry

### DIFF
--- a/docfiles/apptracking.html
+++ b/docfiles/apptracking.html
@@ -1,4 +1,5 @@
 <script type="text/javascript">
+    window.scriptIdRegex = /(?:S?\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
     window.loadAppInsights = function (includeCookie, telemetryInitializer) {
         //Backend will patch / + blb + / with CDN url and the check that URL ends with the sha would pass
         var isProduction = includeCookie && (/[0-9a-f]{40}\/$/.test("/blb/"));
@@ -29,14 +30,29 @@
             }
         });
 
-        var scriptIdRegex = /(?:S?\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
         // Check if the current page contains a share URL
         function isScriptPage(url) {
-            return !!url.match(scriptIdRegex);
+            return !!url.match(window.scriptIdRegex);
         }
-        // Scrub the key (if any) from the URL.
+
+        // Scrub potential PII from the URL.
         function scrubUrl(url) {
-            return url.replace(scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx");
+            debugger;
+            if(!url) return url;
+
+            var scrubbedUrl = new URL(url.toLocaleLowerCase().replace(window.scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx"));
+
+            // Just as a precaution, strip any suspicious query parameters.
+            let blockedParamKeywords = ["username", "password", "token", "pwd"];
+            let searchParams = Array.from(scrubbedUrl.searchParams.keys());
+            for(let param of searchParams) {
+                console.log(param);
+                if(blockedParamKeywords.some(k => param.indexOf(k) != -1)) {
+                    scrubbedUrl.searchParams.delete(param);
+                }
+            }
+
+            return scrubbedUrl.toString();
         }
 
         return isProduction;

--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -1,5 +1,6 @@
 <script type="text/javascript" src="/doccdn/pxtweb.js"></script>
 <script type="text/javascript">
+    window.scriptIdRegex = /(?:S?\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
     window.loadAppInsights = function (includeCookie) {
         //Backend will patch / + doccdn + / with CDN url and the check that URL ends with the sha would pass
         var isProduction = includeCookie && (/[0-9a-f]{40}\/ai\.2\.min\.js$/.test("/doccdn/ai.2.min.js"));
@@ -64,14 +65,29 @@
             }
         });
 
-        var scriptIdRegex = /(?:S?\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
         // Check if the current page contains a share URL
         function isScriptPage(url) {
-            return !!url.match(scriptIdRegex);
+            return !!url.match(window.scriptIdRegex);
         }
-        // Scrub the key (if any) from the URL.
+
+        // Scrub potential PII from the URL.
         function scrubUrl(url) {
-            return url.replace(scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx");
+            debugger;
+            if(!url) return url;
+
+            var scrubbedUrl = new URL(url.toLocaleLowerCase().replace(window.scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx"));
+
+            // Just as a precaution, strip any suspicious query parameters.
+            let blockedParamKeywords = ["username", "password", "token", "pwd"];
+            let searchParams = Array.from(scrubbedUrl.searchParams.keys());
+            for(let param of searchParams) {
+                console.log(param);
+                if(blockedParamKeywords.some(k => param.indexOf(k) != -1)) {
+                    scrubbedUrl.searchParams.delete(param);
+                }
+            }
+
+            return scrubbedUrl.toString();
         }
 
         return isProduction;


### PR DESCRIPTION
This change does two things:
1. Moves where `scriptIdRegex` is defined. Previously, the scope was such that `scriptIdRegex` was actually `undefined` when `scrubUrl` was called.
2. Adds a block-list of keywords and filters out any query parameters that contain those keywords before logging the telemetry. It's not the most efficient check in the world, but it's two very short lists, so I don't think it'll be an issue.

I would love to reduce the duplication here, but I believe that's already been tried before and I didn't want to delay sending the PR. That said, if anyone has ideas, I'm open to suggestions.