### PR TITLE
Troubleshoot section for github-teacher-verification page

### DIFF
--- a/docs/github-teacher-verification.md
+++ b/docs/github-teacher-verification.md
@@ -4,7 +4,7 @@ To access certain curriculum resources, you must have a verified [GitHub Teacher
 
 ## Create a GitHub Teacher Account
 
-### 1. Sign up for a GitHub account
+### Sign up for a GitHub account
 
 If you don’t already have one, create a GitHub Account. Go to https://github.com/signup and use your educator email account.
 
@@ -25,3 +25,26 @@ Fill out your school information in the form and upload proof of your school aff
 ![Approval email for educator account](/static/github-teacher/github-educator-approved-email.png)
 
 If you have any questions or issues, please contact [GitHub Education Support](https://support.github.com/request/education).
+
+## Support and Frequently Asked Questions
+
+* It won’t verify me, what can I do?
+
+>GitHub has successfully verified the academic affiliation of more than one hundred thousand educators worldwide - we are confident we can do the same for you! If you are unable to be verified, make sure to address all of the specific reasons presented to you by the app.
+
+* I don’t have a **.edu** email address, can I still get verified?
+
+>If your school provides academic email then you are required to use it. If not, then capture an image of the official dated proof of your current academic affiliation and follow the app's instructions. That should be enough to get you verified.
+
+* I was verified, but now I’m not. What happened?
+
+>GitHub periodically requires re-verification of all of our academic users. GitHub sends notifications to users in advance of the required re-verification deadline, so check your GitHub notification settings if your status changed without your knowledge.
+
+* I don’t have a GitHub account and don’t use GitHub for anything else. Can I get verified without creating a GitHub account?
+
+>Sorry, no :-(. But non-programmers can benefit from having a GitHub account! Please visit https://education.github.com/teachers to learn more.
+
+* I'm still having issues, how can I get help?
+
+>Try posting your question to the GitHub Education Community Forum. There are many people who can help you there!
+If there is a technical issue, or there is incorrect school information listed, please contact GitHub Education Support.

--- a/docs/github-teacher-verification.md
+++ b/docs/github-teacher-verification.md
@@ -46,5 +46,4 @@ If you have any questions or issues, please contact [GitHub Education Support](h
 
 * I'm still having issues, how can I get help?
 
->Try posting your question to the GitHub Education Community Forum. There are many people who can help you there!
-If there is a technical issue, or there is incorrect school information listed, please contact GitHub Education Support.
+>Try posting your question to the [GitHub Education Community Forum](https://github.com/orgs/community/discussions/categories/github-education). There are many people who can help you there! If there is a technical issue, or there is incorrect school information listed, please contact [GitHub Education Support](https://support.github.com/request/education).

--- a/docs/github-teacher-verification.md
+++ b/docs/github-teacher-verification.md
@@ -24,8 +24,6 @@ Fill out your school information in the form and upload proof of your school aff
 
 ![Approval email for educator account](/static/github-teacher/github-educator-approved-email.png)
 
-If you have any questions or issues, please contact [GitHub Education Support](https://support.github.com/request/education).
-
 ## Support and Frequently Asked Questions
 
 * It won’t verify me, what can I do?


### PR DESCRIPTION
Add a troubleshooting/faq section for the [GitHub Teacher Verification](https://makecode.com/github-teacher-verification) page.

Closes #9701 