### PR TITLE
Always sort by relevance when searching projects in script manager

### DIFF
--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -333,6 +333,7 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
             displayAbove ? 'menuAbove' : '',
             displayRight ? 'menuRight' : '',
             displayLeft ? "menuLeft" : '',
+            disabled ? "disabled" : ''
         ]);
         const menuClasses = cx([
             'menu',

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1682,8 +1682,13 @@ data.mountVirtualApi("headers", {
         return compiler.projectSearchAsync({ term: p, headers })
             .then((searchResults: pxtc.service.ProjectSearchInfo[]) => searchResults)
             .then(searchResults => {
-                let searchResultsMap = U.toDictionary(searchResults || [], h => h.id)
-                return headers.filter(h => searchResultsMap[h.id]);
+                const result: Header[] = [];
+
+                for (const header of searchResults) {
+                    result.push(headers.find(h => h.id === header.id));
+                }
+
+                return result.filter(h => !!h);
             });
     },
     expirationTime: p => 5 * 1000,


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6035

Changing the script manager to always sort by relevance if there is any search term entered. It switches back once you delete the search term.

The search results we get back from the webworker are sorted by relevance, but we were completely ignoring that and sorting by name/time instead which is 100% useless.

