### PR TITLE
potentially fix monaco editor build bug

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -516,16 +516,19 @@ const stripMonacoSourceMaps = () => {
     return Promise.resolve();
 }
 
-const copyMonaco = gulp.series(gulp.parallel(
-    copyMonacoBase,
-    copyMonacoEditor,
-    copyMonacoLoader,
-    copyMonacoEditorMain,
-    copyMonacoJSON,
-    copyMonacoBasicLanguages,
-    copyMonacoTypescript,
-    inlineCodiconFont
-), stripMonacoSourceMaps);
+const copyMonaco = gulp.series(
+    gulp.parallel(
+        copyMonacoBase,
+        copyMonacoEditor,
+        copyMonacoLoader,
+        copyMonacoEditorMain,
+        copyMonacoJSON,
+        copyMonacoBasicLanguages,
+        copyMonacoTypescript,
+    ),
+    inlineCodiconFont,
+    stripMonacoSourceMaps
+);
 
 
 


### PR DESCRIPTION
I think this will fix the bug that rare build issue that caused https://github.com/microsoft/pxt-arcade/pull/6077. The bits leading me to think that are that it's pointing at `/codicons/codicon/codicon.ttf` while grabbing the editor.css, which matches the error we got
![image](https://github.com/microsoft/pxt/assets/5615930/cb16254b-cbe5-45e0-b126-ed05f54f616b)
and that `inlineCodiconFont`'s job is to replace that relative path with an inline font - so the replace in that fn is not being applied to the end result (it's just a few lines above this change). It's a bit hard to induce the bug, but I think it's a race condition with the `fs.readFileSync` vs `gulp.src` in `inlineCodiconFont` and `copyMonacoEditor` functions, where it normally runs fine but very rare fs lag causes inlineCodiconFont to get applied first then overwritten. I guess I can try inducing it by throwing in a `for (let i = 0; i < 10000000000; i++) {i ++}` or something in copyMonacoEditor?

I did a local serve and uploadtrg and both have icons as expected, it also just makes sense that the mutation of the file should not be running parallel to copying the file~

(I also kinda wonder if this was the cause for comment on line 504 -- it's fetching from the cdn relative to the .css file, but the path at the end is just for reference / the hash is what matters, so it was always pulling in the css and trying to use it as ttf. Probably the right fix though as would maybe be a bit of a headache to replace in the right cdn path)