### PR TITLE
Re: Sim missing at exactly 991px width from MicroBit repo

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -166,7 +166,7 @@ namespace pxt.BrowserUtils {
     }
 
     export function isTabletSize(): boolean {
-        return window?.innerWidth < pxt.BREAKPOINT_TABLET;
+        return window?.innerWidth <= pxt.BREAKPOINT_TABLET;
     }
 
     export function isComputerSize(): boolean {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -170,7 +170,7 @@ namespace pxt.BrowserUtils {
     }
 
     export function isComputerSize(): boolean {
-        return window?.innerWidth >= pxt.BREAKPOINT_TABLET;
+        return window?.innerWidth > pxt.BREAKPOINT_TABLET;
     }
 
     export function noSharedLocalStorage(): boolean {


### PR DESCRIPTION
This is concerning issue #5328 in the Microbit repo (https://github.com/microsoft/pxt-microbit/issues/5328). The issue was that the simulator was not showing up when the window width was exactly 991px wide. After a lot of digging I was able to pinpoint that the issue was stemming from the `isTabletSize()` function within the `browserutils.ts` file. 

```
return window?.innerWidth = pxt.BREAKPOINT_TABLET;
```

to

```
return window?.innerWidth <= pxt.BREAKPOINT_TABLET;
```