### PR TITLE
Home Page content inclusion page

### DIFF
--- a/common-docs/SUMMARY.md
+++ b/common-docs/SUMMARY.md
@@ -80,6 +80,7 @@
     * [Sharing projects](/share)
     * [Offline support](/offline)
     * [Save](/save)
+    * [Home page content](/homepage-content)
 
 ## Developers #devs
 

--- a/common-docs/homepage-content.md
+++ b/common-docs/homepage-content.md
@@ -10,33 +10,40 @@ Much of content available on the home page is developed or selected by the MakeC
 
 * Your content should be open source and free to use without any restrictions other than author attribution (you may specify an open source license the provides for such usage if you wish).
 * The instructions should be well written and easy to follow.
-* It should not include any personally identifiable.
+* It should not include any personally identifiable information beyond the author's name (authors can remain anonymous too).
 * Content will be reviewed and approved by the MakeCode Team.
 
 ## What you need to submit
 
 To list a content item on the home page, you need to provide:
 
-1. A full URL for the item. For a tutorial, a complete tutorial URL is needed (see https://makecode.com/writing-docs/user-tutorials for more details).
+1. A name or title for the content item.
 2. A brief one or two sentence description of what your content is or does (preferably in English for localization and is 30 words or less).
-3. A thumbnail image that represents your content. Size the image to approximately 300x200 pixels.
+3. A thumbnail image that represents your content. Size the image to approximately **300 x 200** pixels.
+4. A full URL for the item. For a tutorial, a complete tutorial URL is needed (see https://makecode.com/writing-docs/user-tutorials for more details).
+
+## #target-link-example
 
 ## Submission process
 
-Create and submit a [GitHub issue](@githubUrl@/issues) requesting your content to be listed. In the issue description, include the description, content URL, and copy in the thumbnail image. GitHub will automatically create an image URL for your thumbnail when you paste or drag you image in. Your issue description will look something like this when you write it:
+Create and submit a [GitHub issue](@githubUrl@/issues) requesting your content to be listed. In the issue description, include the name or title of the content item, description, content URL, and copy in the thumbnail image. GitHub will automatically create an image URL for your thumbnail when you paste or drag your image in. Your issue description will look something like this when you write it:
 
 ```
 Request to include a user content source on the editor home page. The content is a simple tutorial on how the create exploding sprites in Arcade.
 
 ## Home page link info
 
-### Content Link
+### Name
 
-https://arcade.makecode.com/#tutorial:https://makecode.com/_rewr9iop
+Exploding Sprites
 
 ### Description
 
 Learn how to create moving sprites that randomly explode!
+
+### Content Link
+
+https://arcade.makecode.com/#tutorial:https://makecode.com/_rewr9iop
 
 ### Thumbnail
 
@@ -47,4 +54,4 @@ Learn how to create moving sprites that randomly explode!
 
 ## Featured content
 
-To request featured space in the Home Page banner carousel, the requirements are similar to gallery items except for the image size. We require a link, a short description, and a "Hero" image that is 2100x500 pixels. Please note that banner space is very limited and approval for items included there is very selective.
+To request featured space in the Home Page banner carousel, the requirements are similar to gallery items except for the image size. We require a link, a short description, and a "Hero" image that is **2100 x 500** pixels. Please note that banner space is very limited and approval for items included there is very selective.

--- a/common-docs/homepage-content.md
+++ b/common-docs/homepage-content.md
@@ -1,0 +1,50 @@
+# Adding content to the home page
+
+The Editor home page contains galleries of card links to projects, tutorials, lessons, videos, and other content sources. Many content items featured on the home page are hosted at the editor's website while some other items are from external sources.
+
+Much of content available on the home page is developed or selected by the MakeCode Team. Content from other contributors is welcomed though and can be featured in the home page galleries.
+
+## #target-homescreen
+
+## Content requirements
+
+* Your content should be open source and free to use without any restrictions other than author attribution (you may specify an open source license the provides for such usage if you wish).
+* The instructions should be well written and easy to follow.
+* It should not include any personally identifiable.
+* Content will be reviewed and approved by the MakeCode Team.
+
+## What you need to submit
+
+To list a content item on the home page, you need to provide:
+
+1. A full URL for the item. For a tutorial, a complete tutorial URL is needed (see https://makecode.com/writing-docs/user-tutorials for more details).
+2. A brief one or two sentence description of what your content is or does (preferably in English for localization and is 30 words or less).
+3. A thumbnail image that represents your content. Size the image to approximately 300x200 pixels.
+
+## Submission process
+
+Create and submit a [GitHub issue](@githubUrl@/issues) requesting your content to be listed. In the issue description, include the description, content URL, and copy in the thumbnail image. GitHub will automatically create an image URL for your thumbnail when you paste or drag you image in. Your issue description will look something like this when you write it:
+
+```
+Request to include a user content source on the editor home page. The content is a simple tutorial on how the create exploding sprites in Arcade.
+
+## Home page link info
+
+### Content Link
+
+https://arcade.makecode.com/#tutorial:https://makecode.com/_rewr9iop
+
+### Description
+
+Learn how to create moving sprites that randomly explode!
+
+### Thumbnail
+
+![image](https://github.com/microsoft/pxt/assets/27789908/f5c21294-1145-4010-8de0-560b8afbfeec)
+```
+
+## #target-approval
+
+## Featured content
+
+To request featured space in the Home Page banner carousel, the requirements are similar to gallery items except for the image size. We require a link, a short description, and a "Hero" image that is 2100x500 pixels. Please note that banner space is very limited and approval for items included there is very selective.


### PR DESCRIPTION
This is a draft of a base page for content additions of user content to a target home page. This is a base page and is extended in the target doc space for target specific images and approval info.

Closes #9666