### PR TITLE
if you have connected an already paired device, skip browser pair dialog

### DIFF
--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -49,13 +49,18 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
         const start = Date.now();
         const TRY_FOR_MS = 1500;
         core.showLoading("attempting-reconnect", lf("Attempting to reconnect automatically to your {0}", boardName));
-        await pxt.Util.promiseTimeout(TRY_FOR_MS, (async () => {
-            while (!pxt.packetio.isConnected() && pxt.packetio.isConnecting() && Date.now() < start + TRY_FOR_MS) {
-                await pxt.Util.delay(10);
-            }
-            connected = pxt.packetio.isConnected();
-        })());
-        core.hideLoading("attempting-reconnect");
+        try {
+            await pxt.Util.promiseTimeout(TRY_FOR_MS, (async () => {
+                while (!pxt.packetio.isConnected() && Date.now() < start + TRY_FOR_MS) {
+                    await pxt.Util.delay(30);
+                }
+                connected = pxt.packetio.isConnected();
+            })());
+        } catch (e) {
+            // continue pairing flow
+        } finally {
+            core.hideLoading("attempting-reconnect");
+        }
     }
 
     let paired = connected;

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -47,7 +47,7 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
 
     if (!connected && pxt.packetio.isConnecting()) {
         const start = Date.now();
-        const TRY_FOR_MS = 1500;
+        const TRY_FOR_MS = 2500;
         core.showLoading("attempting-reconnect", lf("Attempting to reconnect automatically to your {0}", boardName));
         try {
             await pxt.Util.promiseTimeout(TRY_FOR_MS, (async () => {

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -48,7 +48,7 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
     if (!connected && pxt.packetio.isConnecting()) {
         const start = Date.now();
         const TRY_FOR_MS = 2500;
-        core.showLoading("attempting-reconnect", lf("Attempting to reconnect automatically to your {0}", boardName));
+        core.showLoading("attempting-reconnect", lf("Reconnecting to your {0}", boardName));
         try {
             await pxt.Util.promiseTimeout(TRY_FOR_MS, (async () => {
                 while (!pxt.packetio.isConnected() && Date.now() < start + TRY_FOR_MS) {


### PR DESCRIPTION
If you have already paired your micro:bit, press download while unplugged, and get the 'plug in your micro:bit' dialog, we currently still go through the browser pairing flow. With this, we'll bypass that flow when a device successfully reconnects their device, and just skip straight to the 'congrats!' screen, instead of making them go through the pair dialog / failing when they click out even when they've already authorized the device previously and the confirmation is a no-op.

build: https://makecode.microbit.org/app/eaba39d3894b7e260579074cc9edfb971b64899e-98b1d17bae

while testing, when you unplug and replug in micro:bit please wait a few seconds for any existing download to finish -- I ran into issues a few times where it would try and repair + start download on top of eachother when I was testing because I was clicking in / out so quickly, I'll be looking at that in separate pr but for this one please let it settle before hitting download again (e.g. wait till you see the program has flashed or a file has been downloaded to unplug / replug / press download again)

I set a timeout of 2.5 seconds just to be on the safe side when waiting for it to go from connecting -> connected; this typically takes ~100-500ms, and if they plug it in it's very possible that in the time that they have moved their hands to the mouse & pressed continue it will already be connected. It is possible to plug it in and click before our reconnected logic even occurs -- i.e. before the log that says "Connecting..." like this: 
![image](https://github.com/microsoft/pxt/assets/5615930/c43ab4c9-e21d-4256-b1e0-8eb019f7d036)

but that likely requires a bit of rushing if youre not actively testing it (for this change to take affect you will probably have to wait to hear the 'usb device connected' beep from your computer, if one exists, as it's gotta be recognized as connected); maybe worth adding a few more polls on `pxt.packetio.isConnect(ing|ed)` during / after the next step, or a ~3-500ms delay after clicking next if you've previously paired a device, clicked continue, and we don't see it quite yet - maybe a follow up pr if people actually hit it regularly.