### PR TITLE
[stable 9.0] Profile pages: added option for smaller dialog 

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -476,6 +476,8 @@ declare namespace pxt {
         tutorialSimSidebarLayout?: boolean; // Enable tutorial layout with the sim in the sidebar (desktop only)
         showOpenInVscode?: boolean; // show the open in VS Code button
         matchWebUSBDeviceInSim?: boolean; // if set, pass current device id as theme to sim when available.
+        condenseProfile?: boolean; // if set, will make the profile dialog smaller
+        cloudProfileIcon?: string; // the file path for added imagery on smaller profile dialogs
     }
 
     interface DownloadDialogTheme {

--- a/react-common/components/profile/Profile.tsx
+++ b/react-common/components/profile/Profile.tsx
@@ -21,6 +21,8 @@ export const Profile = (props: ProfileProps) => {
     const userProfile = user?.profile || { idp: {} };
     const userBadges = user?.preferences?.badges || { badges: [] };
     const showBadges = pxt.appTarget?.cloud?.showBadges || false;
+    const profileSmall = pxt.appTarget.appTheme?.condenseProfile;
+    const profileIcon = pxt.appTarget.appTheme?.cloudProfileIcon;
 
     const onBadgeClick = (badge: pxt.auth.Badge) => {
         showModalAsync({
@@ -44,5 +46,18 @@ export const Profile = (props: ProfileProps) => {
             userState={userBadges}
             onBadgeClick={onBadgeClick}
         />}
+
+        {profileSmall &&
+            <div className="profile-info-container">
+                <p className="profile-info">
+                    {lf("Now that you're logged in, your projects will be automatically saved to the cloud so you can access them from any device!")}
+                </p>
+                {profileIcon && <img
+                    className="ui image centered medium"
+                    src={profileIcon}
+                    alt=""
+                />}
+            </div>
+        }
     </div>
 }

--- a/react-common/styles/profile/profile.less
+++ b/react-common/styles/profile/profile.less
@@ -299,6 +299,18 @@
     background-color: var(--avatar-initials-background-color);
 }
 
+.profile-info-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.profile-info {
+    line-height: 2em;
+    width: 75%;
+}
+
 .ui.icon.button.sign-out {
     font-family: var(--body-font-family);
 }

--- a/webapp/src/user.tsx
+++ b/webapp/src/user.tsx
@@ -114,8 +114,10 @@ export class ProfileDialog extends auth.Component<ProfileDialogProps, ProfileDia
 
         const { emailSelected } = this.state;
 
+        const makeSmall = pxt.appTarget?.appTheme?.condenseProfile;
+
         return (
-            <sui.Modal isOpen={this.state.visible} className="ui profiledialog" size="fullscreen"
+            <sui.Modal isOpen={this.state.visible} className="ui profiledialog" size={ makeSmall ? "small" : "fullscreen" }
                 onClose={this.hide} dimmer={true}
                 closeIcon={true} header={profile?.idp?.displayName}
                 closeOnDimmerClick={false}


### PR DESCRIPTION
Cherry pick from https://github.com/microsoft/pxt/pull/9551

* Made the profile modal small for microbit

* Adds an info section for profile pages that don't have badges

* Got rid of links for profile, alt text for decorative image on profile dialog