### PR TITLE
Auto start the editor tour on first project

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -119,6 +119,7 @@ namespace pxt.editor {
         extensionUnderTest?: string; // workspace id of the extension under test
         skillmapProject?: boolean;
         simTheme?: Partial<pxt.PackageConfig>;
+        firstProject?: boolean;
     }
 
     export interface ExampleImportOptions {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -239,7 +239,7 @@ namespace pxt.editor {
         exportAsync(): Promise<string>;
 
         newEmptyProject(name?: string, documentation?: string, preferredEditor?: string): void;
-        newProject(options?: ProjectCreationOptions): void;
+        newProject(options?: ProjectCreationOptions, isFirstProject?: boolean): void;
         createProjectAsync(options: ProjectCreationOptions): Promise<void>;
         importExampleAsync(options: ExampleImportOptions): Promise<void>;
         showScriptManager(): void;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -240,7 +240,7 @@ namespace pxt.editor {
         exportAsync(): Promise<string>;
 
         newEmptyProject(name?: string, documentation?: string, preferredEditor?: string): void;
-        newProject(options?: ProjectCreationOptions, isFirstProject?: boolean): void;
+        newProject(options?: ProjectCreationOptions): void;
         createProjectAsync(options: ProjectCreationOptions): Promise<void>;
         importExampleAsync(options: ExampleImportOptions): Promise<void>;
         showScriptManager(): void;

--- a/react-common/components/controls/TeachingBubble.tsx
+++ b/react-common/components/controls/TeachingBubble.tsx
@@ -81,9 +81,21 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
         const bubbleArrowOutline = document.querySelector(".teaching-bubble-arrow-outline") as HTMLElement;
         bubbleArrowOutline.style.border = "none";
         const bubbleBounds = bubble.getBoundingClientRect();
-        const targetElement = document.querySelector(targetContent.targetQuery) as HTMLElement;
-        const targetBounds = targetElement.getBoundingClientRect();
-        const cutoutBounds = getCutoutBounds(targetBounds, targetElement);
+        let cutoutBounds: CutoutBounds;
+        if (targetContent.targetQuery === "nothing") {
+            cutoutBounds = {
+                top: window.innerHeight / 2,
+                bottom: 0,
+                left: window.innerWidth / 2,
+                right: 0,
+                width: 0,
+                height: 0
+            }
+        } else {
+            const targetElement = document.querySelector(targetContent.targetQuery) as HTMLElement;
+            const targetBounds = targetElement.getBoundingClientRect();
+            cutoutBounds = getCutoutBounds(targetBounds, targetElement);
+        }
         setCutout(cutoutBounds);
         setPosition(cutoutBounds, bubble, bubbleBounds, bubbleArrow, bubbleArrowOutline);
     }
@@ -161,14 +173,6 @@ export const TeachingBubble = (props: TeachingBubbleProps) => {
         if (activeTarget) {
             cutout.style.pointerEvents = "none";
         }
-    }
-
-    const clearCutout = () => {
-        const cutout = document.querySelector(".teaching-bubble-cutout") as HTMLElement;
-        cutout.style.top = "0px";
-        cutout.style.left = "0px";
-        cutout.style.width = "0px";
-        cutout.style.height = "0px";
     }
 
     const resetTryFit = () => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2795,7 +2795,7 @@ export class ProjectView
             .then(() => Util.delay(500))
             .finally(() => {
                 core.hideLoading("newproject");
-                if (options?.firstProject) {
+                if (options?.firstProject && pxt.appTarget.appTheme?.tours?.editor) {
                     this.showOnboarding();
                 }
             });

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2787,13 +2787,18 @@ export class ProjectView
         })
     }
 
-    newProject(options: ProjectCreationOptions = {}) {
+    newProject(options: ProjectCreationOptions = {}, isFirstProject?: boolean) {
         pxt.tickEvent("app.newproject");
         core.showLoading("newproject", lf("creating new project..."));
         return this.createProjectAsync(options)
             .then(() => this.autoChooseBoardAsync())
             .then(() => Util.delay(500))
-            .finally(() => core.hideLoading("newproject"));
+            .finally(() => {
+                core.hideLoading("newproject");
+                if (isFirstProject) {
+                    this.showOnboarding();
+                }
+            });
     }
 
     async createProjectAsync(options: ProjectCreationOptions): Promise<void> {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2787,7 +2787,7 @@ export class ProjectView
         })
     }
 
-    newProject(options: ProjectCreationOptions = {}, isFirstProject?: boolean) {
+    newProject(options: ProjectCreationOptions = {}) {
         pxt.tickEvent("app.newproject");
         core.showLoading("newproject", lf("creating new project..."));
         return this.createProjectAsync(options)
@@ -2795,7 +2795,7 @@ export class ProjectView
             .then(() => Util.delay(500))
             .finally(() => {
                 core.hideLoading("newproject");
-                if (isFirstProject) {
+                if (options?.firstProject) {
                     this.showOnboarding();
                 }
             });

--- a/webapp/src/onboarding.ts
+++ b/webapp/src/onboarding.ts
@@ -25,6 +25,9 @@ function getTargetMap(target: string): querySelector {
         },
         "everything" : {
             targetQuery: "#root",
+        },
+        "nothing" : {
+            targetQuery: "nothing",
         }
     }
     return targetMap[target];

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -614,16 +614,16 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
         return headers;
     }
 
-    newProject(isFirstProject?: boolean) {
+    newProject(firstProject?: boolean) {
         pxt.tickEvent("projects.new", undefined, { interactiveConsent: true });
         if (pxt.appTarget.appTheme.nameProjectFirst || pxt.appTarget.appTheme.chooseLanguageRestrictionOnNewProject) {
             this.props.parent.askForProjectCreationOptionsAsync()
                 .then(projectSettings => {
                     const { name, languageRestriction } = projectSettings
-                    this.props.parent.newProject({ name, languageRestriction }, isFirstProject);
+                    this.props.parent.newProject({ name, languageRestriction, firstProject });
                 })
         } else {
-            this.props.parent.newProject({}, isFirstProject);
+            this.props.parent.newProject({ firstProject });
         }
     }
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -570,7 +570,6 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
         this.closeDetail = this.closeDetail.bind(this);
         this.closeDetailOnEscape = this.closeDetailOnEscape.bind(this);
         this.reload = this.reload.bind(this);
-        this.newProject = this.newProject.bind(this);
         this.showScriptManager = this.showScriptManager.bind(this);
         this.handleCardClick = this.handleCardClick.bind(this);
     }
@@ -615,16 +614,16 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
         return headers;
     }
 
-    newProject() {
+    newProject(isFirstProject?: boolean) {
         pxt.tickEvent("projects.new", undefined, { interactiveConsent: true });
         if (pxt.appTarget.appTheme.nameProjectFirst || pxt.appTarget.appTheme.chooseLanguageRestrictionOnNewProject) {
             this.props.parent.askForProjectCreationOptionsAsync()
                 .then(projectSettings => {
                     const { name, languageRestriction } = projectSettings
-                    this.props.parent.newProject({ name, languageRestriction });
+                    this.props.parent.newProject({ name, languageRestriction }, isFirstProject);
                 })
         } else {
-            this.props.parent.newProject({});
+            this.props.parent.newProject({}, isFirstProject);
         }
     }
 
@@ -755,9 +754,10 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
             const headersToShow = headers
                 .filter(h => !h.tutorial?.metadata?.hideIteration)
                 .slice(0, ProjectsCarousel.NUM_PROJECTS_HOMESCREEN);
+            const isFirstProject = (!headers || headers?.length == 0);
             return <carousel.Carousel tickId="myprojects" bleedPercent={20}>
                 {showNewProject && <div role="button" className="ui card link buttoncard newprojectcard" title={lf("Creates a new empty project")}
-                    onClick={this.newProject} onKeyDown={fireClickOnEnter} >
+                    onClick={() => this.newProject(isFirstProject)} onKeyDown={fireClickOnEnter} >
                     <div className="content">
                         <sui.Icon icon="huge add circle" />
                         <span className="header">{lf("New Project")}</span>


### PR DESCRIPTION
Closes https://github.com/microsoft/pxt-microbit/issues/5149

This change will auto-start the editor tour when a user creates a new project and they have zero other projects. So, if you delete all your projects, the next project you open will trigger the tour again. The tour is also still available in the help menu.

This change depends on a change in pxt-microbit to add a welcome step to the editor tour markdown.

Here's a build: https://makecode.microbit.org/app/ae6a0123d79e5e04105f1a55ce497865d6942e07-a402fe3471
Note: The welcome step won't show up in the build since it's from the markdown in pxt-microbit and docs are live.

![autoStartTour](https://github.com/microsoft/pxt/assets/15070078/e2e39f48-4a1e-4df2-81d5-82f1ab048641)
