### PR TITLE
Music editor: Add ability to start playback from cursor position.

### DIFF
--- a/pxtsim/sound/sequencer.ts
+++ b/pxtsim/sound/sequencer.ts
@@ -68,13 +68,17 @@ namespace pxsim.music {
         }
 
         start(song: pxt.assets.music.Song, loop?: boolean) {
+            this.startFrom(song, loop, 0);
+        }
+
+        startFrom(song: pxt.assets.music.Song, loop?: boolean, tick?: number) {
             if (this._state !== "stop") this.stop();
 
             if (loop !== undefined) {
                 this.shouldLoop = loop;
             }
 
-            this._currentTick = 0;
+            this._currentTick = tick ?? 0;
             this.currentlyPlaying = song;
             this.metronome.start(tickToMs(song.beatsPerMinute, song.ticksPerBeat, 1));
             this._state = this.shouldLoop ? "loop" : "play";

--- a/webapp/src/components/musicEditor/PlaybackControls.tsx
+++ b/webapp/src/components/musicEditor/PlaybackControls.tsx
@@ -52,14 +52,14 @@ export const PlaybackControls = (props: PlaybackControlsProps) => {
     }
 
     const onPlayClick = () => {
-        startPlaybackAsync(song, false);
+        startPlaybackAsync(song, false, 0);
         setState("play")
     }
 
     const onLoopClick = () => {
         if (isLooping()) return;
         else if (isPlaying()) setLooping(true);
-        else startPlaybackAsync(song, true);
+        else startPlaybackAsync(song, true, 0);
         setState("loop")
     }
 

--- a/webapp/src/components/musicEditor/keyboardNavigation.ts
+++ b/webapp/src/components/musicEditor/keyboardNavigation.ts
@@ -73,6 +73,8 @@ import { addNoteToTrack, applySelection, deleteSelectedNotes, editNoteEventLengt
  * playback:
  *     start playback from beginning:
  *         space
+ *     start playback from cursor:
+ *         shift + space
  *     stop playback:
  *         space (while playing)
  *     loop playback:
@@ -379,11 +381,14 @@ export function handleKeyboardEvent(song: pxt.assets.music.Song, cursor: CursorS
             break;
         case "Spacebar":
         case " ":
+            event.preventDefault();
             if (isPlaying()) {
                 stopPlayback();
             }
-            else {
-                startPlaybackAsync(song, ctrlPressed);
+            else if(shiftPressed) {
+                startPlaybackAsync(song, ctrlPressed, cursor?.tick);
+            } else {
+                startPlaybackAsync(song, ctrlPressed, 0);
             }
             break;
         case "j":

--- a/webapp/src/components/musicEditor/playback.ts
+++ b/webapp/src/components/musicEditor/playback.ts
@@ -2,7 +2,7 @@ let sequencer: pxsim.music.Sequencer;
 let playbackStateListeners: ((state: "play" | "loop" | "stop") => void)[] = [];
 let onTickListeners: ((tick: number) => void)[] = [];
 
-export async function startPlaybackAsync(song: pxt.assets.music.Song, loop: boolean) {
+export async function startPlaybackAsync(song: pxt.assets.music.Song, loop: boolean, ticks?: number) {
     if (!sequencer) {
         sequencer = new pxsim.music.Sequencer();
         await sequencer.initAsync();
@@ -21,7 +21,7 @@ export async function startPlaybackAsync(song: pxt.assets.music.Song, loop: bool
         sequencer.setVolume(100);
     }
 
-    sequencer.start(song, loop);
+    sequencer.startFrom(song, loop, ticks);
 }
 
 export function isPlaying() {


### PR DESCRIPTION
This allows users to start playback in the music editor from the keyboard cursor position (as opposed to the beginning). In the interest of minimizing confusion, I've only added it as a (new) keyboard shortcut, shift+space, rather than changing the behavior of the existing play button & shortcuts.

Upload target: https://arcade.makecode.com/app/e90f14585861682776e190f5f6988269505c5ce2-95604db35f