### PR TITLE
include ico file extension to patch /static/* images in pxtarget to point to cdnUrl

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1765,7 +1765,7 @@ function getGalleryUrl(props: pxt.GalleryProps | string): string {
 }
 
 function replaceStaticImagesInJsonBlob(cfg: any, staticAssetHandler: (fileLocation: string) => string): any {
-    return pxt.replaceStringsInJsonBlob(cfg, /^\.?\/static\/.+\.(png|gif|jpeg|jpg|svg|mp4)$/i, staticAssetHandler);
+    return pxt.replaceStringsInJsonBlob(cfg, /^\.?\/static\/.+\.(png|gif|jpeg|jpg|svg|mp4|ico)$/i, staticAssetHandler);
 }
 
 function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boolean) {


### PR DESCRIPTION
We need ico for favicons.