### PR TITLE
Experiments: beta card bugs fixed

### DIFF
--- a/theme/scriptsearch.less
+++ b/theme/scriptsearch.less
@@ -33,6 +33,17 @@
                 height: 14em;
             }
         }
+
+    }
+    .ui.card.beta {
+        margin: 0.875em 0.5em !important;
+
+        .ui.button {
+            cursor: default;
+            background-image: none!important;
+            box-shadow: none!important;
+            pointer-events: none!important;
+        }
     }
     /* Search input */
     .ui.search {

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -524,6 +524,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                                 ariaLabel={lf("Open the next version of the editor")}
                                 role="button"
                                 key={'beta'}
+                                className="beta"
                                 icon="lab ui cardimage"
                                 iconColor="secondary"
                                 name={lf("Beta Editor")}


### PR DESCRIPTION
In the experiments view in all of our editors, the beta card was a bit off. It wasn't aligned to the other cards and it would also cover the "beta" label when someone would hover over it. The reason that the hover was behaving differently from the other experiment cards is because was are taking advantage of semantic ui's button creation. On hover, the button that we're using just for styling is popped up a bit and thus covers the beta label. My solution is to essentially make the button disabled even though it looks enabled. 

![image](https://github.com/microsoft/pxt/assets/49178322/b0a85cc2-6be6-4fdc-bbdf-c03fcd4f7d9e)

![image](https://github.com/microsoft/pxt/assets/49178322/4483b282-d1db-4a89-a81f-96484f1d2988)

![image](https://github.com/microsoft/pxt/assets/49178322/01ce8df2-93fc-467c-941d-7ce56f995d03)


I feel like there should be a better solution to this rather than just kind of hacking around the semantic ui button. I'm not a huge fan of the accessibility implications of this, either. Everything on the card does essentially behave like a button, but something feels a bit off to me, and I can't quite put my finger on what it is. 

Closes https://github.com/microsoft/pxt-minecraft/issues/2235
Closes https://github.com/microsoft/pxt-minecraft/issues/2233