### PR TITLE
Fix Non-Python Changes After Leaving Python Mode

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -1197,7 +1197,6 @@ namespace pxt {
             await this.loadAsync()
 
             opts.bannedCategories = this.resolveBannedCategories();
-            opts.target.preferredEditor = this.getPreferredEditor()
             pxt.debug(`building: ${this.sortedDeps().map(p => p.config.name).join(", ")}`)
 
             let variants: string[]
@@ -1240,6 +1239,8 @@ namespace pxt {
                 }
             }
             opts.extinfo = ext
+
+            opts.target.preferredEditor = this.getPreferredEditor();
 
             const noFileEmbed = appTarget.compile.shortPointers ||
                 appTarget.compile.nativeType == "vm" ||


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6034. Essentially, if you switch to python and then change back to typescript or blocks, your typescript/blocks changes will be ignored.

This was happening because the preferred editor in our compile options remained set to python. The call to `getPreferredEditor()` was returning the correct value, but there's a scenario where, when iterating through variants, opts.target is overwritten with the old value from `appTarget.compile` (`opts.target = etarget.target;` in line 1235).

The simplest fix is to set the preferred editor after this happens, so we don't override it. A more involved solution would be to change how we're tracking the editor "mode" (js/py/blocks) and ensure a single source of truth, but I think that'd be a fairly extensive change with a high risk of severe regressions (i.e. code loss if we compile the wrong file, overwrite changes, etc...). Perhaps something to look at down the road, but probably not now...

Upload target: https://arcade.makecode.com/app/5b2685789e1b0aea9d81a9cb38c5162f0f367f74-7aafc43a06