### PR TITLE
Quick change display name for custom namespace

### DIFF
--- a/common-docs/blocks/custom.md
+++ b/common-docs/blocks/custom.md
@@ -82,7 +82,7 @@ enum MyEnum {
 /**
 * Custom blocks
 */
-//% weight=100 color=#0fbc11 icon=""
+//% block="Custom" weight=100 color=#0fbc11 icon=""
 namespace custom {
     /**
     * TODO: describe your function here


### PR DESCRIPTION
Add a custom.ts property to the example so that you can quickly change the display name for the specified namespace.
The user will always be in front of how to change the display name of the category.