### PR TITLE
[stable9.0] hide extra buttons when sim is collapsed in mobile view

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1720,12 +1720,12 @@ p.ui.font.small {
             display: block !important;
         }
     }
-    .collapsedEditorTools:not(.tabTutorial) .simPanel {
+    &.collapsedEditorTools:not(.tabTutorial) .simPanel {
         > div {
             display: none !important;
         }
     }
-    .collapsedEditorTools .simPanel {
+    &.collapsedEditorTools .simPanel {
         aside.simtoolbar button:not(.expand-button) {
             display: none !important;
         }


### PR DESCRIPTION
port https://github.com/microsoft/pxt/pull/9595 