### PR TITLE
when spawning sim from broadcast, defer msg till spawned

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -407,7 +407,7 @@ namespace pxsim {
             }
         }
 
-        protected deferredMessages: SimulatorMessage[];
+        protected deferredMessages: [HTMLIFrameElement, SimulatorMessage][];
         protected postDeferrableMessage(frame: HTMLIFrameElement, msg: SimulatorMessage) {
             const frameStarted = !frame.dataset["loading"];
             if (frameStarted) {
@@ -416,7 +416,7 @@ namespace pxsim {
                 if (!this.deferredMessages) {
                     this.deferredMessages = [];
                 }
-                this.deferredMessages.push(msg);
+                this.deferredMessages.push([frame, msg]);
             }
         }
 
@@ -769,10 +769,13 @@ namespace pxsim {
                         if (this.options.revealElement)
                             this.options.revealElement(frame);
                         delete frame.dataset["loading"];
-                        this.deferredMessages?.forEach(msg => {
-                            this.postMessageCore(frame, msg);
-                        });
-                        this.deferredMessages = undefined;
+                        this.deferredMessages
+                            ?.filter(defMsg => defMsg[0] === frame)
+                            ?.forEach(defMsg => {
+                                const [_, msg] = defMsg;
+                                this.postMessageCore(frame, msg);
+                            });
+                        this.deferredMessages = this.deferredMessages?.filter(defMsg => defMsg[0] !== frame);
                     }
                     if (this.options.onSimulatorReady)
                         this.options.onSimulatorReady();

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -463,7 +463,7 @@ namespace pxsim {
             frame.frameBorder = "0";
             frame.dataset['runid'] = this.runId;
             frame.dataset['origin'] = new URL(furl).origin || "*";
-            frame.dataset['loading'] = "false";
+            frame.dataset['loading'] = "true";
             if (this._runOptions?.autofocus) frame.setAttribute("autofocus", "true");
 
             wrapper.appendChild(frame);

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -422,7 +422,6 @@ namespace pxsim {
 
         private postMessageCore(frame: HTMLIFrameElement, msg: SimulatorMessage) {
             const origin = U.isLocalHostDev() ? "*" : frame.dataset["origin"];
-            // wait to send message here if not yet ready
             frame.contentWindow.postMessage(msg, origin);
         }
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/4986

~If we want I can make it a little more extensible by tagging each sim with an id and including that in `deferredMessages`, so if we extend to > 2 sims in the future it'd still work as expected, but that feels pretty low priority / it's been years with just 2 in the first place. But it wouldn't be hard / would make the code a little more explicit so just let me know what you prefer, whoever ends up reviewing this 😸~ I just went ahead and did it

here's the build without the fix: https://makecode.microbit.org/beta#pub:_KPJbgURehgML - press a and see nothing happens on first press

here's the build with the fix; https://makecode.microbit.org/app/40bfbd4a142932c6ba83c231537276246a59f908-2dfbec65d1#pub:_KPJbgURehgML press a and see it is happy as soon as it comes in