### PR TITLE
datalogger sim: clear when clear block is used

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -103,7 +103,7 @@ namespace pxsim {
         id: string;
         data: string;
         sim?: boolean;
-        csvType?: undefined | "headers" | "row"; // if non-nullish pass to csv view instead
+        csvType?: undefined | "headers" | "row" | "clear"; // if non-nullish pass to csv view instead
         receivedTime?: number;
     }
     export interface SimulatorBulkSerialMessage extends SimulatorMessage {

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -183,6 +183,12 @@ export class Editor extends srceditor.Editor {
     }
 
     processEventCore(smsg: pxsim.SimulatorSerialMessage) {
+        const isClearLog = smsg.csvType === "clear";
+        if (isClearLog && this.isCsvView) {
+            this.clear();
+            return;
+        }
+
         smsg.receivedTime = smsg.receivedTime || Util.now();
         if (!!smsg.csvType) {
             this.receivedCsv = true;
@@ -231,7 +237,7 @@ export class Editor extends srceditor.Editor {
             this.appendRawCsvData(data);
             if (smsg.csvType === "headers") {
                 this.processCsvHeaders(data, receivedTime);
-            } else {
+            } else if (smsg.csvType === "row") {
                 this.processCsvRows(data, receivedTime);
             }
         } else {


### PR DESCRIPTION
fix for https://github.com/microsoft/pxt-microbit/issues/5129 alongside https://github.com/microsoft/pxt-microbit/pull/5147 to send the clear message

build / test https://makecode.microbit.org/app/75ac18b1b2f92b85fefac4d9a613dbda9ca3bcfe-f17fea3dbb#pub:S73614-71882-80362-66035