### PR TITLE
webusb try pair again: return the recursive call

### DIFF
--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -66,7 +66,7 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
     else {
         const tryAgain = await showConnectionFailureAsync(confirmAsync, implicitlyCalled);
 
-        if (tryAgain) await webUsbPairThemedDialogAsync(pairAsync, confirmAsync, implicitlyCalled);
+        if (tryAgain) return webUsbPairThemedDialogAsync(pairAsync, confirmAsync, implicitlyCalled);
     }
 
     if (paired) {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/5099

wasn't using the result from the recursive call, a little interesting this has stuck around for > a year without being noticed but I guess not that many people were using webusb and failing the first time / succeeding the second.