### PR TITLE
Expand on the failure step text a bit

### DIFF
--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -110,7 +110,7 @@ function showUploadInstructionsAsync(fn: string, url: string, confirmAsync: (opt
         className: 'downloaddialog',
         buttons: [
             downloadAgain && {
-                label: userDownload ? lf("Download") : lf("Download again"),
+                label: userDownload ? lf("Download") : lf("Download Again"),
                 className: userDownload ? "primary" : "lightgrey",
                 urlButton: true,
                 url,

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -313,7 +313,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             {(showHome || showShare) && <div className="ui divider mobile only inherit" />}
             {showProjectSettings ? <sui.Item role="menuitem" icon="options" text={lf("Project Settings")} onClick={this.openSettings} /> : undefined}
             {packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Extensions")} onClick={this.showPackageDialog} /> : undefined}
-            {showPairDevice ? <sui.Item role="menuitem" icon={usbIcon} text={lf("Connect device")} onClick={this.pair} /> : undefined}
+            {showPairDevice ? <sui.Item role="menuitem" icon={usbIcon} text={lf("Connect Device")} onClick={this.pair} /> : undefined}
             {pxt.webBluetooth.isAvailable() ? <sui.Item role="menuitem" icon='bluetooth' text={lf("Pair Bluetooth")} onClick={this.pairBluetooth} /> : undefined}
             {showPrint ? <sui.Item role="menuitem" icon="print" text={lf("Print...")} onClick={this.print} /> : undefined}
             {showSave ? <sui.Item role="menuitem" icon="save" text={lf("Save Project")} onClick={this.saveProject} /> : undefined}

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -781,7 +781,7 @@ export function renderBrowserDownloadInstructions(saveonly?: boolean) {
                                                     </div>
                                                     <div className="thirteen wide column">
                                                         {lf("Download your code faster by pairing with web usb!")}
-                                                        <a className="ui button purple" onClick={onPairClicked}>{lf("Pair now")}</a>
+                                                        <a className="ui button purple" onClick={onPairClicked}>{lf("Pair Now")}</a>
                                                     </div>
                                                 </div>
                                             </div>

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -293,15 +293,15 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
             || (packetioConnecting && lf("Connecting..."))
             || (boards ? lf("Click to select hardware") : (webUSBSupported ? lf("Click for one-click downloads.") : undefined));
 
-        const hardwareMenuText = view == View.Mobile ? lf("Hardware") : lf("Choose hardware");
-        const downloadMenuText = view == View.Mobile ? (pxt.hwName || lf("Download")) : lf("Download as file");
+        const hardwareMenuText = view == View.Mobile ? lf("Hardware") : lf("Choose Hardware");
+        const downloadMenuText = view == View.Mobile ? (pxt.hwName || lf("Download")) : lf("Download as File");
         const downloadHelp = pxt.appTarget.appTheme.downloadDialogTheme?.downloadMenuHelpURL;
 
         // Add the ... menu
         const usbIcon = pxt.appTarget.appTheme.downloadDialogTheme?.deviceIcon || "usb";
         el.push(
             <sui.DropdownMenu key="downloadmenu" role="menuitem" icon={`${downloadButtonIcon} horizontal ${hwIconClasses}`} title={lf("Download options")} className={`${hwIconClasses} right attached editortools-btn hw-button button`} dataTooltip={tooltip} displayAbove={true} displayRight={displayRight}>
-                {webUSBSupported && !packetioConnected && <sui.Item role="menuitem" icon={usbIcon} text={lf("Connect device")} tabIndex={-1} onClick={this.onPairClick} />}
+                {webUSBSupported && !packetioConnected && <sui.Item role="menuitem" icon={usbIcon} text={lf("Connect Device")} tabIndex={-1} onClick={this.onPairClick} />}
                 {webUSBSupported && (packetioConnecting || packetioConnected) && <sui.Item role="menuitem" icon={usbIcon} text={lf("Disconnect")} tabIndex={-1} onClick={this.onDisconnectClick} />}
                 {boards && <sui.Item role="menuitem" icon="microchip" text={hardwareMenuText} tabIndex={-1} onClick={this.onHwItemClick} />}
                 <sui.Item role="menuitem" icon="xicon file-download" text={downloadMenuText} tabIndex={-1} onClick={this.onHwDownloadClick} />

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -200,11 +200,17 @@ function showConnectionSuccessAsync(confirmAsync: ConfirmAsync, willTriggerDownl
 
 function showConnectionFailureAsync(confirmAsync: ConfirmAsync, showDownloadAsFileButton?: boolean) {
     const boardName = getBoardName();
+    const tryAgainText = lf("Try Again");
+    const helpText = lf("Help");
+    const downloadAsFileText = lf("Download as file");
 
     const jsxd = () => (
         <div>
             <div className="ui content download-troubleshoot-header">
-                {lf("We couldn't find your {0}. Here's a few ways to fix that:", boardName)}
+                {lf("We couldn't find your {0}.", boardName)}
+                <br />
+                <br />
+                {lf("Click \"{0}\" for more info, \"{1}\" to try to pair again, or \"{2}\" for drag and drop pairing.", helpText, tryAgainText, downloadAsFileText)}
             </div>
         </div>
     );
@@ -213,7 +219,7 @@ function showConnectionFailureAsync(confirmAsync: ConfirmAsync, showDownloadAsFi
     return showPairStepAsync({
         confirmAsync,
         jsxd,
-        buttonLabel: lf("Try Again"),
+        buttonLabel: tryAgainText,
         buttonIcon: pxt.appTarget?.appTheme?.downloadDialogTheme?.deviceIcon,
         header: lf("Failed to connect"),
         tick: "downloaddialog.button.webusbfailed",

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -202,7 +202,7 @@ function showConnectionFailureAsync(confirmAsync: ConfirmAsync, showDownloadAsFi
     const boardName = getBoardName();
     const tryAgainText = lf("Try Again");
     const helpText = lf("Help");
-    const downloadAsFileText = lf("Download as file");
+    const downloadAsFileText = lf("Download as File");
 
     const jsxd = () => (
         <div>
@@ -272,7 +272,7 @@ async function showPairStepAsync({
 
     if (showDownloadAsFileButton) {
         buttons.unshift({
-            label: lf("Download as file"),
+            label: lf("Download as File"),
             className: "secondary",
             icon: pxt.appTarget.appTheme.downloadIcon || "xicon file-download",
             labelPosition: "left",

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -210,7 +210,7 @@ function showConnectionFailureAsync(confirmAsync: ConfirmAsync, showDownloadAsFi
                 {lf("We couldn't find your {0}.", boardName)}
                 <br />
                 <br />
-                {lf("Click \"{0}\" for more info, \"{1}\" to try to pair again, or \"{2}\" for drag and drop pairing.", helpText, tryAgainText, downloadAsFileText)}
+                {lf("Click \"{0}\" for more info, \"{1}\" to retry pairing, or \"{2}\" for drag-and-drop pairing.", helpText, tryAgainText, downloadAsFileText)}
             </div>
         </div>
     );

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -210,7 +210,7 @@ function showConnectionFailureAsync(confirmAsync: ConfirmAsync, showDownloadAsFi
                 {lf("We couldn't find your {0}.", boardName)}
                 <br />
                 <br />
-                {lf("Click \"{0}\" for more info, \"{1}\" to retry pairing, or \"{2}\" for drag-and-drop pairing.", helpText, tryAgainText, downloadAsFileText)}
+                {lf("Click \"{0}\" for more info, \"{1}\" to retry pairing, or \"{2}\" for drag-and-drop flashing.", helpText, tryAgainText, downloadAsFileText)}
             </div>
         </div>
     );


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/5102

expanded on the text a bit: 
<img width="618" alt="image" src="https://user-images.githubusercontent.com/5615930/235775241-b6b6a4d6-3bdc-4fa0-943e-40839701399f.png">

open to any suggestions if it's still not clear; would prefer to avoid making it any longer / adding pictures if possible as kids in the user testing were very much distracted on this step when there were images /  didn't read the lengthy spots of text.