### PR TITLE
Fix Minecraft (Headless) Tutorial Layout

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -514,8 +514,6 @@
 
 #root.headless.tabTutorial {
     #simulator .editor-sidebar {
-        position: relative;
-        display: block !important;
         width: @simulatorWidth;
         height: calc(~'100%' - @mainMenuHeight);
         top: @mainMenuHeight;
@@ -658,6 +656,7 @@
         }
 
         #simulator .editor-sidebar {
+            display: block !important;
             height: @defaultTutorialHeight;
             width: 100%;
         }


### PR DESCRIPTION
This is one part of the fix needed for Minecraft's tutorial layout after the PXT bump. The other part is in the pxt-minecraft repo: https://github.com/microsoft/pxt-minecraft/pull/2314

Tutorials with fixes applied can be seen here: https://minecraft.makecode.com/app/8ef76a97727b2cdaf01a9b01e0703b80e23721a8-8e733a6100

Note that this does **not** fix https://github.com/microsoft/pxt-minecraft/issues/2312, which I'll investigate and address in a separate change.

Before:
<img width="706" alt="image" src="https://github.com/microsoft/pxt/assets/69657545/ebd796d7-c686-40b6-ab41-2d35f68f9ce6">

<img width="471" alt="image" src="https://github.com/microsoft/pxt/assets/69657545/567f2b5f-4587-4c6c-8bd0-7dba3b3c8589">

After:
<img width="607" alt="image" src="https://github.com/microsoft/pxt/assets/69657545/46f7c2ea-5e30-4321-89d3-936deaf3c52e">

<img width="470" alt="image" src="https://github.com/microsoft/pxt/assets/69657545/77c3cce2-ef27-454d-8d94-e82cbd01bf25">