### PR TITLE
Fix audio recording offline compilation

### DIFF
--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -90,7 +90,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
 
         const shareUrlData = await fetchShareUrlDataAsync(searchFor);
         if (shareUrlData) {
-            parsedExt?.unshift(parseShareScript(shareUrlData));
+            parsedExt.unshift(parseShareScript(shareUrlData));
         }
 
         addExtensionsToPool(parsedExt)

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -79,7 +79,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         setSearchComplete(false)
         setExtensionsToShow([emptyCard, emptyCard, emptyCard, emptyCard])
         const exts = await fetchGithubDataAsync([searchFor])
-        const parsedExt = exts.map(repo => parseGithubRepo(repo))
+        const parsedExt = exts?.map(repo => parseGithubRepo(repo)) ?? [];
         //Search bundled extensions as well
         fetchBundled().forEach(e => {
             if (e.name.toLowerCase().indexOf(searchFor.toLowerCase()) > -1) {
@@ -90,7 +90,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
 
         const shareUrlData = await fetchShareUrlDataAsync(searchFor);
         if (shareUrlData) {
-            parsedExt.unshift(parseShareScript(shareUrlData));
+            parsedExt?.unshift(parseShareScript(shareUrlData));
         }
 
         addExtensionsToPool(parsedExt)


### PR DESCRIPTION
This pr https://github.com/microsoft/pxt/pull/7320 is some context you'll probably need to understand why this actually matters; when compiling we alphabetically sort to generate a stable order so the produced sha is consistent even when packages are imported in different orders (e.g. if radio happens to be before or after audio-recording in the list). Probably worth revisiting that logic and sorting in a way that takes into account the source better, but since these are all builtin extensions the behavior I used in the cli should be consistent with webapp (e.g. for builtin packages can use id since it's "*" at runtime / behaves like this change, but make sure github packages use slug / version / etc). Several of the other changes were just minor style nits or fixing logging so I'll point at the main fix

I tested this by packaging and running electron app locally and the package still working with internet turned off after build time, can't produce a signed app to fully test but I think it should be good.

Added in a side fix that I noticed while testing, was getting some null pointer exceptions when you try and search while offline that prevented builtin packages from showing up (was trying to test bluetooth)