### PR TITLE
remove arcade only note from identity pages

### DIFF
--- a/common-docs/identity/cloud-sync.md
+++ b/common-docs/identity/cloud-sync.md
@@ -1,7 +1,5 @@
 # Cloud Synchronization in MakeCode
 
-**Note**: This feature only available in [**MakeCode Arcade**](https://arcade.makecode.com).
-
 ## What is Cloud Sync?
 
 Cloud Synchronization, or Cloud Sync, is a feature available to signed in users that lets MakeCode save your projects in the cloud, where they're available anywhere you can sign in to MakeCode.


### PR DESCRIPTION
Remove the 'arcade only' notes from common target 'identity' pages.

The note in `sign-in.md` was removed by a direct commit earlier: https://github.com/microsoft/pxt/commit/58dcaae51cb33bbecf6b255ec808f75528d120d0. A similar note is removed from `cloud-sync.md` here.

Closes https://github.com/microsoft/pxt-microbit/issues/5263