### PR TITLE
Make "show icon" block display text when icon is undefined

### DIFF
--- a/pxtblocks/fields/field_imagedropdown.ts
+++ b/pxtblocks/fields/field_imagedropdown.ts
@@ -138,6 +138,11 @@ namespace pxtblockly {
             }
         }
 
+        doValueUpdate_(newValue: any): void {
+            (this as any).selectedOption_ = undefined;
+            super.doValueUpdate_(newValue);
+        }
+
         /**
          * Callback for when a button is clicked inside the drop-down.
          * Should be bound to the FieldIconMenu.


### PR DESCRIPTION
This change is related to this PR to correct the misspelling of "eighth" note: https://github.com/microsoft/pxt-microbit/pull/5107

Now any JavaScript using the old spelling will convert to blocks and show up as text instead of a symbol. Without this fix, converting to blocks would show the default heart icon. Note: upgrade rules will correct the spelling in any old code and display the eighth note symbol. This text will only show if users write new code in JavaScript with the old spelling and then convert to blocks.

![image](https://user-images.githubusercontent.com/15070078/235798206-abd0bb90-82e0-4b28-8226-1f6fb473c97c.png)
