### PR TITLE
Fix Hint Flickering

### DIFF
--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -22,7 +22,7 @@ export function TutorialCallout(props: TutorialCalloutProps) {
     React.useEffect(() => {
         function checkSize() {
             const lowerBuffer = (document.getElementById("editortools")?.clientHeight ?? 0) + 30;
-            if (contentRef.current?.getBoundingClientRect().bottom > window.innerHeight - lowerBuffer) {
+            if (contentRef.current?.getBoundingClientRect().bottom >= window.innerHeight - lowerBuffer) {
                 setTop("unset");
                 setBottom(`${lowerBuffer}px`);
                 setMaxHeight("90vh");


### PR DESCRIPTION
@jwunderl warned me and I forgot... Fixes https://github.com/microsoft/pxt-microbit/issues/5245

With the greater than (and not equals) check, it would back and forth between the two cases. By using >= instead, that won't happen.