### PR TITLE
Fix Tempo in Melody Editor

### DIFF
--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -375,7 +375,7 @@ namespace pxtblockly {
             if (s.parentBlock_) {
                 const p = s.parentBlock_;
                 for (const input of p.inputList) {
-                    if (input.name === "tempo") {
+                    if (input.name === "tempo" || input.name === "bpm") {
                         const tempoBlock = input.connection.targetBlock();
                         if (tempoBlock) {
                             if (blockToEditor)


### PR DESCRIPTION
The tempo field wasn't syncing with the block correctly anymore. This was happening because, in the new block, the input field is called "bpm", not "tempo". Updated the sync code to account for both.

Upload Target: https://makecode.microbit.org/app/ac0f4fe2dc3372d752d581d359dc3294da026f15-80284e55a1

Fixes: https://github.com/microsoft/pxt-microbit/issues/5179