### PR TITLE
Remove preliminary null check for storedState

### DIFF
--- a/multiplayer/src/services/simHost.ts
+++ b/multiplayer/src/services/simHost.ts
@@ -375,7 +375,7 @@ export async function simulateAsync(
             driver.run(js, runOptions);
         }
         if (msg.command == "setstate") {
-            if (msg.stateKey && msg.stateValue != null) {
+            if (msg.stateKey) {
                 setStoredState(runOpts, msg.stateKey, msg.stateValue);
             }
         }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -391,7 +391,7 @@ namespace pxt.runner {
                 simDriver.run(js, runOptions);
             }
             if (msg.command == "setstate") {
-                if (msg.stateKey && msg.stateValue != null) {
+                if (msg.stateKey) {
                     setStoredState(simOptions.id, msg.stateKey, msg.stateValue)
                 }
             }


### PR DESCRIPTION
Cleanup for https://github.com/microsoft/pxt/pull/9634, https://github.com/microsoft/pxt-arcade/issues/6003

We don't actually want to check that the value is null before calling `setStoredState` because that function uses the null check to determine whether to set the value or delete the entry. If we check beforehand, we won't be deleting the entry.
See `setStoredState` function here: https://github.com/microsoft/pxt/blob/master/pxtrunner/runner.ts#L552