### PR TITLE
Fix Python Over-Indenting 

### DIFF
--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -1290,7 +1290,7 @@ namespace pxt.py {
         }
         function emitMultiLnStrLitExp(s: ts.NoSubstitutionTemplateLiteral | ts.TaggedTemplateExpression): ExpRes {
             if (ts.isNoSubstitutionTemplateLiteral(s)) {
-                return asExpRes(`"""\n${indent1(s.text.trim())}\n"""`)
+                return asExpRes(`"""${s.text.split('\n').map(x => indent1(x.trim())).join('\n')}"""`)
             }
 
             let [tag, tagSup] = emitExp(s.tag)

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -1290,7 +1290,8 @@ namespace pxt.py {
         }
         function emitMultiLnStrLitExp(s: ts.NoSubstitutionTemplateLiteral | ts.TaggedTemplateExpression): ExpRes {
             if (ts.isNoSubstitutionTemplateLiteral(s)) {
-                return asExpRes(`"""${s.text.split('\n').map(x => indent1(x.trim())).join('\n')}"""`)
+                // manually perform indent1(), trimming existing indentation for multiline strings.
+                return asExpRes(`"""${s.text.split('\n').map(x => `${INDENT}${x.trim()}`).join('\n')}"""`)
             }
 
             let [tag, tagSup] = emitExp(s.tag)

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -1291,7 +1291,7 @@ namespace pxt.py {
         function emitMultiLnStrLitExp(s: ts.NoSubstitutionTemplateLiteral | ts.TaggedTemplateExpression): ExpRes {
             if (ts.isNoSubstitutionTemplateLiteral(s)) {
                 // manually perform indent1(), trimming existing indentation for multiline strings.
-                return asExpRes(`"""${s.text.split('\n').map(x => `${INDENT}${x.trim()}`).join('\n')}"""`)
+                return asExpRes(`"""\n${s.text.trim().split('\n').map(x => `${INDENT}${x.trim()}`).join('\n')}\n${INDENT}"""`)
             }
 
             let [tag, tagSup] = emitExp(s.tag)

--- a/tests/pydecompile-test/baselines/indentation.py
+++ b/tests/pydecompile-test/baselines/indentation.py
@@ -1,0 +1,19 @@
+mySprite = sprites.create(img("""    
+        . . . . . . . e c 7 . . . . . .
+        . . . . e e e c 7 7 e e . . . .
+        . . c e e e e c 7 e 2 2 e e . .
+        . c e e e e e c 6 e e 2 2 2 e .
+        . c e e e 2 e c c 2 4 5 4 2 e .
+        c e e e 2 2 2 2 2 2 4 5 5 2 2 e
+        c e e 2 2 2 2 2 2 2 2 4 4 2 2 e
+        c e e 2 2 2 2 2 2 2 2 2 2 2 2 e
+        c e e 2 2 2 2 2 2 2 2 2 2 2 2 e
+        c e e 2 2 2 2 2 2 2 2 2 2 2 2 e
+        c e e 2 2 2 2 2 2 2 2 2 2 4 2 e
+        . e e e 2 2 2 2 2 2 2 2 2 4 e .
+        . 2 e e 2 2 2 2 2 2 2 2 4 2 e .
+        . . 2 e e 2 2 2 2 2 4 4 2 e . .
+        . . . 2 2 e e 4 4 4 2 e e . . .
+        . . . . . 2 2 e e e e . . . . .
+        """),
+    SpriteKind.player)

--- a/tests/pydecompile-test/baselines/indentation.py
+++ b/tests/pydecompile-test/baselines/indentation.py
@@ -1,19 +1,7 @@
-mySprite = sprites.create(img("""    
-        . . . . . . . e c 7 . . . . . .
-        . . . . e e e c 7 7 e e . . . .
-        . . c e e e e c 7 e 2 2 e e . .
-        . c e e e e e c 6 e e 2 2 2 e .
-        . c e e e 2 e c c 2 4 5 4 2 e .
-        c e e e 2 2 2 2 2 2 4 5 5 2 2 e
-        c e e 2 2 2 2 2 2 2 2 4 4 2 2 e
-        c e e 2 2 2 2 2 2 2 2 2 2 2 2 e
-        c e e 2 2 2 2 2 2 2 2 2 2 2 2 e
-        c e e 2 2 2 2 2 2 2 2 2 2 2 2 e
-        c e e 2 2 2 2 2 2 2 2 2 2 4 2 e
-        . e e e 2 2 2 2 2 2 2 2 2 4 e .
-        . 2 e e 2 2 2 2 2 2 2 2 4 2 e .
-        . . 2 e e 2 2 2 2 2 4 4 2 e . .
-        . . . 2 2 e e 4 4 4 2 e e . . .
-        . . . . . 2 2 e e e e . . . . .
-        """),
-    SpriteKind.player)
+basic.show_leds("""
+    # . . . .
+    . . . . .
+    . . . . .
+    . . . . .
+    . . . . #
+    """)

--- a/tests/pydecompile-test/cases/indentation.ts
+++ b/tests/pydecompile-test/cases/indentation.ts
@@ -1,0 +1,18 @@
+let mySprite = sprites.create(img`
+    . . . . . . . e c 7 . . . . . . 
+    . . . . e e e c 7 7 e e . . . . 
+    . . c e e e e c 7 e 2 2 e e . . 
+    . c e e e e e c 6 e e 2 2 2 e . 
+    . c e e e 2 e c c 2 4 5 4 2 e . 
+    c e e e 2 2 2 2 2 2 4 5 5 2 2 e 
+    c e e 2 2 2 2 2 2 2 2 4 4 2 2 e 
+    c e e 2 2 2 2 2 2 2 2 2 2 2 2 e 
+    c e e 2 2 2 2 2 2 2 2 2 2 2 2 e 
+    c e e 2 2 2 2 2 2 2 2 2 2 2 2 e 
+    c e e 2 2 2 2 2 2 2 2 2 2 4 2 e 
+    . e e e 2 2 2 2 2 2 2 2 2 4 e . 
+    . 2 e e 2 2 2 2 2 2 2 2 4 2 e . 
+    . . 2 e e 2 2 2 2 2 4 4 2 e . . 
+    . . . 2 2 e e 4 4 4 2 e e . . . 
+    . . . . . 2 2 e e e e . . . . . 
+    `, SpriteKind.Player)

--- a/tests/pydecompile-test/cases/indentation.ts
+++ b/tests/pydecompile-test/cases/indentation.ts
@@ -1,18 +1,7 @@
-let mySprite = sprites.create(img`
-    . . . . . . . e c 7 . . . . . . 
-    . . . . e e e c 7 7 e e . . . . 
-    . . c e e e e c 7 e 2 2 e e . . 
-    . c e e e e e c 6 e e 2 2 2 e . 
-    . c e e e 2 e c c 2 4 5 4 2 e . 
-    c e e e 2 2 2 2 2 2 4 5 5 2 2 e 
-    c e e 2 2 2 2 2 2 2 2 4 4 2 2 e 
-    c e e 2 2 2 2 2 2 2 2 2 2 2 2 e 
-    c e e 2 2 2 2 2 2 2 2 2 2 2 2 e 
-    c e e 2 2 2 2 2 2 2 2 2 2 2 2 e 
-    c e e 2 2 2 2 2 2 2 2 2 2 4 2 e 
-    . e e e 2 2 2 2 2 2 2 2 2 4 e . 
-    . 2 e e 2 2 2 2 2 2 2 2 4 2 e . 
-    . . 2 e e 2 2 2 2 2 4 4 2 e . . 
-    . . . 2 2 e e 4 4 4 2 e e . . . 
-    . . . . . 2 2 e e e e . . . . . 
-    `, SpriteKind.Player)
+basic.showLeds(`
+    # . . . .
+    . . . . .
+    . . . . .
+    . . . . .
+    . . . . #
+    `)


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4891

## Context
When a block like the one shown below is converted to Python, the lines after the first are over-indented.

This
<img width="149" alt="image" src="https://github.com/microsoft/pxt/assets/4691428/50f8be29-cde3-42aa-931f-9fbce0edb4a8">

Turns into this
```py
def on_forever():
    basic.show_leds("""
        # . . . .
                . # . . .
                # . . . .
                . . . . .
                . . . . .
    """)
basic.forever(on_forever)

```

when it _should_ look like this:
```py
def on_forever():
    basic.show_leds("""
        # . . . .
        . # . . .
        # . . . .
        . . . . .
        . . . . .
        """)
basic.forever(on_forever)

```
## Analysis
The problem function is `emitMultiLnStrLitExp`. In it we see `return asExpRes(`"""\n${indent1(s.text.trim())}\n"""`)`.

Notice `s.text` is trimmed before being passed into indent1, and see an example string that gets passed into the function:

```

8-spaces. . . # #
        . . . # .
        . . . . .
        . . . . .
        . . . . .
        
```

The `trim()` call removes the first line's indent, then `indent1()` indents every line. This is why we see the first indentation looking correct, and all lines after are over-indented.

Note: I can't tell for certain, but it appears that the string that gets passed in already carries the relative level of indentation that's needed, but this function should assume we're already at the correct indentation. Ex: If we get a multiline string with two levels of indentation and return those same two indents, the resulting python file will appear triple indented because we were already at a certain level of indentation. I'd need clarification on this, as I got to this fix by making this assumption.

Assuming my assumption abov eis correct, the solution here is to manually perform the `indent1` function, except we _trim each line_ rather than trimming the whole string.

The result:

```ts
basic.show_leds("""
    . . . # #
    # # . . .
    . . # . #
    . . . # #
    . . # . .
    """)
def on_forever():
    basic.show_leds("""
            . . . . .
            . . # . .
            . . . . .
            . . . # .
            . . . . .
            """)
basic.forever(on_forever)

```

Note this problem also exists in arcade. Without this fix we see:
```py
mySprite = sprites.create(img("""
        . . . . . . . e c 7 . . . . . . 
            . . . . e e e c 7 7 e e . . . . 
            . . c e e e e c 7 e 2 2 e e . . 
            . c e e e e e c 6 e e 2 2 2 e . 
            . c e e e 2 e c c 2 4 5 4 2 e . 
            c e e e 2 2 2 2 2 2 4 5 5 2 2 e 
            c e e 2 2 2 2 2 2 2 2 4 4 2 2 e 
            c e e 2 2 2 2 2 2 2 2 2 2 2 2 e 
            c e e 2 2 2 2 2 2 2 2 2 2 2 2 e 
            c e e 2 2 2 2 2 2 2 2 2 2 2 2 e 
            c e e 2 2 2 2 2 2 2 2 2 2 4 2 e 
            . e e e 2 2 2 2 2 2 2 2 2 4 e . 
            . 2 e e 2 2 2 2 2 2 2 2 4 2 e . 
            . . 2 e e 2 2 2 2 2 4 4 2 e . . 
            . . . 2 2 e e 4 4 4 2 e e . . . 
            . . . . . 2 2 e e e e . . . . .
    """),
    SpriteKind.player)
```

With the fix we see:
```py
mySprite = sprites.create(img("""    
        . . . . . . . e c 7 . . . . . .
        . . . . e e e c 7 7 e e . . . .
        . . c e e e e c 7 e 2 2 e e . .
        . c e e e e e c 6 e e 2 2 2 e .
        . c e e e 2 e c c 2 4 5 4 2 e .
        c e e e 2 2 2 2 2 2 4 5 5 2 2 e
        c e e 2 2 2 2 2 2 2 2 4 4 2 2 e
        c e e 2 2 2 2 2 2 2 2 2 2 2 2 e
        c e e 2 2 2 2 2 2 2 2 2 2 2 2 e
        c e e 2 2 2 2 2 2 2 2 2 2 2 2 e
        c e e 2 2 2 2 2 2 2 2 2 2 4 2 e
        . e e e 2 2 2 2 2 2 2 2 2 4 e .
        . 2 e e 2 2 2 2 2 2 2 2 4 2 e .
        . . 2 e e 2 2 2 2 2 4 4 2 e . .
        . . . 2 2 e e 4 4 4 2 e e . . .
        . . . . . 2 2 e e e e . . . . .
        """),
    SpriteKind.player)
```

