### PR TITLE
Fix defaults for web manifest

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1720,10 +1720,6 @@ function buildWebManifest(cfg: pxt.TargetBundle) {
     if (fs.existsSync("webmanifest.json"))
         diskManifest = nodeutil.readJson("webmanifest.json")
     U.jsonCopyFrom(webmanifest, diskManifest);
-    // webmanifest = replaceStaticImagesInJsonBlob(
-    //     webmanifest,
-    //     fn => uploadedArtFileCdnUrl(fn)
-    // );
     return webmanifest;
 }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1697,8 +1697,8 @@ function buildWebManifest(cfg: pxt.TargetBundle) {
         "icons": [],
         "scope": "/",
         "start_url": "/",
-        "display": "standalone",
-        "orientation": "landscape"
+        "display": "fullscreen",
+        "orientation": "any"
     }
     if (cfg.appTheme) {
         if (cfg.appTheme.accentColor)
@@ -1719,7 +1719,11 @@ function buildWebManifest(cfg: pxt.TargetBundle) {
     let diskManifest: any = {}
     if (fs.existsSync("webmanifest.json"))
         diskManifest = nodeutil.readJson("webmanifest.json")
-    U.jsonCopyFrom(webmanifest, diskManifest)
+    U.jsonCopyFrom(webmanifest, diskManifest);
+    // webmanifest = replaceStaticImagesInJsonBlob(
+    //     webmanifest,
+    //     fn => uploadedArtFileCdnUrl(fn)
+    // );
     return webmanifest;
 }
 


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-microbit/issues/4629, fix the defaults for webmanifest / pwa install; allow any orientation / system default. See https://stackoverflow.com/questions/68522783/web-app-manifest-orientation-property-what-is-the-difference-between-its-proper for a quick description of all the options; any allows it to rotate freely if that's what the device wants / to match device. The other option would be natural, which is basically 'any' but doesn't allow the 180 flipped ones (e.g if you rotate your phone 90 counter clockwise instead of clockwise when making it go to landscape it'll be upside down), but I don't see a reason to enforce that personally.

Quick build: https://makecode.microbit.org/app/c282d34d33f1de156bded94036d54eb692dc8b14-217c936519 you can see the value for this by opening dev tools -> "Application" tab -> 'Manifest'

![image](https://github.com/microsoft/pxt/assets/5615930/a7c85db9-165b-4c43-8d65-7c31d7091c82)

and here's what the file looks like when you generate it during an uploadtrg (after my follow up pr in pxt-microbit):

```json
{
    "lang": "en",
    "dir": "ltr",
    "name": "makecode.microbit.org",
    "short_name": "microbit",
    "background_color": "#FAFAFA",
    "icons": [
        {
            "src": "/static/icons/android-chrome-36x36.png",
            "sizes": "36x36",
            "type": "image/png"
        },
        {
            "src": "/static/icons/android-chrome-48x48.png",
            "sizes": "48x48",
            "type": "image/png"
        },
        {
            "src": "/static/icons/android-chrome-72x72.png",
            "sizes": "72x72",
            "type": "image/png"
        },
        {
            "src": "/static/icons/android-chrome-96x96.png",
            "sizes": "96x96",
            "type": "image/png"
        },
        {
            "src": "/static/icons/android-chrome-144x144.png",
            "sizes": "144x144",
            "type": "image/png"
        },
        {
            "src": "/static/icons/android-chrome-192x192.png",
            "sizes": "192x192",
            "type": "image/png"
        },
        {
            "src": "/static/icons/android-chrome-256x256.png",
            "sizes": "256x256",
            "type": "image/png"
        },
        {
            "src": "/static/icons/android-chrome-384x384.png",
            "sizes": "384x384",
            "type": "image/png"
        },
        {
            "src": "/static/icons/android-chrome-512x512.png",
            "sizes": "512x512",
            "type": "image/png"
        },
        {
            "src": "/static/icons/maskable-icon-640x640.png",
            "sizes": "640x640",
            "type": "image/png",
            "purpose": "maskable"
        }
    ],
    "scope": "/",
    "start_url": "/",
    "display": "fullscreen",
    "orientation": "any",
    "theme_color": "#ffffff",
    "related_applications": []
}
```

One thing to note, this does end up as another case where we're not patching for /static/; I wrote up why I didn't add it over in https://github.com/microsoft/pxt-backend/issues/791#issuecomment-1541006660, basically just that the backend isn't running replacements on this file and we need to fix that before applying it. For reference the commented out code in https://github.com/microsoft/pxt/commit/eaff607ebf4b907c3b6ec1d240e417758af3830e is what we'll want to add after this file gets replacements handled in the backend.