### PR TITLE
Keep Long Hints In Screen

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -2219,7 +2219,6 @@ p.ui.font.small {
     max-width: 100%;
     min-width: 100%;
     height:100%;
-    --tutorialCalloutTop: 15rem;
 }
 
 .simView #boardview {

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -810,7 +810,7 @@
         .tutorial-callout {
             bottom: unset;
             left: unset;
-            top: var(--tutorialCalloutTop);
+            top: unset;
             max-width: 80%;
             transform: translateY(15px);
         }
@@ -1033,6 +1033,15 @@
                 }
             }
         }
+
+        .topInstructionsWrapper {
+            .tutorial-callout {
+                right: unset;
+                top: unset !important;
+                bottom: @editorToolsCollapsedHeight + 0.2rem !important;
+                left: unset;
+            }
+        }
     }
 
     .topInstructionsWrapper {
@@ -1040,7 +1049,7 @@
         
         .tutorial-callout {
             right: unset;
-            top: var(--tutorialCalloutTop);
+            top: unset; //var(--tutorialCalloutTop);
             bottom: unset;
             left: unset;
         }

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -1033,15 +1033,6 @@
                 }
             }
         }
-
-        .topInstructionsWrapper {
-            .tutorial-callout {
-                right: unset;
-                top: unset !important;
-                bottom: @editorToolsCollapsedHeight + 0.2rem !important;
-                left: unset;
-            }
-        }
     }
 
     .topInstructionsWrapper {
@@ -1049,7 +1040,7 @@
         
         .tutorial-callout {
             right: unset;
-            top: unset; //var(--tutorialCalloutTop);
+            top: unset;
             bottom: unset;
             left: unset;
         }

--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -13,7 +13,32 @@ interface TutorialCalloutProps extends React.PropsWithChildren<{}> {
 export function TutorialCallout(props: TutorialCalloutProps) {
     const { children, className, buttonIcon, buttonLabel } = props;
     const [ visible, setVisible ] = React.useState(false);
+    const [ maxHeight, setMaxHeight ] = React.useState("unset");
+    const [ top, setTop ] = React.useState("unset");
+    const [ bottom, setBottom ] = React.useState("unset");
     const popupRef = React.useRef<HTMLDivElement>(null);
+    const contentRef = React.useRef<HTMLDivElement>(null);
+
+    React.useEffect(() => {
+        function checkSize() {
+            const editorToolsHeight = document.getElementById("editortools")?.clientHeight || 0;
+            if(contentRef.current?.getBoundingClientRect().bottom > window.innerHeight - editorToolsHeight - 10) {
+                setTop("unset");
+                setBottom(`${editorToolsHeight - 10}px`);
+                setMaxHeight("90vh");
+            }
+        }
+
+        const observer = new ResizeObserver(() => {
+            window.requestAnimationFrame(checkSize)
+        });
+
+        observer.observe(document.body);
+        if (contentRef.current) observer.observe(contentRef.current);
+
+        checkSize();
+        return () => observer.disconnect();
+    });
 
     const captureEvent = (e: any) => {
         e.preventDefault();
@@ -57,7 +82,7 @@ export function TutorialCallout(props: TutorialCalloutProps) {
             ariaLabel={buttonTitle}
             disabled={!children}
             onClick={children ? handleButtonClick : undefined} />
-        {visible && <div className={`tutorial-callout no-select`} onClick={captureEvent}>
+        {visible && <div ref={contentRef} className={`tutorial-callout no-select`} onClick={captureEvent} style={{top: top, bottom: bottom, maxHeight: maxHeight}}> {/*top: top, bottom: bottom, maxHeight: maxHeight*/}
             <Button icon="close" className="tutorial-callout-close" onClick={closeCallout} />
             {children}
         </div>}

--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -84,7 +84,7 @@ export function TutorialCallout(props: TutorialCalloutProps) {
             ariaLabel={buttonTitle}
             disabled={!children}
             onClick={children ? handleButtonClick : undefined} />
-        {visible && <div ref={contentRef} className={`tutorial-callout no-select`} onClick={captureEvent} style={{top: top, bottom: bottom, maxHeight: maxHeight}}> {/*top: top, bottom: bottom, maxHeight: maxHeight*/}
+        {visible && <div ref={contentRef} className={`tutorial-callout no-select`} onClick={captureEvent} style={{top: top, bottom: bottom, maxHeight: maxHeight}}>
             <Button icon="close" className="tutorial-callout-close" onClick={closeCallout} />
             {children}
         </div>}

--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -21,7 +21,7 @@ export function TutorialCallout(props: TutorialCalloutProps) {
 
     React.useEffect(() => {
         function checkSize() {
-            const lowerBuffer = document.getElementById("editortools")?.clientHeight || 0 + 30;
+            const lowerBuffer = (document.getElementById("editortools")?.clientHeight ?? 0) + 30;
             if (contentRef.current?.getBoundingClientRect().bottom > window.innerHeight - lowerBuffer) {
                 setTop("unset");
                 setBottom(`${lowerBuffer}px`);

--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -21,16 +21,18 @@ export function TutorialCallout(props: TutorialCalloutProps) {
 
     React.useEffect(() => {
         function checkSize() {
-            const editorToolsHeight = document.getElementById("editortools")?.clientHeight || 0;
-            if(contentRef.current?.getBoundingClientRect().bottom > window.innerHeight - editorToolsHeight - 10) {
+            const lowerBuffer = document.getElementById("editortools")?.clientHeight || 0 + 30;
+            if (contentRef.current?.getBoundingClientRect().bottom > window.innerHeight - lowerBuffer) {
                 setTop("unset");
-                setBottom(`${editorToolsHeight - 10}px`);
+                setBottom(`${lowerBuffer}px`);
                 setMaxHeight("90vh");
+            } else {
+                setBottom("unset");
             }
         }
 
         const observer = new ResizeObserver(() => {
-            window.requestAnimationFrame(checkSize)
+            window.requestAnimationFrame(checkSize);
         });
 
         observer.observe(document.body);

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -120,11 +120,6 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     protected setComponentHeight = (height?: number, isResize?: boolean) => {
         if (height != this.state.height || isResize != this.state.resized) {
             this.setState({resized: this.state.resized || isResize, height: height});
-
-            this.simPanelRef.style.setProperty(
-                "--tutorialCalloutTop",
-                `${height}px`
-            );
         }
     }
 

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -186,7 +186,8 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                         minHeight="100px"
                         initialHeight={editorSidebarHeight}
                         resizeEnabled={pxt.BrowserUtils.isTabletSize() || this.props.tutorialSimSidebar}
-                        onResizeDrag={newSize => this.setComponentHeight(newSize, true)}>
+                        onResizeDrag={newSize => this.setComponentHeight(newSize, true)}
+                        onResizeEnd={newSize => pxt.tickEvent("tutorial.resizeInstructions", {newSize: newSize})}>
                         <TutorialContainer
                             parent={parent}
                             tutorialId={tutorialOptions.tutorial}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5227

When a hint is going off the bottom of the screen, move it up. While debugging this, I found that the tutorialCalloutTop variable wasn't working or doing anything, so I removed it.

I also added a small tick event for when someone resizes the tutorial instructions.

Upload Target: https://makecode.microbit.org/app/e973301c9b0f9be87ba85072fe0864b54855b967-ca062a1773