### PR TITLE
Ensure title is visible when tutorial loads a new step

### DIFF
--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -89,8 +89,8 @@ export function TutorialContainer(props: TutorialContainerProps) {
 
     React.useEffect(() => {
         const contentDiv = contentRef?.current;
-        contentDiv.scrollTo(0, 0);
         contentDiv.querySelector(".tutorial-step-content")?.focus();
+        contentDiv.scrollTo(0, 0);
         setShowScrollGradient(contentDiv.scrollHeight > contentDiv.offsetHeight);
         setStepErrorAttemptCount(0);
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5083

The `focus` call was re-positioning the scroll in our tutorial container and pushing the title out of view. By moving `scrollTo` after that call, we can avoid the issue.