### PR TITLE
Hide SimToolbar in Arcade's Sandbox Mode

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1472,7 +1472,7 @@ p.ui.font.small {
 }
 
 .sandbox .simPanel .simtoolbar {
-    display: none;
+    display: none !important;
 }
 
 /***********************************


### PR DESCRIPTION
In microbit, this worked without !important, but in arcade it gets overridden, so the !important is necessary.