### PR TITLE
only show internet connection page in sidedocs for network failure, not rendering errors

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -116,7 +116,7 @@ namespace pxt.Cloud {
         })
     }
 
-    export async function markdownAsync(docid: string, locale?: string): Promise<string> {
+    export async function markdownAsync(docid: string, locale?: string, propagateExceptions?: boolean): Promise<string> {
         // 1h check on markdown content if not on development server
         const MARKDOWN_EXPIRATION = pxt.BrowserUtils.isLocalHostDev() ? 0 : 1 * 60 * 60 * 1000;
         // 1w check don't use cached version and wait for new content
@@ -137,8 +137,12 @@ namespace pxt.Cloud {
                     return r.md;
                 }
                 return entry.md;
-            } catch {
-                return ""; // no translation
+            } catch (e) {
+                if (propagateExceptions) {
+                    throw e;
+                } else {
+                    return ""; // no translation
+                }
             }
         };
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/4933

This one is a little fun as it had issues on each level (code, docs, and translations)

* the code was aggressively showing a network error on any compile issue, which doesn't match our docs behavior
*  That page in particular had a bad package import statement; trying to import music? https://github.com/microsoft/pxt-microbit/blob/master/docs/reference/music/volume.md looks like a few of the others did as well
* The japanese translation for that page had a bad translation applied to that import statement, causing the import to fail: https://crowdin.com/translate/makecode/10350/en-ja#967414

we should also fix the docs pages with that bad import (which will also fix the translation by just getting rid of it),  but this change will make it so we have a similar level of ignoring errors / showing what we can in side docs as we have in normal docs pages