### PR TITLE
Check definition name before accepting translation

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -798,8 +798,9 @@ namespace ts.pxtc {
             const bParam = b.actualNameToParam[aParam.actualName];
             if (!bParam
                 || aParam.type != bParam.type
-                || aParam.shadowBlockId != bParam.shadowBlockId) {
-                pxt.debug(`Parameter ${aParam.actualName} type or shadow block does not match after localization`);
+                || aParam.shadowBlockId != bParam.shadowBlockId
+                || aParam.definitionName != bParam.definitionName) {
+                pxt.debug(`Parameter ${aParam.actualName} type, shadow block, or definition name does not match after localization`);
                 return false;
             }
         }

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -304,7 +304,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
             });
 
         pxt.Util.toArray(content.querySelectorAll('Video.ams-embed'))
-            .forEach((inlineVideo: HTMLElement) => {
+            .forEach((inlineVideo: HTMLMediaElement) => {
 
                 let player = MediaPlayer().create()
                 player.initialize(inlineVideo, inlineVideo.getAttribute("src"), /** autoPlay **/ false);


### PR DESCRIPTION
This check is needed to prevent a broken translation in Italian, in which the definition name was "note" instead of "name."

Fixes #https://github.com/microsoft/pxt-microbit/issues/4905

There will also be a PR shortly to add upgrade rules in pxt-microbit to prevent breaking old projects that have the broken translation.