### PR TITLE
[stable8.5] Fix deprecation warning in tsconfigs (#9492)

### DIFF
--- a/backendutils/tsconfig.json
+++ b/backendutils/tsconfig.json
@@ -4,7 +4,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "declaration": true,
-        "out": "../built/backendutils.js",
+        "outFile": "../built/backendutils.js",
         "newLine": "LF",
         "sourceMap": false,
         "moduleResolution": "node",

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1495,16 +1495,16 @@ function buildFolderAsync(p: string, optional?: boolean, outputName?: string): P
 
     const tsConfig = JSON.parse(fs.readFileSync(path.join(p, "tsconfig.json"), "utf8"));
     let isNodeModule = false;
-    if (outputName && tsConfig.compilerOptions.out !== `../built/${outputName}.js`) {
+    if (outputName && tsConfig.compilerOptions.outFile !== `../built/${outputName}.js`) {
         // Special case to support target sim as an NPM package
         if (/^node_modules[\/\\]+pxt-.*?-sim$/.test(p)) {
             // Allow the out dir be inside the folder being built, and manually copy the result to ./built afterwards
-            if (tsConfig.compilerOptions.out !== `./built/${outputName}.js`) {
-                U.userError(`${p}/tsconfig.json expected compilerOptions.out:"./built/${outputName}.js", got "${tsConfig.compilerOptions.out}"`);
+            if (tsConfig.compilerOptions.outFile !== `./built/${outputName}.js`) {
+                U.userError(`${p}/tsconfig.json expected compilerOptions.outFile:"./built/${outputName}.js", got "${tsConfig.compilerOptions.outFile}"`);
             }
             isNodeModule = true;
         } else {
-            U.userError(`${p}/tsconfig.json expected compilerOptions.out:"../built/${outputName}.js", got "${tsConfig.compilerOptions.out}"`);
+            U.userError(`${p}/tsconfig.json expected compilerOptions.outFile:"../built/${outputName}.js", got "${tsConfig.compilerOptions.outFile}"`);
         }
     }
 
@@ -1521,17 +1521,17 @@ function buildFolderAsync(p: string, optional?: boolean, outputName?: string): P
     }).then(() => {
         if (tsConfig.prepend) {
             let files: string[] = tsConfig.prepend
-            files.push(tsConfig.compilerOptions.out)
+            files.push(tsConfig.compilerOptions.outFile)
             let s = ""
             for (let f of files) {
                 s += fs.readFileSync(path.resolve(p, f), "utf8") + "\n"
             }
-            fs.writeFileSync(path.resolve(p, tsConfig.compilerOptions.out), s)
+            fs.writeFileSync(path.resolve(p, tsConfig.compilerOptions.outFile), s)
         }
 
         if (isNodeModule) {
-            const content = fs.readFileSync(path.resolve(p, tsConfig.compilerOptions.out), "utf8");
-            fs.writeFileSync(path.resolve("built", path.basename(tsConfig.compilerOptions.out)), content);
+            const content = fs.readFileSync(path.resolve(p, tsConfig.compilerOptions.outFile), "utf8");
+            fs.writeFileSync(path.resolve("built", path.basename(tsConfig.compilerOptions.outFile)), content);
         }
     })
 }
@@ -1553,7 +1553,7 @@ function buildFolderAndBrowserifyAsync(p: string, optional?: boolean, outputName
 
     const tsConfig = JSON.parse(fs.readFileSync(path.join(p, "tsconfig.json"), "utf8"));
     if (outputName && tsConfig.compilerOptions.outDir !== `../built/${outputName}`) {
-        U.userError(`${p}/tsconfig.json expected compilerOptions.ourDir:"../built/${outputName}", got "${tsConfig.compilerOptions.outDir}"`);
+        U.userError(`${p}/tsconfig.json expected compilerOptions.outDir:"../built/${outputName}", got "${tsConfig.compilerOptions.outDir}"`);
     }
 
     if (!fs.existsSync("node_modules/typescript")) {

--- a/docfiles/pxtweb/tsconfig.json
+++ b/docfiles/pxtweb/tsconfig.json
@@ -4,7 +4,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "declaration": true,
-        "out": "../../built/web/pxtweb.js",
+        "outFile": "../../built/web/pxtweb.js",
         "newLine": "LF",
         "sourceMap": false,
         "lib": ["dom", "dom.iterable", "scripthost", "es2018"],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -191,7 +191,7 @@ function compileTsProject(dirname, destination, useOutdir, filename) {
     let opts = useOutdir ? {
         outDir: path.resolve(destination)
     } : {
-            out: path.resolve(destination, path.basename(filename || dirname) + ".js")
+            outFile: path.resolve(destination, path.basename(filename || dirname) + ".js")
         };
 
     let configPath = path.join(dirname, "tsconfig.json");

--- a/pxtblocks/tsconfig.json
+++ b/pxtblocks/tsconfig.json
@@ -4,7 +4,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "declaration": true,
-        "out": "../built/pxtblocks.js",
+        "outFile": "../built/pxtblocks.js",
         "newLine": "LF",
         "sourceMap": false,
         "moduleResolution": "node",

--- a/pxtcompiler/tsconfig.json
+++ b/pxtcompiler/tsconfig.json
@@ -5,7 +5,7 @@
         "noImplicitReturns": true,
         "noImplicitThis": true,
         "declaration": true,
-        "out": "../built/pxtcompiler.js",
+        "outFile": "../built/pxtcompiler.js",
         "newLine": "LF",
         "sourceMap": false,
         "lib": [

--- a/pxteditor/tsconfig.json
+++ b/pxteditor/tsconfig.json
@@ -4,7 +4,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "declaration": true,
-        "out": "../built/pxteditor.js",
+        "outFile": "../built/pxteditor.js",
         "newLine": "LF",
         "sourceMap": false,
         "moduleResolution": "node",

--- a/pxtlib/tsconfig.json
+++ b/pxtlib/tsconfig.json
@@ -5,7 +5,7 @@
         "noImplicitReturns": true,
         "noImplicitThis": true,
         "declaration": true,
-        "out": "../built/pxtlib.js",
+        "outFile": "../built/pxtlib.js",
         "newLine": "LF",
         "sourceMap": false,
         "lib": [

--- a/pxtpy/tsconfig.json
+++ b/pxtpy/tsconfig.json
@@ -6,7 +6,7 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "declaration": true,
-        "out": "../built/pxtpy.js",
+        "outFile": "../built/pxtpy.js",
         "newLine": "LF",
         "sourceMap": false,
         "lib": [

--- a/pxtrunner/tsconfig.json
+++ b/pxtrunner/tsconfig.json
@@ -4,7 +4,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "declaration": true,
-        "out": "../built/pxtrunner.js",
+        "outFile": "../built/pxtrunner.js",
         "newLine": "LF",
         "sourceMap": false,
         "lib": [

--- a/pxtsim/tsconfig.json
+++ b/pxtsim/tsconfig.json
@@ -5,7 +5,7 @@
         "noImplicitReturns": true,
         "noImplicitThis": true,
         "declaration": true,
-        "out": "../built/pxtsim.js",
+        "outFile": "../built/pxtsim.js",
         "newLine": "LF",
         "sourceMap": false,
         "moduleResolution": "node",

--- a/tests/blocklycompiler-test/tsconfig.json
+++ b/tests/blocklycompiler-test/tsconfig.json
@@ -4,7 +4,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "declaration": true,
-        "out": "../../built/tests/tests.spec.js",
+        "outFile": "../../built/tests/tests.spec.js",
         "newLine": "LF",
         "types": [
             "chai",

--- a/tests/blocks-test/tsconfig.json
+++ b/tests/blocks-test/tsconfig.json
@@ -4,7 +4,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "declaration": true,
-        "out": "../../built/tests/blocksrunner.js",
+        "outFile": "../../built/tests/blocksrunner.js",
         "newLine": "LF",
         "lib": [
             "dom",


### PR DESCRIPTION
for arcade hotfix, easiest to pull this in vs. retroactively porting off change in pxt-arcade-sim (and makes switching branches easier as less dep graph thinking)