### PR TITLE
Adding project shares to the version history

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -116,6 +116,15 @@ namespace pxt.Cloud {
         })
     }
 
+    export function downloadScriptMetaAsync(id: string): Promise<JsonScriptMeta> {
+        return privateRequestAsync({
+            url: id + (id.startsWith("S") ? `?time=${Date.now()}` : ""),
+            forceLiveEndpoint: true,
+        }).then(resp => {
+            return JSON.parse(resp.text).meta;
+        })
+    }
+
     export async function markdownAsync(docid: string, locale?: string, propagateExceptions?: boolean): Promise<string> {
         // 1h check on markdown content if not on development server
         const MARKDOWN_EXPIRATION = pxt.BrowserUtils.isLocalHostDev() ? 0 : 1 * 60 * 60 * 1000;

--- a/react-common/components/controls/Tree.tsx
+++ b/react-common/components/controls/Tree.tsx
@@ -11,6 +11,7 @@ export interface TreeItemProps extends ContainerProps {
     role?: "treeitem";
     onClick?: () => void;
     initiallyExpanded?: boolean;
+    title?: string;
 }
 
 export interface TreeItemBodyProps extends ContainerProps {
@@ -66,7 +67,8 @@ export const TreeItem = (props: TreeItemProps) => {
         ariaDescribedBy,
         role,
         initiallyExpanded,
-        onClick
+        onClick,
+        title
     } = props;
 
     const [expanded, setExpanded] = React.useState(initiallyExpanded);
@@ -105,7 +107,7 @@ export const TreeItem = (props: TreeItemProps) => {
             aria-hidden={ariaHidden}
             aria-describedby={ariaDescribedBy}
             role={role || "treeitem"}
-
+            title={title}
         >
             <div className={classList("common-treeitem", className)} onClick={onTreeItemClick}>
                 {hasSubtree &&

--- a/tests/pxt-editor-test/editorrunner.ts
+++ b/tests/pxt-editor-test/editorrunner.ts
@@ -220,7 +220,7 @@ describe("updateHistory", () => {
         for (let i = 1; i < testVersions.length; i++) {
             let nextText = { ...testVersions[i] };
 
-            pxt.workspace.updateHistory(prevText, nextText, i * ONE_HOUR, diffText, patchText);
+            pxt.workspace.updateHistory(prevText, nextText, i * ONE_HOUR, [], diffText, patchText);
 
             prevText = nextText;
         }
@@ -246,7 +246,7 @@ describe("updateHistory", () => {
         for (let i = 1; i < testVersions.length; i++) {
             let nextText = { ...testVersions[i] };
 
-            pxt.workspace.updateHistory(prevText, nextText, i * ONE_MINUTE, diffText, patchText);
+            pxt.workspace.updateHistory(prevText, nextText, i * ONE_MINUTE, [], diffText, patchText);
 
             prevText = nextText;
         }
@@ -275,7 +275,7 @@ describe("updateHistory", () => {
         for (let i = 1; i < testVersions.length; i++) {
             let nextText = { ...testVersions[i] };
 
-            pxt.workspace.updateHistory(prevText, nextText, i * ONE_HOUR, diffText, patchText);
+            pxt.workspace.updateHistory(prevText, nextText, i * ONE_HOUR, [], diffText, patchText);
 
             prevText = nextText;
         }
@@ -304,7 +304,7 @@ describe("updateHistory", () => {
         for (let i = 1; i < testVersions.length; i++) {
             let nextText = { ...testVersions[i] };
 
-            pxt.workspace.updateHistory(prevText, nextText, i * period, diffText, patchText);
+            pxt.workspace.updateHistory(prevText, nextText, i * period, [], diffText, patchText);
 
             prevText = nextText;
         }

--- a/theme/timeMachine.less
+++ b/theme/timeMachine.less
@@ -6,7 +6,7 @@
     bottom: 0;
     right: 0;
     position: absolute;
-    z-index: 999999999999;
+    z-index: @modalFullscreenZIndex + 1;
     background-color: white;
 }
 
@@ -107,6 +107,7 @@
 
     .common-treeitem {
         border-left: solid 2px @treeitemBackgroundColor;
+        user-select: none;
     }
 
     .common-treeitem.selected {
@@ -126,6 +127,7 @@
         padding-right: 1rem;
         padding-left: 1rem;
         padding-top: 1rem;
+        flex-shrink: 0;
     }
 }
 

--- a/webapp/src/timeMachine.tsx
+++ b/webapp/src/timeMachine.tsx
@@ -193,23 +193,19 @@ export const TimeMachine = (props: TimeMachineProps) => {
         }
     };
 
-    const onGoPressed = React.useCallback(() => {
-        (async () => {
-            if (selected === undefined) {
-                hideDialog();
-            }
-            else {
-                const { files, editorVersion } = await getTextAtTimestampAsync(text, history, selected);
-                onProjectLoad(files, editorVersion, selected.timestamp);
-            }
-        })();
+    const onGoPressed = React.useCallback(async () => {
+        if (selected === undefined) {
+            hideDialog();
+        }
+        else {
+            const { files, editorVersion } = await getTextAtTimestampAsync(text, history, selected);
+            onProjectLoad(files, editorVersion, selected.timestamp);
+        }
     }, [selected, onProjectLoad]);
 
-    const onSaveCopySelect = React.useCallback(() => {
-        (async () => {
-            const { files, editorVersion } = await getTextAtTimestampAsync(text, history, selected);
-            onProjectCopy(files, editorVersion, selected?.timestamp)
-        })();
+    const onSaveCopySelect = React.useCallback(async () => {
+        const { files, editorVersion } = await getTextAtTimestampAsync(text, history, selected);
+        onProjectCopy(files, editorVersion, selected?.timestamp)
     }, [selected, onProjectCopy]);
 
     const url = `${window.location.origin + window.location.pathname}?timeMachine=1&controller=1&skillsMap=1&noproject=1&nocookiebanner=1`;

--- a/webapp/src/timeMachine.tsx
+++ b/webapp/src/timeMachine.tsx
@@ -3,7 +3,7 @@ import * as workspace from "./workspace";
 import { Tree, TreeItem, TreeItemBody } from "../../react-common/components/controls/Tree";
 import { createPortal } from "react-dom";
 import { Button } from "../../react-common/components/controls/Button";
-import { hideDialog } from "./core";
+import { hideDialog, warningNotification } from "./core";
 import { FocusTrap } from "../../react-common/components/controls/FocusTrap";
 import { classList } from "../../react-common/components/util";
 
@@ -27,7 +27,7 @@ interface TimelineEntry {
 interface TimeEntry {
     label: string;
     timestamp: number;
-    kind: "snapshot" | "diff";
+    kind: "snapshot" | "diff" | "share";
 }
 
 interface Project {
@@ -40,8 +40,8 @@ type FrameState = "loading" | "loaded" | "loading-project" | "loaded-project";
 export const TimeMachine = (props: TimeMachineProps) => {
     const { text, history, onProjectLoad, onProjectCopy } = props;
 
-    // -1 here is a standin for "now"
-    const [selected, setSelected] = React.useState<number>(-1);
+    // undefind here is a standin for "now"
+    const [selected, setSelected] = React.useState<TimeEntry>(undefined);
     const [loading, setLoading] = React.useState<FrameState>("loading");
     const [entries, setEntries] = React.useState(getTimelineEntries(history));
 
@@ -162,28 +162,45 @@ export const TimeMachine = (props: TimeMachineProps) => {
         setEntries(getTimelineEntries(history));
     }, [history]);
 
-    const onTimeSelected = async (newValue: number) => {
-        if (importProject.current) {
-            setSelected(newValue);
+    const onTimeSelected = async (entry: TimeEntry) => {
+        if (!importProject.current) return;
 
-            if (newValue === -1) {
-                importProject.current(text);
+        if (entry.timestamp === -1) {
+            entry = undefined;
+        }
+        const previouslySelected = selected;
+
+        setSelected(entry);
+
+        if (entry === undefined) {
+            importProject.current(text);
+            return;
+        }
+
+        try {
+            const { files } = await getTextAtTimestampAsync(text, history, entry);
+            importProject.current(files)
+        }
+        catch (e) {
+            if (entry.kind === "share") {
+                warningNotification(lf("Unable to fetch shared project. Are you offline?"));
             }
             else {
-                const { files } = await getTextAtTimestampAsync(text, history, newValue);
-                importProject.current(files)
+                warningNotification(lf("Unable to restore project version. Try selecting a different time."))
             }
+
+            setSelected(previouslySelected);
         }
     };
 
     const onGoPressed = React.useCallback(() => {
         (async () => {
-            if (selected === -1) {
+            if (selected === undefined) {
                 hideDialog();
             }
             else {
                 const { files, editorVersion } = await getTextAtTimestampAsync(text, history, selected);
-                onProjectLoad(files, editorVersion, selected);
+                onProjectLoad(files, editorVersion, selected.timestamp);
             }
         })();
     }, [selected, onProjectLoad]);
@@ -191,7 +208,7 @@ export const TimeMachine = (props: TimeMachineProps) => {
     const onSaveCopySelect = React.useCallback(() => {
         (async () => {
             const { files, editorVersion } = await getTextAtTimestampAsync(text, history, selected);
-            onProjectCopy(files, editorVersion, selected)
+            onProjectCopy(files, editorVersion, selected?.timestamp)
         })();
     }, [selected, onProjectCopy]);
 
@@ -212,7 +229,7 @@ export const TimeMachine = (props: TimeMachineProps) => {
                 <div className="time-machine-actions-container">
                     <div className="time-machine-actions">
                         <div className="time-machine-label">
-                            {formatFullDate(selected)}
+                            {selected ? formatFullDate(selected.timestamp) : lf("Now")}
                         </div>
                         <Button
                             label={lf("Save a copy")}
@@ -255,16 +272,33 @@ export const TimeMachine = (props: TimeMachineProps) => {
                                         {e.label}
                                     </TreeItemBody>
                                     <Tree role="group">
-                                        {e.entries.map(entry =>
-                                            <TreeItem
-                                                key={entry.timestamp}
-                                                onClick={() => onTimeSelected(entry.timestamp)}
-                                                className={classList(selected === entry.timestamp && "selected", entry.kind)}
-                                            >
-                                                <TreeItemBody>
-                                                    {entry.label}
-                                                </TreeItemBody>
-                                            </TreeItem>
+                                        {e.entries.map((entry, index) => {
+                                            const isSelected = (!selected && entry.timestamp === -1) ||
+                                                (selected?.kind === entry.kind && selected?.timestamp === entry.timestamp);
+
+                                            let title: string;
+
+                                            if (entry.kind === "share") {
+                                                title = lf("Select shared version from {0} at {1}", e.label, entry.label);
+                                            }
+                                            else {
+                                                title = lf("Select project version from {0} at {1}", e.label, entry.label);
+                                            }
+
+                                            return (
+                                                <TreeItem
+                                                    key={index}
+                                                    onClick={() => onTimeSelected(entry)}
+                                                    className={classList(isSelected && "selected", entry.kind)}
+                                                    title={title}
+                                                >
+                                                    <TreeItemBody>
+                                                        {entry.label}
+                                                        {entry.kind === "share" && <i className="fas fa-share-alt" />}
+                                                    </TreeItemBody>
+                                                </TreeItem>
+                                            );
+                                        }
                                         )}
                                     </Tree>
                                 </TreeItem>
@@ -277,27 +311,24 @@ export const TimeMachine = (props: TimeMachineProps) => {
     , document.body);
 }
 
-async function getTextAtTimestampAsync(text: pxt.workspace.ScriptText, history: pxt.workspace.HistoryFile, timestamp: number): Promise<Project> {
+async function getTextAtTimestampAsync(text: pxt.workspace.ScriptText, history: pxt.workspace.HistoryFile, time: TimeEntry): Promise<Project> {
     const editorVersion = pxt.appTarget.versions.target;
 
-    if (timestamp < 0) return { files: text, editorVersion };
+    if (!time || time.timestamp < 0) return { files: text, editorVersion };
 
-    const snapshot = history.snapshots.find(s => s.timestamp === timestamp)
-    if (snapshot) {
+    if (time.kind === "snapshot") {
+        const snapshot = history.snapshots.find(s => s.timestamp === time.timestamp)
         return patchPxtJson(pxt.workspace.applySnapshot(text, snapshot.text), snapshot.editorVersion);
     }
+    else if (time.kind === "share") {
+        const share = history.shares.find(s => s.timestamp === time.timestamp);
+        const files = await pxt.Cloud.downloadScriptFilesAsync(share.id);
+        const meta = await pxt.Cloud.downloadScriptMetaAsync(share.id);
 
-    const share = history.shares.find(s => s.timestamp === timestamp);
-    if (share) {
-        try {
-            text = await pxt.Cloud.downloadScriptFilesAsync(share.id);
-            return patchPxtJson(text, share.editorVersion)
-        }
-        catch (e) {
-            if (!history.entries.some(e => e.timestamp === timestamp)) {
-                // ERROR
-            }
-        }
+        return {
+            files,
+            editorVersion: meta.versions?.target || editorVersion
+        };
     }
 
     let currentText = text;
@@ -306,7 +337,7 @@ async function getTextAtTimestampAsync(text: pxt.workspace.ScriptText, history: 
         const index = history.entries.length - 1 - i;
         const entry = history.entries[index];
         currentText = workspace.applyDiff(currentText, entry);
-        if (entry.timestamp === timestamp) {
+        if (entry.timestamp === time.timestamp) {
             const version = index > 0 ? history.entries[index - 1].editorVersion : entry.editorVersion;
             return patchPxtJson(currentText, version)
         }
@@ -418,7 +449,7 @@ function isToday(time: number) {
 function getTimelineEntries(history: pxt.workspace.HistoryFile): TimelineEntry[] {
     const buckets: {[index: string]: TimeEntry[]} = {};
 
-    const createTimeEntry = (timestamp: number, kind: "snapshot" | "diff") => {
+    const createTimeEntry = (timestamp: number, kind: "snapshot" | "diff" | "share") => {
         const date = new Date(timestamp);
         const key = new Date(date.toLocaleDateString(
             pxt.U.userLanguage(),
@@ -453,7 +484,7 @@ function getTimelineEntries(history: pxt.workspace.HistoryFile): TimelineEntry[]
         const bucket = buckets[bucketKey];
         const deduped: TimeEntry[] = [];
 
-        // Deduplicate entries that exist in the same minute and sort
+        // Deduplicate entries that exist in the same minute
         for (const entry of bucket) {
             const eIndex = deduped.findIndex(e => e.label === entry.label);
             const existing = deduped[eIndex];
@@ -477,8 +508,17 @@ function getTimelineEntries(history: pxt.workspace.HistoryFile): TimelineEntry[]
             }
         }
 
-        deduped.sort((a, b) => b.timestamp - a.timestamp);
         buckets[bucketKey] = deduped;
+    }
+
+    // Always show all of the shares, don't dedupe these
+    for (const entry of history.shares) {
+        createTimeEntry(entry.timestamp, "share");
+    }
+
+    // Sort all of the buckets
+    for (const bucketKey of sortedBuckets) {
+        buckets[bucketKey].sort((a, b) => b.timestamp - a.timestamp);
     }
 
     // Always add an entry for "now"

--- a/webapp/src/timeMachine.tsx
+++ b/webapp/src/timeMachine.tsx
@@ -40,7 +40,7 @@ type FrameState = "loading" | "loaded" | "loading-project" | "loaded-project";
 export const TimeMachine = (props: TimeMachineProps) => {
     const { text, history, onProjectLoad, onProjectCopy } = props;
 
-    // undefind here is a standin for "now"
+    // undefined here is a standin for "now"
     const [selected, setSelected] = React.useState<TimeEntry>(undefined);
     const [loading, setLoading] = React.useState<FrameState>("loading");
     const [entries, setEntries] = React.useState(getTimelineEntries(history));

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -586,7 +586,7 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
                     const previous = await impl.getAsync(h);
 
                     if (previous) {
-                        pxt.workspace.updateHistory(previous.text, toWrite, Date.now(), diffText, patchText);
+                        pxt.workspace.updateHistory(previous.text, toWrite, Date.now(), h.pubVersions || [], diffText, patchText);
                     }
                 }
             }
@@ -648,14 +648,13 @@ function computePath(h: Header) {
 
     return path
 }
+const differ = new dmp.diff_match_patch();
 
 function diffText(a: string, b: string) {
-    const differ = new dmp.diff_match_patch();
     return differ.patch_make(a, b);
 }
 
 function patchText(patch: unknown, a: string) {
-    const differ = new dmp.diff_match_patch();
     return differ.patch_apply(patch as any, a)[0]
 }
 


### PR DESCRIPTION
These have a share icon next to them:

![image](https://github.com/microsoft/pxt/assets/13754588/76bdcef6-6797-4e52-907f-8cbfc7baa5a5)

We already store shares in the project header, so share entries will actually appear for pre-time machine projects (albeit, all with the same timestamp).