### PR TITLE
Add "Duplicate with Parent" option for blocks in the toolbox.

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -841,6 +841,8 @@ declare namespace ts.pxtc {
         locs?: pxt.Map<string>;
         toolboxParent?: string; // The ID of a block that will wrap this block in the toolbox. Useful for having multiple instances of the same parent block with different child shadows
         toolboxParentArgument?: string; // Used with toolboxParent. The name of the arg that this block should be inserted into as a shadow
+        duplicateWithToolboxParent?: string; // The ID of an additional block that will be created, which wraps this block in the toolbox. The original (unwrapped) block will also remain in the toolbox.
+        duplicateWithToolboxParentArgument?: string; // Used with duplicateWithToolboxParent. The name of the arg that this block should be inserted into as a shadow.
 
         // On namepspace
         subcategories?: string[];

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1858,6 +1858,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                             setblock.appendChild(value);
                         }
                         blockXml = setblock;
+                    } else if(fn.attributes.duplicateWithToolboxParent) {
+                        const blockWithParentFn = {...fn, attributes: {...fn.attributes, toolboxParent: fn.attributes.duplicateWithToolboxParent, toolboxParentArgument: fn.attributes.duplicateWithToolboxParentArgument}};
+                        const duplicatedBlock = pxt.blocks.createToolboxBlock(this.blockInfo, blockWithParentFn, comp);
+                        return [duplicatedBlock, blockXml];
                     }
                 }
             } else {


### PR DESCRIPTION
This option allows blocks to specify that they should be duplicated in the toolbox, and the duplicate should be wrapped in a parent. It functions much like `toolboxParent` (and `toolboxParentArgument`) but adds a new block instead of wrapping the existing one.

Needed for https://github.com/microsoft/pxt-microbit/pull/5123 so we can include the sound effect block by itself *and* include the sound effect block wrapped in the play block parent without having to create a whole new play block. (See comment: https://github.com/microsoft/pxt-microbit/pull/5123#issuecomment-1544424908)