### PR TITLE
Use forget device api to directly disconnect when available

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -495,6 +495,9 @@ declare namespace pxt {
         connectionSuccessImage?: string;
         incompatibleHardwareImage?: string;
 
+        browserUnpairImage?: string;
+        usbDeviceForgottenImage?: string;
+
         // The following fields used to be displayed, but students
         // found the dialog confusing / hard to use; now we redirect
         // them to help docs instead if pairing fails for step by step instructions.

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -31,6 +31,7 @@ namespace pxt.commands {
     export let renderUsbPairDialog: (firmwareUrl?: string, failedOnce?: boolean) => any /* JSX.Element */ = undefined;
     export let renderIncompatibleHardwareDialog: (unsupportedParts: string[]) => any /* JSX.Element */ = undefined;
     export let renderDisconnectDialog: () => { header: string, jsx: any, helpUrl: string }
+    export let showUsbDeviceForgottenDialog: (confirmAsync: (options: any) => Promise<number>) => Promise<void>;
     export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>, saveOnly?: boolean, redeploy?: () => Promise<void>) => Promise<void> = undefined;
     export let showProgramTooLargeErrorAsync: (variants: string[], confirmAsync: (options: any) => Promise<number>, saveOnly?: boolean) => Promise<RecompileOptions>;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -166,6 +166,8 @@ namespace pxt.usb {
         isochronousTransferIn(endpointNumber: number, packetLengths: number[]): Promise<USBIsochronousInTransferResult>;
         isochronousTransferOut(endpointNumber: number, data: BufferSource, packetLengths: number[]): Promise<USBIsochronousOutTransferResult>;
         reset(): Promise<void>;
+        // chromium 101+
+        forget?(): Promise<void>;
     }
 
     class WebUSBHID implements pxt.packetio.PacketIO {
@@ -262,6 +264,17 @@ namespace pxt.usb {
                     this.clearDev()
                     return U.delay(500)
                 })
+        }
+
+        async forgetAsync(): Promise<boolean> {
+            if (!this.dev?.forget)
+                return false;
+            try {
+                await this.dev.forget();
+                return true;
+            } catch (e) {
+                return false;
+            }
         }
 
         reconnectAsync() {
@@ -492,7 +505,7 @@ namespace pxt.usb {
             })
     }
 
-    async function tryGetDevicesAsync(): Promise<USBDevice[]> {
+    export async function tryGetDevicesAsync(): Promise<USBDevice[]> {
         log(`webusb: get devices`)
         try {
             const devs = await ((navigator as any).usb.getDevices() as Promise<USBDevice[]>);
@@ -511,6 +524,16 @@ namespace pxt.usb {
             _hid = new WebUSBHID();
         _hid.enable();
         return Promise.resolve(_hid);
+    }
+
+    // returns true if device has been successfully forgotten, false otherwise.
+    export async function forgetDeviceAsync(): Promise<boolean> {
+        pxt.debug(`packetio: forget webusb io`);
+        if (!_hid) {
+            // No device to forget
+            return false;
+        }
+        return _hid.forgetAsync();
     }
 
     export let isEnabled = false

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -272,6 +272,7 @@ namespace pxt.usb {
             try {
                 await this.dev.forget();
                 return true;
+                // connection changed listener will handle disconnecting when access is revoked.
             } catch (e) {
                 return false;
             }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -423,6 +423,7 @@ export async function initAsync() {
         log(`deploy: webusb`);
         pxt.commands.deployCoreAsync = hidDeployCoreAsync;
         pxt.commands.renderDisconnectDialog = webusb.renderUnpairDialog;
+        pxt.commands.showUsbDeviceForgottenDialog = webusb.showDeviceForgottenDialog;
     } else if (hidbridge.shouldUse()) {
         log(`deploy: hid`);
         pxt.commands.deployCoreAsync = hidDeployCoreAsync;
@@ -493,12 +494,18 @@ export async function pairAsync(implicitlyCalled?: boolean): Promise<boolean> {
 
 }
 
-export function showDisconnectAsync(): Promise<void> {
-    if (pxt.commands.renderDisconnectDialog) {
+export async function showDisconnectAsync(): Promise<void> {
+    if (await pxt.usb.forgetDeviceAsync()) {
+        await pxt.commands.showUsbDeviceForgottenDialog(core.confirmAsync);
+    } else if (pxt.commands.renderDisconnectDialog) {
         const { header, jsx, helpUrl } = pxt.commands.renderDisconnectDialog();
-        return core.dialogAsync({ header, jsx, helpUrl, hasCloseIcon: true });
+        await core.dialogAsync({
+            header,
+            jsx,
+            helpUrl,
+            hasCloseIcon: true
+        });
     }
-    return Promise.resolve();
 }
 
 export function disconnectAsync(): Promise<void> {

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -470,16 +470,65 @@ function theme() {
 export function renderUnpairDialog() {
     const boardName = getBoardName();
     const header = lf("How to unpair your {0}", boardName);
-    const jsx = <div><p>
-        {lf("You can unpair your {0} if the WebUSB download is malfunctioning. Click on the lock icon and uncheck your device.", boardName)}
-    </p>
-        <img className="ui image centered medium" src={"./static/webusb/unpair.gif"} alt={lf("A gif showing how to unpair the {0}", boardName)} />
+    const unpairImg = theme().browserUnpairImage;
+    const jsx = <div>
+        <p>
+            {lf("You can unpair your {0} if the WebUSB download is malfunctioning.", boardName)}
+        </p>
+        <p>
+            {lf("Click on the icon on the left side of the address bar and uncheck your device.")}
+        </p>
+        {unpairImg && <img
+            className="ui image centered medium"
+            src={unpairImg}
+            alt={lf("A gif showing how to unpair the {0}", boardName)}
+        />}
     </div>
 
-    // TODO: show usb forget here
     const helpUrl = pxt.appTarget.appTheme.usbDocs
         && (pxt.appTarget.appTheme.usbDocs + "/webusb#unpair");
     return { header, jsx, helpUrl };
+}
+
+export async function showDeviceForgottenDialog(confirmAsync: ConfirmAsync) {
+    const boardName = getBoardName();
+    const deviceForgottenImage = theme().usbDeviceForgottenImage;
+    const columns = deviceForgottenImage ? "two" : "one";
+
+    const jsxd = () => (
+        <div className={`ui ${columns} column grid padded download-dialog`}>
+            <div className="column">
+                <div className="ui">
+                    <div className="content">
+                        <div className="description">
+                            {lf("Your {0} has been disconnected.", boardName)}
+                            <br />
+                            <br />
+                            {lf("Unplug it from your computer and disconnect any battery to fully reset it.")}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {deviceForgottenImage &&
+                <div className="column">
+                    <div className="ui">
+                        <div className="image download-dialog-image">
+                            <img alt={lf("Image of {0} being disconnected", boardName)} className="ui medium rounded image" src={deviceForgottenImage} />
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    );
+
+    await showPairStepAsync({
+        confirmAsync,
+        jsxd,
+        buttonLabel: lf("Done"),
+        header: lf("{0} disconnected", boardName),
+        tick: "downloaddialog.button.webusbforgotten",
+        help: undefined,
+    });
 }
 
 


### PR DESCRIPTION
close https://github.com/microsoft/pxt-microbit/issues/5109
also part of https://github.com/microsoft/pxt-microbit/issues/5164, I'll close that one in a separate pr over in micro:bit adding the two images in this pr.

Could use wording critique on the two dialogs I'm updating:

New short dialog for 'we successfully disconnected your device' case, where forget worked:

![image](https://github.com/microsoft/pxt/assets/5615930/b0b52485-7b04-4ae4-9e9d-e502b23de944)
gif is just the 'connected device' one reversed. This dialog is purely informational, besides a suggestion to unplug (but that only really matters if they wish to reconnect right away, which is a bit of a niche use case.)

The other one is the existing dialog, just updated the wording a bit to accommodate upcoming browser changes (getting rid of lock icon). This one shouldn't be hit for up to date browsers that support the api, just older chrome / edge, or if somehow something errored out in the forget api (I induced it here by just causing a null pointer exception by setting something to undefined in `forgetAsync`):

![image](https://github.com/microsoft/pxt/assets/5615930/b031aa3e-8273-4c17-82d6-a0c3bc7cc035) 

build: https://makecode.microbit.org/app/b4c4c2fcdeff73191ccb9a3216f8ee199d47aef2-da9e91d6ab