### PR TITLE
Add disabled state for mute button

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -42,6 +42,12 @@ namespace pxt.editor {
         Expanded = "errorListExpanded"
     }
 
+    export enum MuteState {
+        Muted = "muted",
+        Unmuted = "unmuted",
+        Disabled = "disabled"
+    }
+
     export interface IAppProps { }
     export interface IAppState {
         active?: boolean; // is this tab visible at all
@@ -69,7 +75,7 @@ namespace pxt.editor {
         showParts?: boolean;
         fullscreen?: boolean;
         showMiniSim?: boolean;
-        mute?: boolean;
+        mute?: MuteState;
         embedSimView?: boolean;
         editorPosition?: {
             lineNumber: number;
@@ -300,7 +306,7 @@ namespace pxt.editor {
         toggleTrace(intervalSpeed?: number): void;
         setTrace(enabled: boolean, intervalSpeed?: number): void;
         toggleMute(): void;
-        setMute(on: boolean): void;
+        setMute(state: MuteState): void;
         openInstructions(): void;
         closeFlyout(): void;
         printCode(): void;

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -275,6 +275,11 @@ namespace pxsim {
         color: string;
     }
 
+    export interface SetMuteButtonStateMessage extends SimulatorMessage {
+        type: "setmutebuttonstate";
+        state: "muted" | "unmuted" | "disabled";
+    }
+
     export namespace multiplayer {
         type MessageBase = {
             type: "multiplayer";

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1761,6 +1761,12 @@ namespace pxsim {
         }
     }
 
+    export function setParentMuteState(state: "muted" | "unmuted" | "disabled") {
+        Runtime.postMessage({
+            type: "setmutebuttonstate",
+            state
+        } as SetMuteButtonStateMessage)
+    }
 
     export class PerfCounter {
         start = 0;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -12,6 +12,7 @@ namespace pxsim {
         onSimulatorReady?: () => void;
         onSimulatorCommand?: (msg: pxsim.SimulatorCommandMessage) => void;
         onTopLevelCodeEnd?: () => void;
+        onMuteButtonStateChange?: (state: "muted" | "unmuted" | "disabled") => void;
         simUrl?: string;
         stoppedClass?: string;
         invalidatedClass?: string;
@@ -827,6 +828,7 @@ namespace pxsim {
                 }
                 case 'debugger': this.handleDebuggerMessage(msg as DebuggerMessage); break;
                 case 'toplevelcodefinished': if (this.options.onTopLevelCodeEnd) this.options.onTopLevelCodeEnd(); break;
+                case 'setmutebuttonstate': this.options.onMuteButtonStateChange?.((msg as SetMuteButtonStateMessage).state); break;
                 default:
                     this.postMessage(msg, source);
                     break;

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -278,6 +278,10 @@ namespace pxsim {
                 ctx.resume();
         }
 
+        export function isMuted() {
+            return _mute;
+        }
+
         function stopTone() {
             setCurrentToneGain(0);
             _frequency = 0;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1093,6 +1093,7 @@ export class ProjectView
             },
             onSimulatorReady: () => {
             },
+            onMuteButtonStateChange: state => this.setMute(state),
             setState: (k, v) => {
                 pkg.mainEditorPkg().setSimState(k, v)
             },
@@ -3555,12 +3556,26 @@ export class ProjectView
     }
 
     toggleMute() {
-        this.setMute(!this.state.mute);
+        switch (this.state.mute) {
+            case pxt.editor.MuteState.Muted:
+                this.setMute(pxt.editor.MuteState.Unmuted);
+                break;
+            case pxt.editor.MuteState.Unmuted:
+                this.setMute(pxt.editor.MuteState.Muted);
+                break;
+        }
     }
 
-    setMute(on: boolean) {
-        simulator.mute(on);
-        this.setState({ mute: on });
+    setMute(mute: pxt.editor.MuteState) {
+        switch (mute) {
+            case pxt.editor.MuteState.Muted:
+                simulator.mute(true);
+                break;
+            case pxt.editor.MuteState.Unmuted:
+                simulator.mute(false);
+                break;
+        }
+        this.setState({ mute });
     }
 
     openInstructions() {
@@ -3736,7 +3751,7 @@ export class ProjectView
             && pxt.appTarget.simulator
             && !!pxt.appTarget.simulator.emptyRunCode
             && !this.isBlocksEditor();
-        if (this.firstRun && pxt.BrowserUtils.isSafari()) this.setMute(true);
+        if (this.firstRun && pxt.BrowserUtils.isSafari()) this.setMute(pxt.editor.MuteState.Disabled);
 
         pxt.debug(`sim: start run (autorun ${this.state.autoRun}, first ${this.firstRun})`)
         this.firstRun = false
@@ -3793,7 +3808,7 @@ export class ProjectView
                             const hc = data.getData<boolean>(auth.HIGHCONTRAST)
                             if (!pxt.react.isFieldEditorViewVisible?.()) {
                                 simulator.run(pkg.mainPkg, opts.debug, resp, {
-                                    mute: this.state.mute,
+                                    mute: this.state.mute === pxt.editor.MuteState.Muted,
                                     highContrast: hc,
                                     light: pxt.options.light,
                                     clickTrigger: opts.clickTrigger,

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -13,6 +13,7 @@ interface SimulatorConfig {
     onStateChanged(state: pxsim.SimulatorState): void;
     onSimulatorReady(): void;
     setState(key: string, value: any): void;
+    onMuteButtonStateChange(state: pxt.editor.MuteState): void;
     editor: string;
 }
 
@@ -232,6 +233,7 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
         onTopLevelCodeEnd: () => {
             postSimEditorEvent("toplevelfinished");
         },
+        onMuteButtonStateChange: cfg.onMuteButtonStateChange,
         stoppedClass: pxt.appTarget.simulator && pxt.appTarget.simulator.stoppedClass,
         invalidatedClass: pxt.appTarget.simulator && pxt.appTarget.simulator.invalidatedClass,
         nestedEditorSim,


### PR DESCRIPTION
Part 1 of https://github.com/microsoft/pxt-microbit/issues/5158 fix

This PR adds a third "disabled" state to the simulator mute button that can be triggered by a message from the simulator.

This is for Safari, so that we can show a mute button inside the iframe. I'll be opening a PR in pxt-microbit that adds that button momentarily