### PR TITLE
Add option to rename and delete user kinds

### DIFF
--- a/pxtblocks/fields/field_kind.ts
+++ b/pxtblocks/fields/field_kind.ts
@@ -14,6 +14,60 @@ namespace pxtblockly {
                 promptAndCreateKind(this.sourceBlock_.workspace, this.opts, lf("New {0}:", this.opts.memberName),
                     newName => newName && this.setValue(newName));
             }
+            else if (value === "RENAME") {
+                const ws = this.sourceBlock_.workspace;
+                const toRename = ws.getVariable(this.value_, kindType(this.opts.name))
+                const oldName = toRename.name;
+
+                if (this.opts.initialMembers.indexOf(oldName) !== -1) {
+                    Blockly.alert(lf("The built-in {0} '{1}' cannot be renamed. Try creating a new kind instead!", this.opts.memberName, oldName));
+                    return;
+                }
+
+                promptAndRenameKind(
+                    ws,
+                    { ...this.opts, toRename },
+                    lf("Rename '{0}':", oldName),
+                    newName => {
+                        // Update the values of all existing field instances
+                        const allFields = getAllFields(ws, field => field instanceof FieldKind);
+                        for (const field of allFields) {
+                            if (field.ref.getValue() === oldName) {
+                                field.ref.setValue(newName)
+                            }
+                        }
+                    }
+                );
+            }
+            else if (value === "DELETE") {
+                const ws = this.sourceBlock_.workspace;
+                const toDelete = ws.getVariable(this.value_, kindType(this.opts.name));
+                const varName = toDelete.name;
+
+                if (this.opts.initialMembers.indexOf(varName) !== -1) {
+                    Blockly.alert(lf("The built-in {0} '{1}' cannot be deleted.", this.opts.memberName, varName));
+                    return;
+                }
+
+                const uses = getAllFields(ws, field => field instanceof FieldKind && field.getValue() === varName);
+
+                if (uses.length > 1) {
+                    Blockly.confirm(lf("Delete {0} uses of the \"{1}\" {2}?", uses.length, varName, this.opts.memberName), response => {
+                        if (!response) return;
+                        Blockly.Events.setGroup(true);
+                        for (const use of uses) {
+                            use.block.dispose(true);
+                        }
+                        ws.deleteVariableById(toDelete.getId());
+                        this.setValue(this.opts.initialMembers[0]);
+                        Blockly.Events.setGroup(false);
+                    });
+                }
+                else {
+                    ws.deleteVariableById(toDelete.getId());
+                    this.setValue(this.opts.initialMembers[0]);
+                }
+            }
             else {
                 super.onItemSelected_(menu, menuItem);
             }
@@ -40,7 +94,7 @@ namespace pxtblockly {
                     }
                 });
 
-                if (this.getValue() === "CREATE") {
+                if (this.getValue() === "CREATE" || this.getValue() === "RENAME" || this.getValue() === "DELETE") {
                     if (this.opts.initialMembers.length) {
                         this.setValue(this.opts.initialMembers[0]);
                     }
@@ -66,12 +120,17 @@ namespace pxtblockly {
 
 
             res.push([lf("Add a new {0}...", opts.memberName), "CREATE"]);
+            res.push([undefined, "SEPARATOR"]);
+            res.push([lf("Rename {0}...", opts.memberName), "RENAME"]);
+            res.push([lf("Delete {0}...", opts.memberName), "DELETE"]);
 
             return res;
         }
     }
 
-    function promptAndCreateKind(ws: Blockly.Workspace, opts: pxtc.KindInfo, message: string, cb: (newValue: string) => void) {
+    type PromptFunction<U extends pxtc.KindInfo> = (ws: Blockly.Workspace, opts: U, message: string, cb: (newValue: string) => void) => void;
+
+    function promptForName<U extends pxtc.KindInfo>(ws: Blockly.Workspace, opts: U, message: string, cb: (newValue: string) => void, prompt: PromptFunction<U>) {
         Blockly.prompt(message, null, response => {
             if (response) {
                 let nameIsValid = false;
@@ -86,13 +145,13 @@ namespace pxtblockly {
 
                 if (!nameIsValid) {
                     Blockly.alert(lf("Names must start with a letter and can only contain letters, numbers, '$', and '_'."),
-                        () => promptAndCreateKind(ws, opts, message, cb));
+                        () => promptForName(ws, opts, message, cb, prompt));
                     return;
                 }
 
-                if (pxt.blocks.isReservedWord(response)) {
+                if (pxt.blocks.isReservedWord(response) || response === "CREATE" || response === "RENAME" || response === "DELETE") {
                     Blockly.alert(lf("'{0}' is a reserved word and cannot be used.", response),
-                        () => promptAndCreateKind(ws, opts, message, cb));
+                        () => promptForName(ws, opts, message, cb, prompt));
                     return;
                 }
 
@@ -101,19 +160,40 @@ namespace pxtblockly {
                     const name = existing[i];
                     if (name === response) {
                         Blockly.alert(lf("A {0} named '{1}' already exists.", opts.memberName, response),
-                            () => promptAndCreateKind(ws, opts, message, cb));
+                            () => promptForName(ws, opts, message, cb, prompt));
                         return;
                     }
                 }
 
                 if (response === opts.createFunctionName) {
                     Blockly.alert(lf("'{0}' is a reserved name.", opts.createFunctionName),
-                        () => promptAndCreateKind(ws, opts, message, cb));
+                        () => promptForName(ws, opts, message, cb, prompt));
                 }
 
-                cb(createVariableForKind(ws, opts, response));
+                cb(response);
             }
         }, { placeholder: opts.promptHint });
+    }
+
+    function promptAndCreateKind(ws: Blockly.Workspace, opts: pxtc.KindInfo, message: string, cb: (newValue: string) => void) {
+        const responseHandler = (response: string) => {
+            cb(createVariableForKind(ws, opts, response));
+        };
+
+        promptForName(ws, opts, message, responseHandler, promptAndCreateKind);
+    }
+
+    interface RenameOptions extends pxtc.KindInfo {
+        toRename: Blockly.VariableModel;
+    }
+
+    function promptAndRenameKind(ws: Blockly.Workspace, opts: RenameOptions, message: string, cb: (newValue: string) => void) {
+        const responseHandler = (response: string) => {
+            ws.getVariableMap().renameVariable(opts.toRename, response);
+            cb(response);
+        };
+
+        promptForName(ws, opts, message, responseHandler, promptAndRenameKind);
     }
 
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5899

Adds "rename" and "delete" options to the SpriteKind dropdown! These work exactly the same as the variable ones; if you delete a kind you will delete all blocks that use that field and have the kind set as the value. In practice this is less destructive than the variable delete because we always use this field on shadow-style blocks so there are no children that will also get deleted.

One caveat: the built-in kinds (Player, Enemy, Projectile, and Food) cannot be deleted or renamed.