### PR TITLE
Remove PD section from CSP page

### DIFF
--- a/docs/csp.md
+++ b/docs/csp.md
@@ -26,14 +26,6 @@ Some additional features of the Microsoft MakeCode curriculum include:
 
 Microsoft is recognized by the College Board as an endorsed provider of curriculum and professional development for AP® Computer Science Principles (AP CSP). Using an Endorsed Provider affords schools access to resources including an AP CSP syllabus pre-approved by the College Board’s AP Course Audit, and officially recognized professional development that prepares teachers to teach AP CSP. This endorsement affirms only that components of Microsoft's offerings are aligned to all the AP Curriculum Framework standards and the AP CSP assessment.
 
-## Professional Development
-
-There are three free professional development opportunities available this summer to help prepare Educators to teach the AP CS Principles with Microsoft MakeCode course for the 2023-2024 academic year. These professional development workshops will focus on the course's Big Ideas, Learning Objectives and Essential Knowledge skills. Additionally, you will learn how Microsoft MakeCode's curriculum meets the course's learning objectives and prepares students for the AP Exam and Create Performance Task. By attending the training and using Microsoft MakeCode's curriculum, you will be prepared with a syllabus, pacing plan, and lesson plans, PowerPoints, student handouts, and resources for every day of the course. The workshop session dates are listed below. Each session has limited capacity so secure your place by submitting a [registration application](https://forms.office.com/r/KkL4RG9DK2).
-
-* **Workshop 1** : June 5th, 7th, 12th, 14th (Mondays and Wednesdays for 2 weeks)
-* **Workshop 2** : June 20th - June 23rd (Tuesday - Friday)
-* **Workshop 3** : July 6th, 13th, 20th, 27th (Thursdays for 4 weeks)
-
 ## Course Overview 
 
 Technical Requirements: Students will need access to a computer with an internet connection.


### PR DESCRIPTION
Remove the "Professional Development" section from the CSP course landing page. The section only applies seasonally.

Closes #9098 