### PR TITLE
Fix high contrast bug so that extension descriptions are visible

### DIFF
--- a/react-common/styles/extensions/ExtensionCard.less
+++ b/react-common/styles/extensions/ExtensionCard.less
@@ -55,7 +55,7 @@
         border-bottom-left-radius: 0.5rem;
         border-bottom-right-radius: 0.5rem;
     }
-    
+
     .common-button.link-button {
         float: right;
     }
@@ -87,5 +87,16 @@
 
     .common-spinner {
         opacity: 1;
+    }
+}
+
+/****************************************************
+ *                 High Contrast                    *
+ ****************************************************/
+
+ .high-contrast, .hc {
+    .common-extension-card {
+        border-color: @highContrastTextColor;
+        background-color: @highContrastBackgroundColor;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5078
![image](https://user-images.githubusercontent.com/15070078/236038999-90f61a38-ff18-48df-aaad-93e97c137f0a.png)
