### PR TITLE
Webusb: catch errors more errors, stop saying success when pairing not complete

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -377,7 +377,7 @@ namespace pxt.editor {
         showPackageDialog(query?: string): void;
         showBoardDialogAsync(features?: string[], closeIcon?: boolean): Promise<void>;
         checkForHwVariant(): boolean;
-        pairAsync(): Promise<void>;
+        pairAsync(): Promise<boolean>;
 
         createModalClasses(classes?: string): string;
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -574,7 +574,7 @@ namespace pxt.editor {
                                         .then(() => projectView.printCode());
                                 }
                                 case "pair": {
-                                    return projectView.pairAsync();
+                                    return projectView.pairAsync().then(() => {});
                                 }
                                 case "info": {
                                     return Promise.resolve()

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -27,11 +27,11 @@ namespace pxt.commands {
     export let patchCompileResultAsync: (r: pxtc.CompileResult) => Promise<void> = undefined;
     export let browserDownloadAsync: (text: string, name: string, contentType: string) => Promise<void> = undefined;
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
-    export let renderBrowserDownloadInstructions: (saveonly?: boolean) => any /* JSX.Element */ = undefined;
+    export let renderBrowserDownloadInstructions: (saveonly?: boolean, redeploy?: () => Promise<void>) => any /* JSX.Element */ = undefined;
     export let renderUsbPairDialog: (firmwareUrl?: string, failedOnce?: boolean) => any /* JSX.Element */ = undefined;
     export let renderIncompatibleHardwareDialog: (unsupportedParts: string[]) => any /* JSX.Element */ = undefined;
     export let renderDisconnectDialog: () => { header: string, jsx: any, helpUrl: string }
-    export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>, saveonly?: boolean) => Promise<void> = undefined;
+    export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>, saveonly?: boolean, redeploy?: () => Promise<void>) => Promise<void> = undefined;
     export let showProgramTooLargeErrorAsync: (variants: string[], confirmAsync: (options: any) => Promise<number>) => Promise<RecompileOptions>;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3061,7 +3061,7 @@ export class ProjectView
             );
     }
 
-    pairAsync(): Promise<void> {
+    pairAsync(): Promise<boolean> {
         return cmds.pairAsync();
     }
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -72,12 +72,18 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
     }
     else {
         // save does the same as download as far iOS is concerned
-        return pxt.commands.showUploadInstructionsAsync(fn, url, core.confirmAsync, resp.saveOnly)
+        return pxt.commands.showUploadInstructionsAsync(fn, url, core.confirmAsync, resp.saveOnly, () => hidDeployCoreAsync(resp))
             .then(() => window.URL?.revokeObjectURL(url));
     }
 }
 
-function showUploadInstructionsAsync(fn: string, url: string, confirmAsync: (options: core.PromptOptions) => Promise<number>, saveonly?: boolean): Promise<void> {
+function showUploadInstructionsAsync(
+    fn: string,
+    url: string,
+    confirmAsync: (options: core.PromptOptions) => Promise<number>,
+    saveonly?: boolean,
+    redeploy?: () => Promise<void>
+): Promise<void> {
     const boardName = pxt.appTarget.appTheme.boardName || lf("device");
     const boardDriveName = pxt.appTarget.appTheme.driveDisplayName || pxt.appTarget.compile.driveName || "???";
 
@@ -90,7 +96,7 @@ function showUploadInstructionsAsync(fn: string, url: string, confirmAsync: (opt
     const saveAs = pxt.BrowserUtils.hasSaveAs();
     const ext = pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex";
     const connect = pxt.usb.isEnabled && pxt.appTarget?.compile?.webUSB;
-    const jsx = !userDownload && !saveAs && pxt.commands.renderBrowserDownloadInstructions && pxt.commands.renderBrowserDownloadInstructions(saveonly);
+    const jsx = !userDownload && !saveAs && pxt.commands.renderBrowserDownloadInstructions?.(saveonly, redeploy);
     const body = userDownload ? lf("Click 'Download' to open the {0} app.", pxt.appTarget.appTheme.boardName) :
         saveAs ? lf("Click 'Save As' and save the {0} file to the {1} drive to transfer the code into your {2}.",
             ext,

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -235,7 +235,9 @@ export async function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.comma
         // This is hit when we connect to an hf2 device (e.g. arcade) for the first time,
         // and need the user to select / pair one more time. see pxtlib/hf2.ts
         if (e.type === "repairbootloader") {
-            // TODO: slightly different flow vs implicit, as this is in a 'half paired' state? not sure
+            // TODO: slightly different flow vs implicit, as this is in a 'half paired' state?
+            // Ideally, we should be including this in the pairing webusb.tsx pairing dialog flow
+            // directly instead of deferring it all the way here.
             await pairAsync();
             return hidDeployCoreAsync(resp, d);
         } else if (e.message === "timeout") {

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -737,15 +737,17 @@ export function promptTranslateBlock(blockid: string, blockTranslationIds: strin
     });
 }
 
-export function renderBrowserDownloadInstructions(saveonly?: boolean) {
+export function renderBrowserDownloadInstructions(saveonly?: boolean, redeploy?: () => Promise<void>) {
     const boardName = pxt.appTarget.appTheme.boardName || lf("device");
     const boardDriveName = pxt.appTarget.appTheme.driveDisplayName || pxt.appTarget.compile.driveName || "???";
     const fileExtension = pxt.appTarget.compile?.useUF2 ? ".uf2" : ".hex";
     const webUSBSupported = pxt.usb.isEnabled && pxt.appTarget?.compile?.webUSB;
 
-    const onPairClicked = () => {
+    const onPairClicked = async () => {
         core.hideDialog();
-        pairAsync();
+        const successfulPairing = await pairAsync(true);
+        if (redeploy && successfulPairing)
+            await redeploy();
     }
 
     const onCheckboxClicked = (value: boolean) => {


### PR DESCRIPTION
https://makecode.microbit.org/app/ffbdd7bc4924b3b24a8d03c86d3dd5b68a77b717-cc763a8701

I'll be double checking this on monday, I'm sure I messed something up a bit, but this should overall catch the errors more consistently, route to 'congrats you succeeded' screen more accurately (both confirming connection was actually successful before congratulating user, and ignoring false negatives when e.g. escaping from browser pair screen with an already pair micro:bit), giving download dialog consistently when downloading to device was unsucessfully, and deploy automatically when 'download success -> pair now for faster downloads -> successful pairing' path occurs

Should:
* fix https://github.com/microsoft/pxt-microbit/issues/5146
* fix https://github.com/microsoft/pxt-microbit/issues/5090
* fix a few other slight variants on the above that other team members have sent me that didn't get their own bugs filed ^^
* fix https://github.com/microsoft/pxt-microbit/issues/4425 (remaining portion of the issue is that it still shows micro:bit connection when you have two paired browsers open at once; I can look at that but there are several other features waiting / I would be very surprised if a significant amount of users actually hit this, since it requires 2 browsers open / attempting to connect concurrently which seems... rare. We don't have any control at all over 'taking focus' or even really notifying them of it, as the behavior would be the same as if they e.g. unplugged mid flash / or there was any other hardware error.)
* fix https://github.com/microsoft/pxt-microbit/issues/5157 (this makes the 'downloaded -> saw suggestion in dialog complete modal -> paired' flow now deploy immediately, but left the `...` menu as 'only pairing no forced download' for the same 'probably nobody ends up seeing that anyway' type of reason I mentioned in standup)
* fix for https://github.com/microsoft/pxt-microbit/issues/5130
* When the failure occurs and it downloads as a file, consistently show 'file downloaded' instead of showing it half the time & just downloading without display half the time

(sorry the code is a little uglier / more complicated now, so many edge cases D:)