### PR TITLE
Sign-in button css improvements

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -2338,15 +2338,17 @@ div.simframe.ui.embed {
     -ms-interpolation-mode: nearest-neighbor;
 }
 
-.ui.menu .logged-in-dropdown {
-    justify-content: center;
+.ui.menu .item.logged-in-dropdown {
+    padding-right: .25rem;
+    width: auto !important; // override .menu @largestMobileScreen breakpoint in menu.overrides
 }
 
 .ui.menu .item.sign-in-dropdown {
-    padding-right: .2rem;
+    padding-right: .25rem;
+    width: auto !important; // override .menu @largestMobileScreen breakpoint in menu.overrides
 }
 
-div.signin-button {
+.ui.menu .signin-button {
     display: flex;
     align-items: center;
     background-color: @homeScreenBackground;
@@ -2356,6 +2358,10 @@ div.signin-button {
     padding: 0 .6rem;
     font-family: @segoeUIFont;
     font-weight: 500;
+
+    .icon {
+        margin: 0 !important; // override .menu @largestMobileScreen breakpoint in menu.overrides
+    }
 
     .text {
         margin-right: .5rem;

--- a/theme/themes/pxt/modules/dropdown.overrides
+++ b/theme/themes/pxt/modules/dropdown.overrides
@@ -58,11 +58,3 @@
 .ui.form.inverted .ui.dropdown {
     background: #333940 !important;
 }
-
-/* Small + Large Monitor */
-@media only screen and (min-width: @computerBreakpoint) {
-    .ui.dropdown > .avatar {
-        margin-left: -0.5rem;
-        margin-right: -0.5rem;
-    }
-}

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -119,7 +119,7 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
 
         const signedOutElem = (
             <div className="signin-button">
-                <div className="ui text desktop only">{lf("Sign In")}</div>
+                <div className="ui text widedesktop only">{lf("Sign In")}</div>
                 {sui.genericContent({
                     icon
                 })}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5077

Layout is better at the previously problematic breakpoint:
![image](https://user-images.githubusercontent.com/12176807/236016211-74bc785e-775b-4b18-9efa-f79fcc35de40.png)

Also:
* Fixed this button squeezing issue:
![image](https://user-images.githubusercontent.com/12176807/236016309-1c244971-5786-44bb-b100-8b1bfa77813f.png)

* Removed some extra css that was complicating the signed-in/avatar button.