### PR TITLE
Branding: Add Microsoft logo to first loading screen

### DIFF
--- a/theme/themes/pxt/elements/loader.overrides
+++ b/theme/themes/pxt/elements/loader.overrides
@@ -21,7 +21,7 @@
 }
 
 .ui.loader.main.msft:after {
-  background: transparent @loaderMsftImage no-repeat center center;
+  background-image: @loaderMsftImage;
   background-size: 99%;
 }
 

--- a/theme/themes/pxt/elements/loader.overrides
+++ b/theme/themes/pxt/elements/loader.overrides
@@ -22,7 +22,7 @@
 
 .ui.loader.main.msft:after {
   background-image: @loaderMsftImage;
-  background-size: 99%;
+  background-size: 99%; // Must be less than 100% to avoid being cut off
 }
 
 .ui.loader.avatar:after {

--- a/theme/themes/pxt/elements/loader.overrides
+++ b/theme/themes/pxt/elements/loader.overrides
@@ -3,7 +3,7 @@
 *******************************/
 
 
-.ui.loader.main:before, 
+.ui.loader.main:before,
 .ui.loader.avatar:before {
    border: none;
    border-radius: 0px;
@@ -15,9 +15,14 @@
   box-shadow: none;
   border-radius: 0px;
   background: transparent @loaderImage no-repeat center center;
-  background-size: 100%;
+  background-size: @loaderImageSize;
  -webkit-animation: @loaderAnimation @loaderSpeed infinite linear;
  animation: @loaderAnimation @loaderSpeed infinite linear;
+}
+
+.ui.loader.main.msft:after {
+  background: transparent @loaderMsftImage no-repeat center center;
+  background-size: 99%;
 }
 
 .ui.loader.avatar:after {

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -111,6 +111,10 @@
 
 @loaderImageUrl: "../docs/static/loader.svg";
 @loaderImage: data-uri(@loaderImageUrl);
+@loaderImageSize: 100%;
+
+@loaderMsftImageUrl: "../docs/static/orglogowide.png";
+@loaderMsftImage: data-uri(@loaderMsftImageUrl);
 
 @includePoweredByLogos: false;
 @poweredBySmallUrl: "../docs/static/logo/Powered-By-Microsoft-logo-small.png";

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -34,7 +34,7 @@
 
 <body class="main">
     <div id='loading' class="ui active dimmer">
-        <div class="ui large main loader"></div>
+        <div class="ui large main loader msft"></div>
     </div>
 
     <div id='custom-content'>


### PR DESCRIPTION
The following loading screen is displayed on first load for all targets instead of a target-specific icon.
![microsoftLoad](https://github.com/microsoft/pxt/assets/15070078/f6878763-a462-4719-a04c-ba4009e89019)
