### PR TITLE
Fixing a few time machine bugs

### DIFF
--- a/pxteditor/history.ts
+++ b/pxteditor/history.ts
@@ -311,8 +311,7 @@ namespace pxt.workspace {
         }
 
         // If no source changed, we can bail at this point
-        const diffed = diffScriptText(previousText, toWrite, currentTime, diff);
-        if (!diffed) {
+        if (scriptEquals(previousText, toWrite)) {
             toWrite[pxt.HISTORY_FILE] = JSON.stringify(history);
             return;
         }
@@ -340,7 +339,11 @@ namespace pxt.workspace {
             }
         }
         else {
-            history.entries.push(diffed);
+            const diffed = diffScriptText(previousText, toWrite, currentTime, diff);
+
+            if (diffed) {
+                history.entries.push(diffed);
+            }
         }
 
         // Finally, update the snapshots. These are failsafes in case something
@@ -378,5 +381,19 @@ namespace pxt.workspace {
             editorVersion: pxt.appTarget.versions.target,
             text: pxt.workspace.createSnapshot(text)
         };
+    }
+
+    function scriptEquals(a: ScriptText, b: ScriptText) {
+        const aKeys = Object.keys(a);
+        const bKeys = Object.keys(b);
+
+        if (aKeys.length !== bKeys.length) return false;
+
+        for (const key of aKeys) {
+            if (bKeys.indexOf(key) === -1) return false;
+            if (a[key] !== b[key]) return false;
+        }
+
+        return true;
     }
 }

--- a/theme/timeMachine.less
+++ b/theme/timeMachine.less
@@ -138,6 +138,7 @@
 
         .time-machine-back-button {
             flex-grow: 1;
+            flex-shrink: 0;
         }
     }
 

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -860,7 +860,7 @@ export function isDontShowDownloadDialogFlagSet() {
 }
 
 export async function showTurnBackTimeDialogAsync(header: pxt.workspace.Header, reloadHeader: () => void) {
-    const text = await workspace.getTextAsync(header.id);
+    const text = await workspace.getTextAsync(header.id, true);
     let history: pxt.workspace.HistoryFile;
 
     if (text?.[pxt.HISTORY_FILE]) {


### PR DESCRIPTION
Fixes three bugs:

1. If you shared a script and then immediately opened the history, the share wouldn't show up
2. There was a minor text bleeding issue in the header on small screens
3. Sometimes the updateHistory would calculate an extra diff when collapsing history entries: one to check for equality, another to actually push on the stack. I replaced the first one with a simple equality check since that's a much cheaper operation