### PR TITLE
hide extra buttons when sim is collapsed in mobile view

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1737,8 +1737,6 @@ p.ui.font.small {
         height: 8rem;
     }
 
-
-
     .simPanel {
         bottom: @editorToolsCollapsedMobileHeight;
     }

--- a/theme/common.less
+++ b/theme/common.less
@@ -1720,12 +1720,12 @@ p.ui.font.small {
             display: block !important;
         }
     }
-    .collapsedEditorTools:not(.tabTutorial) .simPanel {
+    &.collapsedEditorTools:not(.tabTutorial) .simPanel {
         > div {
             display: none !important;
         }
     }
-    .collapsedEditorTools .simPanel {
+    &.collapsedEditorTools .simPanel {
         aside.simtoolbar button:not(.expand-button) {
             display: none !important;
         }
@@ -1736,6 +1736,8 @@ p.ui.font.small {
         width: 10rem; /* match width of div.simframe */
         height: 8rem;
     }
+
+
 
     .simPanel {
         bottom: @editorToolsCollapsedMobileHeight;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/5307

I believe the class got moved up slightly at some point and this associated css did not get fixed alongside it. The `collapsedEditorTools` class is applied to root, so have to make the selector start with & so it narrows the element selected by the rule it's enclosed in, rather than another element inside this one

Worth noting this hides the other buttons on the mini sim button as well when collapsed (debug, fullscreen) so it gives back even more space; e.g. live:
![image](https://github.com/microsoft/pxt/assets/5615930/866ce000-bc3b-4e05-bf19-037ea66b3dfc)

(with a bit of the area to the left of the buttons not working as blockly canvas / just being a fullscreen button)

vs with this change:
![image](https://github.com/microsoft/pxt/assets/5615930/4333067f-fb6a-4d03-90df-c760946991b8)


built to test with (based off master, not stable) https://makecode.microbit.org/app/a0cdefb6098a3c45d9938770d948941667ec095a-d0114f0c19