### PR TITLE
Switch Editor Modes When Changing Between Py/TS in File Explorer

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1283,10 +1283,19 @@ export class ProjectView
     setSideFile(fn: pkg.File, line?: number) {
         let fileName = fn.name;
         let currFile = this.state.currFile.name;
+
         if (fileName != currFile && pxt.editor.isBlocks(fn)) {
-            // Going from ts -> blocks
+            // Going from ts/py -> blocks
             pxt.tickEvent("sidebar.showBlocks");
             this.openBlocks();
+        } else if (fileName.endsWith(".py") && currFile.endsWith(".ts")) {
+            // Going from ts -> py
+            pxt.tickEvent("sidebar.showPython");
+            this.openPythonAsync();
+        } else if (fileName.endsWith(".ts") && currFile.endsWith(".py")) {
+            // Going from py -> ts
+            pxt.tickEvent("sidebar.showTypescript");
+            this.openTypeScriptAsync();
         } else {
             if (this.isTextEditor() || this.isPxtJsonEditor()) {
                 this.textEditor.giveFocusOnLoading = false

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1291,11 +1291,11 @@ export class ProjectView
         } else if (fileName.endsWith(".py") && currFile.endsWith(".ts")) {
             // Going from ts -> py
             pxt.tickEvent("sidebar.showPython");
-            this.openPythonAsync();
+            this.openPython();
         } else if (fileName.endsWith(".ts") && currFile.endsWith(".py")) {
             // Going from py -> ts
             pxt.tickEvent("sidebar.showTypescript");
-            this.openTypeScriptAsync();
+            this.openJavaScript();
         } else {
             if (this.isTextEditor() || this.isPxtJsonEditor()) {
                 this.textEditor.giveFocusOnLoading = false

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -488,7 +488,7 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
         const noBlocks = languageRestriction === pxt.editor.LanguageRestriction.NoBlocks;
 
         // show python in toggle if: python editor currently active, or blocks editor active & saved language pref is python
-        const pythonIsActive = parent.isPythonActive() || (parent.isBlocksActive() && pxt.shell.isPyLangPref());
+        const pythonIsActive = (parent.isPythonActive() || pxt.shell.isPyLangPref());
         const showPython = python && !tsOnly && !blocksOnly && !noPython;
         const showBlocks = !pyOnly && !tsOnly && !noBlocks && !!pkg.mainEditorPkg().files[pxt.MAIN_BLOCKS];
         const showJavaScript = !noJavaScript && !pyOnly && !blocksOnly;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -488,7 +488,7 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
         const noBlocks = languageRestriction === pxt.editor.LanguageRestriction.NoBlocks;
 
         // show python in toggle if: python editor currently active, or blocks editor active & saved language pref is python
-        const pythonIsActive = (parent.isPythonActive() || pxt.shell.isPyLangPref());
+        const pythonIsActive = parent.isPythonActive() || (parent.isBlocksActive() && pxt.shell.isPyLangPref());
         const showPython = python && !tsOnly && !blocksOnly && !noPython;
         const showBlocks = !pyOnly && !tsOnly && !noBlocks && !!pkg.mainEditorPkg().files[pxt.MAIN_BLOCKS];
         const showJavaScript = !noJavaScript && !pyOnly && !blocksOnly;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6028

With this change, when a user selects `main.py` (or any other python file) while in typescript mode, the editor will fully switch to python mode, which means any updated javascript will be translated into python before the file switch occurs, preventing code loss. The same will also happen in reverse when selecting a typescript file while in python mode. This behavior aligns with what happens when you click on `main.blocks` (it will switch to the blocks editor).

Upload target: https://arcade.makecode.com/app/962a0b823b61325c162a2fed0995f02a87f2aec4-d0020cc65b
