### PR TITLE
fix trgblb/sim.manifest req

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1057,6 +1057,7 @@ function uploadCoreAsync(opts: UploadOptions) {
             "/doccdn/": opts.localDir,
             "/sim/": opts.localDir,
             "/blb/": opts.localDir,
+            "/trgblb/": opts.localDir,
             "@monacoworkerjs@": `${opts.localDir}monacoworker.js`,
             "@gifworkerjs@": `${opts.localDir}gifjs/gif.worker.js`,
             "@workerjs@": `${opts.localDir}worker.js`,

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -417,6 +417,7 @@ export function expandHtml(html: string, params?: pxt.Map<string>, appTheme?: px
     params["description"] = params["description"] || pxt.appTarget.appTheme.description;
     params["locale"] = params["locale"] || pxt.appTarget.appTheme.defaultLocale || "en"
 
+
     // page overrides
     let m = /<title>([^<>@]*)<\/title>/.exec(html)
     if (m) params["name"] = m[1]
@@ -1169,7 +1170,7 @@ export function serveAsync(options: ServeOptions) {
         }
 
         let dd = dirs
-        let mm = /^\/(cdn|parts|sim|doccdn|blb)(\/.*)/.exec(pathname)
+        let mm = /^\/(cdn|parts|sim|doccdn|blb|trgblb)(\/.*)/.exec(pathname)
         if (mm) {
             pathname = mm[2]
         } else if (U.startsWith(pathname, "/docfiles/")) {


### PR DESCRIPTION
just fixes a 404 on local serve that constantly shows up (`sim.webconfig`), still get the `/api/store/` ones a lot (in particular when not logged in) but those seem less trivial to remove / probably need a little rethinking if we wanted to clear them -- they're semi 'expected' failures but they're quite noisy when you're not logged in
![image](https://github.com/microsoft/pxt/assets/5615930/7300756d-23c2-4c34-8c35-7e8f5c6fde55)
/ I still see some spurious 404's even when signed in occasionally that fill up the log a bit (for csrf token & for theme)