### PR TITLE
Fix signin button font on linux

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -2356,7 +2356,6 @@ div.simframe.ui.embed {
     border-radius: 6px;
     height: 3rem;
     padding: 0 .6rem;
-    font-family: @segoeUIFont;
     font-weight: 500;
 
     .icon {


### PR DESCRIPTION
Removal of font-family attribute fixes the issue on Linux. Still looks fine on Windows (tested Arcade and microbit). It seems this value was unnecessary. Unsure why Chrome on Linux would resolve the css differently than on other platforms.

Fixes https://github.com/microsoft/pxt-microbit/issues/5272
