### PR TITLE
packetio expose deviceVariant, propagate to sim/flashing

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -475,6 +475,7 @@ declare namespace pxt {
         }
         tutorialSimSidebarLayout?: boolean; // Enable tutorial layout with the sim in the sidebar (desktop only)
         showOpenInVscode?: boolean; // show the open in VS Code button
+        matchWebUSBDeviceInSim?: boolean; // if set, pass current device id as theme to sim when available.
     }
 
     interface DownloadDialogTheme {

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -27,12 +27,12 @@ namespace pxt.commands {
     export let patchCompileResultAsync: (r: pxtc.CompileResult) => Promise<void> = undefined;
     export let browserDownloadAsync: (text: string, name: string, contentType: string) => Promise<void> = undefined;
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
-    export let renderBrowserDownloadInstructions: (saveonly?: boolean, redeploy?: () => Promise<void>) => any /* JSX.Element */ = undefined;
+    export let renderBrowserDownloadInstructions: (saveOnly?: boolean, redeploy?: () => Promise<void>) => any /* JSX.Element */ = undefined;
     export let renderUsbPairDialog: (firmwareUrl?: string, failedOnce?: boolean) => any /* JSX.Element */ = undefined;
     export let renderIncompatibleHardwareDialog: (unsupportedParts: string[]) => any /* JSX.Element */ = undefined;
     export let renderDisconnectDialog: () => { header: string, jsx: any, helpUrl: string }
-    export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>, saveonly?: boolean, redeploy?: () => Promise<void>) => Promise<void> = undefined;
-    export let showProgramTooLargeErrorAsync: (variants: string[], confirmAsync: (options: any) => Promise<number>, saveonly?: boolean) => Promise<RecompileOptions>;
+    export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>, saveOnly?: boolean, redeploy?: () => Promise<void>) => Promise<void> = undefined;
+    export let showProgramTooLargeErrorAsync: (variants: string[], confirmAsync: (options: any) => Promise<number>, saveOnly?: boolean) => Promise<RecompileOptions>;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts
     export let webUsbPairDialogAsync: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<WebUSBPairResult>, implicitlyCalled?: boolean) => Promise<WebUSBPairResult> = undefined;

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -32,7 +32,7 @@ namespace pxt.commands {
     export let renderIncompatibleHardwareDialog: (unsupportedParts: string[]) => any /* JSX.Element */ = undefined;
     export let renderDisconnectDialog: () => { header: string, jsx: any, helpUrl: string }
     export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>, saveonly?: boolean, redeploy?: () => Promise<void>) => Promise<void> = undefined;
-    export let showProgramTooLargeErrorAsync: (variants: string[], confirmAsync: (options: any) => Promise<number>) => Promise<RecompileOptions>;
+    export let showProgramTooLargeErrorAsync: (variants: string[], confirmAsync: (options: any) => Promise<number>, saveonly?: boolean) => Promise<RecompileOptions>;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts
     export let webUsbPairDialogAsync: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<WebUSBPairResult>, implicitlyCalled?: boolean) => Promise<WebUSBPairResult> = undefined;

--- a/pxtlib/packetio.ts
+++ b/pxtlib/packetio.ts
@@ -23,6 +23,8 @@ namespace pxt.packetio {
         // returns a list of part ids that are not supported by the connected hardware. currently
         // only used by pxt-microbit to warn users about v2 blocks on v1 hardware
         unsupportedParts?(): string[];
+        // the variant id for the currently connected device
+        devVariant?: string;
     }
 
     export interface PacketIO {
@@ -82,6 +84,10 @@ namespace pxt.packetio {
 
     export function unsupportedParts() {
         return wrapper?.unsupportedParts ? wrapper.unsupportedParts() : [];
+    }
+
+    export function deviceVariant() {
+        return wrapper?.devVariant;
     }
 
     let disconnectPromise: Promise<void>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3216,7 +3216,7 @@ export class ProjectView
 
                     if (noHexFileDiagnostic?.code === 9283 /*program too large*/ && pxt.commands.showProgramTooLargeErrorAsync) {
                         pxt.tickEvent("compile.programTooLargeDialog");
-                        const res = await pxt.commands.showProgramTooLargeErrorAsync(pxt.appTarget.multiVariants, core.confirmAsync);
+                        const res = await pxt.commands.showProgramTooLargeErrorAsync(pxt.appTarget.multiVariants, core.confirmAsync, saveOnly);
                         if (res?.recompile) {
                             pxt.tickEvent("compile.programTooLargeDialog.recompile");
                             const oldVariants = pxt.appTarget.multiVariants;

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -330,7 +330,7 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
         ipc: isIpcRenderer,
         dependencies,
         activePlayer: playerNumber,
-        theme: pkg.config.theme,
+        theme: pkg.config.theme || (pxt.appTarget.appTheme.matchWebUSBDeviceInSim && pxt.packetio.deviceVariant()),
     }
     //if (pxt.options.debug)
     //    pxt.debug(JSON.stringify(opts, null, 2))


### PR DESCRIPTION
for skipping over 'too big for v1' modal on v2.

Also included a flag to pass it as the theme if that is not explicitly defined for the project (same field I use in arcade for e.g. zune), since I realized that was easy to address https://github.com/microsoft/pxt-microbit/issues/4724 with this field anyways

For ref i added devVariant over in microbits packetio wrapper implementation https://github.com/microsoft/pxt-microbit/blob/a0d6ca1b5d1c33386d6374101dbcdbd5bd25f36a/editor/flash.ts#L248, this is exposing it on the wrapper interface / using it from the existing implementation