### PR TITLE
one more fix for pageviews; include pathname

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -201,6 +201,7 @@ namespace pxt {
                 envelope.baseData.properties = {};
             }
             envelope.baseData.properties.pageName = pageName;
+            envelope.baseData.properties.pathName = window.location.pathname;
             // no url scrubbing for webapp (no share url, etc)
         }
 

--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -22,8 +22,9 @@
                         envelope.baseData.properties.pageName = pageName;
                         var scrubbedUrl = scrubUrl(envelope.baseData.uri);
                         envelope.baseData.uri = scrubbedUrl;
+                        var toUrl = new URL(scrubbedUrl);
+                        envelope.baseData.properties.pathName = toUrl ? toUrl.pathname : "";
                         if (envelope.ext && envelope.ext.trace) {
-                            var toUrl = new URL(scrubbedUrl);
                             envelope.ext.trace.name = toUrl ? toUrl.pathname : "";
                         }
                     }


### PR DESCRIPTION
quick follow up on https://github.com/microsoft/pxt/pull/9602 before I port it to other editors, include pathname so we can compare those as well (vs. just page titles); share pages come in as xxxxx-xxxxx-xxxxx-xxxxx e.g. 
![image](https://github.com/microsoft/pxt/assets/5615930/3b1ff6d1-990e-4830-a0f6-6cf02eecbc7f)
