### PR TITLE
Allow for smaller share dialog when we don't want previews

### DIFF
--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -59,7 +59,8 @@ export const ShareInfo = (props: ShareInfoProps) => {
     const [ isAnonymous, setIsAnonymous ] = React.useState(!isLoggedIn || anonymousShareByDefault);
     const [ isShowingMultiConfirmation, setIsShowingMultiConfirmation ] = React.useState(false);
 
-    const showSimulator = !!simRecorder;
+    const { simScreenshot, simGif } = pxt.appTarget.appTheme;
+    const showSimulator = (simScreenshot || simGif) && !!simRecorder;
     const showDescription = shareState !== "publish";
     let qrCodeButtonRef: HTMLButtonElement;
     let inputRef: HTMLInputElement;

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -195,9 +195,7 @@ export class ShareEditor extends auth.Component<ShareEditorProps, ShareEditorSta
         const { visible, projectName: newProjectName, title, screenshotUri } = this.state;
         const { simScreenshot, simGif } = pxt.appTarget.appTheme;
         const hasIdentity = auth.hasIdentity() && this.isLoggedIn();
-        const light = !!pxt.options.light;
-        const thumbnails = pxt.appTarget.cloud && pxt.appTarget.cloud.thumbnails
-            && (simScreenshot || simGif);
+        const thumbnails = simScreenshot || simGif;
 
         const hasProjectBeenPersistentShared = parent.hasHeaderBeenPersistentShared();
 
@@ -209,7 +207,7 @@ export class ShareEditor extends auth.Component<ShareEditorProps, ShareEditorSta
         return visible
             ? <Modal
                 title={lf("Share Project")}
-                className="sharedialog wide"
+                className={`sharedialog${thumbnails ? " wide" : ""}`}
                 parentElement={document.getElementById("root") || undefined}
                 onClose={this.hide}>
                 <Share projectName={newProjectName}


### PR DESCRIPTION
The new share dialog allows for the recording and screenshotting of the simulators in micro:bit and arcade, but we don't have something to easily preview in Minecraft at the moment. That means that the "record gif" or "take screenshot" area of the share dialog is not useful and is also buggy. 

If one of our targets specifies that it doesn't want to record GIF previews or allow screenshots of a simulator in `pxtarget.json`, we now get rid of that part of the share modal. When getting rid of the preview area of the share modal, the input for the project name was awkwardly long. So I've also updated the styling so that if we don't have something to preview for the project, we use a smaller share modal.

**Before**
![image](https://github.com/microsoft/pxt/assets/49178322/951276eb-3771-495d-9faa-6a6f58663b0c)

**After**
![image](https://github.com/microsoft/pxt/assets/49178322/a80ef4a5-a669-4da3-add9-fc25135d0a99)
![image](https://github.com/microsoft/pxt/assets/49178322/0e95dfd5-3578-4509-95ab-ac170e8c94e2)


Closes https://github.com/microsoft/pxt-minecraft/issues/2317