### PR TITLE
Make Minecraft Play Button Clickable Again

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1502,17 +1502,7 @@ p.ui.font.small {
 
 #root.headless.collapsedEditorTools {
     #simulator .editor-sidebar {
-        position: absolute;
-        width: auto;
-        top: auto;
-        left: 5rem;
-        background: none transparent;
-        min-width: inherit;
-        max-width: inherit;
-
-        .simulator-container {
-            display: none;
-        }
+        display: none;
     }
 
     #boardview, .filemenu {

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -514,6 +514,11 @@
 
 #root.headless.tabTutorial {
     #simulator .editor-sidebar {
+        display: block;
+        position: absolute;
+        background: none transparent;
+        min-width: inherit;
+        max-width: inherit;
         width: @simulatorWidth;
         height: calc(~'100%' - @mainMenuHeight);
         top: @mainMenuHeight;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2338.

The play button was being covered up by editor sidebar, which was invisible but still capturing mouse clicks. We can simply hide the editor sidebar in headless mode, since it's empty anyway, but it's still needed in tutorials to show the instructions, so I've moved some of the css into `tutorial-sidebar.less` instead.

Upload target: https://minecraft.makecode.com/app/fd04ae820f3da7f25778379ab1dd7ec0f64b937c-450a4c099f