### PR TITLE
fix high contrast mode for skillmap progress bar

### DIFF
--- a/react-common/styles/controls/ProgressBar.less
+++ b/react-common/styles/controls/ProgressBar.less
@@ -13,11 +13,13 @@
 }
 
 // attach directly to progress-bar so it overrides wrapper
-.hc progress[value].common-progressbar {
-    --progress-bar-filled-color: @highContrastTextColor;
-    --progress-bar-unfilled-color: @highContrastBackgroundColor;
-    --progress-bar-border-color: @highContrastTextColor;
-    box-shadow: none;
+.hc, .high-contrast {
+    progress[value].common-progressbar {
+        --progress-bar-filled-color: @highContrastTextColor;
+        --progress-bar-unfilled-color: @highContrastBackgroundColor;
+        --progress-bar-border-color: @highContrastTextColor;
+        box-shadow: none;
+    }
 }
 
 progress[value].common-progressbar {


### PR DESCRIPTION
Just noticed the skillmap progress bar was missing the hc theming while testing other pr, reason was that skillmap uses `.high-contrast` class instead of `.hc`. Might be good to unify that a bit as there isn't really a good reason to have to remember to support two classes for this, but just patching this for now :)

![image](https://github.com/microsoft/pxt/assets/5615930/c3946c37-3dea-48d0-ac04-e322eeb57725)
