### PR TITLE
Fix firefox download dialog, ignored null pointer exception on firefox/safari

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -190,10 +190,6 @@ namespace pxt.BrowserUtils {
         return typeof window != "undefined" && !!(window as any).PointerEvent;
     }
 
-    export function hasSaveAs(): boolean {
-        return isEdge() || isIE() || isFirefox();
-    }
-
     export function os(): string {
         if (isWindows()) return "windows";
         else if (isMac()) return "mac";

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -93,17 +93,12 @@ function showUploadInstructionsAsync(
     const userDownload = pxt.BrowserUtils.isBrowserDownloadWithinUserContext();
     const downloadAgain = !pxt.BrowserUtils.isIE() && !pxt.BrowserUtils.isEdge();
     const helpUrl = pxt.appTarget.appTheme.usbDocs;
-    const saveAs = pxt.BrowserUtils.hasSaveAs();
     const ext = pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex";
-    const connect = pxt.usb.isEnabled && pxt.appTarget?.compile?.webUSB;
-    const jsx = !userDownload && !saveAs && pxt.commands.renderBrowserDownloadInstructions?.(saveonly, redeploy);
+    const jsx = !userDownload && pxt.commands.renderBrowserDownloadInstructions?.(saveonly, redeploy);
     const body = userDownload ? lf("Click 'Download' to open the {0} app.", pxt.appTarget.appTheme.boardName) :
-        saveAs ? lf("Click 'Save As' and save the {0} file to the {1} drive to transfer the code into your {2}.",
+        !jsx && lf("Move the {0} file to the {1} drive to transfer the code into your {2}.",
             ext,
-            boardDriveName, boardName)
-            : !jsx && lf("Move the {0} file to the {1} drive to transfer the code into your {2}.",
-                ext,
-                boardDriveName, boardName);
+            boardDriveName, boardName);
     const timeout = pxt.BrowserUtils.isBrowserDownloadWithinUserContext() ? 0 : 10000;
     return confirmAsync({
         header: userDownload ? lf("Download ready...") : lf("Download completed..."),
@@ -398,7 +393,7 @@ export async function initAsync() {
             log(`enabled webusb`);
             pxt.usb.setEnabled(true);
             pxt.packetio.mkPacketIOAsync = pxt.usb.mkWebUSBHIDPacketIOAsync;
-        } else if (!pxt.appTarget?.compile?.disableHIDBridge) {
+        } else if (!pxt.appTarget?.compile?.disableHIDBridge && pxt.BrowserUtils.isLocalHost()) {
             log(`enabled hid bridge (webusb disabled)`);
             pxt.usb.setEnabled(false);
             pxt.packetio.mkPacketIOAsync = hidbridge.mkHIDBridgePacketIOAsync;

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -393,10 +393,13 @@ export async function initAsync() {
             log(`enabled webusb`);
             pxt.usb.setEnabled(true);
             pxt.packetio.mkPacketIOAsync = pxt.usb.mkWebUSBHIDPacketIOAsync;
-        } else if (!pxt.appTarget?.compile?.disableHIDBridge && pxt.BrowserUtils.isLocalHost()) {
-            log(`enabled hid bridge (webusb disabled)`);
+        } else {
+            log(`webusb disabled`);
             pxt.usb.setEnabled(false);
-            pxt.packetio.mkPacketIOAsync = hidbridge.mkHIDBridgePacketIOAsync;
+            if (!pxt.appTarget?.compile?.disableHIDBridge && pxt.BrowserUtils.isLocalHost()) {
+                log(`enabled hid bridge`);
+                pxt.packetio.mkPacketIOAsync = hidbridge.mkHIDBridgePacketIOAsync;
+            }
         }
     }
 

--- a/webapp/src/hidbridge.ts
+++ b/webapp/src/hidbridge.ts
@@ -42,23 +42,19 @@ function onOOB(v: OOB) {
     }
 }
 
-function init() {
-    if (!iface) {
-        if (!pxt.BrowserUtils.isLocalHost() || !Cloud.localToken)
-            return;
-        pxt.debug('initializing hid pipe');
-        iface = pxt.worker.makeWebSocket(
-            `ws://localhost:${pxt.options.wsPort}/${Cloud.localToken}/hid`, onOOB)
-    }
-}
-
 export function shouldUse() {
     let serial = pxt.appTarget.serial
     return serial && serial.useHF2 && (pxt.BrowserUtils.isLocalHost() && !!Cloud.localToken);
 }
 
 export function mkHIDBridgePacketIOAsync(): Promise<pxt.packetio.PacketIO> {
-    init()
+    if (!iface) {
+        if (!pxt.BrowserUtils.isLocalHost() || !Cloud.localToken)
+            return Promise.resolve(undefined);
+        pxt.debug('initializing hid pipe');
+        iface = pxt.worker.makeWebSocket(
+            `ws://localhost:${pxt.options.wsPort}/${Cloud.localToken}/hid`, onOOB)
+    }
     let raw = false
     if (pxt.appTarget.serial && pxt.appTarget.serial.rawHID)
         raw = true


### PR DESCRIPTION
closes https://github.com/microsoft/pxt-microbit/issues/5241

Apparently firefox has always (> 2 years, code from 2017 and we changed the flow a good amount a while back) been hitting an alternate save dialog path:

![image](https://github.com/microsoft/pxt/assets/5615930/bc9bfe56-951d-4688-bf4b-ae550e329d8f)

vs what you normally see on other browsers, plus or minus a webusb suggestion:

![image](https://github.com/microsoft/pxt/assets/5615930/f94dca3c-d884-4e8f-aba4-cbfbbd0c25df)

Also fixed a minor, mostly ignored null pointer exception that's also been around forever where we tried to connect to hidbridge that doesn't work on non-webusb targets (init was returning without setting iface when on not localhost, and then crashing a little bit later in initAsync)

build https://makecode.microbit.org/app/7f06460f3a35e00446f1080eeba1b5ed14b71522-86ebee0213