### PR TITLE
Local serve share page quick fixes

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -854,7 +854,7 @@ function scriptPageTestAsync(id: string) {
                 filepath: "/" + id
             })
             return html
-        })
+        });
 }
 
 // use http://localhost:3232/pkg/microsoft/pxt-neopixel for testing
@@ -1143,6 +1143,7 @@ export function serveAsync(options: ServeOptions) {
         if (!!pxt.Cloud.parseScriptId(pathname)) {
             scriptPageTestAsync(pathname)
                 .then(sendHtml)
+                .catch(() => error(404, "Script not found"));
             return
         }
 

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -825,7 +825,7 @@ function certificateTestAsync(): Promise<string> {
 
 // use http://localhost:3232/45912-50568-62072-42379 for testing
 function scriptPageTestAsync(id: string) {
-    return Cloud.privateGetAsync(id)
+    return Cloud.privateGetAsync(pxt.Cloud.parseScriptId(id))
         .then((info: Cloud.JsonScript) => {
             // if running against old cloud, infer 'thumb' field
             // can be removed after new cloud deployment
@@ -1140,8 +1140,8 @@ export function serveAsync(options: ServeOptions) {
             return
         }
 
-        if (/^\/(\d\d\d\d[\d-]+)$/.test(pathname)) {
-            scriptPageTestAsync(pathname.slice(1))
+        if (!!pxt.Cloud.parseScriptId(pathname)) {
+            scriptPageTestAsync(pathname)
                 .then(sendHtml)
             return
         }

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -251,7 +251,7 @@ namespace pxt.Cloud {
         const domainCheck = `(?:(?:https:\/\/)?(?:${domains.join('|')})\/)`;
         const versionRefCheck = "(?:v[0-9]+\/)";
         const oembedCheck = "api\/oembed\\?url=.*%2F([^&#]*)&.*";
-        const sharePageCheck = "([a-z0-9\\-_]+)(?:[#?&].*)?";
+        const sharePageCheck = "\/?([a-z0-9\\-_]+)(?:[#?&].*)?";
         const scriptIdCheck = `^${domainCheck}?${versionRefCheck}?(?:(?:${oembedCheck})|(?:${sharePageCheck}))$`;
         const m = new RegExp(scriptIdCheck, 'i').exec(uri.trim());
         const scriptid = m?.[1] /** oembed res **/ || m?.[2] /** share page res **/;


### PR DESCRIPTION
when fixing https://github.com/microsoft/pxt/pull/9609 took me a second to realize I was using an S link to check, which wasn't supported. This makes the localhost serve resolve _asdfasdfasdf links & s12345-... links in addition to just share ids.

Also make it so `pxt.Cloud.parseScriptId(window.location.pathname)` works when on a script page (that is, support a leading slash in case of copy paste typos / etc)