### PR TITLE
On/off colors added as block params for grids

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -813,6 +813,8 @@ declare namespace ts.pxtc {
         iconURL?: string;
         imageLiteral?: number;
         gridLiteral?: number;
+        gridLiteralOnColor?: string;
+        gridLiteralOffColor?: string;
         imageLiteralColumns?: number; // optional number of columns
         imageLiteralRows?: number; // optional number of rows
         imageLiteralScale?: number; // button sizing between 0.6 and 2, default is 1

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -686,8 +686,10 @@ namespace pxt.blocks {
             const columns = (fn.attributes.imageLiteralColumns || 5) * gridTemplateString;
             const rows = fn.attributes.imageLiteralRows || 5;
             const scale = fn.attributes.imageLiteralScale;
+            const onColor = fn.attributes.gridLiteralOnColor;
+            const offColor = fn.attributes.gridLiteralOffColor;
             let ri = block.appendDummyInput();
-            ri.appendField(new pxtblockly.FieldMatrix("", { columns, rows, scale }), "LEDS");
+            ri.appendField(new pxtblockly.FieldMatrix("", { columns, rows, scale, onColor, offColor }), "LEDS");
         }
 
         if (fn.attributes.inlineInputMode === "external") {

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -233,7 +233,8 @@ namespace pxtblockly {
         }
 
         private getOpacity(x: number, y: number) {
-            return this.cellState[x][y] ? '1.0' : '0.2';
+            const offOpacity = this.offColor ? '1.0': '0.2';
+            return this.cellState[x][y] ? '1.0' : offOpacity;
         }
 
         private updateCell(x: number, y: number) {


### PR DESCRIPTION
In an addition to https://github.com/microsoft/pxt/pull/9512, for the cybersecurity curriculum, they are trying to make rules that match a specific pattern of a grid (color and shape). However, we didn't have a way to allow for customizations for the cell colors. By default, the cell colors of a grid for "off" is black with an opacity and "on" is white. 

With these changes, if a user specifies on and off colors in comment attributes for block definitions, when clicking on a box in the grid, you can toggle between the two colors specified. 

<img width="294" alt="image" src="https://github.com/microsoft/pxt/assets/49178322/1d702289-da25-45ae-9374-aa21a5282a84">

![image](https://github.com/microsoft/pxt/assets/49178322/350a9249-be38-4c3c-b143-cc633282da25)

Closes https://github.com/microsoft/pxt-minecraft/issues/2313