### PR TITLE
clean up PageviewPerformanceData tick a bit

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -195,9 +195,6 @@ namespace pxt {
         }
 
         if (envelope.baseType == "PageviewPerformanceData") {
-            if (!envelope.baseData.properties) {
-                return false;
-            }
             const pageName = envelope.baseData.name;
             envelope.baseData.name = window.location.origin;
             if (!envelope.baseData.properties) {

--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -194,6 +194,19 @@ namespace pxt {
             return false;
         }
 
+        if (envelope.baseType == "PageviewPerformanceData") {
+            if (!envelope.baseData.properties) {
+                return false;
+            }
+            const pageName = envelope.baseData.name;
+            envelope.baseData.name = window.location.origin;
+            if (!envelope.baseData.properties) {
+                envelope.baseData.properties = {};
+            }
+            envelope.baseData.properties.pageName = pageName;
+            // no url scrubbing for webapp (no share url, etc)
+        }
+
         if (typeof pxtConfig === "undefined" || !pxtConfig) return true;
 
         const telemetryItem = envelope.baseData;

--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -14,9 +14,6 @@
                     }
 
                     if (envelope.baseType == "PageviewPerformanceData") {
-                        if (!envelope.baseData.properties) {
-                            return false;
-                        }
                         var pageName = envelope.baseData.name;
                         envelope.baseData.name = window.location.origin;
                         if (!envelope.baseData.properties) {

--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -9,8 +9,26 @@
                 sdk.addTelemetryInitializer(function (envelope) {
                     // App Insights automatically sends a page view event on setup, but we send our own later with additional properties.
                     // This stops the automatic event from firing, so we don't end up with duplicate page view events.
-                    if(envelope.baseType == "PageviewData" && !envelope.baseData.properties) {
+                    if (envelope.baseType == "PageviewData" && !envelope.baseData.properties) {
                         return false;
+                    }
+
+                    if (envelope.baseType == "PageviewPerformanceData") {
+                        if (!envelope.baseData.properties) {
+                            return false;
+                        }
+                        var pageName = envelope.baseData.name;
+                        envelope.baseData.name = window.location.origin;
+                        if (!envelope.baseData.properties) {
+                            envelope.baseData.properties = {};
+                        }
+                        envelope.baseData.properties.pageName = pageName;
+                        var scrubbedUrl = scrubUrl(envelope.baseData.uri);
+                        envelope.baseData.uri = scrubbedUrl;
+                        if (envelope.ext && envelope.ext.trace) {
+                            var toUrl = new URL(scrubbedUrl);
+                            envelope.ext.trace.name = toUrl ? toUrl.pathname : "";
+                        }
                     }
 
                     var telemetryItem = envelope.baseData;


### PR DESCRIPTION
Here's an example of what the tick looks like when it goes through this fn:

into ->

```json
{
    "name": "Microsoft.ApplicationInsights.{0}.PageviewPerformance",
    "time": "2023-07-12T16:44:43.715Z",
    "iKey": "9801ed01-c40f-46ec-aa40-2a1742a9e71c",
    "ext": {
        "app": {
            "sesId": "{b64ish}"
        },
        "device": {
            "localId": "browser",
            "deviceClass": "Browser"
        },
        "trace": {
            "traceID": "{b16ish}",
            "name": "/75618-11489-17671-85517"
        },
        "user": {
            "id": "{b64ish}"
        }
    },
    "tags": [],
    "data": {
        "duration": 3642.60000000149
    },
    "baseType": "PageviewPerformanceData",
    "baseData": {
        "name": "world_race",
        "uri": "http://localhost:3232/75618-11489-17671-85517",
        "isValid": true,
        "durationMs": 3642.60000000149,
        "duration": "00:00:03.643",
        "perfTotal": "00:00:03.643",
        "networkConnect": "00:00:00.319",
        "sentRequest": "00:00:00.876",
        "receivedResponse": "00:00:00.002",
        "domProcessing": "00:00:02.446"
    },
    "ver": "4.0"
}
```

end of fn

```json
{
    "name": "Microsoft.ApplicationInsights.{0}.PageviewPerformance",
    "time": "2023-07-12T16:44:43.715Z",
    "iKey": "9801ed01-c40f-46ec-aa40-2a1742a9e71c",
    "ext": {
        "app": {
            "sesId": "{b64ish}"
        },
        "device": {
            "localId": "browser",
            "deviceClass": "Browser"
        },
        "trace": {
            "traceID": "{b16ish}",
            "name": "/xxxxx-xxxxx-xxxxx-xxxxx"
        },
        "user": {
            "id": "{b64ish}"
        }
    },
    "tags": [],
    "data": {
        "duration": 3642.60000000149
    },
    "baseType": "PageviewPerformanceData",
    "baseData": {
        "name": "http://localhost:3232",
        "uri": "http://localhost:3232/xxxxx-xxxxx-xxxxx-xxxxx",
        "isValid": true,
        "durationMs": 3642.60000000149,
        "duration": "00:00:03.643",
        "perfTotal": "00:00:03.643",
        "networkConnect": "00:00:00.319",
        "sentRequest": "00:00:00.876",
        "receivedResponse": "00:00:00.002",
        "domProcessing": "00:00:02.446",
        "properties": {
            "pageName": "world_race",
            "cookie": false
        }
    },
    "ver": "4.0"
}
```

It looks like these are the ones that are getting specially handled to create the perf data table with non matching names.