### PR TITLE
Restore absolute url on kiosk qr code

### DIFF
--- a/kiosk/src/Components/AddingGame.tsx
+++ b/kiosk/src/Components/AddingGame.tsx
@@ -193,7 +193,7 @@ const AddingGame: React.FC<IProps> = ({ kiosk }) => {
 
     const qrDivContent = () => {
         if (renderQRCode && kioskCode) {
-            const kioskUrl = `${kioskCodeUrl}#add-game:${kioskCode}`;
+            const kioskUrl = `${window.location.origin}${kioskCodeUrl}#add-game:${kioskCode}`;
             return (
                 <div className="innerQRCodeContent">
                     <h3>{kioskTimeOutInMinutes} minute Kiosk ID</h3>


### PR DESCRIPTION
I broke it when moving the codebase to pxt :(

This uses window.location.origin to complete the url. I believe this will work everywhere.
