### PR TITLE
don't extension search on blur + fix for blur losing input on repeated blur

### DIFF
--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -47,11 +47,6 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         setSearchFor(newValue || "");
     }
 
-    const onSearchBarChangeDebounced: (newValue: string) => void = React.useMemo(
-        () => pxt.Util.debounce(onSearchBarChange, 1000),
-        []
-    );
-
     useEffect(() => {
         updateExtensionTags();
         updatePreferredExts();
@@ -522,7 +517,6 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                         placeholder={lf("Search or enter project URL...")}
                         ariaLabel={lf("Search or enter project URL...")}
                         onEnterKey={onSearchBarChange}
-                        onChange={onSearchBarChangeDebounced}
                         preserveValueOnBlur={true}
                         icon="fas fa-search"
                     />

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -42,6 +42,16 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
     const [preferredExts, setPreferredExts] = useState<(ExtensionMeta & EmptyCard)[]>([])
     const [extensionTags, setExtensionTags] = useState(new Map<string, string[]>())
 
+
+    const onSearchBarChange = (newValue: string) => {
+        setSearchFor(newValue || "");
+    }
+
+    const onSearchBarChangeDebounced: (newValue: string) => void = React.useMemo(
+        () => pxt.Util.debounce(onSearchBarChange, 1000),
+        []
+    );
+
     useEffect(() => {
         updateExtensionTags();
         updatePreferredExts();
@@ -492,10 +502,6 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
 
     const categoryNames = getCategoryNames();
 
-    const onSearchBarChange = (newValue: string) => {
-        setSearchFor(newValue || "");
-    }
-
     return (
         <Modal
             title={lf("Extensions")}
@@ -517,7 +523,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                         ariaLabel={lf("Search or enter project URL...")}
                         initialValue={searchFor}
                         onEnterKey={onSearchBarChange}
-                        onBlur={onSearchBarChange}
+                        onChange={onSearchBarChangeDebounced}
                         icon="fas fa-search"
                     />
                     <div className="extension-tags">

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -521,9 +521,9 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                     <Input
                         placeholder={lf("Search or enter project URL...")}
                         ariaLabel={lf("Search or enter project URL...")}
-                        initialValue={searchFor}
                         onEnterKey={onSearchBarChange}
                         onChange={onSearchBarChangeDebounced}
+                        preserveValueOnBlur={true}
                         icon="fas fa-search"
                     />
                     <div className="extension-tags">


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/4959; see https://github.com/microsoft/pxt-microbit/issues/4959#issuecomment-1542583536 for an easier repro.

~The root of the issue is that onBlur is kinda a messy place to start the search from -- it running means you've already clicked / navigated elsewhere (e.g. the scrollbar or one of the extension buttons), so the results will be changing from underneath you (sort of like if you're reading a website and about to click a link, and then a big add pops in and pushes down the link you were going to click; it feels bad), and typically navigating away can mean that something has caught your eye in the first place -- so the update will potentially cause that to disappear.~

~Tagging in hassan / abhijith here as well as a check on if this feels fine for hitting our search endpoint with; I could bump it up to be a little longer (1.5seconds? 2 seconds?) if we want?~

If we don't wanna do the search on change for any reason, I'd lean towards making this pr just delete `onBlur={onSearchBarChange}`, add in the `preserveValueOnBlur={true}`, and leave the rest as is. << decided to do this, to avoid unnecessary network traffic

~Build with change: https://makecode.microbit.org/app/71e42671356a4958e8509ec38d919eb348f21005-3d945dca17#editor~

Also small fix for losing input after clicking in and out of the input a few times in arow, I'm a little surprised `preserveValueOnBlur` isn't the default behavior / feels like it should be?