### PR TITLE
GitHub Integration: Don't commit block pngs to repo

### DIFF
--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -52,20 +52,13 @@ ${lf("This repository can be added as an **extension** in MakeCode.")}
 * ${lf("click on **Extensions** under the gearwheel menu")}
 * ${lf("search for **https://github.com/@REPO@** and import")}
 
-## ${lf("Edit this project")} ![${lf("Build status badge")}](https://github.com/@REPO@/workflows/MakeCode/badge.svg)
+## ${lf("Edit this project")}
 
 ${lf("To edit this repository in MakeCode.")}
 
 * ${lf("open [@HOMEURL@](@HOMEURL@)")}
 * ${lf("click on **Import** then click on **Import URL**")}
 * ${lf("paste **https://github.com/@REPO@** and click import")}
-
-## ${lf("Blocks preview")}
-
-${lf("This image shows the blocks code from the last commit in master.")}
-${lf("This image may take a few minutes to refresh.")}
-
-![${lf("A rendered view of the blocks")}](https://github.com/@REPO@/raw/master/.github/makecode/blocks.png)
 
 #### ${lf("Metadata (used for search, rendering)")}
 

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -686,16 +686,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
 - [ ] ${lf("reviewer approves or requests changes")}
 - [ ] ${lf("apply requested changes if any")}
 - [ ] ${lf("merge once approved")}
-`; // TODO
-            /*
-                        `
-            ![${lf("A rendered view of the blocks")}](https://github.com/${gh.fullName}/raw/${gh.tag}/.github/makecode/blocks.png)
-
-            ${lf("This image shows the blocks code from the last commit in this pull request.")}
-            ${lf("This image may take a few minutes to refresh.")}
-
-            `
-            */
+`;
             const id = await pxt.github.createPRFromBranchAsync(gh.slug, "master", gh.tag, title, msg);
             data.invalidateHeader("pkg-git-pr", this.props.parent.state.header);
             core.infoNotification(lf("Pull request created successfully!", id));

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -889,8 +889,6 @@ export interface CommitOptions {
     blocksDiffScreenshotAsync?: () => Promise<string>;
 }
 
-const BLOCKS_PREVIEW_PATH = ".github/makecode/blocks.png";
-const BLOCKSDIFF_PREVIEW_PATH = ".github/makecode/blocksdiff.png";
 const BINARY_JS_PATH = "assets/js/binary.js";
 const VERSION_TXT_PATH = "assets/version.txt";
 export async function commitAsync(hd: Header, options: CommitOptions = {}) {
@@ -916,22 +914,6 @@ export async function commitAsync(hd: Header, options: CommitOptions = {}) {
 
     if (treeUpdate.tree.length == 0)
         U.userError(lf("Nothing to commit!"))
-
-    // add screenshots
-    let blocksDiffSha: string;
-    if (options
-        && treeUpdate.tree.find(e => e.path == pxt.MAIN_BLOCKS)) {
-        if (options.blocksScreenshotAsync) {
-            const png = await options.blocksScreenshotAsync();
-            if (png)
-                await addToTree(BLOCKS_PREVIEW_PATH, png);
-        }
-        if (options.blocksDiffScreenshotAsync) {
-            const png = await options.blocksDiffScreenshotAsync();
-            if (png)
-                blocksDiffSha = await addToTree(BLOCKSDIFF_PREVIEW_PATH, png);
-        }
-    }
 
     // add compiled javascript to be run in github pages
     if (pxt.appTarget.appTheme.githubCompiledJs
@@ -977,13 +959,6 @@ export async function commitAsync(hd: Header, options: CommitOptions = {}) {
         return commitId
     } else {
         data.invalidate("gh-commits:*"); // invalid any cached commits
-        // if we created a block preview, add as comment
-        if (blocksDiffSha) {
-            await pxt.github.postCommitComment(
-                parsed.slug,
-                commitId,
-                `![${lf("Difference between blocks")}](https://raw.githubusercontent.com/${pxt.github.join(parsed.slug, commitId, parsed.fileName, BLOCKSDIFF_PREVIEW_PATH)}`);
-        }
 
         await githubUpdateToAsync(hd, {
             repo: gitjson.repo,


### PR DESCRIPTION
When integrating a blocks project with GitHub, we add some pngs of the blocks to the repo (showing either the entire canvas or just the most recent diff). They look nice in the README, but are a source of problems for collaboration via GitHub. These are binary files, which make them a guaranteed source of merge conflicts when more than one user is committing to the repo.

I also removed the build status badge because it's never worked for me. If you know what the url should be, please let me know and I'll update it.

Test target for **microbit**: https://makecode.microbit.org/app/7881dff3cd82ba086e640657975c2cfb0eb3d4d9-df8e864a28
Test target for **Arcade**: https://arcade.makecode.com/app/d6e06a69c459bfeb811db0abe049789288cf62f8-58b4692010

Fixes https://github.com/microsoft/pxt-microbit/issues/5075
Fixes https://github.com/microsoft/pxt-arcade/issues/1908
