### PR TITLE
High contrast: Icons for block categories now have colors in Minecraft

### DIFF
--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -260,6 +260,50 @@ div.blocklyTreeIcon span {
 }
 
 /*******************************
+    Inverted Toolbox
+*******************************/
+#root.hc .invertedToolbox div div {
+    div.blocklyTreeRow .blocklyTreeIcon {
+        color: var(--block-meta-color);
+    }
+
+    div.blocklyTreeRow.blocklyTreeSelected .blocklyTreeIcon {
+        color: #fff;
+    }
+}
+
+.invertedToolbox .blocklyTreeRoot div div {
+    div.blocklyTreeRow {
+        background-color: var(--block-meta-color);
+        color: #fff;
+    }
+
+    div.blocklyTreeRow.blocklyTreeSelected {
+        background-color: var(--block-meta-color);
+    }
+
+    div.blocklyTreeRow:hover {
+        background-color: var(--block-faded-color);
+        color: #fff;
+    }
+}
+
+/*******************************
+    Colored Toolbox
+*******************************/
+.coloredToolbox .blocklyTreeRoot div div {
+    div.blocklyTreeRow {
+        color: var(--block-meta-color);
+        border-left: var(--block-category-border);
+    }
+
+    div.blocklyTreeRow.blocklyTreeSelected {
+        background-color: var(--block-meta-color);
+        color: #fff;
+    }
+}
+
+/*******************************
         Media Adjustments
 *******************************/
 

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -229,6 +229,14 @@ div.blocklyTreeIcon span {
 .blocklyFlyoutLabelIcon.blocklyFlyoutIconfunctions {
     font-family: xicon !important;
 }
+.blocklyTreeIcon.image-icon {
+    background-image: var(--image-icon-url);
+    width: 30px;
+    height: 100%;
+    background-size: 20px !important;
+    background-repeat: no-repeat !important;
+    background-position: 50% 50% !important;
+}
 
 /*******************************
       Toolbox Animation
@@ -262,7 +270,7 @@ div.blocklyTreeIcon span {
 /*******************************
     Inverted Toolbox
 *******************************/
-#root.hc .invertedToolbox div div {
+#root.hc .invertedToolbox {
     div.blocklyTreeRow .blocklyTreeIcon {
         color: var(--block-meta-color);
     }
@@ -272,7 +280,7 @@ div.blocklyTreeIcon span {
     }
 }
 
-.invertedToolbox .blocklyTreeRoot div div {
+.invertedToolbox .blocklyTreeRoot {
     div.blocklyTreeRow {
         background-color: var(--block-meta-color);
         color: #fff;
@@ -291,10 +299,10 @@ div.blocklyTreeIcon span {
 /*******************************
     Colored Toolbox
 *******************************/
-.coloredToolbox .blocklyTreeRoot div div {
+.coloredToolbox .blocklyTreeRoot {
     div.blocklyTreeRow {
         color: var(--block-meta-color);
-        border-left: var(--block-category-border);
+        border-left: 8px solid var(--block-meta-color);
     }
 
     div.blocklyTreeRow.blocklyTreeSelected {

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -747,7 +747,6 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
         const { nameid, advancedButtonState, subns, name, icon } = this.props.treeRow;
         const appTheme = pxt.appTarget.appTheme;
         const metaColor = this.getMetaColor();
-        const hc = core.getHighContrastOnce();
 
         const invertedMultipler = appTheme.blocklyOptions
             && appTheme.blocklyOptions.toolboxOptions
@@ -756,33 +755,27 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
         let treeRowStyle: React.CSSProperties = {
             paddingLeft: '0px',
             "--block-meta-color": metaColor,
-            "--block-faded-color": pxt.toolbox.fadeColor(metaColor || '#ddd', invertedMultipler, false),
-            "--block-category-border": `8px solid ${metaColor}`
+            "--block-faded-color": pxt.toolbox.fadeColor(metaColor || '#ddd', invertedMultipler, false)
         } as React.CSSProperties;
 
         let treeRowClass = `blocklyTreeRow${selected ? ' blocklyTreeSelected' : '' }`;
-        // left this commented out because I want to chat about it first
-            // if (topRowIndex && this.props.shouldAnimate) {
-            //     treeRowStyle.animationDelay = `${(topRowIndex * this.animationDelay) + this.baseAnimationDelay}s`;
-            //     treeRowClass += ' blocklyTreeAnimate';
-            // }
+
+        if (topRowIndex && this.props.shouldAnimate) {
+            treeRowStyle.animationDelay = `${(topRowIndex * this.animationDelay) + this.baseAnimationDelay}s`;
+            treeRowClass += ' blocklyTreeAnimate';
+        }
 
         // Icon
-        const iconClass = `blocklyTreeIcon${subns ? 'more' : icon ? (nameid || icon).toLowerCase() : 'Default'}`.replace(/\s/g, '');
+        let iconClass = `blocklyTreeIcon${subns ? 'more' : icon ? (nameid || icon).toLowerCase() : 'Default'}`.replace(/\s/g, '');
         let iconContent = subns ? pxt.toolbox.getNamespaceIcon('more') : icon || pxt.toolbox.getNamespaceIcon('default');
-        let iconImageStyle: JSX.Element;
+        let iconImageStyle: React.CSSProperties = {
+            "--image-icon-url": `url("${Util.pathJoin(pxt.webConfig.commitCdnUrl, encodeURI(icon))}")!important`,
+            display: "inline-block"
+        } as React.CSSProperties;
+
         if (iconContent.length > 1) {
             // It's probably an image icon, and not an icon code
-            iconImageStyle = <style>
-                {`.blocklyTreeIcon.${iconClass} {
-                    background-image: url("${Util.pathJoin(pxt.webConfig.commitCdnUrl, encodeURI(icon))}")!important;
-                    width: 30px;
-                    height: 100%;
-                    background-size: 20px !important;
-                    background-repeat: no-repeat !important;
-                    background-position: 50% 50% !important;
-                }`}
-            </style>
+            iconClass += ' image-icon';
             iconContent = undefined;
         }
         const rowTitle = name ? name : Util.capitalize(subns || nameid);
@@ -795,8 +788,7 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
             aria-label={lf("Toggle category {0}", rowTitle)} aria-expanded={selected}
             onClick={onClick} onContextMenu={onClick} onKeyDown={onKeyDown ? onKeyDown : fireClickOnEnter}>
             <span className="blocklyTreeIcon" role="presentation"></span>
-            {iconImageStyle}
-            <span style={{ display: 'inline-block' }} className={`blocklyTreeIcon ${iconClass} ${extraIconClass}`} role="presentation">{iconContent}</span>
+            <span style={iconImageStyle} className={`blocklyTreeIcon ${iconClass} ${extraIconClass}`} role="presentation">{iconContent}</span>
             <span className="blocklyTreeLabel">{rowTitle}</span>
             {hasDeleteButton ? <i className="blocklyTreeButton icon times circle" onClick={this.handleDeleteClick}/>: undefined}
         </div>

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -787,13 +787,6 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
             treeRowStyle.color = '#fff';
             if (hc) {
                 treeIconStyle.color = metaColor;
-                if (nameid === "agent") {
-                    this.props.treeRow.icon = "icons/Agent_icon_orange.png"
-                }
-            } else {
-                if (nameid === "agent") {
-                    this.props.treeRow.icon = "icons/Agent_icon_white.png"
-                }
             }
         } else {
             if (appTheme.coloredToolbox) {

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -491,7 +491,6 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         ])
 
         let index = 0;
-        // I don't think this is working.. may remove or try to fix.
         let topRowIndex = 0; // index of top-level rows for animation
         const advancedButtonState = showAdvanced ? "advancedexpanded" : "advancedcollapsed";
         return <div ref={this.handleRootElementRef} className={classes} id={`${editorname}EditorToolbox`}>

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -767,13 +767,13 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
         // Icon
         let iconClass = `blocklyTreeIcon${subns ? 'more' : icon ? (nameid || icon).toLowerCase() : 'Default'}`.replace(/\s/g, '');
         let iconContent = subns ? pxt.toolbox.getNamespaceIcon('more') : icon || pxt.toolbox.getNamespaceIcon('default');
+        const isImageIcon = iconContent.length > 1;  // It's probably an image icon, and not an icon code
         let iconImageStyle: React.CSSProperties = {
-            "--image-icon-url": `url("${Util.pathJoin(pxt.webConfig.commitCdnUrl, encodeURI(icon))}")!important`,
+            "--image-icon-url": isImageIcon ? `url("${Util.pathJoin(pxt.webConfig.commitCdnUrl, encodeURI(icon))}")!important`: undefined,
             display: "inline-block"
         } as React.CSSProperties;
 
-        if (iconContent.length > 1) {
-            // It's probably an image icon, and not an icon code
+        if (isImageIcon) {
             iconClass += ' image-icon';
             iconContent = undefined;
         }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -768,6 +768,7 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
         const { nameid, advancedButtonState, subns, name, icon } = this.props.treeRow;
         const appTheme = pxt.appTarget.appTheme;
         const metaColor = this.getMetaColor();
+        const hc = core.getHighContrastOnce();
 
         const invertedMultipler = appTheme.blocklyOptions
             && appTheme.blocklyOptions.toolboxOptions
@@ -776,11 +777,24 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
         let treeRowStyle: React.CSSProperties = {
             paddingLeft: '0px'
         }
+        let treeIconStyle: React.CSSProperties = {
+            color: '#fff', display: 'inline-block'
+        }
         let treeRowClass = 'blocklyTreeRow';
         if (appTheme.invertedToolbox) {
             // Inverted toolbox
             treeRowStyle.backgroundColor = (metaColor || '#ddd');
             treeRowStyle.color = '#fff';
+            if (hc) {
+                treeIconStyle.color = metaColor;
+                if (nameid === "agent") {
+                    this.props.treeRow.icon = "icons/Agent_icon_orange.png"
+                }
+            } else {
+                if (nameid === "agent") {
+                    this.props.treeRow.icon = "icons/Agent_icon_white.png"
+                }
+            }
         } else {
             if (appTheme.coloredToolbox) {
                 // Colored toolbox
@@ -803,6 +817,9 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
             treeRowClass += ' blocklyTreeSelected';
             if (appTheme.invertedToolbox) {
                 treeRowStyle.backgroundColor = `${pxt.toolbox.fadeColor(metaColor, invertedMultipler, false)}`;
+                if (hc) {
+                    treeIconStyle.color = '#fff';
+                }
             } else {
                 treeRowStyle.backgroundColor = (metaColor || '#ddd');
             }
@@ -839,7 +856,7 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
             onClick={onClick} onContextMenu={onClick} onKeyDown={onKeyDown ? onKeyDown : fireClickOnEnter}>
             <span className="blocklyTreeIcon" role="presentation"></span>
             {iconImageStyle}
-            <span style={{ display: 'inline-block' }} className={`blocklyTreeIcon ${iconClass} ${extraIconClass}`} role="presentation">{iconContent}</span>
+            <span style={treeIconStyle} className={`blocklyTreeIcon ${iconClass} ${extraIconClass}`} role="presentation">{iconContent}</span>
             <span className="blocklyTreeLabel">{rowTitle}</span>
             {hasDeleteButton ? <i className="blocklyTreeButton icon times circle" onClick={this.handleDeleteClick}/>: undefined}
         </div>

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -491,6 +491,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         ])
 
         let index = 0;
+        // I don't think this is working.. may remove or try to fix.
         let topRowIndex = 0; // index of top-level rows for animation
         const advancedButtonState = showAdvanced ? "advancedexpanded" : "advancedcollapsed";
         return <div ref={this.handleRootElementRef} className={classes} id={`${editorname}EditorToolbox`}>
@@ -715,8 +716,6 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
         this.state = {
         }
 
-        this.onmouseenter = this.onmouseenter.bind(this);
-        this.onmouseleave = this.onmouseleave.bind(this);
         this.handleDeleteClick = this.handleDeleteClick.bind(this);
     }
 
@@ -727,26 +726,6 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
     getProperties() {
         const { treeRow } = this.props;
         return treeRow;
-    }
-
-    onmouseenter() {
-        const appTheme = pxt.appTarget.appTheme;
-        const metaColor = this.getMetaColor();
-        const invertedMultipler = appTheme.blocklyOptions
-            && appTheme.blocklyOptions.toolboxOptions
-            && appTheme.blocklyOptions.toolboxOptions.invertedMultiplier || 0.3;
-
-        if (appTheme.invertedToolbox) {
-            this.treeRow.style.backgroundColor = pxt.toolbox.fadeColor(metaColor || '#ddd', invertedMultipler, false);
-        }
-    }
-
-    onmouseleave() {
-        const appTheme = pxt.appTarget.appTheme;
-        const metaColor = this.getMetaColor();
-        if (appTheme.invertedToolbox) {
-            this.treeRow.style.backgroundColor = (metaColor || '#ddd');
-        }
     }
 
     getMetaColor() {
@@ -775,49 +754,18 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
             && appTheme.blocklyOptions.toolboxOptions.invertedMultiplier || 0.3;
 
         let treeRowStyle: React.CSSProperties = {
-            paddingLeft: '0px'
-        }
-        let treeIconStyle: React.CSSProperties = {
-            color: '#fff', display: 'inline-block'
-        }
-        let treeRowClass = 'blocklyTreeRow';
-        if (appTheme.invertedToolbox) {
-            // Inverted toolbox
-            treeRowStyle.backgroundColor = (metaColor || '#ddd');
-            treeRowStyle.color = '#fff';
-            if (hc) {
-                treeIconStyle.color = metaColor;
-            }
-        } else {
-            if (appTheme.coloredToolbox) {
-                // Colored toolbox
-                treeRowStyle.color = `${metaColor}`;
-            }
-            const border = `8px solid ${metaColor}`;
-            if (isRtl) {
-                treeRowStyle.borderRight = border;
-            } else {
-                treeRowStyle.borderLeft = border;
-            }
-            if (topRowIndex && this.props.shouldAnimate) {
-                treeRowStyle.animationDelay = `${(topRowIndex * this.animationDelay) + this.baseAnimationDelay}s`;
-                treeRowClass += ' blocklyTreeAnimate';
-            }
-        }
+            paddingLeft: '0px',
+            "--block-meta-color": metaColor,
+            "--block-faded-color": pxt.toolbox.fadeColor(metaColor || '#ddd', invertedMultipler, false),
+            "--block-category-border": `8px solid ${metaColor}`
+        } as React.CSSProperties;
 
-        // Selected
-        if (selected) {
-            treeRowClass += ' blocklyTreeSelected';
-            if (appTheme.invertedToolbox) {
-                treeRowStyle.backgroundColor = `${pxt.toolbox.fadeColor(metaColor, invertedMultipler, false)}`;
-                if (hc) {
-                    treeIconStyle.color = '#fff';
-                }
-            } else {
-                treeRowStyle.backgroundColor = (metaColor || '#ddd');
-            }
-            treeRowStyle.color = '#fff';
-        }
+        let treeRowClass = `blocklyTreeRow${selected ? ' blocklyTreeSelected' : '' }`;
+        // left this commented out because I want to chat about it first
+            // if (topRowIndex && this.props.shouldAnimate) {
+            //     treeRowStyle.animationDelay = `${(topRowIndex * this.animationDelay) + this.baseAnimationDelay}s`;
+            //     treeRowClass += ' blocklyTreeAnimate';
+            // }
 
         // Icon
         const iconClass = `blocklyTreeIcon${subns ? 'more' : icon ? (nameid || icon).toLowerCase() : 'Default'}`.replace(/\s/g, '');
@@ -845,11 +793,10 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
             style={treeRowStyle} tabIndex={0}
             data-ns={dataNs}
             aria-label={lf("Toggle category {0}", rowTitle)} aria-expanded={selected}
-            onMouseEnter={this.onmouseenter} onMouseLeave={this.onmouseleave}
             onClick={onClick} onContextMenu={onClick} onKeyDown={onKeyDown ? onKeyDown : fireClickOnEnter}>
             <span className="blocklyTreeIcon" role="presentation"></span>
             {iconImageStyle}
-            <span style={treeIconStyle} className={`blocklyTreeIcon ${iconClass} ${extraIconClass}`} role="presentation">{iconContent}</span>
+            <span style={{ display: 'inline-block' }} className={`blocklyTreeIcon ${iconClass} ${extraIconClass}`} role="presentation">{iconContent}</span>
             <span className="blocklyTreeLabel">{rowTitle}</span>
             {hasDeleteButton ? <i className="blocklyTreeButton icon times circle" onClick={this.handleDeleteClick}/>: undefined}
         </div>


### PR DESCRIPTION
All of our other targets still have the colors on the icons for the block categories, so we want Minecraft to match that. 

Most of the categories are super straightforward because you can just change the icon color via code. However, the `Agent` category is a bit tricky because the icon that we're using doesn't have an associated icon in Semantic; we're using a static png. Because of this, changing the color of the `Agent` icon via code isn't really possible. That's where the new `Agent_icon_orange` file comes in. I just alternate between the two files to make the color changes work. I wasn't sure if referencing files across the repos like this would cause problems in production, so we might have to find another solution, but it works locally. One thing to note, though, is that when you first switch to high contrast mode, it takes a second for the agent icon to load in, so there is definitely room for improvements.

<img width="476" alt="image" src="https://github.com/microsoft/pxt/assets/49178322/394a58a9-45b2-416d-b2c9-efd23403b172">

Will get an upload target on Monday.

Closes: https://github.com/microsoft/pxt-minecraft/issues/2062