### PR TITLE
Fix toolboxParent attr when no shadow is given in the parent block

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -342,11 +342,34 @@ namespace pxt.blocks {
             const parentFn = info.blocksById[fn.attributes.toolboxParent];
 
             if (parentFn) {
-                parent = createToolboxBlock(info, parentFn, pxt.blocks.compileInfo(parentFn));
+                const parentInfo = pxt.blocks.compileInfo(parentFn);
+                parent = createToolboxBlock(info, parentFn, parentInfo);
 
-                parentInput = fn.attributes.toolboxParentArgument ?
-                    parent.querySelector(`value[name=${fn.attributes.toolboxParentArgument}]`) :
-                    parent.querySelector(`value`);
+                if (fn.attributes.toolboxParentArgument) {
+                    parentInput = parent.querySelector(`value[name=${fn.attributes.toolboxParentArgument}]`);
+
+                    if (!parentInput && parentInfo.parameters.some(p => p.definitionName === fn.attributes.toolboxParentArgument)) {
+                        // The input is valid, it just doesn't have a shadow block specified in the parent function. Create
+                        // a new input and add it to the parent block
+                        parentInput = document.createElement("value");
+                        parentInput.setAttribute("name", fn.attributes.toolboxParentArgument);
+                        parent.appendChild(parentInput);
+                    }
+                }
+                else {
+                    parentInput = parent.querySelector("value");
+
+                    if (!parentInput) {
+                        // try looking for the first parameter that isn't a field
+                        for (const param of parentInfo.parameters) {
+                            if (parent.querySelector(`field[name=${param.definitionName}]`)) continue;
+
+                            parentInput = document.createElement("value");
+                            parentInput.setAttribute("name", param.definitionName);
+                            parent.appendChild(parentInput);
+                        }
+                    }
+                }
 
                 if (parentInput) {
                     while (parentInput.firstChild) parentInput.removeChild(parentInput.firstChild);

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -367,6 +367,7 @@ namespace pxt.blocks {
                             parentInput = document.createElement("value");
                             parentInput.setAttribute("name", param.definitionName);
                             parent.appendChild(parentInput);
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Fixing a bug that @thsparks ran into while using the `//% toolboxParent` comment attribute.

If a block doesn't specify a shadow block id or default value for a parameter, then we don't actually create a value tag for that parameter in the toolbox block XML. That's a problem when that block is used as the toolboxParent for another block.

If that value tag doesn't exist in the parent XML, the query selector we use when applying the toolboxParent attribute comes up empty and the attribute is ignored completely.

If you want to see the bug for yourself, you can use this code:

```
enum Bar {
    A,
    B
}

//% weight=100 color=#0fbc11 icon=""
namespace custom {
    export class Foo {
    }

    //% block="create foo"
    //% toolboxParent=use_foo
    export function createFoo(): Foo {
        return new Foo();
    }

    //% block="create foo 2"
    //% toolboxParent=use_foo
    //% toolboxParentArgument=foo
    export function createFoo2(): Foo {
        return new Foo();
    }

    //% block="use $bar foo $foo"
    //% blockId=use_foo
    export function useFoo(bar: Bar, foo: Foo) {
    }
}
```