### PR TITLE
Only show micro:bit board (no external parts) for thumbnail recorder

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -470,15 +470,19 @@ namespace pxt.BrowserUtils {
     }
 
     export function scaleImageData(img: ImageData, scale: number): ImageData {
-        const cvs = document.createElement("canvas");
-        cvs.width = img.width * scale;
-        cvs.height = img.height * scale;
-        const ctx = cvs.getContext("2d")
+        const inputCanvas = document.createElement("canvas");
+        const outputCanvas = document.createElement("canvas");
+        inputCanvas.width = img.width;
+        inputCanvas.height = img.height;
+        outputCanvas.width = img.width * scale;
+        outputCanvas.height = img.height * scale;
+        const ctx = inputCanvas.getContext("2d");
+        const outCtx = outputCanvas.getContext("2d");
         ctx.putImageData(img, 0, 0);
-        ctx.imageSmoothingEnabled = false;
-        ctx.scale(scale, scale);
-        ctx.drawImage(cvs, 0, 0);
-        return ctx.getImageData(0, 0, img.width * scale, img.height * scale);
+        outCtx.imageSmoothingEnabled = false;
+        outCtx.scale(scale, scale);
+        outCtx.drawImage(inputCanvas, 0, 0);
+        return outCtx.getImageData(0, 0, img.width * scale, img.height * scale);
     }
 
     export function imageDataToPNG(img: ImageData, scale = 1): string {

--- a/pxtsim/visuals/boardhost.ts
+++ b/pxtsim/visuals/boardhost.ts
@@ -155,9 +155,11 @@ namespace pxsim.visuals {
         }
 
         public screenshotAsync(width?: number): Promise<ImageData> {
-            const svg = this.view.cloneNode(true) as SVGSVGElement;
-            svg.setAttribute('width', this.view.viewBox.baseVal.width + "");
-            svg.setAttribute('height', this.view.viewBox.baseVal.height + "");
+            // only clone the svg node with class="sim" so that screenshot doesn't include external parts
+            const simEl = this.view.querySelector(".sim");
+            const svg = simEl.cloneNode(true) as SVGSVGElement;
+            svg.setAttribute('width', svg.viewBox.baseVal.width + "");
+            svg.setAttribute('height', svg.viewBox.baseVal.height + "");
             const xml = new XMLSerializer().serializeToString(svg);
             const data = "data:image/svg+xml,"
                 + encodeURIComponent(xml.replace(/\s+/g, ' ').replace(/"/g, "'"));


### PR DESCRIPTION
Closes https://github.com/microsoft/pxt-microbit/issues/5155

This also fixes a lingering issue where the thumbnail had two simulators duplicated. It was fixed for screenshots before, but it became apparent during this bug fix that it was lingering for gifs. (See https://github.com/microsoft/pxt-microbit/issues/4988)

This change does not impact Arcade.

![thumbnail](https://github.com/microsoft/pxt/assets/15070078/eba43c71-ac0a-49d5-9486-c169837c001a)
