### PR TITLE
Add insufficient blocks case to code validation

### DIFF
--- a/webapp/src/components/tutorialValidators.tsx
+++ b/webapp/src/components/tutorialValidators.tsx
@@ -84,7 +84,7 @@ export class BlocksExistValidator extends CodeValidatorBase {
             errorDescription = lf("Make sure your blocks are connected to the rest of your code like this.");
         } else if (insufficientBlocks.length > 0) {
             isValid = false;
-            errorDescription = lf("Make sure you have enough blocks in your workspace. It should look like this.");
+            errorDescription = lf("Make sure you have enough blocks and that they're connected to the rest of your code. It should look like this.");
         }
 
         const blockImages = stepInfo?.hintContentMd ? (<div>

--- a/webapp/src/components/tutorialValidators.tsx
+++ b/webapp/src/components/tutorialValidators.tsx
@@ -64,6 +64,7 @@ export class BlocksExistValidator extends CodeValidatorBase {
         const {
             missingBlocks,
             disabledBlocks,
+            insufficientBlocks
         } = pxt.blocks.validateBlocksExist({
             usedBlocks: editor.getAllBlocks(false /* ordered */),
             requiredBlockCounts: stepHighlights,
@@ -81,6 +82,9 @@ export class BlocksExistValidator extends CodeValidatorBase {
         } else if (disabledBlocks.length > 0) {
             isValid = false;
             errorDescription = lf("Make sure your blocks are connected to the rest of your code like this.");
+        } else if (insufficientBlocks.length > 0) {
+            isValid = false;
+            errorDescription = lf("Make sure you have enough blocks in your workspace. It should look like this.");
         }
 
         const blockImages = stepInfo?.hintContentMd ? (<div>


### PR DESCRIPTION
The insufficient blocks case is when the tutorial step requires more than one of the same type of block and the user has at least one of that type of block, but not all of the blocks. For example, in the picture below the user needs two "variables_set" blocks but only has one. Note: this example is a made-up tutorial step as I don't think we have any current tutorials that require more than one block of the same type in a single step.

Joey already added a check for insufficient blocks here: https://github.com/microsoft/pxt/blob/master/pxtblocks/code-validation/validateBlocksExist.ts#L27
This PR just uses that check to create the appropriate code validation message to the user.
![image](https://github.com/microsoft/pxt/assets/15070078/701d4189-9df3-4ad4-8b32-7c8e096f00cb)
