### PR TITLE
localization for webusb connection failed msg

### DIFF
--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -479,11 +479,11 @@ export async function pairAsync(implicitlyCalled?: boolean): Promise<boolean> {
                 return true;
             } catch (e) {
                 // Device
-                core.infoNotification("Oops, connection failed.");
+                core.infoNotification(lf("Oops, connection failed."));
                 return false;
             }
         case pxt.commands.WebUSBPairResult.Failed:
-            core.infoNotification("Oops, no device was paired.");
+            core.infoNotification(lf("Oops, no device was paired."));
             return false;
         case pxt.commands.WebUSBPairResult.UserRejected:
             // User exited pair flow intentionally


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-microbit/issues/5357

The extension labels would need to be extracted from `targetconfig.json` and uploaded at build time (along with an `rlf` if that isn't already there). We do similar things here https://github.com/microsoft/pxt/blob/master/cli/cli.ts#L1852 for gallery, so it'd be walking through all approved extensions, aggregating list of labels, and including in translation. Maybe worth considering packaging in translations for `targetConfig.multiplayer.games[?].title` as well (suggestion cards underneath multiplayer host screen), since those aren't translatable either right now