### PR TITLE
Fix settings in iframe editor embed

### DIFF
--- a/pxtlib/auth.ts
+++ b/pxtlib/auth.ts
@@ -77,7 +77,10 @@ namespace pxt.auth {
     };
 
     let _client: AuthClient;
-    export function client(): AuthClient { return _client; }
+    export function client(): AuthClient {
+        if (authDisabled) return undefined;
+        return _client;
+    }
 
     const PREFERENCES_DEBOUNCE_MS = 1 * 1000;
     const PREFERENCES_DEBOUNCE_MAX_MS = 10 * 1000;

--- a/pxtlib/localStorage.ts
+++ b/pxtlib/localStorage.ts
@@ -7,6 +7,7 @@ namespace pxt.storage {
     }
 
     class MemoryStorage implements IStorage {
+        type: "memory";
         items: pxt.Map<string> = {};
 
         removeItem(key: string) {
@@ -24,6 +25,7 @@ namespace pxt.storage {
     }
 
     class LocalStorage implements IStorage {
+        type = "localstorage";
 
         constructor(private storageId: string) {
         }
@@ -74,9 +76,10 @@ namespace pxt.storage {
         // no local storage in sandbox mode
         if (!pxt.shell.isSandboxMode()) {
             try {
-                window.localStorage[sid] = '1';
-                let v = window.localStorage[sid];
-                supported = true;
+                const rand = pxt.Util.guidGen();
+                window.localStorage[sid] = rand;
+                const v = window.localStorage[sid];
+                supported = v === rand;
             } catch (e) { }
         }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2729,14 +2729,33 @@ export class ProjectView
             if (hash && ((pxt.BrowserUtils.isIFrame() && (hash.cmd === "pub" || hash.cmd === "sandbox")) || hash.cmd == "tutorial")) {
                 location.hash = `#${hash.cmd}:${hash.arg}`;
             }
-            else if (this.state && this.state.home) {
-                location.hash = "#reload"
+            else if (this.state?.home) {
+                location.hash = "#reload";
             }
             // if in editor, reload project
-            else if (this.state && this.state.header && !this.state.header.isDeleted) {
+            else if (this.state?.header && !this.state.header.isDeleted) {
                 location.hash = "#editor"
             }
-            location.reload();
+
+            if (pxt.BrowserUtils.isIFrame() && !pxt.BrowserUtils.getCookieLang()) {
+                // Include language in the refreshed page to persist refreshes
+                // when cookies not allowed
+                const lang = pxt.Util.userLanguage();
+                const params = new URLSearchParams(location.search);
+                params.set("lang", lang);
+                const hcParamSet = !!params.get("hc");
+                const hc = !!core.getHighContrastOnce();
+                if (hc != hcParamSet) {
+                    if (hc) params.set("hc", "1");
+                    else params.delete("hc");
+                }
+                location.search = params.toString();
+                // .reload refreshes without hitting server so it loses the params,
+                // so have to navigate directly
+                location.assign(location.toString());
+            } else {
+                location.reload();
+            }
         } catch (e) {
             pxt.reportException(e);
             location.reload();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4768,7 +4768,7 @@ export class ProjectView
     }
 
     setHighContrast(on: boolean) {
-        return core.setHighContrast(on);;
+        return core.setHighContrast(on);
     }
 
     toggleGreenScreen() {
@@ -5611,6 +5611,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     pxt.setBundledApiInfo((window as any).pxtTargetBundle.apiInfo);
     pxt.perf.measureEnd("setAppTarget");
 
+    let theme = pxt.appTarget.appTheme;
+    const isControllerIFrame = (theme.allowParentController || pxt.shell.isControllerMode()) && pxt.BrowserUtils.isIFrame();
+    // disable auth in iframe scenarios
+    if (isControllerIFrame)
+        pxt.auth.enableAuth(false);
     enableAnalytics()
 
     if (!pxt.BrowserUtils.isBrowserSupported() && !/skipbrowsercheck=1/i.exec(window.location.href)) {
@@ -5682,17 +5687,14 @@ document.addEventListener("DOMContentLoaded", async () => {
     // github token set in cloud provider
 
     const isSandbox = pxt.shell.isSandboxMode() || pxt.shell.isReadOnly();
-    const isController = pxt.shell.isControllerMode();
-    let theme = pxt.appTarget.appTheme;
+
     if (query["ws"]) workspace.setupWorkspace(query["ws"]);
-    else if ((theme.allowParentController || isController) && pxt.BrowserUtils.isIFrame()) workspace.setupWorkspace("iframe");
+    else if (isControllerIFrame) workspace.setupWorkspace("iframe");
     else if (isSandbox) workspace.setupWorkspace("mem");
     else if (pxt.BrowserUtils.isIpcRenderer()) workspace.setupWorkspace("idb");
     else if (pxt.BrowserUtils.isPxtElectron()) workspace.setupWorkspace("fs");
     else workspace.setupWorkspace("browser");
-    // disable auth in iframe scenarios
-    if (workspace.getWorkspaceType() === "iframe")
-        pxt.auth.enableAuth(false)
+
     Promise.resolve()
         .then(async () => {
             const href = window.location.href;

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -233,7 +233,7 @@ export async function setHighContrastPrefAsync(highContrast: boolean): Promise<v
     }
 }
 
-export async function setLangaugePrefAsync(lang: string): Promise<void> {
+export async function setLanguagePrefAsync(lang: string): Promise<void> {
     const cli = await clientAsync();
     if (cli) {
         await cli.patchUserPreferencesAsync({

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -342,7 +342,8 @@ export async function setHighContrast(on: boolean) {
 
 export async function setLanguage(lang: string) {
     pxt.BrowserUtils.setCookieLang(lang);
-    await auth.setLangaugePrefAsync(lang);
+    pxt.Util.setUserLanguage(lang);
+    await auth.setLanguagePrefAsync(lang);
 }
 
 export function resetFocus() {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/5209

Here's a forked build from the one in that issue pointing at a build with this change: https://wyttlr.csb.app/ (there will be an overlay button in the bottom right to see the code of the sandbox)
microbit build: https://makecode.microbit.org/app/4e857c4bdf435b028015828dbd8d4af76e3d2c48-72860080ee
arcade build: https://arcade.makecode.com/app/15ee7b4f6abf540a00d30fa275c70925a5bdceeb-35abd09842--skillmap

I believe the change in `pxtlib/auth.ts` should technically be enough to cover this regression (+ https://github.com/microsoft/pxt/commit/a673adfed979c0356fcd270d331e0c4ed54e2012 to make it so language / high contrast persist through refreshes), but I ran into some other things while trying to figure out why it wasn't working so poked around a bit (e.g. we have some logic to cut auth from embed scenarios, but it was running after some initialization code that was leaving around some half initialized login state).