### PR TITLE
add button when webusb is disabled in chrome/edge

### DIFF
--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -524,7 +524,7 @@ namespace pxt.usb {
     export async function checkAvailableAsync() {
         if (_available !== undefined) return;
 
-        pxt.debug(`webusb: checking availability`)
+        pxt.debug(`webusb: checking availability`);
         // not supported by editor, cut short
         if (!pxt.appTarget?.compile?.webUSB) {
             _available = false;

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -577,7 +577,7 @@ namespace pxt.usb {
         // check security
         try {
             // iframes must specify allow="usb" in order to support WebUSB
-            await _usb.getDevices()
+            await _usb.getDevices();
         } catch (e) {
             return "security";
         }

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -11,7 +11,7 @@ import * as identity from "./identity";
 import { ProjectView } from "./app";
 import { clearDontShowDownloadDialogFlag } from "./dialogs";
 import { userPrefersDownloadFlagSet } from "./webusb";
-import { dialogAsync } from "./core";
+import { dialogAsync, hideDialog } from "./core";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -232,6 +232,13 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
             header: lf("WebUSB unavailable"),
             body: modalBody,
             hasCloseIcon: true,
+            buttons: [
+                {
+                    label: lf("Okay"),
+                    className: "primary",
+                    onclick: hideDialog
+                }
+            ]
         });
     }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -215,7 +215,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         let modalBody: string;
         switch (reasonUnsupported) {
             case "security":
-                modalBody = lf("WebUSB appears to have been disabled by browser policy; check your browser's policy page at chrome://policy for more info.");
+                modalBody = lf("WebUSB appears to have been disabled by browser policy; check with your technical adminstrator for details.");
                 break;
             case "oldwindows":
                 modalBody = lf("WebUSB is not available on Windows devices with versions below 8.1.");

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -229,7 +229,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         }
 
         dialogAsync({
-            header: lf("WebUSB unavailable"),
+            header: lf("Cannot Connect Device"),
             body: modalBody,
             hasCloseIcon: true,
             buttons: [

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -215,7 +215,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         let modalBody: string;
         switch (reasonUnsupported) {
             case "security":
-                modalBody = lf("WebUSB appears to have been disabled by browser policy; check with your technical adminstrator for details.");
+                modalBody = lf("WebUSB is disabled by browser policies. Check with your admin for help.");
                 break;
             case "oldwindows":
                 modalBody = lf("WebUSB is not available on Windows devices with versions below 8.1.");

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -338,7 +338,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         el.push(
             <sui.DropdownMenu key="downloadmenu" role="menuitem" icon={`${downloadButtonIcon} horizontal ${hwIconClasses}`} title={lf("Download options")} className={`${hwIconClasses} right attached editortools-btn hw-button button`} dataTooltip={tooltip} displayAbove={true} displayRight={displayRight}>
                 {webUSBSupported && !packetioConnected && <sui.Item role="menuitem" icon={usbIcon} text={lf("Connect Device")} tabIndex={-1} onClick={this.onPairClick} />}
-                {showUsbNotSupportedHint && <sui.Item role="menuitem" icon={"exclamation triangle"} text={lf("Cannot Connect Device")} tabIndex={-1} onClick={this.onCannotPairClick} />}
+                {showUsbNotSupportedHint && <sui.Item role="menuitem" icon={usbIcon} text={lf("Connect Device")} tabIndex={-1} onClick={this.onCannotPairClick} />}
                 {webUSBSupported && (packetioConnecting || packetioConnected) && <sui.Item role="menuitem" icon={usbIcon} text={lf("Disconnect")} tabIndex={-1} onClick={this.onDisconnectClick} />}
                 {boards && <sui.Item role="menuitem" icon="microchip" text={hardwareMenuText} tabIndex={-1} onClick={this.onHwItemClick} />}
                 <sui.Item role="menuitem" icon="xicon file-download" text={downloadMenuText} tabIndex={-1} onClick={this.onHwDownloadClick} />


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-microbit/issues/4914, I did a quick check and it looks like about 3-3.5% of our chrome / edge users end up with webusb being unavailable. There are several known reasons for that, which will cause us to cut webusb features from being displayed (same as behavior in firefox / safari), but most versions of chrome / edge *should* support it so debugging can be hard.

This ads in a download menu item when 1. on chrome or edge and 2. webusb features are disabled for some reason.
<img width="265" alt="image" src="https://user-images.githubusercontent.com/5615930/236268996-e53ab0cd-daf0-4efd-883d-9f3a384c8ee1.png">

This pops up a quick modal with a short explanation of the issue 
<img width="645" alt="image" src="https://user-images.githubusercontent.com/5615930/236269068-258c67d2-78b7-4993-b25d-5158ad0b7a02.png">

and just to note explicitly, this only shows up in chromium edge / chrome, safari and firefox will not get this option as the browsers explicitly do not support webusb. If anyone feels that I should put it in for all 'webusb not working' browsers let me know, I'm a bit indecisive on it (the menu is just a repeat of the main button + help on safari / firefox anyway, so maybe it is alright to have a small suggestion to try a different browser. At least exclude ios though)
<img width="204" alt="image" src="https://user-images.githubusercontent.com/5615930/236076165-6a751909-43d2-4fd0-8a52-ea011fb980b7.png">

** updated images above re: wording change + returning the button to look like normal
