### PR TITLE
Profile pages: added option for smaller dialog

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -476,6 +476,7 @@ declare namespace pxt {
         tutorialSimSidebarLayout?: boolean; // Enable tutorial layout with the sim in the sidebar (desktop only)
         showOpenInVscode?: boolean; // show the open in VS Code button
         matchWebUSBDeviceInSim?: boolean; // if set, pass current device id as theme to sim when available.
+        condenseProfile?: boolean; // if set, will make the profile dialog smaller
     }
 
     interface DownloadDialogTheme {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -477,6 +477,7 @@ declare namespace pxt {
         showOpenInVscode?: boolean; // show the open in VS Code button
         matchWebUSBDeviceInSim?: boolean; // if set, pass current device id as theme to sim when available.
         condenseProfile?: boolean; // if set, will make the profile dialog smaller
+        cloudProfileIcon?: string; // the file path for added imagery on smaller profile dialogs
     }
 
     interface DownloadDialogTheme {

--- a/react-common/components/profile/Profile.tsx
+++ b/react-common/components/profile/Profile.tsx
@@ -22,6 +22,7 @@ export const Profile = (props: ProfileProps) => {
     const userBadges = user?.preferences?.badges || { badges: [] };
     const showBadges = pxt.appTarget?.cloud?.showBadges || false;
     const profileSmall = pxt.appTarget.appTheme?.condenseProfile;
+    const profileIcon = pxt.appTarget.appTheme?.cloudProfileIcon;
 
     const onBadgeClick = (badge: pxt.auth.Badge) => {
         showModalAsync({
@@ -47,9 +48,21 @@ export const Profile = (props: ProfileProps) => {
         />}
 
         {profileSmall &&
-            <div>
-               Now that you're logged in, your projects will be automatically saved to the cloud so you can
-                access them from any device! Learn more at Cloud Sync or Identity or Privacy
+            <div className="profile-info-container">
+                <p className="profile-info">
+                    {lf("Now that you're logged in, your projects will be automatically saved to the cloud so you can access them from any device! ")}
+                    {lf("Learn more at ")}
+                    <a href="https://arcade.makecode.com/identity/cloud-sync" target="_blank" rel="noopener noreferrer" tabIndex={0}>{lf("Cloud Sync ")}</a>
+                    {lf("or ")}
+                    <a href="https://makecode.com/privacy-faq" target="_blank" rel="noopener noreferrer" tabIndex={0}>{lf("Privacy ")}</a>
+                    {lf("or ")}
+                    <a href="https://arcade.makecode.com/identity/sign-in" target="_blank" rel="noopener noreferrer" tabIndex={0}>{lf("Identity.")}</a>
+                </p>
+                {profileIcon && <img
+                    className="ui image centered medium"
+                    src={profileIcon}
+                    alt={lf("Image of microbit microcontroller surrounded by clouds")}
+                />}
             </div>
         }
     </div>

--- a/react-common/components/profile/Profile.tsx
+++ b/react-common/components/profile/Profile.tsx
@@ -50,18 +50,12 @@ export const Profile = (props: ProfileProps) => {
         {profileSmall &&
             <div className="profile-info-container">
                 <p className="profile-info">
-                    {lf("Now that you're logged in, your projects will be automatically saved to the cloud so you can access them from any device! ")}
-                    {lf("Learn more at ")}
-                    <a href="https://arcade.makecode.com/identity/cloud-sync" target="_blank" rel="noopener noreferrer" tabIndex={0}>{lf("Cloud Sync ")}</a>
-                    {lf("or ")}
-                    <a href="https://makecode.com/privacy-faq" target="_blank" rel="noopener noreferrer" tabIndex={0}>{lf("Privacy ")}</a>
-                    {lf("or ")}
-                    <a href="https://arcade.makecode.com/identity/sign-in" target="_blank" rel="noopener noreferrer" tabIndex={0}>{lf("Identity.")}</a>
+                    {lf("Now that you're logged in, your projects will be automatically saved to the cloud so you can access them from any device!")}
                 </p>
                 {profileIcon && <img
                     className="ui image centered medium"
                     src={profileIcon}
-                    alt={lf("Image of microbit microcontroller surrounded by clouds")}
+                    alt=""
                 />}
             </div>
         }

--- a/react-common/components/profile/Profile.tsx
+++ b/react-common/components/profile/Profile.tsx
@@ -21,6 +21,7 @@ export const Profile = (props: ProfileProps) => {
     const userProfile = user?.profile || { idp: {} };
     const userBadges = user?.preferences?.badges || { badges: [] };
     const showBadges = pxt.appTarget?.cloud?.showBadges || false;
+    const profileSmall = pxt.appTarget.appTheme?.condenseProfile;
 
     const onBadgeClick = (badge: pxt.auth.Badge) => {
         showModalAsync({
@@ -44,5 +45,12 @@ export const Profile = (props: ProfileProps) => {
             userState={userBadges}
             onBadgeClick={onBadgeClick}
         />}
+
+        {profileSmall &&
+            <div>
+               Now that you're logged in, your projects will be automatically saved to the cloud so you can
+                access them from any device! Learn more at Cloud Sync or Identity or Privacy
+            </div>
+        }
     </div>
 }

--- a/react-common/styles/profile/profile.less
+++ b/react-common/styles/profile/profile.less
@@ -299,6 +299,18 @@
     background-color: var(--avatar-initials-background-color);
 }
 
+.profile-info-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.profile-info {
+    line-height: 2em;
+    width: 75%;
+}
+
 .ui.icon.button.sign-out {
     font-family: var(--body-font-family);
 }

--- a/webapp/src/user.tsx
+++ b/webapp/src/user.tsx
@@ -114,8 +114,10 @@ export class ProfileDialog extends auth.Component<ProfileDialogProps, ProfileDia
 
         const { emailSelected } = this.state;
 
+        const makeSmall = pxt.appTarget?.appTheme?.condenseProfile;
+
         return (
-            <sui.Modal isOpen={this.state.visible} className="ui profiledialog" size="fullscreen"
+            <sui.Modal isOpen={this.state.visible} className="ui profiledialog" size={ makeSmall ? "small" : "fullscreen" }
                 onClose={this.hide} dimmer={true}
                 closeIcon={true} header={profile?.idp?.displayName}
                 closeOnDimmerClick={false}


### PR DESCRIPTION
For micro:bit that doesn't have any badges, or any other targets that might not have something to fill the profile page space, we don't want the profile page to be the full screen. With these changes, a target can have a smaller profile page. 

![image](https://github.com/microsoft/pxt/assets/49178322/630007db-7a02-4e8e-9d00-a1ce038ad43a)

EDIT: Here's an upload target: https://makecode.microbit.org/app/29277b08cefbec40fdc2f89cd0afd2933226581d-321f1764ea

Part of the solution for: https://github.com/microsoft/pxt-microbit/issues/5084