### PR TITLE
Fix screenshot null pointer exception

### DIFF
--- a/pxtsim/visuals/boardhost.ts
+++ b/pxtsim/visuals/boardhost.ts
@@ -156,8 +156,8 @@ namespace pxsim.visuals {
 
         public screenshotAsync(width?: number): Promise<ImageData> {
             // only clone the svg node with class="sim" so that screenshot doesn't include external parts
-            const simEl = this.view.querySelector(".sim");
-            const svg = simEl.cloneNode(true) as SVGSVGElement;
+            const simEl = this.view.classList.contains("sim") ? this.view : this.view.querySelector(".sim");
+            const svg = simEl ? simEl.cloneNode(true) as SVGSVGElement : this.view.cloneNode(true) as SVGSVGElement;
             svg.setAttribute('width', svg.viewBox.baseVal.width + "");
             svg.setAttribute('height', svg.viewBox.baseVal.height + "");
             const xml = new XMLSerializer().serializeToString(svg);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5211

Before I was looking only at the child nodes to find the simulator svg (class = "sim"), but when there are no external parts, the node itself contains the simulator svg. So now we first check if the node itself contains the class "sim" and if not, we check the child nodes. I also added a null check in case neither the parent or children contain the "sim" class.

Here's an upload target for testing: https://makecode.microbit.org/app/54d7a1abebbcc13f4668cc9838aa322ba63372e8-19f5fb88ef