### PR TITLE
Exposing some state from AudioContextManager and sound expression for…

### DIFF
--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -233,6 +233,10 @@ namespace pxsim {
         // destination. Used for muting
         let destination: GainNode;
 
+        export function isAudioElementActive() {
+            return !!_vca;
+        }
+
         export let soundEventCallback: (ev: "playinstructions" | "muteallchannels", data?: Uint8Array) => void;
 
         function context(): AudioContext {

--- a/pxtsim/sound/soundexpression.ts
+++ b/pxtsim/sound/soundexpression.ts
@@ -219,6 +219,10 @@ namespace pxsim.codal.music {
         cancelled: false
     };
 
+    export function isSoundExpPlaying(): boolean {
+        return playing;
+    }
+
     export function __playSoundExpression(notes: string, waitTillDone: boolean): void {
         if (!soundQueue) soundQueue = [];
 


### PR DESCRIPTION
… isSoundPlaying block sim implementation

For the new `is sound playing` block in micro:bit, the simulator implementation needs to know when audio is playing. With the `AudioContextManager` and the logic in `soundexpression.ts`, we already have the context for when audio is playing, we just need to surface those values so that the `pxsim.music` namespace can use them. 

Part of the solution for https://github.com/microsoft/pxt-microbit/issues/3777