### PR TITLE
Do Not Expand Sim After Tutorial in Headless Mode

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4658,7 +4658,7 @@ export class ProjectView
                         return this.loadHeaderAsync(curr);
                     }).finally(() => {
                         core.hideLoading("leavingtutorial")
-                        if (this.state.collapseEditorTools) {
+                        if (this.state.collapseEditorTools && !pxt.appTarget.simulator.headless) {
                             this.expandSimulator();
                         }
                         this.postTutorialProgress();


### PR DESCRIPTION
When a tutorial ends and the user clicks "Done" to go to the main code editor, we were calling into `expandSimulator`, which will open the sidebar even when we don't have an actual simulator to show. This change prevents that call if we're in headless mode (i.e. no simulator).

I considered putting this check inside `expandSimulator` so it no-oped there if we're in headless mode, but I think this may still be used to see the file explorer in javascript mode, so I left that untouched for now.

Fixes https://github.com/microsoft/pxt-minecraft/issues/2323