### PR TITLE
extract localization for multiplayer hero games & tags

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1849,7 +1849,7 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
     walkDocs(theme.docMenu);
     if (nodeutil.fileExistsSync("targetconfig.json")) {
         const targetConfig = nodeutil.readJson("targetconfig.json") as pxt.TargetConfig;
-        if (targetConfig && targetConfig.galleries) {
+        if (targetConfig?.galleries) {
             const docsRoot = nodeutil.targetDir;
             let gcards: pxt.CodeCard[] = [];
             let tocmd: string =
@@ -1899,6 +1899,25 @@ ${JSON.stringify(gcards, null, 4)}
 ${gcards.map(gcard => `[${gcard.name}](${gcard.url})`).join(',\n')}
 
 `, { encoding: "utf8" });
+        }
+        const multiplayerGames = targetConfig?.multiplayer?.games;
+        for (const game of (multiplayerGames ?? [])) {
+            if (game.title) targetStrings[`{id:game-title}${game.title}`] = game.title;
+            if (game.subtitle) targetStrings[`{id:game-subtitle}${game.subtitle}`] = game.subtitle;
+        }
+
+        const approvedRepoLib = targetConfig?.packages?.approvedRepoLib;
+        for (const [extension, repoData] of Object.entries(approvedRepoLib ?? {})) {
+            for (const tag of (repoData.tags ?? [])) {
+                targetStrings[`{id:extension-tag}${tag}`] = tag;
+            }
+        }
+
+        const builtinExtensionLib = targetConfig?.packages?.builtinExtensionsLib;
+        for (const [extension, repoData] of Object.entries(builtinExtensionLib ?? {})) {
+            for (const tag of (repoData.tags ?? [])) {
+                targetStrings[`{id:extension-tag}${tag}`] = tag;
+            }
         }
     }
     // extract strings from editor

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1919,6 +1919,13 @@ ${gcards.map(gcard => `[${gcard.name}](${gcard.url})`).join(',\n')}
                 targetStrings[`{id:extension-tag}${tag}`] = tag;
             }
         }
+
+        const hardwareOptions = targetConfig?.hardwareOptions;
+        for (const opt of (hardwareOptions ?? [])) {
+            // Not translating hardware name, as that is typically a brand name / etc.
+            if (opt.description)
+                targetStrings[`{id:hardware-description}${opt.description}`] = opt.description;
+        }
     }
     // extract strings from editor
     ["editor", "fieldeditors", "cmds"]

--- a/multiplayer/src/components/JoinOrHost.tsx
+++ b/multiplayer/src/components/JoinOrHost.tsx
@@ -157,8 +157,8 @@ export default function Render() {
                             return (
                                 <HostGameButton
                                     shareId={game.shareId}
-                                    title={game.title}
-                                    subtitle={game.subtitle}
+                                    title={pxt.Util.rlf(`{id:game-title}${game.title}`)}
+                                    subtitle={pxt.Util.rlf(`{id:game-subtitle}${game.subtitle}`)}
                                     image={resourceUrl(game.image)}
                                     key={i}
                                 />

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -524,7 +524,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                         {categoryNames.map(c =>
                             <Button title={pxt.Util.rlf(c)}
                                 key={c}
-                                label={pxt.Util.rlf(c)}
+                                label={pxt.Util.rlf(`{id:extension-tag}${c}`)}
                                 onClick={() => handleCategoryClick(c)}
                                 onKeydown={() => handleCategoryClick}
                                 className={"extension-tag " + (selectedTag == c ? "selected" : "")}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1695,7 +1695,7 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
                                 key={'card' + card.name}
                                 name={card.name}
                                 ariaLabel={card.name}
-                                description={card.description}
+                                description={pxt.Util.rlf(`{id:hardware-description}${card.description}`)}
                                 imageUrl={card.imageUrl}
                                 learnMoreUrl={card.url}
                                 onClick={card.onClick}


### PR DESCRIPTION
re: https://github.com/microsoft/pxt/pull/9688, should fix https://github.com/microsoft/pxt-microbit/issues/5357 (the tags bit)

I'll merge https://github.com/microsoft/pxt/pull/9696 first & then add in localization for descriptions of hardware options, but I'm not certain whether we want names since they're actually products? Will check in stand up tomorrow & update this pr. Also need to check I formatted it correctly for multiplayer, just gotta spin up multiplayer serve tomorrow