### PR TITLE
Keep up browser webusb dialog gif while pairAsync

### DIFF
--- a/webapp/src/coretsx.tsx
+++ b/webapp/src/coretsx.tsx
@@ -109,7 +109,11 @@ export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogSt
         buttons.forEach(btn => {
             const onclick = btn.onclick;
             btn.onclick = () => {
-                this.close(onclick ? onclick() : 0);
+                if (!btn.noCloseOnClick) {
+                    this.close(onclick ? onclick() : 0);
+                } else {
+                    onclick?.();
+                }
             }
             if (!btn.className) btn.className = "approve positive";
             if (btn.approveButton) this.okButton = btn;

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1134,6 +1134,7 @@ export interface ModalButton {
     approveButton?: boolean;
     labelPosition?: "left" | "right";
     ariaLabel?: string;
+    noCloseOnClick?: boolean;
 }
 
 export interface ModalProps extends ReactModal.Props {

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -77,15 +77,12 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
         } else if (!webUsbInstrDialogRes) {
             return notPairedResult();
         } else {
-            core.showLoading("pair", lf("Select your {0} and press \"Connect\".", boardName));
-
             let errMessage: any;
             try {
                 paired = await pairAsync();
             } catch (e) {
                 errMessage = e.message;
             }
-            core.hideLoading("pair");
             core.hideDialog();
 
             if (pxt.packetio.isConnected()) {

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -73,10 +73,11 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
         connected = pxt.packetio.isConnected();
         if (connected) {
             // plugged in underneath previous dialog, continue;
+            core.hideDialog();
         } else if (!webUsbInstrDialogRes) {
             return notPairedResult();
         } else {
-            core.showLoading("pair", lf("Select your {0} and press \"Connect\".", boardName))
+            core.showLoading("pair", lf("Select your {0} and press \"Connect\".", boardName));
 
             let errMessage: any;
             try {
@@ -85,6 +86,7 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
                 errMessage = e.message;
             }
             core.hideLoading("pair");
+            core.hideDialog();
 
             if (pxt.packetio.isConnected()) {
                 // user connected previously paired device &&
@@ -210,6 +212,7 @@ function showPickWebUSBDeviceDialogAsync(confirmAsync: ConfirmAsync, showDownloa
         showDownloadAsFileButton,
         header: lf("2. Pair your {0} to your browser", boardName),
         tick: "downloaddialog.button.pickusbdevice",
+        doNotHideOnAgree: true,
     });
 }
 
@@ -296,6 +299,7 @@ interface PairStepOptions {
     headerIcon?: string;
     showDownloadAsFileButton?: boolean;
     hideClose?: boolean;
+    doNotHideOnAgree?: boolean;
 }
 
 async function showPairStepAsync({
@@ -309,8 +313,17 @@ async function showPairStepAsync({
     headerIcon,
     showDownloadAsFileButton,
     hideClose,
+    doNotHideOnAgree,
 }: PairStepOptions) {
     let tryAgain = false;
+
+    /**
+     * The deferred below is only used when doNotHideOnAgree is set
+     */
+    let deferred: () => void;
+    const agreeButtonClicked = doNotHideOnAgree && new Promise((_res: (val: void) => void, rej: () => void) => {
+        deferred = _res;
+    });
 
     const buttons: ModalButton[] = [
         {
@@ -320,9 +333,12 @@ async function showPairStepAsync({
             labelPosition: "left",
             onclick: () => {
                 pxt.tickEvent(tick);
-                core.hideDialog();
                 tryAgain = true;
+                if (doNotHideOnAgree) {
+                    deferred();
+                }
             },
+            noCloseOnClick: doNotHideOnAgree,
         }
     ];
 
@@ -336,12 +352,11 @@ async function showPairStepAsync({
                 pxt.tickEvent("downloaddialog.button.webusb.preferdownload");
                 userPrefersDownloadFlag = true;
                 tryAgain = false;
-                core.hideDialog();
             },
         });
     }
 
-    await confirmAsync({
+    const dialog = confirmAsync({
         header,
         jsxd,
         hasCloseIcon: !hideClose,
@@ -353,6 +368,14 @@ async function showPairStepAsync({
         headerIcon: headerIcon ? headerIcon + " header-inline-icon" : undefined,
         buttons,
     });
+
+    if (doNotHideOnAgree) {
+        await Promise.race([agreeButtonClicked, dialog]);
+        // resolve possibly dangling promise
+        deferred?.();
+    } else {
+        await dialog;
+    }
 
     return tryAgain;
 }


### PR DESCRIPTION
build 1: keeping loading desc https://makecode.microbit.org/app/b27c8f0a6318ffa253f9a3428e7f45cc90aded25-69b95af966
build 2: keep modal, no loader https://makecode.microbit.org/app/a5a814b3ed8e2ffbc1eab582358cda71de10b496-93118d9002

Not my favorite code I've written, but a possible approach to an issue we saw in user testing this morning. Rough estimate that I saw was that about 1/3rd to 1/2 of students fully successfully paired the first time on their own with just the dialog, about half the remaining got it the second time, and the others ended up needing a neighbor or educator to point out what they were missing in the dialog. A good chunk of these students just ignored the gif in the dialog before the pairing step, or skimmed over it, and got stuck while trying to press connect without choosing the device first. (for what it's worth, I feel like this success ratio is a bit better than normal download / drag & drop ever really got, so that's a good improvement at least.)

The implementation in this is a little ugly (maybe I can find a better way to write it in the morning, had a bit of a headache while finishing it up -- any time I'm writing an explicit deferred promise I give it a ), and it's definitely less appealing design wise, but I do think a noticeable number of users would be able to complete the pairing on the first try who were unsuccessful or took an extra attempt to succeed this morning would be helped by this. 2-3 of the 80 students gave feedback that they would have loved a gif showing how to do the step, meaning the gif going away before the action clearly didn't leave an impression on them but likely could have helped

I'm inclined to push this in as I have it written, though I'm not fully opposed to keeping the loader or just not merging for now, mainly figured it was worth a discussion at least.

with loader left in
![image](https://github.com/microsoft/pxt/assets/5615930/ce705eb1-df31-43fd-be27-5e685b007336)
cutting out loader, just keeping modal till pair finishes up
![image](https://github.com/microsoft/pxt/assets/5615930/1e7c88cb-53ed-43b4-a96b-8d0794dbe5d6)
