### PR TITLE
bump version of checkout, setup-node in pr workflow

### DIFF
--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@main
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@main
         with:
           node-version: '16.x'
       - name: npm install

--- a/.github/workflows/pxt-buildpr.yml
+++ b/.github/workflows/pxt-buildpr.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@main
       - name: Set Node.js version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@main
         with:
           node-version: '16.x'
       - name: npm install

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@main
       - name: Set Node.js version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@main
         with:
           node-version: '16.x'
       - name: npm install


### PR DESCRIPTION
I noticed in https://github.com/microsoft/pxt/actions/runs/5250237669 we seemed to be getting a spurious warning in all of our builds related to the node 12 deprecation 
![image](https://github.com/microsoft/pxt/assets/5615930/ba2f987c-2759-493e-99ec-f2c5a8398422)

I checked some of our other repos and backend had it pointing at main without that warning. The error in that run comes down to 'weird, inconsistent npm install' stuff (if you search the error, the most common result is "try rm -rfing node modules" followed by "that worked thanks"), and the error seems to indicate it's trying to use different versions of node within the same workflow run. I can pin to v3 if we want latest, just figured it's probably fine on main for this standard action.

I only put it in for buildpr in this change to start so I can watch the build go through / read through it for a quick check, since that is the action with the least entitlements (no secret credentials passed), will need to copy this change over to other builds in this repo / other repos we care about build for after confirming it's good