### PR TITLE
return a 204 (no content) for local host storage failure, handle client side

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -304,7 +304,7 @@ async function handleApiStoreRequestAsync(req: http.IncomingMessage, res: http.S
                 res.end(val.toString());
             }
         } else {
-            res.writeHead(404);
+            res.writeHead(204);
             res.end();
         }
     } else if (meth === "POST") {

--- a/pxtlib/localStorage.ts
+++ b/pxtlib/localStorage.ts
@@ -141,7 +141,10 @@ namespace pxt.storage.shared {
                 method: "GET",
                 allowHttpErrors: true
             });
-            if (resp.json) {
+
+            if (resp.statusCode === 204) {
+                throw new Error(`Missing ${key} not available in ${container}`);
+            } else if (resp.json) {
                 return resp.json as T;
             } else if (resp.text) {
                 return resp.text as any as T;


### PR DESCRIPTION
re: https://github.com/microsoft/pxt/pull/9516, I've been getting ~10-40 of these in my console whenever I do local host development when not logged in and it's been a bit distracting when looking for 'real' errors -- the console doesn't suppress the default 404 error logs even when caught. This changes to a [204 (no content)](https://http.cat/204) and handles the rest client side, feel like an okay compromise?

And just to double check my understanding, this one is only used for localhost sign in / shared context related things, and doesn not get touched on the prod / uploaded versions? Is it just that it forks on https://github.com/microsoft/pxt/blob/cleanUpCsrfErrors/pxtlib/localStorage.ts#L127 in `getAsync` to use `getLocal` / `setLocal`, so 'prod' uses the `else` path vs. the `if` I modified in `localStorage.ts`?