### PR TITLE
do not use comma sepd pseudo-selectors

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1697,7 +1697,7 @@ p.ui.font.small {
            Mini sim view
 *******************************/
 
-#root.miniSim:not(.fullscreensim, .sandbox) {
+#root.miniSim:not(.fullscreensim):not(.sandbox) {
     /* Layout */
     .simPanel.ui.items {
         position: fixed;
@@ -2109,7 +2109,7 @@ p.ui.font.small {
         display: inline-block!important;
     }
 
-    #root.miniSim:not(.fullscreensim, .sandbox) {
+    #root.miniSim:not(.fullscreensim):not(.sandbox) {
         div.simframe {
             margin-bottom: -0.4rem
         }
@@ -2398,12 +2398,12 @@ button.ui.button.hostmultiplayergame-button {
     --multiplayer-presence-icon-4: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='25' height='29' fill='%234DA64D'%3E%3Cpath d='M12.754 14.686a7 7 0 100-14 7 7 0 000 14zm-8.5 2a3.5 3.5 0 00-3.5 3.5v.5c0 2.393 1.523 4.417 3.685 5.793 2.174 1.384 5.117 2.207 8.315 2.207 3.199 0 6.141-.823 8.315-2.206 2.163-1.377 3.685-3.4 3.685-5.794v-.5a3.5 3.5 0 00-3.5-3.5h-17z'/%3E%3C/svg%3E");
 }
 
-#root:not(.fullscreensim, .sandbox) .multiplayer-presence {
+#root:not(.fullscreensim):not(.sandbox) .multiplayer-presence {
     margin: 0;
     margin-bottom: -.5rem;
 }
 
-.miniSim:not(.fullscreensim, .sandbox):not(.tabTutorial) .multiplayer-presence {
+.miniSim:not(.fullscreensim):not(.sandbox):not(.tabTutorial) .multiplayer-presence {
     display: none;
 }
 


### PR DESCRIPTION
Should fix https://github.com/microsoft/pxt-microbit/issues/5305. The pxt diff between v6.0.5 and v6.0.15 is https://github.com/microsoft/pxt/compare/v9.0.5...v9.0.11, I just had a gut feeling this might be related as I remembered being pleasantly surprised that it worked in the first place :)

@vsbogd if you have time could you check if this link works on your device: https://makecode.microbit.org/app/be0eecc7a88c77bfe1125aeeb3fc7c6d4286f4bd-a7b9522d32 (just in browser should be fine, as they share a webview) that build is just changes that will be released to live site soon + this