### PR TITLE
Make EditorTools bar use full screen width on microbit tutorials

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -964,7 +964,7 @@
 *******************************/
 
 @media only screen and (min-width: @largestSmallMonitor) {
-    #root.tabTutorial:not(.fullscreensim, .greenscreen) {
+    #root.tabTutorial:not(.fullscreensim, .greenscreen, .tutorialSimSidebar) {
         #editortools {
             width: calc(100% - @simulatorWidth);
             left: unset;
@@ -975,7 +975,7 @@
 
 
 @media only screen and (min-width: @largestTabletScreen) and (max-width: @largestSmallMonitor) {
-    #root.tabTutorial:not(.fullscreensim, .greenscreen) {
+    #root.tabTutorial:not(.fullscreensim, .greenscreen, .tutorialSimSidebar) {
         #editortools {
             width: calc(100% - @simulatorWidthSmall);
             left: unset;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4953,6 +4953,7 @@ export class ProjectView
             inTutorialExpanded && !isTabTutorial ? 'tutorialExpanded' : '',
             isTabTutorial ? 'tabTutorial' : '',
             isSidebarTutorial ? 'sidebarTutorial' : '',
+            tutorialSimSidebar ? 'tutorialSimSidebar' : '',
             inDebugMode ? 'debugger' : '',
             pxt.options.light ? 'light' : '',
             pxt.BrowserUtils.isTouchEnabled() ? 'has-touch' : '',


### PR DESCRIPTION
This is more consistent with the non-tutorial layout. Left as-is for Arcade to preserve room for instructions.

Fixes https://github.com/microsoft/pxt-microbit/issues/5065

Upload Target: https://makecode.microbit.org/app/956475fa5aa067910eeda453ca8cd5e3f8014549-36012f9afb

Sample gif:
![FullWidthEditorToolsToolbar](https://github.com/microsoft/pxt/assets/69657545/6afda2ab-4229-42ad-beb6-8c908dfb7c83)

Arcade is unaffected:
<img width="672" alt="image" src="https://github.com/microsoft/pxt/assets/69657545/7a90a3f9-ce46-4022-b0a4-de95834b0a6f">
