### PR TITLE
[stable8.5] only mutate kinds of the same type on delete / rename

### DIFF
--- a/pxtblocks/fields/field_kind.ts
+++ b/pxtblocks/fields/field_kind.ts
@@ -30,11 +30,11 @@ namespace pxtblockly {
                     lf("Rename '{0}':", oldName),
                     newName => {
                         // Update the values of all existing field instances
-                        const allFields = getAllFields(ws, field => field instanceof FieldKind);
+                        const allFields = getAllFields(ws, field => field instanceof FieldKind
+                            && field.getValue() === oldName
+                            && field.opts.blockId === this.opts.blockId);
                         for (const field of allFields) {
-                            if (field.ref.getValue() === oldName) {
-                                field.ref.setValue(newName)
-                            }
+                            field.ref.setValue(newName);
                         }
                     }
                 );
@@ -49,7 +49,9 @@ namespace pxtblockly {
                     return;
                 }
 
-                const uses = getAllFields(ws, field => field instanceof FieldKind && field.getValue() === varName);
+                const uses = getAllFields(ws, field => field instanceof FieldKind
+                    && field.getValue() === varName
+                    && field.opts.blockId === this.opts.blockId);
 
                 if (uses.length > 1) {
                     Blockly.confirm(lf("Delete {0} uses of the \"{1}\" {2}?", uses.length, varName, this.opts.memberName), response => {

--- a/pxtblocks/fields/field_kind.ts
+++ b/pxtblocks/fields/field_kind.ts
@@ -32,7 +32,7 @@ namespace pxtblockly {
                         // Update the values of all existing field instances
                         const allFields = getAllFields(ws, field => field instanceof FieldKind
                             && field.getValue() === oldName
-                            && field.opts.blockId === this.opts.blockId);
+                            && field.opts.name === this.opts.name);
                         for (const field of allFields) {
                             field.ref.setValue(newName);
                         }
@@ -51,7 +51,7 @@ namespace pxtblockly {
 
                 const uses = getAllFields(ws, field => field instanceof FieldKind
                     && field.getValue() === varName
-                    && field.opts.blockId === this.opts.blockId);
+                    && field.opts.name === this.opts.name);
 
                 if (uses.length > 1) {
                     Blockly.confirm(lf("Delete {0} uses of the \"{1}\" {2}?", uses.length, varName, this.opts.memberName), response => {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/5965; we may want to think on prohibiting names from duplicating across kinds, but that seemed a little unnecessary as it wasn't a regression / arguable in the first place.

This one's targeting the release branch since I was already on that accidentally (which I suppose is a good thing), will reverse port to master.

build (off stable1.12 in arcade, stable8.5 here): https://arcade.makecode.com/app/bf6c7d16c202bec13b3afdab05cdd54b7d5a5093-6edb864625

with the sample from that issue: https://arcade.makecode.com/app/bf6c7d16c202bec13b3afdab05cdd54b7d5a5093-6edb864625#pub:S63783-19068-25507-81035

![notouchyspritekindfood](https://github.com/microsoft/pxt/assets/5615930/7a311be4-1461-4c68-9a7f-c2522a7060c5)

