### PR TITLE
Null check instead of falsey check for storedState value

### DIFF
--- a/multiplayer/src/services/simHost.ts
+++ b/multiplayer/src/services/simHost.ts
@@ -253,7 +253,7 @@ function setStoredState(runOpts: RunOptions, key: string, value: any) {
     const id = runOpts.id;
     let storedState: pxt.Map<string> = getStoredState(runOpts);
 
-    if (value) storedState[key] = value;
+    if (value != null) storedState[key] = value;
     else delete storedState[key];
 
     try {
@@ -375,7 +375,7 @@ export async function simulateAsync(
             driver.run(js, runOptions);
         }
         if (msg.command == "setstate") {
-            if (msg.stateKey && msg.stateValue) {
+            if (msg.stateKey && msg.stateValue != null) {
                 setStoredState(runOpts, msg.stateKey, msg.stateValue);
             }
         }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -391,7 +391,7 @@ namespace pxt.runner {
                 simDriver.run(js, runOptions);
             }
             if (msg.command == "setstate") {
-                if (msg.stateKey && msg.stateValue) {
+                if (msg.stateKey && msg.stateValue != null) {
                     setStoredState(simOptions.id, msg.stateKey, msg.stateValue)
                 }
             }
@@ -549,7 +549,7 @@ namespace pxt.runner {
             return
         }
 
-        if (value)
+        if (value != null)
             storedState[key] = value
         else
             delete storedState[key]


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6003

This fixes a bug that was happening when an arcade game was storing a setting as an empty array. When saving the settings on restart, it was getting serialized as an empty string, which resulted in the value not being set since it evaluates to falsey. Then later the game referenced the setting, causing a "dereferencing null/undefined value" error.

Now we check for null/undefined instead of falsey values when setting the storedState.

Big thanks to @jwunderl for walking me through this bug.