### PR TITLE
Make Top-Instructions Resizable

### DIFF
--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+import { classList, ContainerProps } from "../util";
+
+export interface VerticalResizeContainerProps extends ContainerProps {
+    minHeight?: string;
+    maxHeight?: string;
+    heightProperty?: string;
+    style?: any;
+    onResizeDrag?: () => void;
+    onResizeEnd?: () => void;
+}
+
+export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => {
+    const {
+        id,
+        className,
+        ariaDescribedBy,
+        ariaHidden,
+        ariaLabel,
+        minHeight,
+        maxHeight,
+        heightProperty,
+        onResizeDrag,
+        onResizeEnd,
+        style,
+        children
+    } = props;
+
+    const RESIZABLE_BORDER_SIZE = 4;
+
+    const containerRef: React.MutableRefObject<HTMLDivElement> = React.useRef(undefined);
+
+    const resize = (e: React.MouseEvent | MouseEvent) => {
+        const containerEl: HTMLDivElement = document.querySelector(`#${id}`);
+
+        containerEl.style.setProperty(
+            heightProperty,
+            `max(min(${maxHeight}, ${e.pageY - containerEl.offsetTop}px), ${minHeight})`
+        );
+        e.preventDefault();
+        e.stopPropagation();
+
+        if(onResizeDrag) {
+            onResizeDrag();
+        }
+    }
+
+    const cleanEvents = () => {
+        document.removeEventListener("pointermove", resize, false);
+        document.removeEventListener("pointerup", cleanEvents, false);
+        document.querySelector("body")?.classList.remove("cursor-resize");
+        
+        if(onResizeEnd) {
+            onResizeEnd();
+        }
+    }
+
+    React.useEffect(() => cleanEvents, []);
+
+    const onPointerDown = (e: React.MouseEvent) => {
+        const computedStyle = getComputedStyle(containerRef?.current);
+        const containerHeight = parseInt(computedStyle.height) - parseInt(computedStyle.borderWidth);
+        if (e.nativeEvent.offsetY > containerHeight - RESIZABLE_BORDER_SIZE - 4) {
+            document.querySelector("body")?.classList.add("cursor-resize");
+            document.addEventListener("pointermove", resize, false);
+            document.addEventListener("pointerup", cleanEvents, false);
+        }
+    }
+
+    return <div
+        id={id}
+        ref={containerRef}
+        className={classList("vertical-resize-container", className)}
+        aria-describedby={ariaDescribedBy}
+        aria-hidden={ariaHidden}
+        aria-label={ariaLabel}
+        onPointerDown={onPointerDown}
+        style={style}>
+            {children}
+    </div>
+}

--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -4,11 +4,10 @@ import { classList, ContainerProps } from "../util";
 export interface VerticalResizeContainerProps extends ContainerProps {
     minHeight?: string;
     maxHeight?: string;
-    style?: any;
+    initialHeight?: string;
     resizeEnabled?: boolean;
-    heightProperty?: string;
     onResizeDrag?: (newSize: number) => void;
-    onResizeEnd?: () => void;
+    onResizeEnd?: (newSize: number) => void;
 }
 
 export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => {
@@ -20,30 +19,34 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         ariaLabel,
         minHeight,
         maxHeight,
-        style,
+        initialHeight,
         children,
         resizeEnabled,
         onResizeDrag,
         onResizeEnd
     } = props;
-    const heightProperty = props.heightProperty ? props.heightProperty : `--${id}-height`;
 
     const RESIZABLE_BORDER_SIZE = 4;
     const containerRef: React.MutableRefObject<HTMLDivElement> = React.useRef(undefined);
+    const heightProperty = `--${id}-height`;
+    let [hasResized, setHasResized] = React.useState(false);
 
     const resize = (e: React.MouseEvent | MouseEvent) => {
-        const containerEl: HTMLDivElement = document.querySelector(`#${id}`);
+        const containerEl: HTMLDivElement = document.querySelector(`#${id}`); // TODO thsparks : Move this out?
 
         containerEl.style.setProperty(
             heightProperty,
             `max(min(${maxHeight}, ${e.pageY - containerEl.offsetTop}px), ${minHeight})`
         );
-        e.preventDefault();
-        e.stopPropagation();
 
         if (onResizeDrag) {
             onResizeDrag(containerEl.clientHeight);
         }
+
+        setHasResized(true);
+
+        e.preventDefault();
+        e.stopPropagation();
     }
 
     const cleanEvents = () => {
@@ -52,7 +55,8 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         document.querySelector("body")?.classList.remove("cursor-resize");
         
         if (onResizeEnd) {
-            onResizeEnd();
+            const containerEl: HTMLDivElement = document.querySelector(`#${id}`); // TODO thsparks : Move this out?
+            onResizeEnd(containerEl.clientHeight);
         }
     }
 
@@ -80,7 +84,7 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         aria-hidden={ariaHidden}
         aria-label={ariaLabel}
         onPointerDown={onPointerDown}
-        style={style}>
+        style={{height: hasResized ? `var(${heightProperty})` : initialHeight}}>
             {children}
     </div>
 }

--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -34,10 +34,11 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
     let [hasResized, setHasResized] = React.useState(false);
 
     const resize = (e: React.MouseEvent | MouseEvent) => {
-        containerEl.style.setProperty(
-            heightProperty,
-            `max(min(${maxHeight}, ${e.pageY - containerEl.offsetTop}px), ${minHeight})`
-        );
+        let heightVal = `${e.pageY - containerEl.offsetTop}px`;
+        if (maxHeight) heightVal = `min(${maxHeight}, ${heightVal})`;
+        if(minHeight) heightVal = `max(${minHeight}, ${heightVal})`;
+
+        containerEl.style.setProperty(heightProperty, heightVal);
 
         if (onResizeDrag) {
             onResizeDrag(containerEl.clientHeight);
@@ -49,17 +50,19 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         e.stopPropagation();
     }
 
-    const cleanEvents = () => {
+    const onPointerUp = () => {
+        // Clean resize events
         document.removeEventListener("pointermove", resize, false);
-        document.removeEventListener("pointerup", cleanEvents, false);
+        document.removeEventListener("pointerup", onPointerUp, false);
         document.querySelector("body")?.classList.remove("cursor-resize");
-        
+
+        // Notify resize end
         if (onResizeEnd) {
             onResizeEnd(containerEl.clientHeight);
         }
     }
 
-    React.useEffect(() => cleanEvents, []);
+    React.useEffect(() => onPointerUp, []);
 
     const onPointerDown = (e: React.MouseEvent) => {
         if (!resizeEnabled) {
@@ -71,7 +74,7 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         if (e.nativeEvent.offsetY > containerHeight - RESIZABLE_BORDER_SIZE - 4) {
             document.querySelector("body")?.classList.add("cursor-resize");
             document.addEventListener("pointermove", resize, false);
-            document.addEventListener("pointerup", cleanEvents, false);
+            document.addEventListener("pointerup", onPointerUp, false);
         }
     }
 

--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -36,7 +36,7 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
     const resize = (e: React.MouseEvent | MouseEvent) => {
         let heightVal = `${e.pageY - containerEl.offsetTop}px`;
         if (maxHeight) heightVal = `min(${maxHeight}, ${heightVal})`;
-        if(minHeight) heightVal = `max(${minHeight}, ${heightVal})`;
+        if (minHeight) heightVal = `max(${minHeight}, ${heightVal})`;
 
         containerEl.style.setProperty(heightProperty, heightVal);
 

--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -4,10 +4,10 @@ import { classList, ContainerProps } from "../util";
 export interface VerticalResizeContainerProps extends ContainerProps {
     minHeight?: string;
     maxHeight?: string;
-    heightProperty?: string;
     style?: any;
     resizeEnabled?: boolean;
-    onResizeDrag?: () => void;
+    heightProperty?: string;
+    onResizeDrag?: (newSize: number) => void;
     onResizeEnd?: () => void;
 }
 
@@ -20,16 +20,15 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         ariaLabel,
         minHeight,
         maxHeight,
-        heightProperty,
         style,
         children,
         resizeEnabled,
         onResizeDrag,
         onResizeEnd
     } = props;
+    const heightProperty = props.heightProperty ? props.heightProperty : `--${id}-height`;
 
     const RESIZABLE_BORDER_SIZE = 4;
-
     const containerRef: React.MutableRefObject<HTMLDivElement> = React.useRef(undefined);
 
     const resize = (e: React.MouseEvent | MouseEvent) => {
@@ -43,7 +42,7 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         e.stopPropagation();
 
         if (onResizeDrag) {
-            onResizeDrag();
+            onResizeDrag(containerEl.clientHeight);
         }
     }
 

--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -29,11 +29,11 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
     const RESIZABLE_BORDER_SIZE = 4;
     const containerRef: React.MutableRefObject<HTMLDivElement> = React.useRef(undefined);
     const heightProperty = `--${id}-height`;
+    const containerEl: HTMLDivElement = document.querySelector(`#${id}`); // TODO thsparks : Move this out?
+
     let [hasResized, setHasResized] = React.useState(false);
 
     const resize = (e: React.MouseEvent | MouseEvent) => {
-        const containerEl: HTMLDivElement = document.querySelector(`#${id}`); // TODO thsparks : Move this out?
-
         containerEl.style.setProperty(
             heightProperty,
             `max(min(${maxHeight}, ${e.pageY - containerEl.offsetTop}px), ${minHeight})`
@@ -55,7 +55,6 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         document.querySelector("body")?.classList.remove("cursor-resize");
         
         if (onResizeEnd) {
-            const containerEl: HTMLDivElement = document.querySelector(`#${id}`); // TODO thsparks : Move this out?
             onResizeEnd(containerEl.clientHeight);
         }
     }

--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -6,6 +6,7 @@ export interface VerticalResizeContainerProps extends ContainerProps {
     maxHeight?: string;
     heightProperty?: string;
     style?: any;
+    resizeEnabled?: boolean;
     onResizeDrag?: () => void;
     onResizeEnd?: () => void;
 }
@@ -20,10 +21,11 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         minHeight,
         maxHeight,
         heightProperty,
-        onResizeDrag,
-        onResizeEnd,
         style,
-        children
+        children,
+        resizeEnabled,
+        onResizeDrag,
+        onResizeEnd
     } = props;
 
     const RESIZABLE_BORDER_SIZE = 4;
@@ -40,7 +42,7 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         e.preventDefault();
         e.stopPropagation();
 
-        if(onResizeDrag) {
+        if (onResizeDrag) {
             onResizeDrag();
         }
     }
@@ -50,7 +52,7 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         document.removeEventListener("pointerup", cleanEvents, false);
         document.querySelector("body")?.classList.remove("cursor-resize");
         
-        if(onResizeEnd) {
+        if (onResizeEnd) {
             onResizeEnd();
         }
     }
@@ -58,6 +60,10 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
     React.useEffect(() => cleanEvents, []);
 
     const onPointerDown = (e: React.MouseEvent) => {
+        if (!resizeEnabled) {
+            return;
+        }
+
         const computedStyle = getComputedStyle(containerRef?.current);
         const containerHeight = parseInt(computedStyle.height) - parseInt(computedStyle.borderWidth);
         if (e.nativeEvent.offsetY > containerHeight - RESIZABLE_BORDER_SIZE - 4) {
@@ -70,7 +76,7 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
     return <div
         id={id}
         ref={containerRef}
-        className={classList("vertical-resize-container", className)}
+        className={classList(resizeEnabled ? "vertical-resize-container" : "", className)}
         aria-describedby={ariaDescribedBy}
         aria-hidden={ariaHidden}
         aria-label={ariaLabel}

--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -29,7 +29,7 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
     const RESIZABLE_BORDER_SIZE = 4;
     const containerRef: React.MutableRefObject<HTMLDivElement> = React.useRef(undefined);
     const heightProperty = `--${id}-height`;
-    const containerEl: HTMLDivElement = document.querySelector(`#${id}`); // TODO thsparks : Move this out?
+    const containerEl: HTMLDivElement = document.querySelector(`#${id}`);
 
     let [hasResized, setHasResized] = React.useState(false);
 

--- a/react-common/styles/controls/VerticalResizeContainer.less
+++ b/react-common/styles/controls/VerticalResizeContainer.less
@@ -1,0 +1,18 @@
+.cursor-resize {
+    cursor: ns-resize !important;
+    #editorSidebar::after {
+        background-color: @green;
+    }
+}
+
+.vertical-resize-container {
+    &::after {
+        content: "";
+        background-color: darken(desaturate(@editorToolsBackground, 60%), 10%);
+        position: absolute;
+        bottom: 0;
+        width: 100%;
+        height: 4px;
+        cursor: ns-resize;
+    }
+}

--- a/react-common/styles/react-common.less
+++ b/react-common/styles/react-common.less
@@ -20,6 +20,7 @@
 @import "controls/RadioButtonGroup.less";
 @import "controls/Spinner.less";
 @import "controls/Textarea.less";
+@import "controls/VerticalResizeContainer.less";
 @import "./react-common-variables.less";
 
 @import "fontawesome-free/less/solid.less";

--- a/theme/common.less
+++ b/theme/common.less
@@ -2219,6 +2219,7 @@ p.ui.font.small {
     max-width: 100%;
     min-width: 100%;
     height:100%;
+    --tutorialCalloutTop: 15rem;
 }
 
 .simView #boardview {

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -699,7 +699,7 @@
 
     .editor-sidebar {
         border-right: 0;
-        border-bottom: 2px solid darken(desaturate(@blocklyToolboxColor, 60%), 10%);
+        border-bottom: 0;
     }
 
     .tutorial-container-outer {

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -812,7 +812,7 @@
         .tutorial-callout {
             bottom: unset;
             left: unset;
-            top: 15rem;
+            top: var(--tutorialCalloutTop);
             max-width: 80%;
             transform: translateY(15px);
         }
@@ -1043,7 +1043,7 @@
         
         .tutorial-callout {
             right: unset;
-            top: 15rem;
+            top: var(--tutorialCalloutTop);
             bottom: unset;
             left: unset;
         }

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -65,11 +65,16 @@ export function TutorialContainer(props: TutorialContainerProps) {
     }, [document.body])
 
     React.useEffect(() => {
-        const parentObserver = new ResizeObserver(() => {
-            updateScrollGradient();
-         });
-         parentObserver.observe(document.querySelector("#tutorialWrapper"));
-         return () => parentObserver.disconnect();
+        const parent = document.querySelector("#tutorialWrapper");
+        if (parent) {
+            const parentObserver = new ResizeObserver(() => {
+                updateScrollGradient();
+             });
+             parentObserver.observe(parent);
+             return () => parentObserver.disconnect();
+        }
+
+        return null;
      });
 
     React.useEffect(() => {

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -62,21 +62,15 @@ export function TutorialContainer(props: TutorialContainerProps) {
             updateScrollGradient();
         });
         observer.observe(document.body)
-        return () => observer.disconnect();
-    }, [document.body])
 
-    React.useEffect(() => {
+        // We also want to update the scroll gradient if the tutorial wrapper is resized by the user.
         const parent = document.querySelector("#tutorialWrapper");
         if (parent) {
-            const parentObserver = new ResizeObserver(() => {
-                updateScrollGradient();
-             });
-             parentObserver.observe(parent);
-             return () => parentObserver.disconnect();
+            observer.observe(parent);
         }
 
-        return null;
-     });
+        return () => observer.disconnect();
+    }, [document.body])
 
     React.useEffect(() => {
         if (props.hasBeenResized) {

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -65,6 +65,14 @@ export function TutorialContainer(props: TutorialContainerProps) {
     }, [document.body])
 
     React.useEffect(() => {
+        const parentObserver = new ResizeObserver(() => {
+            updateScrollGradient();
+         });
+         parentObserver.observe(document.querySelector("#tutorialWrapper"));
+         return () => parentObserver.disconnect();
+     });
+
+    React.useEffect(() => {
         if (isHorizontal) {
             let scrollHeight = 0;
             const children = contentRef?.current?.children ? pxt.Util.toArray(contentRef?.current?.children) : [];

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -20,6 +20,7 @@ interface TutorialContainerProps {
     hideIteration?: boolean;
     hasTemplate?: boolean;
     preferredEditor?: string;
+    hasBeenResized?: boolean;
 
     tutorialOptions?: pxt.tutorial.TutorialOptions; // TODO (shakao) pass in only necessary subset
     tutorialSimSidebar?: boolean;
@@ -78,6 +79,10 @@ export function TutorialContainer(props: TutorialContainerProps) {
      });
 
     React.useEffect(() => {
+        if (props.hasBeenResized) {
+            return;
+        }
+
         if (isHorizontal) {
             let scrollHeight = 0;
             const children = contentRef?.current?.children ? pxt.Util.toArray(contentRef?.current?.children) : [];

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -119,7 +119,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     }
 
     protected setComponentHeight = (height?: number) => {
-        if(this.state.resized) return; // Preserve user-set height.
+        if (this.state.resized) return; // Preserve user-set height.
         
         const tutorialWrapper: HTMLDivElement = document.querySelector(`#tutorialWrapper`);
         var currentHeight = tutorialWrapper?.style.getPropertyValue(this.heightVar);
@@ -197,6 +197,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                         maxHeight="500px"
                         minHeight="100px"
                         heightProperty={this.heightVar}  // TODO thsparks - can this just be pushed into the div inside the container? Maybe bring back default height logic?
+                        resizeEnabled={pxt.BrowserUtils.isTabletSize() || this.props.tutorialSimSidebar}
                         onResizeDrag={this.onResizeDrag}>
                         <TutorialContainer
                             parent={parent}

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -120,6 +120,11 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     protected setComponentHeight = (height?: number, isResize?: boolean) => {
         if (this.state.height != height || this.state.resized != isResize) {
             this.setState({resized: this.state.resized || isResize, height: height});
+
+            this.simPanelRef.style.setProperty(
+                "--tutorialCalloutTop",
+                `${height}px`
+            );
         }
     }
 

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -14,8 +14,8 @@ import { TutorialContainer } from "./components/tutorial/TutorialContainer";
 import { fireClickOnEnter } from "./util";
 import { VerticalResizeContainer } from '../../react-common/components/controls/VerticalResizeContainer'
 
+// TODO thsparks : Remove if not needed
 interface SidepanelState {
-    resized?: boolean;
 }
 
 interface SidepanelProps extends pxt.editor.ISettingsProps {
@@ -113,19 +113,12 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         }
     }
 
-    protected onResizeDrag = () => {
-        this.setState({resized: true});
-        this.props.setEditorOffset();
-    }
-
-    protected setComponentHeight = (height?: number) => {
-        if (this.state.resized) return; // Preserve user-set height.
-        
-        const tutorialWrapper: HTMLDivElement = document.querySelector(`#tutorialWrapper`);
-        var currentHeight = tutorialWrapper?.style.getPropertyValue(this.heightVar);
-        var newHeight = `${height}px`;
+    protected setComponentHeight = (height?: number) => {        
+        const wrapperEl: HTMLDivElement = document.querySelector(`#simulator`);
+        var currentHeight = wrapperEl?.style.getPropertyValue(this.heightVar);
+        var newHeight = height ? `${height}px` : undefined;
         if (currentHeight != newHeight) {
-            tutorialWrapper.style.setProperty(
+            wrapperEl.style.setProperty(
                 this.heightVar,
                 newHeight
             );
@@ -198,7 +191,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                         minHeight="100px"
                         heightProperty={this.heightVar}  // TODO thsparks - can this just be pushed into the div inside the container? Maybe bring back default height logic?
                         resizeEnabled={pxt.BrowserUtils.isTabletSize() || this.props.tutorialSimSidebar}
-                        onResizeDrag={this.onResizeDrag}>
+                        onResizeDrag={this.setComponentHeight}>
                         <TutorialContainer
                             parent={parent}
                             tutorialId={tutorialOptions.tutorial}

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -14,8 +14,8 @@ import { TutorialContainer } from "./components/tutorial/TutorialContainer";
 import { fireClickOnEnter } from "./util";
 import { VerticalResizeContainer } from '../../react-common/components/controls/VerticalResizeContainer'
 
-// TODO thsparks : Remove if not needed
 interface SidepanelState {
+    resized?: boolean;
 }
 
 interface SidepanelProps extends pxt.editor.ISettingsProps {
@@ -113,7 +113,15 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         }
     }
 
-    protected setComponentHeight = (height?: number) => {        
+    protected onResizeDrag = (newSize: number) => {
+        if (!this.state.resized) { 
+            this.setState({resized: true});
+        }
+
+        this.setComponentHeight(newSize);
+    }
+
+    protected setComponentHeight = (height?: number) => {
         const wrapperEl: HTMLDivElement = document.querySelector(`#simulator`);
         var currentHeight = wrapperEl?.style.getPropertyValue(this.heightVar);
         var newHeight = height ? `${height}px` : undefined;
@@ -191,7 +199,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                         minHeight="100px"
                         heightProperty={this.heightVar}  // TODO thsparks - can this just be pushed into the div inside the container? Maybe bring back default height logic?
                         resizeEnabled={pxt.BrowserUtils.isTabletSize() || this.props.tutorialSimSidebar}
-                        onResizeDrag={this.setComponentHeight}>
+                        onResizeDrag={this.onResizeDrag}>
                         <TutorialContainer
                             parent={parent}
                             tutorialId={tutorialOptions.tutorial}
@@ -203,6 +211,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                             hasTemplate={!!tutorialOptions.templateCode}
                             preferredEditor={tutorialOptions.metadata?.preferredEditor}
                             tutorialSimSidebar={this.props.tutorialSimSidebar}
+                            hasBeenResized={this.state.resized}
                             onTutorialStepChange={onTutorialStepChange}
                             onTutorialComplete={onTutorialComplete}
                             setParentHeight={this.setComponentHeight} />

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -118,7 +118,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     }
 
     protected setComponentHeight = (height?: number, isResize?: boolean) => {
-        if(this.state.height != height || this.state.resized != isResize) {
+        if (this.state.height != height || this.state.resized != isResize) {
             this.setState({resized: this.state.resized || isResize, height: height});
         }
     }

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -51,10 +51,6 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         }
     }
 
-    componentDidUpdate(props: SidepanelProps, state: SidepanelState) {
-        if ((this.state.height || state.height) && this.state.height != state.height) this.props.setEditorOffset();
-    }
-
     UNSAFE_componentWillReceiveProps(props: SidepanelProps) {
         // This is necessary because we are not properly mounting and
         // unmounting the component as we enter/exit the editor. We
@@ -70,6 +66,10 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         ) {
             this.showSimulator();
         }
+    }
+
+    componentDidUpdate(props: SidepanelProps, state: SidepanelState) {
+        if ((this.state.height || state.height) && this.state.height != state.height) this.props.setEditorOffset();
     }
 
     protected tryShowSimulator = () => {
@@ -118,7 +118,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     }
 
     protected setComponentHeight = (height?: number, isResize?: boolean) => {
-        if (this.state.height != height || this.state.resized != isResize) {
+        if (height != this.state.height || isResize != this.state.resized) {
             this.setState({resized: this.state.resized || isResize, height: height});
 
             this.simPanelRef.style.setProperty(


### PR DESCRIPTION
This makes the instructions resizable (when in the top-instructions view). I created a new `VerticalResizeContainer` so it will _theoretically_ be easier to make similar changes easier in the future, if we decide to make other components resizable. (I did consider adding horizontal resizing too, but since it's not needed for this change, I decided to hold off. Can be added later if/when we need it.)

The change is primarily based on @jwunderl's https://github.com/microsoft/pxt/pull/9102.

Try it here: https://makecode.microbit.org/app/c07cbb23d6fd576dccb1afa91e15a1566e0a2c68-80c4cf5b23

Fixes https://github.com/microsoft/pxt-microbit/issues/5024

![ResizeInstructions](https://github.com/microsoft/pxt/assets/69657545/f8179ad5-ba8a-4c11-a109-1711da203a61)
