### PR TITLE
disable app insights correlation headers

### DIFF
--- a/docfiles/apptracking.html
+++ b/docfiles/apptracking.html
@@ -12,6 +12,7 @@
                 disableAjaxTracking: true,
                 overridePageViewDuration: false,
                 disableExceptionTracking: true,
+                disableCorrelationHeaders: true,
                 disableCookiesUsage: !isProduction,
                 isStorageUseDisabled: !isProduction,
                 url: "/blb/ai.2.min.js"

--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -64,6 +64,7 @@
                 disableAjaxTracking: true,
                 overridePageViewDuration: false,
                 disableExceptionTracking: true,
+                disableCorrelationHeaders: true,
                 disableCookiesUsage: !isProduction,
                 isStorageUseDisabled: !isProduction,
                 url: "/doccdn/ai.2.min.js"


### PR DESCRIPTION
This seems to disable the sending of the `traceparent` header in fetch requests.

Hopeful this fixes https://github.com/microsoft/pxt-arcade/issues/6013