### PR TITLE
Fix duplicate simulator in thumbnail

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -484,15 +484,19 @@ namespace pxt.BrowserUtils {
     export function imageDataToPNG(img: ImageData, scale = 1): string {
         if (!img) return undefined;
 
-        const canvas = document.createElement("canvas")
-        canvas.width = img.width * scale
-        canvas.height = img.height * scale
-        const ctx = canvas.getContext("2d")
+        const inputCanvas = document.createElement("canvas");
+        const outputCanvas = document.createElement("canvas");
+        inputCanvas.width = img.width;
+        inputCanvas.height = img.height;
+        outputCanvas.width = img.width * scale;
+        outputCanvas.height = img.height * scale;
+        const ctx = inputCanvas.getContext("2d");
+        const outCtx = outputCanvas.getContext("2d");
         ctx.putImageData(img, 0, 0);
-        ctx.imageSmoothingEnabled = false;
-        ctx.scale(scale, scale);
-        ctx.drawImage(canvas, 0, 0);
-        return canvas.toDataURL("image/png");
+        outCtx.imageSmoothingEnabled = false;
+        outCtx.scale(scale, scale);
+        outCtx.drawImage(inputCanvas, 0, 0);
+        return outputCanvas.toDataURL("image/png");
     }
 
     const MAX_SCREENSHOT_SIZE = 1e6; // max 1Mb

--- a/pxtsim/visuals/boardhost.ts
+++ b/pxtsim/visuals/boardhost.ts
@@ -156,8 +156,8 @@ namespace pxsim.visuals {
 
         public screenshotAsync(width?: number): Promise<ImageData> {
             const svg = this.view.cloneNode(true) as SVGSVGElement;
-            svg.setAttribute('width', this.view.width.baseVal.value + "");
-            svg.setAttribute('height', this.view.height.baseVal.value + "");
+            svg.setAttribute('width', this.view.viewBox.baseVal.width + "");
+            svg.setAttribute('height', this.view.viewBox.baseVal.height + "");
             const xml = new XMLSerializer().serializeToString(svg);
             const data = "data:image/svg+xml,"
                 + encodeURIComponent(xml.replace(/\s+/g, ' ').replace(/"/g, "'"));

--- a/react-common/components/share/ThumbnailRecorder.tsx
+++ b/react-common/components/share/ThumbnailRecorder.tsx
@@ -86,8 +86,8 @@ export const ThumbnailRecorder = (props: ThumbnailRecorderProps) => {
     }
 
     const targetTheme = pxt.appTarget.appTheme;
-    const screenshotLabel = lf("Screenshot ({0})", targetTheme.simScreenshotKey);
-    const startRecordingLabel = lf("Record ({0})", targetTheme.simGifKey);
+    const screenshotLabel = targetTheme.simScreenshotKey ? lf("Screenshot ({0})", targetTheme.simScreenshotKey) : lf("Screenshot");
+    const startRecordingLabel = targetTheme.simGifKey ? lf("Record ({0})", targetTheme.simGifKey) : lf("Record");
     const stopRecordingLabel = lf("Stop recording ({0})", targetTheme.simGifKey);
     const renderingLabel = lf("Rendering...");
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4988

This removes the duplicate simulator and also fixes the aspect ratio of the preview. Before, the thumbnail looked squished because the rendering was including extra padding. Now we use the `viewBox` to get the width and height, which does not include the padding.

I also made a fix for the label so that if no keyboard shortcuts are defined, it doesn't show `((undef))`

Before:
![image](https://user-images.githubusercontent.com/59192069/225235173-24203a43-65a0-4b40-bbf3-1668b0bce57d.png)
After:
![image](https://github.com/microsoft/pxt/assets/15070078/5b4ebfc4-9ae4-4dce-9f96-9e6a8efd7752)