### PR TITLE
Prevent Sim from Shrinking on Short Screens 

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -452,6 +452,12 @@
             .simtoolbar, #miniSimOverlay { display: block; }
             .play-button { display: none !important; }
             .expand-button, .fullscreen-button, .tutorial.mute-button { display: block !important; }
+
+            display: flex;
+            align-items: flex-end;
+            aside.simtoolbar {
+                float: unset;
+            }
         }
 
         .tutorial-controls { display: none; }
@@ -470,14 +476,6 @@
 
         aside.simtoolbar {
             z-index: 5;
-        }
-
-        .simPanel {
-            display: flex;
-            align-items: flex-end;
-            aside.simtoolbar {
-                float: unset;
-            }
         }
     }
     .simulator-container:not(.hidden) {
@@ -1013,7 +1011,7 @@
         }
     }
     
-    /* Short Deskstop Only */
+    /* Short Desktop Only */
     @media (max-height: @tallEditorBreakpoint) {
         #root.tabTutorial:not(.fullscreensim) {
             .simulator-container:not(.hidden) {
@@ -1030,7 +1028,6 @@
                     min-height: @tutorialSimulatorMinHeight;
                 }
                 .simframe {
-                    padding-bottom: unset !important;
                     height: 100%;
                     min-height: @tutorialSimulatorMinHeight;
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5214

On short screens, the sim was shrinking and looked very small. In non-tutorial mode, this doesn't happen. Instead, it just scrolls. By removing `padding-bottom: unset !important;`, we get the same behavior in tutorials.

Also did a little cleanup to reduce redundancy.

Try it here: https://makecode.microbit.org/app/1bd5e26f5481b85e4000d211b5641976886e78d5-51943d1273 (recommend using morse-chat to test, since that tutorial has audio blocks)