### PR TITLE
[stable8.5] clean up PageviewPerformanceData tick a bit

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -194,6 +194,16 @@ namespace pxt {
             return false;
         }
 
+        if (envelope.baseType == "PageviewPerformanceData") {
+            const pageName = envelope.baseData.name;
+            envelope.baseData.name = window.location.origin;
+            if (!envelope.baseData.properties) {
+                envelope.baseData.properties = {};
+            }
+            envelope.baseData.properties.pageName = pageName;
+            // no url scrubbing for webapp (no share url, etc)
+        }
+
         if (typeof pxtConfig === "undefined" || !pxtConfig) return true;
 
         const telemetryItem = envelope.baseData;

--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -9,8 +9,23 @@
                 sdk.addTelemetryInitializer(function (envelope) {
                     // App Insights automatically sends a page view event on setup, but we send our own later with additional properties.
                     // This stops the automatic event from firing, so we don't end up with duplicate page view events.
-                    if(envelope.baseType == "PageviewData" && !envelope.baseData.properties) {
+                    if (envelope.baseType == "PageviewData" && !envelope.baseData.properties) {
                         return false;
+                    }
+
+                    if (envelope.baseType == "PageviewPerformanceData") {
+                        var pageName = envelope.baseData.name;
+                        envelope.baseData.name = window.location.origin;
+                        if (!envelope.baseData.properties) {
+                            envelope.baseData.properties = {};
+                        }
+                        envelope.baseData.properties.pageName = pageName;
+                        var scrubbedUrl = scrubUrl(envelope.baseData.uri);
+                        envelope.baseData.uri = scrubbedUrl;
+                        if (envelope.ext && envelope.ext.trace) {
+                            var toUrl = new URL(scrubbedUrl);
+                            envelope.ext.trace.name = toUrl ? toUrl.pathname : "";
+                        }
                     }
 
                     var telemetryItem = envelope.baseData;


### PR DESCRIPTION
port #9602 for arcade release; unfortunately to really test this need to just port & ship a hotfix so we can see the telemetry data change a day or so later; going to arcade first as a standalone fix & can do rest later on after validating
