### PR TITLE
Fix for high-contrast and language settings when not signed in

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "file.autoSave": "on",
     "files.watcherExclude": {
         "**/.git/objects/**": true,
         "**/built/**": true,
@@ -18,6 +17,8 @@
     },
     "typescript.tsdk": "node_modules/typescript/lib",
     "editor.formatOnType": false,
+    "editor.formatOnPaste": false,
+    "editor.formatOnSave": false,
     "tslint.enable": true,
     "tslint.rulesDirectory": "node_modules/tslint-microsoft-contrib",
     "files.associations": {

--- a/pxtlib/auth.ts
+++ b/pxtlib/auth.ts
@@ -120,17 +120,13 @@ namespace pxt.auth {
 
     export async function getUserStateAsync(): Promise<Readonly<UserState>> {
         let userState: UserState;
-        if (await hasAuthTokenAsync()) {
-            try { userState = await pxt.storage.shared.getAsync(AUTH_CONTAINER, AUTH_USER_STATE_KEY); } catch {}
-        }
+        try { userState = await pxt.storage.shared.getAsync(AUTH_CONTAINER, AUTH_USER_STATE_KEY); } catch { userState = {}; }
         cachedUserState = userState;
         return userState;
     }
     async function setUserStateAsync(state: UserState): Promise<void> {
-        if (await hasAuthTokenAsync()) {
-            cachedUserState = { ...state };
-            return await pxt.storage.shared.setAsync(AUTH_CONTAINER, AUTH_USER_STATE_KEY, state);
-        }
+        cachedUserState = { ...state };
+        return await pxt.storage.shared.setAsync(AUTH_CONTAINER, AUTH_USER_STATE_KEY, state);
     }
     async function delUserStateAsync(): Promise<void> {
         cachedUserState = undefined;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -225,6 +225,7 @@ export interface ProjectSettingsMenuState {
 }
 
 export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps, ProjectSettingsMenuState> {
+    dropdown: sui.DropdownMenu;
 
     constructor(props: ProjectSettingsMenuProps) {
         super(props);
@@ -245,6 +246,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
 
     toggleHighContrast() {
         pxt.tickEvent("home.togglecontrast", undefined, { interactiveConsent: true });
+        this.hide();
         core.toggleHighContrast();
     }
 
@@ -278,6 +280,10 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         this.props.parent.signOutGithub();
     }
 
+    hide() {
+        this.dropdown?.hide();
+    }
+
     renderCore() {
         const hasIdentity = pxt.auth.hasIdentity();
         const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
@@ -287,7 +293,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         const reportAbuse = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
         const showDivider = targetTheme.selectLanguage || targetTheme.highContrast || githubUser;
 
-        return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
+        return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem" ref={ref => this.dropdown = ref}>
             {targetTheme.selectLanguage && <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} />}
             {targetTheme.highContrast && <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} />}
             {githubUser && <div className="ui divider"></div>}


### PR DESCRIPTION
Also in this PR: vscode flags to disable auto-formatting

Fixes https://github.com/microsoft/pxt-microbit/issues/5079
Fixes https://github.com/microsoft/pxt-microbit/issues/5076
