### PR TITLE
add block attribute for grid that emits to string literal

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -806,6 +806,7 @@ declare namespace ts.pxtc {
         jresURL?: string;
         iconURL?: string;
         imageLiteral?: number;
+        gridLiteral?: number;
         imageLiteralColumns?: number; // optional number of columns
         imageLiteralRows?: number; // optional number of rows
         imageLiteralScale?: number; // button sizing between 0.6 and 2, default is 1

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1765,7 +1765,7 @@ namespace pxt.blocks {
                         attrs: fn.attributes,
                         isExtensionMethod: instance,
                         isExpression: fn.retType && fn.retType !== "void",
-                        imageLiteral: fn.attributes.imageLiteral,
+                        imageLiteral: fn.attributes.imageLiteral || fn.attributes.gridLiteral,
                         imageLiteralColumns: fn.attributes.imageLiteralColumns,
                         imageLiteralRows: fn.attributes.imageLiteralRows,
                         hasHandler: pxt.blocks.hasHandler(fn),

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -680,8 +680,10 @@ namespace pxt.blocks {
                 })
             }
         });
-        if (fn.attributes.imageLiteral) {
-            const columns = (fn.attributes.imageLiteralColumns || 5) * fn.attributes.imageLiteral;
+
+        const gridTemplateString = fn.attributes.imageLiteral || fn.attributes.gridLiteral;
+        if (gridTemplateString) {
+            const columns = (fn.attributes.imageLiteralColumns || 5) * gridTemplateString;
             const rows = fn.attributes.imageLiteralRows || 5;
             const scale = fn.attributes.imageLiteralScale;
             let ri = block.appendDummyInput();
@@ -695,7 +697,7 @@ namespace pxt.blocks {
             block.setInputsInline(true);
         }
         else {
-            block.setInputsInline(!fn.parameters || (fn.parameters.length < 4 && !fn.attributes.imageLiteral));
+            block.setInputsInline(!fn.parameters || (fn.parameters.length < 4 && !gridTemplateString));
         }
 
         const body = fn.parameters?.find(pr => pxtc.parameterTypeIsArrowFunction(pr));

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1634,7 +1634,7 @@ ${output}</xml>`;
             res.fields = [];
 
             const leds = ((arg as ts.StringLiteral).text || '').replace(/\s+/g, '');
-            const nc = (attributes.imageLiteralColumns || 5) * attributes.imageLiteral;
+            const nc = (attributes.imageLiteralColumns || 5) * (attributes.imageLiteral || attributes.gridLiteral);
             const nr = attributes.imageLiteralRows || 5;
             const nleds = nc * nr;
             if (nleds != leds.length) {
@@ -2076,7 +2076,7 @@ ${output}</xml>`;
                 attributes.blockId = builtin.blockId;
             }
 
-            if (attributes.imageLiteral) {
+            if (attributes.imageLiteral || attributes.gridLiteral) {
                 return getImageLiteralStatement(node, info);
             }
 
@@ -2807,7 +2807,7 @@ ${output}</xml>`;
             const comp = pxt.blocks.compileInfo(api);
             const totalDecompilableArgs = comp.parameters.length + (comp.thisParameter ? 1 : 0);
 
-            if (attributes.imageLiteral) {
+            if (attributes.imageLiteral || attributes.gridLiteral) {
                 // Image literals do not show up in the block string, so it won't be in comp
                 if (info.args.length - totalDecompilableArgs > 1) {
                     return Util.lf("Function call has more arguments than are supported by its block");
@@ -2819,7 +2819,7 @@ ${output}</xml>`;
                 }
                 const leds = ((arg as ts.StringLiteral).text || '').replace(/\s+/g, '');
                 const nr = attributes.imageLiteralRows || 5;
-                const nc = (attributes.imageLiteralColumns || 5) * attributes.imageLiteral;
+                const nc = (attributes.imageLiteralColumns || 5) * (attributes.imageLiteral || attributes.gridLiteral);
                 const nleds = nc * nr;
                 if (nc * nr != leds.length) {
                     return Util.lf("Invalid image pattern ({0} expected vs {1} actual)", nleds, leds.length);

--- a/tests/blocklycompiler-test/baselines/grid_template_string.ts
+++ b/tests/blocklycompiler-test/baselines/grid_template_string.ts
@@ -1,0 +1,7 @@
+let stringGrid = basic.createTemplateGrid(`
+    . . . . .
+    . . . . .
+    . . . . .
+    # # # # #
+    . . . . .
+`)

--- a/tests/blocklycompiler-test/cases/grid_template_string.blocks
+++ b/tests/blocklycompiler-test/cases/grid_template_string.blocks
@@ -1,0 +1,16 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block type="pxt-on-start">
+    <statement name="HANDLER">
+      <block type="variables_set">
+        <field name="VAR">stringGrid</field>
+        <value name="VALUE">
+          <shadow type="math_number"><field name="NUM">0</field></shadow>
+          <block type="device_build_string_literal">
+            <field name="LEDS"
+              >&#96;.....&#10;.....&#10;.....&#10;&#35;&#35;&#35;&#35;&#35;&#10;.....&#10;&#96;</field>
+          </block>
+        </value>
+      </block>
+    </statement>
+  </block>
+</xml>

--- a/tests/blocklycompiler-test/test-library/mbit.ts
+++ b/tests/blocklycompiler-test/test-library/mbit.ts
@@ -25,6 +25,16 @@ namespace basic {
     export function showString(text: string, interval?: number): void {
 
     }
+
+    /**
+     * Creates a template string
+     */
+    //% weight=75
+    //% blockId=device_build_string_literal block="create string grid"
+    //% gridLiteral=1
+    export function createTemplateGrid(leds: string): string {
+        return leds
+    }
 }
 
 

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -510,6 +510,10 @@ describe("blockly compiler", function () {
         it("should convert enums to constants when emitAsConstant is set", done => {
             blockTestAsync("enum_constants").then(done, done);
         });
+
+        it("should compile gridTemplate blocks to template strings", done => {
+            blockTestAsync("grid_template_string").then(done, done);
+        })
     });
 
     describe("compiling expandable blocks", () => {

--- a/tests/decompile-test/baselines/images.blocks
+++ b/tests/decompile-test/baselines/images.blocks
@@ -39,6 +39,17 @@
 <field name="LEDS">&#96;.....&#35;&#10;.&#35;.&#35;.&#35;&#10;......&#10;.&#35;&#35;&#35;.&#35;&#10;&#96;</field>
 </block>
 </value>
+<next>
+<block type="variables_set">
+<field name="VAR">stringGrid</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="device_build_string_literal">
+<field name="LEDS">&#96;.....&#10;.....&#10;.....&#10;&#35;&#35;&#35;&#35;&#35;&#10;.....&#10;&#96;</field>
+</block>
+</value>
+</block>
+</next>
 </block>
 </next>
 </block>

--- a/tests/decompile-test/cases/images.ts
+++ b/tests/decompile-test/cases/images.ts
@@ -36,3 +36,11 @@ let a = images.createTallBigImage(`
     . . . . . .
     . # # # . #
 `)
+
+let stringGrid = images.createTemplateGrid(`
+    . . . . .
+    . . . . .
+    . . . . .
+    # # # # #
+    . . . . .
+`)

--- a/tests/decompile-test/cases/testBlocks/mb.ts
+++ b/tests/decompile-test/cases/testBlocks/mb.ts
@@ -148,6 +148,16 @@ namespace images {
     export function createTallBigImage(leds: string): Image {
         return undefined;
     }
+
+    /**
+     * Creates a template string
+     */
+    //% weight=75
+    //% blockId=device_build_string_literal block="create string grid"
+    //% gridLiteral=1
+    export function createTemplateGrid(leds: string): string {
+        return leds
+    }
 }
 
 //% color=#0078D7 weight=100


### PR DESCRIPTION
Basically, just the grid field editor that doesn't require explicit sim / cpp side handling / emits to a string template

```typescript
//% color="#AA278D" weight=100
namespace hello {
    //% weight=75
    //% blockId=buildagrid block="my special grid"
    //% imageLiteralColumns=7
    //% imageLiteralRows=4
    //% gridLiteral=1
    export function createImage(leds: string) {
        console.log(leds)

    }

    //% weight=70
    //% blockId=gridthatreturns block="my special grid that returns"
    //% imageLiteralColumns=7
    //% imageLiteralRows=2
    //% gridLiteral=1
    export function createImageAndReturn(leds: string) {
        return leds;
    }
}
```

ends up as 

![image](https://github.com/microsoft/pxt/assets/5615930/94c3a273-2180-4225-8fe1-4213bc7453e6)

and doesn't go through the all the special cases in the -> binary js / -> cpp compilers, so it's useable for defining grids that aren't explicitly micro:bit images (and therefore doesn't just immediately cause a runtime error anywhere outside of micro:bit) - in particular where the bitpacking just doesn't make sense like in sim only editors.

(I'll add compile / decompile tests / a note in the docs if this feels okay, just easier to justify writing them after it's approved :) )
