### PR TITLE
Ignore invalid locales files in extensions

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -969,11 +969,11 @@ namespace pxt {
             const files = this.config.files;
 
             let fn = `_locales/${initialLang}/${filename}-strings.json`;
-            if (files.indexOf(fn) === -1){
+            if (initialLangLowerCase && files.indexOf(fn) === -1) {
                 fn = `_locales/${initialLangLowerCase}/${filename}-strings.json`;
-                if (files.indexOf(fn) === -1) {
-                    fn = `_locales/${baseLang}/${filename}-strings.json`;
-                }
+            }
+            if (baseLang && files.indexOf(fn) === -1) {
+                fn = `_locales/${baseLang}/${filename}-strings.json`;
             }
 
             if (files.indexOf(fn) > -1) {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -980,7 +980,18 @@ namespace pxt {
                 try {
                     r = JSON.parse(this.readFile(fn));
                 } catch (e) {
-                    pxt.log(`Failed to parse ${fn}`);
+                    pxt.reportError("extension", "Extension localization JSON failed to parse", {
+                        fileName: fn,
+                        lang: lang,
+                        extension: this.verArgument(),
+                    });
+                    const isGithubRepo = this.verProtocol() === "github";
+                    if (isGithubRepo) {
+                        pxt.tickEvent("loc.errors.json", {
+                            repo: this.verArgument(),
+                            file: fn,
+                        });
+                    }
                 }
             }
 

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -969,20 +969,21 @@ namespace pxt {
             const files = this.config.files;
 
             let fn = `_locales/${initialLang}/${filename}-strings.json`;
-            if (files.indexOf(fn) > -1) {
-                r = JSON.parse(this.readFile(fn)) as Map<string>;
-            }
-            else if (initialLangLowerCase) {
+            if (files.indexOf(fn) === -1){
                 fn = `_locales/${initialLangLowerCase}/${filename}-strings.json`;
-                if (files.indexOf(fn) > -1)
-                    r = JSON.parse(this.readFile(fn)) as Map<string>;
-                else if (baseLang) {
+                if (files.indexOf(fn) === -1) {
                     fn = `_locales/${baseLang}/${filename}-strings.json`;
-                    if (files.indexOf(fn) > -1) {
-                        r = JSON.parse(this.readFile(fn)) as Map<string>;
-                    }
                 }
             }
+
+            if (files.indexOf(fn) > -1) {
+                try {
+                    r = JSON.parse(this.readFile(fn));
+                } catch (e) {
+                    pxt.log(`Failed to parse ${fn}`);
+                }
+            }
+
             return r;
         }
     }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -764,8 +764,13 @@ namespace ts.pxtc {
                     updateBlockDef(fn.attributes);
                     const locps = pxt.blocks.compileInfo(fn);
                     if (!hasEquivalentParameters(ps, locps)) {
-                        pxt.log(`block has non matching arguments: ${oldBlock} vs ${fn.attributes.block}`);
-                        pxt.reportError(`loc.errors`, `invalid translations`, {
+                        pxt.reportError("loc.errors", "block has non matching arguments", {
+                            block: fn.attributes.blockId,
+                            lang: lang,
+                            originalDefinition: oldBlock,
+                            translatedBlock: fn.attributes.block,
+                        });
+                        pxt.tickEvent("loc.errors", {
                             block: fn.attributes.blockId,
                             lang: lang,
                         });


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/5186; we should not crash when loading extensions with invalid localization files; just ignore them. (if we want I can walk up the loading path here a bit and find a place to place to catch more broadly, but I don't see errors here often / feels like something we can do later as clean up, probably go to an "extension failed to load" dialog of something?).

@abchatra not sure if we'd care about ticks for this, as it should only really apply to third party extensions? I left it as just a log for now similar to the existing 'ignored translations' logic without the `reportError` https://github.com/microsoft/pxt/blob/ignoreInvalidLocalesFiles/pxtlib/service.ts#L767 so extension developers can check that without a tick for that reason, happy to add one in though if you want it tracked.

test build: https://makecode.microbit.org/app/8b8692a266bacc35344bdf582a3e39fa2cd76f22-9a85c1acb4