### PR TITLE
Enable editor tour for monaco

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -77,7 +77,7 @@ export class DocsMenu extends data.PureComponent<DocsMenuProps, {}> {
         const targetTheme = pxt.appTarget.appTheme;
         return <sui.DropdownMenu role="menuitem" icon="help circle large"
             className="item mobile hide help-dropdown-menuitem" textClass={"landscape only"} title={lf("Help")} >
-            {(this.props.editor === "Blocks") && targetTheme.tours?.editor && getTourItem(parent)}
+            {targetTheme.tours?.editor && getTourItem(parent)}
             {renderDocItems(parent, targetTheme.docMenu)}
             {getDocsLanguageItem(this.props.editor, parent)}
         </sui.DropdownMenu>

--- a/webapp/src/onboarding.ts
+++ b/webapp/src/onboarding.ts
@@ -12,10 +12,16 @@ function getTargetMap(target: string): querySelector {
         "toolbox": {
             targetQuery: ".blocklyToolboxDiv",
         },
+        "monaco toolbox": {
+            targetQuery: ".monacoToolboxDiv",
+        },
         "workspace": {
             targetQuery: "#blocksEditor", // includes the toolbox
             sansQuery: ".blocklyToolboxDiv",
             sansLocation: pxt.tour.BubbleLocation.Left
+        },
+        "monaco workspace": {
+            targetQuery: "#monacoEditorRightArea",
         },
         "share": {
             targetQuery: ".shareproject",
@@ -53,7 +59,7 @@ export async function parseTourStepsAsync(name: string): Promise<pxt.tour.Bubble
                 console.log(`Tour steps: "${step.attributes.highlight}" is not a valid element to highlight!`);
             } else if (querySelector.targetQuery !== "nothing") {   // check that element is visible before adding to tour
                 const target = document.querySelector(querySelector.targetQuery) as HTMLElement;
-                if (window.getComputedStyle(target).display === "none" || target.offsetParent === null) continue;
+                if (!target || target.offsetParent === null || window.getComputedStyle(target).display === "none") continue;
             }
             const targetQuery = querySelector.targetQuery;
             const sansQuery = querySelector.sansQuery ?? undefined;


### PR DESCRIPTION
This PR enables the editor tour for JavaScript and Python. (The steps will be added in the markdown file in pxt-microbit.) Closes https://github.com/microsoft/pxt-microbit/issues/5187.

It also checks whether the element is visible before adding it to the tour, which fixes https://github.com/microsoft/pxt-microbit/issues/5190.

![tour-monaco](https://github.com/microsoft/pxt/assets/15070078/622467e0-0638-4c89-83e5-2e641794c62e)
