### PR TITLE
Remove SimPanel in Headless-Mode Tutorials

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -518,6 +518,10 @@
         height: calc(~'100%' - @mainMenuHeight);
         top: @mainMenuHeight;
         left: 0;
+
+        .simPanel {
+            display: none;
+        }
     }
 
     #boardview, .filemenu {


### PR DESCRIPTION
This panel is empty anyway, but it was blocking the play button's mouse interaction on certain screen sizes (as seen below) causing https://github.com/microsoft/pxt-minecraft/issues/2315.

Sim Panel blocking interaction:
![image](https://github.com/microsoft/pxt/assets/69657545/0f97e8b8-3a08-4994-8f55-8632270408ed)

Fixes https://github.com/microsoft/pxt-minecraft/issues/2315

Upload Target: https://minecraft.makecode.com/app/0ea39a6562a0aa92f02d646175612dbe5d70428d-ae0451e946