### PR TITLE
Fix the home screen's project row card size on mobile

### DIFF
--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -222,12 +222,27 @@ a.ui.card:focus,
     /* Mobile only */
     @media only screen and (max-width: @largestMobileScreen) {
         .projectsdialog {
+            // tutorial cards
             .ui.card.example {
                 height: 9rem;
 
                 .ui.image, .ui.cardimage {
                     height: 8.4rem !important;
                 }
+            }
+
+            // project cards
+            .ui.card.link {
+                height: 9rem;
+
+                // new project card +
+                i.huge.icon {
+                    font-size: 2.5em;
+                }
+            }
+
+            .ui.card.link.blocksprj .ui.fileimage {
+                margin-left: -4px;
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2243

I also had to make the (+) icon smaller on the new project card and nudge the blocks file image 4 pixels to the left because the svg for it has margins baked in

![image](https://github.com/microsoft/pxt/assets/13754588/62eb47e7-9e64-4994-9f19-aaf7e648c221)
