### PR TITLE
Fix instruction resize when hint is open (#9576)

### DIFF
--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -71,7 +71,7 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
 
         const computedStyle = getComputedStyle(containerRef?.current);
         const containerHeight = parseInt(computedStyle.height) - parseInt(computedStyle.borderWidth);
-        if (e.nativeEvent.offsetY > containerHeight - RESIZABLE_BORDER_SIZE - 4) {
+        if (e.nativeEvent.offsetY < containerHeight && e.nativeEvent.offsetY > containerHeight - RESIZABLE_BORDER_SIZE - 4) {
             document.querySelector("body")?.classList.add("cursor-resize");
             document.addEventListener("pointermove", resize, false);
             document.addEventListener("pointerup", onPointerUp, false);


### PR DESCRIPTION
Port of https://github.com/microsoft/pxt/pull/9576

The issue is not actually specific to touch. When the hint is open, the popup is considered a child of the VerticalResizeContainer that contains the instructions, and it causes the resize "OnPointerDown" event to fire even when the mouse is below the main instruction container. Since I didn't add a max bounds check on before entering resize mode, it resize would trigger even when the mouse was below the instruction pane. We can stop this by checking that the mouse Y is less than the container's height before entering resize mode.