### PR TITLE
More Minecraft Tutorial Fixes

### DIFF
--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -86,7 +86,7 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         aria-hidden={ariaHidden}
         aria-label={ariaLabel}
         onPointerDown={onPointerDown}
-        style={{height: hasResized ? `var(${heightProperty})` : initialHeight}}>
+        style={{height: resizeEnabled && hasResized ? `var(${heightProperty})` : initialHeight}}>
             {children}
     </div>
 }

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -1113,15 +1113,6 @@
         .tutorial-hint .tutorial-callout-button.ui.button {
             margin: 0;
         }
-
-        .tutorial-controls {
-            position: absolute;
-            right: 5.5rem;
-            height: 100%;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
     }
     .tutorial-title {
         max-width: 100%;

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -85,7 +85,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         } else {
             setParentHeight();
         }
-    })
+    }, [props.hasBeenResized, document.body])
 
     React.useEffect(() => {
         setCurrentStep(props.currentStep);

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -145,7 +145,8 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
 
         const simContainerClassName = `simulator-container ${this.props.tutorialSimSidebar ? "" : " hidden"}`;
         const outerTutorialContainerClassName = `editor-sidebar tutorial-container-outer${this.props.tutorialSimSidebar ? " topInstructions" : ""}`
-        const editorSidebarHeight = `${this.state.height}px`;
+        const shouldResize = pxt.BrowserUtils.isTabletSize() || this.props.tutorialSimSidebar;
+        const editorSidebarHeight = shouldResize ? `${this.state.height}px` : undefined;
 
         return <div id="simulator" className="simulator">
             {!hasSimulator && <div id="boardview" className="headless-sim" role="region" aria-label={lf("Simulator")} tabIndex={-1} />}
@@ -185,7 +186,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                         maxHeight="500px"
                         minHeight="100px"
                         initialHeight={editorSidebarHeight}
-                        resizeEnabled={pxt.BrowserUtils.isTabletSize() || this.props.tutorialSimSidebar}
+                        resizeEnabled={shouldResize}
                         onResizeDrag={newSize => this.setComponentHeight(newSize, true)}
                         onResizeEnd={newSize => pxt.tickEvent("tutorial.resizeInstructions", {newSize: newSize})}>
                         <TutorialContainer
@@ -199,7 +200,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                             hasTemplate={!!tutorialOptions.templateCode}
                             preferredEditor={tutorialOptions.metadata?.preferredEditor}
                             tutorialSimSidebar={this.props.tutorialSimSidebar}
-                            hasBeenResized={this.state.resized}
+                            hasBeenResized={this.state.resized && shouldResize}
                             onTutorialStepChange={onTutorialStepChange}
                             onTutorialComplete={onTutorialComplete}
                             setParentHeight={newSize => this.setComponentHeight(newSize, false)} />


### PR DESCRIPTION
Fixes up a few additional tutorial layout bugs, including:

1. Fixes https://github.com/microsoft/pxt-minecraft/issues/2312 (need to ensure the vertical resize container is turned off and reset once the instructions are re-expanded)

2. Fix navigation buttons on mobile screen size (more headless-mode css adjustments)

Upload Target: https://minecraft.makecode.com/app/2d4dd01b4eb9f96d87fb427cf3ccf4d91e0af147-cb16e8b4bb