### PR TITLE
Update the 'Identity' and 'share' base pages

### DIFF
--- a/common-docs/identity/cloud-sync.md
+++ b/common-docs/identity/cloud-sync.md
@@ -1,20 +1,16 @@
 # Cloud Synchronization in MakeCode
 
-**Note**: This feature only available in [**MakeCode Arcade**](https://arcade.makecode.com).
-
 ## What is Cloud Sync?
 
-Cloud Synchronization, or Cloud Sync, is a feature available to signed in users that lets MakeCode save your projects in the cloud, where they're available anywhere you can sign in to MakeCode.
+Cloud Synchronization, or Cloud Sync, is a feature available to signed-in users that saves your MakeCode projects and tutorial progress to the cloud. This means you can access your work from any computer.
 
 ## How do I enable Cloud Sync?
 
-All you need to do is sign in to MakeCode with your Microsoft Account and Cloud Sync is automatically enabled. Learn more about signing in to MakeCode [here](/identity/sign-in).
-
-![Home screen sign in button](/static/identity/sign-in-button.jpg)
+All you need to do is sign in to MakeCode with an online account and Cloud Sync is automatically enabled – so any new project you create, tutorial you start, or any existing project you open will be automatically saved to the cloud. To learn more about how to sign-in, visit [Online Accounts and MakeCode](https://makecode.microbit.org/identity/sign-in). 
 
 ## Does it cost money?
 
-Nope! Cloud Sync completely is free.
+No. The Cloud Sync feature is free.
 
 ## What are the limits?
 
@@ -22,36 +18,26 @@ Individual projects must be less than 512K bytes in size to be synced to cloud. 
 
 ## When is a project saved to the cloud?
 
-Projects are transferred to the cloud the next time they're opened for editing. When you first sign in, your local projects remain local. To transfer a project to the cloud, just open it in the editor. The rest is automatic.
+Projects are transferred to the cloud the next time they’re opened for editing. When you first sign in, your local projects remain local (saved in the browser’s cache). To transfer a project to the cloud, just open it in the editor. The projects that are saved to the cloud will appear with a Cloud icon on them.
+ 
+![Home screen project cards](/static/identity/project-cards.png)
 
-Your local project card before it's saved to the cloud:
+## How can I tell if my edits to a project have been saved to the cloud?
 
-![Local saved project card](/static/identity/local-saved-project.jpg)
+At the bottom of the editor, look for the cloud status indicator. You should notice it automatically saving to the cloud as you edit your project.
 
-Your project now saved to the cloud and showing the cloud icon in the card:
-
-![Cloud saved project card](/static/identity/cloud-saved-project.jpg)
-
-## When is a project updated from the cloud?
-
-Your project list is refreshed when you navigate to the home screen. When a project is opened, a quick cloud check is done to make sure you're opening the latest version.
-
-## How can I tell if a project is stored in the cloud?
-
-In your project list, look for a little cloud icon on the project card. If it's there, your project is backed up to the cloud. In the editor, look for the cloud status indicator in the lower left. You should notice it automatically saving to cloud as you edit your project.
-
-![Cloud save icon](/static/identity/cloud-save-icon.jpg)
+![Cloud status inidicator](/static/identity/saving.gif)
 
 ## What if I edit the project in two places?
 
-If you're editing a project in two places at the same time, you may make changes that conflict. When this happens, the editor that detected the conflict will resolve it by making a copy of the project and applying the conflicting change to the new one. At this point the two browsers will be editing different projects.
+If you’re editing a project in two places at the same time, you may make changes that conflict. When this happens, the editor that detected the conflict will resolve it by making a copy of the project and applying the conflicting change to the new one. At this point the two browsers will be editing different projects.
 
 ## Is anything else saved to cloud?
 
-If you've set your High Contrast or Language settings, they will be cloud-synchronized too.
+If you’ve set your High Contrast or Language settings, they will be cloud-synchronized too.
 
 ## When I sign out all my projects disappeared! What happened?
 
-When you're signed out, your cloud projects aren't shown until you sign in again. Instead, you'll see just one card on under **My Projects** for all of the projects saved in the cloud. You can just click on this card to sign in and see those projects again.
+When you’re signed out, your cloud projects aren’t shown until you sign in again. Instead, you’ll see just one card on under My Projects for all of the projects saved in the cloud. You can just click on this card to sign in and see those projects again.
 
-![Cloud projects card](/static/identity/cloud-projects-card.jpg)
+![Cloud projects card](/static/identity/cloud-projects.png)

--- a/common-docs/identity/cloud-sync.md
+++ b/common-docs/identity/cloud-sync.md
@@ -6,7 +6,7 @@ Cloud Synchronization, or Cloud Sync, is a feature available to signed-in users 
 
 ## How do I enable Cloud Sync?
 
-All you need to do is sign in to MakeCode with an online account and Cloud Sync is automatically enabled - so any new project you create, tutorial you start, or any existing project you open will be automatically saved to the cloud. To learn more about how to sign-in, visit [Online Accounts and MakeCode](https://makecode.microbit.org/identity/sign-in). 
+All you need to do is sign in to MakeCode with an online account and Cloud Sync is automatically enabled - so any new project you create, tutorial you start, or any existing project you open will be automatically saved to the cloud. To learn more about how to sign-in, visit [Online Accounts and MakeCode](/identity/sign-in). 
 
 ## Does it cost money?
 

--- a/common-docs/identity/cloud-sync.md
+++ b/common-docs/identity/cloud-sync.md
@@ -38,6 +38,8 @@ If you’ve set your High Contrast or Language settings, they will be cloud-sync
 
 ## When I sign out all my projects disappeared! What happened?
 
-When you’re signed out, your cloud projects aren’t shown until you sign in again. Instead, you’ll see just one card on under My Projects for all of the projects saved in the cloud. You can just click on this card to sign in and see those projects again.
+When you’re signed out, your cloud projects aren’t shown until you sign in again. Instead, you’ll see just one card on under **My Projects** for all of the projects saved in the cloud. You can just click on this card to sign in and see those projects again.
 
 ![Cloud projects card](/static/identity/cloud-projects.png)
+
+## #target-specific

--- a/common-docs/identity/cloud-sync.md
+++ b/common-docs/identity/cloud-sync.md
@@ -6,7 +6,7 @@ Cloud Synchronization, or Cloud Sync, is a feature available to signed-in users 
 
 ## How do I enable Cloud Sync?
 
-All you need to do is sign in to MakeCode with an online account and Cloud Sync is automatically enabled – so any new project you create, tutorial you start, or any existing project you open will be automatically saved to the cloud. To learn more about how to sign-in, visit [Online Accounts and MakeCode](https://makecode.microbit.org/identity/sign-in). 
+All you need to do is sign in to MakeCode with an online account and Cloud Sync is automatically enabled - so any new project you create, tutorial you start, or any existing project you open will be automatically saved to the cloud. To learn more about how to sign-in, visit [Online Accounts and MakeCode](https://makecode.microbit.org/identity/sign-in). 
 
 ## Does it cost money?
 

--- a/common-docs/identity/sign-in.md
+++ b/common-docs/identity/sign-in.md
@@ -2,7 +2,7 @@
 
 ## What is an Online Account?
 
-An online account is a user account with a reputable provider of online services. While MakeCode does not have its own accounts, MakeCode does allow you to sign-in using an online account with either Microsoft, Google or Clever.
+An online account is a user account with a reputable provider of online services. While MakeCode does not have its own accounts, MakeCode does allow you to sign-in using an online account with either Microsoft, Google, or Clever.
 
 ### Microsoft Account
 
@@ -18,7 +18,7 @@ Clever is an educational identity provider used by many schools to aggregate stu
 
 ## What’s the benefit of signing in to MakeCode?
 
-MakeCode doesn’t require you to sign-in with an online account to use the product. However, it is recommended in order to reliably save your work and progress to the cloud. This also allows you to access your projects from any computer. When you are logged-in, you can also create persistent project sharing links which allow you use a single published URL for a project, even if you make subsequent changes. To learn more, see [Cloud Synchronization in MakeCode](https://arcade.makecode.com/identity/cloud-sync) and [Sharing your project]( https://arcade.makecode.com/share).
+MakeCode doesn’t require you to sign in with an online account to use the product. However, it is recommended in order to reliably save your work and progress to the cloud. This also allows you to access your projects from any computer. When you are logged-in, you can also create persistent project sharing links which allow you use a single published URL for a project, even if you make subsequent changes. To learn more, see [Cloud Synchronization in MakeCode](https://arcade.makecode.com/identity/cloud-sync) and [Sharing your project]( https://arcade.makecode.com/share).
 
 ## Is it required?
 
@@ -34,7 +34,7 @@ Nothing. Your signed in status is visible only to you.
 
 ## What if I don’t have a Microsoft, Google or Clever account?
 
-You can create a Microsoft or Google account using your current email address for free and check with your school if you already have a Clever account. But remember that you can still use MakeCode even without an account.
+You can create a Microsoft or Google account using your current email address for free and check with your school if you already have a Clever account. But remember, you can still use MakeCode even without an account.
 
 ## Can I use my school or work account?
 
@@ -57,7 +57,7 @@ GitHub provides a source code repository for your projects to help with version 
 
 ## We use Google school accounts and I’m having trouble accessing MakeCode, what do I need to do?
 
-Google Workspace for Education made some changes in October 2023 that requires schools to explicitly authorize any 3rd party applications. Please work with your IT Administrator to make the following changes in the Google Admin Console to enable use of MakeCode with Google accounts:
+Google Workspace for Education made some changes in October 2023 that require schools to explicitly authorize any 3rd party applications. Please work with your IT Administrator to make the following changes in the Google Admin Console to enable use of MakeCode with Google accounts:
 
 1. Sign in to your Google Admin console using an administrator account at https://admin.google.com
 2. In the Admin console, go to **Menu | Security | Access and data control | API controls**

--- a/common-docs/identity/sign-in.md
+++ b/common-docs/identity/sign-in.md
@@ -18,7 +18,7 @@ Clever is an educational identity provider used by many schools to aggregate stu
 
 ## What’s the benefit of signing in to MakeCode?
 
-MakeCode doesn’t require you to sign in with an online account to use the product. However, it is recommended in order to reliably save your work and progress to the cloud. This also allows you to access your projects from any computer. When you are logged-in, you can also create persistent project sharing links which allow you use a single published URL for a project, even if you make subsequent changes. To learn more, see [Cloud Synchronization in MakeCode](https://arcade.makecode.com/identity/cloud-sync) and [Sharing your project]( https://arcade.makecode.com/share).
+MakeCode doesn’t require you to sign in with an online account to use the product. However, it is recommended in order to reliably save your work and progress to the cloud. This also allows you to access your projects from any computer. When you are logged-in, you can also create persistent project sharing links which allow you use a single published URL for a project, even if you make subsequent changes. To learn more, see [Cloud Synchronization in MakeCode](/identity/cloud-sync) and [Sharing your project](/share).
 
 ## Is it required?
 
@@ -53,7 +53,7 @@ No. At the time you delete your profile, all of your cloud saved projects are ex
 
 ## How does this work with GitHub?
 
-GitHub provides a source code repository for your projects to help with version control. You can still sign into MakeCode with a Microsoft, Google or Clever Account and use Cloud Sync to store your projects in the cloud, even while using GitHub. To learn more, visit [GitHub with MakeCode](https://arcade.makecode.com/github).
+GitHub provides a source code repository for your projects to help with version control. You can still sign into MakeCode with a Microsoft, Google or Clever Account and use Cloud Sync to store your projects in the cloud, even while using GitHub. To learn more, visit [GitHub with MakeCode](/github).
 
 ## We use Google school accounts and I’m having trouble accessing MakeCode, what do I need to do?
 

--- a/common-docs/identity/sign-in.md
+++ b/common-docs/identity/sign-in.md
@@ -1,71 +1,75 @@
 # Online Accounts and MakeCode
 
-## What is a Online Account?
+## What is an Online Account?
 
-An online account is a user account with a provider of online services such as Microsoft or Google. MakeCode allows you to sign in using an account with either Microsoft or Google.
+An online account is a user account with a reputable provider of online services. While MakeCode does not have its own accounts, MakeCode does allow you to sign-in using an online account with either Microsoft, Google or Clever.
 
 ### Microsoft Account
 
-A Microsoft Account, or MSA, is the personal user account you create when you want to sign into Microsoft services like outlook.com, Xbox, Skype, etc. Read more [here](https://aka.ms/AAdd6f8). We also support Microsoft 365 accounts that you can use from school or your workplace.
+A Microsoft account may either be a personal or a work/school user account. You can also create a Microsoft account using your existing email address. To learn more about Microsoft accounts and see if you have one, visit https://account.microsoft.com/account.
 
 ### Google Account
 
-Google accounts are for sign-in access to Google's services such as GMail, YouTube, and more. See [Create a Google Account](https://support.google.com/accounts/answer/27441) for more information.
+Google accounts may also be personal or work/school user accounts. To learn more about Google accounts and see if you have one, visit https://www.google.com/account/about.
 
-## How does it work in MakeCode?
+### Clever Account
 
-A number of new features are coming that will only be available to signed-in users. These features need to know your identity so they can do things for you like store data in the cloud, and connect you to other users. The first of these features is one we're calling [Cloud Sync](/identity/cloud-sync). With Cloud Sync, when you're signed into MakeCode, we'll store your projects in the cloud where they're accessible from anywhere.  [Multiplayer](https://arcade.makecode.com/--multiplayer) is another feature in MakeCode Arcade which is only availabled to signed-in users.
+Clever is an educational identity provider used by many schools to aggregate student data and applications in a safe and secure manner. Schools with Clever can find the MakeCode apps in the Clever Library and users can login using their Clever accounts. To learn more about Clever, please visit https://www.clever.com.
 
-Click the sign in button in the upper right corner to log into MakeCode.
+## What’s the benefit of signing in to MakeCode?
 
-![Home screen sign in button](/static/identity/sign-in-button.jpg)
-
-Watch this video for a demonstration of creating a Microsoft Account and signing in to MakeCode:
-
-https://youtu.be/4r5tGfi2BFI
-
-Once you've signed in, you'll see your profile picture (or your login initials if you don't have a picture) displayed in the upper-right corner of the editor.
-
-![Identity initials](/static/identity/login-id.jpg)
+MakeCode doesn’t require you to sign-in with an online account to use the product. However, it is recommended in order to reliably save your work and progress to the cloud. This also allows you to access your projects from any computer. When you are logged-in, you can also create persistent project sharing links which allow you use a single published URL for a project, even if you make subsequent changes. To learn more, see [Cloud Synchronization in MakeCode](https://arcade.makecode.com/identity/cloud-sync) and [Sharing your project]( https://arcade.makecode.com/share).
 
 ## Is it required?
 
-No. Sign in only if you want to take advantage of features like Cloud Sync.
+No. Sign in only if you want to take advantage of features like saving your projects to the cloud.
 
 ## Does it cost money?
 
-Nope! Creating a Microsoft or Google account is free. Using MakeCode is also free. As a reminder, Microsoft accounts work across a range of Microsoft products and services, so you can use it outside MakeCode. Some of these products and services may not be free (Minecraft Marketplace content, for example), but this is outside the MakeCode ecosystem.
+No. Using an online account with MakeCode is free.
 
 ## What will other users see?
 
-Your signed in status is visible only to you. In the future we may add features that allow others to see your presence. When that time comes, we would ask you to create a MakeCode Profile so that your name and picture are decoupled from your MSA profile.
+Nothing. Your signed in status is visible only to you.
 
-## Do I already have a Microsoft Account?
+## What if I don’t have a Microsoft, Google or Clever account?
 
-It is possible! Do you play Minecraft, game on an Xbox, subscribe to Office 365, or use any other Microsoft products or services? If so, you probably already have a Microsoft Account.
-
-## Does this mean I have to create a new email address?
-
-No. You can create a Microsoft or Google account using your current email address.
-
-Find out more about creating a Microsoft Account using your current email address here: https://account.microsoft.com/account.
+You can create a Microsoft or Google account using your current email address for free and check with your school if you already have a Clever account. But remember that you can still use MakeCode even without an account.
 
 ## Can I use my school or work account?
 
-If your school or employer's email system is managed by Microsoft or Google, then generally it should work in MakeCode subject to restrictions put in place by your IT department.
+Yes. If your school or employer’s email system is managed by Microsoft, Google or Clever, then it will work in MakeCode subject to restrictions put in place by your IT department.
 
 ## When I sign in, what information does MakeCode collect about me?
 
-The privacy and safety of our users is very important to us. Microsoft MakeCode adheres to [Microsoft's Privacy Policies](https://makecode.com/privacy). We do not collect or use personal data beyond that needed to operate and support MakeCode features and services. Read the [MakeCode Privacy Frequently Asked Questions](https://makecode.com/privacy-faq) page for more information.
+The privacy and safety of our users is very important to us. Microsoft MakeCode adheres to Microsoft’s [Privacy Policies](https://makecode.com/privacy). We do not collect or use personal data beyond that needed to operate and support MakeCode features and services. Read the MakeCode [Privacy Frequently Asked Questions](https://makecode.com/privacy-faq) page for more information.
 
 ## How can I completely remove my data and profile information?
 
-After you sign into MakeCode, you can delete your user profile and all associated data at any time by clicking on 'My Profile' and selecting 'I want to delete my profile'. This will remove you from our system and permanently delete all your cloud saved information.
+After you sign into MakeCode, you can delete your user profile and all associated data at any time by clicking on **'My Profile'** and selecting **'Delete Profile'**. This will remove you from our system and permanently delete all your cloud saved information.
 
-## When my profile is deleted, do all of my cloud projects just vanish?
-
+When my profile is deleted, do all of my cloud projects just vanish?
 No. At the time you delete your profile, all of your cloud saved projects are exported and saved locally to the current browser on the computer or device you are using.
 
 ## How does this work with GitHub?
 
-GitHub provides a source code repository for your projects to help with version control (learn more here https://arcade.makecode.com/github). You can still sign into MakeCode with a Microsoft or Google Account and use Cloud Sync to store your projects in the cloud, even while using GitHub.
+GitHub provides a source code repository for your projects to help with version control. You can still sign into MakeCode with a Microsoft, Google or Clever Account and use Cloud Sync to store your projects in the cloud, even while using GitHub. To learn more, visit [GitHub with MakeCode](https://arcade.makecode.com/github).
+
+## We use Google school accounts and I’m having trouble accessing MakeCode, what do I need to do?
+
+Google Workspace for Education made some changes in October 2023 that requires schools to explicitly authorize any 3rd party applications. Please work with your IT Administrator to make the following changes in the Google Admin Console to enable use of MakeCode with Google accounts:
+
+1. Sign in to your Google Admin console using an administrator account at https://admin.google.com
+2. In the Admin console, go to **Menu | Security | Access and data control | API controls**
+3. Click **Manage Third-Party App Access** 
+4. For **Configured apps**, click **Add app**
+5. Choose **OAuth App Name**, type in "MakeCode" and click Search
+6. Select MakeCode and click **Continue**
+7. Select **Trusted** app option
+8. Click **Finish**
+
+For more information about these changes, please see [Confirm your third-party app settings]( https://support.google.com/a/answer/13289151). For more information about Google Workspace settings, please visit the [Google Help Center]( https://support.google.com/a/answer/7281227).
+
+## My school has Clever but I can’t find the MakeCode apps in the Library, what should I do?
+
+If you can’t find the MakeCode apps in the Clever Library, it’s possible you’re in a district that allows apps for classroom use only on a case-by-case basis. Please contact your district IT administrator for help with allowing the MakeCode apps within your district.

--- a/common-docs/share.md
+++ b/common-docs/share.md
@@ -20,7 +20,7 @@ This link is not published anywhere else and it is not tied to a specific user (
 
 ## Persistent Share Link
 
-If you sign-in to MakeCode, you can create a persistent share link for your project. This means that you can create one link to a project, share it with others, or include it in curriculum. Then, for any subsequent changes you make to the project, you can keep the same link. For more information on signing in to MakeCode, see [Online Accounts and MakeCode](https://makecode.microbit.org/share/sign-in).
+If you sign-in to MakeCode, you can create a persistent share link for your project. This means that you can create one link to a project, share it with others, or include it in curriculum. Then, for any subsequent changes you make to the project, you can keep the same link. For more information on signing in to MakeCode, see [Online Accounts and MakeCode](/identity/sign-in).
 
 Persistent share links start with an "S" followed by a series of numbers.
 

--- a/common-docs/share.md
+++ b/common-docs/share.md
@@ -1,10 +1,10 @@
 # Sharing your project
 
-There are a few different methods to share MakeCode projects, and places you can share your projects to.
+There are a few different methods to share your MakeCode projects and for places to share your projects to.
 
 ## Anonymous Share Link
 
-If you are not signed-in to MakeCode, you can create an anonymous link to your project that you can share with others.  On the top right, click the Share icon:
+If you are not signed-in to MakeCode, you can create an anonymous link to your project that you can share with others. On the top right, click the Share icon:
 
 ![Share icon](/static/share/share-icon.png)
 
@@ -16,23 +16,23 @@ Clicking "Share Project" will create a link to your project.
 
 ![Share project anonomously](/static/share/anon-share-link.png)
 
-This link is not published anywhere else, and it is not tied to a specific user (it’s an "anonymous link").  If you lose the link, then there’s no way to get it back – you will have to share your project again to create a new link. These links are snapshots in time of a project, so if you make any subsequent changes to your project, you will have to Share your project again to create a new link with the changes. There is also no way to remove or “unpublish” an anonymous share link, except through the “Report Abuse” function (see below for more information).
+This link is not published anywhere else and it is not tied to a specific user (it’s an "anonymous link"). If you lose the link, then there’s no way to get it back - you will have to share your project again to create a new link. These links are snapshots in time of a project, so if you make any subsequent changes to your project, you will have to Share your project again to create a new link with the changes. There is also no way to remove or "unpublish" an anonymous share link, except through the "Report Abuse" function (see below for more information).
 
 ## Persistent Share Link
 
-If you sign-in to MakeCode, you can create a persistent share link for your project. This means that you can create one link to a project, share it with others or include it in curriculum, and for any subsequent changes you make to the project, you can keep the same link.  For more information on signing in to MakeCode, see [Online Accounts and MakeCode](https://makecode.microbit.org/share/sign-in).
+If you sign-in to MakeCode, you can create a persistent share link for your project. This means that you can create one link to a project, share it with others, or include it in curriculum. Then, for any subsequent changes you make to the project, you can keep the same link. For more information on signing in to MakeCode, see [Online Accounts and MakeCode](https://makecode.microbit.org/share/sign-in).
 
-Persistent share links start with an “S” followed by a series of numbers.
+Persistent share links start with an "S" followed by a series of numbers.
 
 ![Persistent share link](/static/share/persist-share-link.png)
 
-If you want to update, or publish changes to a shared project, click to share it again and select the "Update existing share link for this project" checkbox.
+If you want to update or publish changes to a shared project, click to share it again and select the "Update existing share link for this project" checkbox.
 
 ![Update link](/static/share/update-link.png)
 
 ## Sharing to Google Classroom or Microsoft Teams
 
-As well as being able to share projects to popular social media sites, users can also share their projects to Learning Management Systems (LMS) like Google Classroom or Microsoft Teams.  In the Share Project window, click on the appropriate icon and you will be prompted to sign into the LMS and select where you want to share to.
+As well as being able to share projects to popular social media sites, users can also share their projects to Learning Management Systems (LMS) like Google Classroom or Microsoft Teams. In the Share Project window, click on the appropriate icon and you will be prompted to sign into the LMS and select where you want to share to.
 
 ![Share project using LMS](/static/share/share-lms.png)
 
@@ -46,18 +46,18 @@ For sharing projects to phones or other mobile devices, you can use your device�
 
 ## Embedding into a blog or web site
 
-MakeCode projects can also be embedded into a blog or web site.  In the Share Project window, click on the Embed icon and copy/paste the HTML content.  You can choose to embed just the project code, a read-only view of the editor, or just the simulator part of the project.
+MakeCode projects can also be embedded into a blog or web site. In the Share Project window, click on the Embed icon and copy/paste the HTML content. You can choose to embed just the project code, a read-only view of the editor, or just the simulator part of the project.
 
 ![Share project with embedded HTML](/static/share/share-embed.png)
 
-## Editing Shared Projects
+## Editing Shared Projects #editing
 
-By default, all shared projects in MakeCode can be copied and edited. There is no way to share a read-only project, or a project where people can’t make a copy or can’t see the code. When a user opens a project from a Share Link (either anonymous or persistent), they can see the simulator, the blocks or the text code. And they can download the code onto the micro:bit. They may also make a copy of the project and edit it by pressing the Edit or Edit Code buttons in the top right corner. Any edits they make will not change the original project – if they want to share their changes back, they will have to create a new share link.
+By default, all shared projects in MakeCode can be copied and edited. There is no way to share a read-only project, or a project where people can’t make a copy or can’t see the code. Any edits they make will not change the original project - if they want to share their changes back, they will have to create a new share link.
 
 ![Edit shared project button](/static/share/edit-shared-project.png)
 
 ## Report Abuse
 
-All MakeCode shared projects pass through Microsoft standard scanning for security and safety compliance. In addition, the “Report Abuse” option is available on any shared project if you deem the contents of the project not appropriate (contains unsafe content or includes personally identifiable information).  For these types of projects, the MakeCode Team will remove the project from our databases. 
+All MakeCode shared projects pass through Microsoft standard scanning for security and safety compliance. In addition, the "Report Abuse" option is available on any shared project if you deem the contents of the project not appropriate (contains unsafe content or includes personally identifiable information). For these types of projects, the MakeCode Team will remove the project from our databases. 
 
 ![Report abuse link](/static/share/report-abuse.png)

--- a/common-docs/share.md
+++ b/common-docs/share.md
@@ -1,75 +1,63 @@
 # Sharing your project
 
-Once you've made your project, you can save it the cloud, share it, or embed it on another website.
+There are a few different methods to share MakeCode projects, and places you can share your projects to.
 
-* Click **More...**, then **Embed Project**:
-* Click **Publish project**. This will make the project publicly available
-* You will then see this information:
+## Anonymous Share Link
 
-## Sharing the URL
+If you are not signed-in to MakeCode, you can create an anonymous link to your project that you can share with others.  On the top right, click the Share icon:
 
-You can share the URL for the project with other people, and they will be able to visit that page to see your project, download it, or edit it. 
+![Share icon](/static/share/share-icon.png)
 
-### ~hint
+Give your project a Title and optionally, you can create a thumbnail image or animated GIF of your project.
 
-**Developers:** This page supports [OEmbed](https://oembed.com/).
+![Share project](/static/share/share-project.png)
 
-### ~
+Clicking "Share Project" will create a link to your project.
+
+![Share project anonomously](/static/share/anon-share-link.png)
+
+This link is not published anywhere else, and it is not tied to a specific user (it’s an "anonymous link").  If you lose the link, then there’s no way to get it back – you will have to share your project again to create a new link. These links are snapshots in time of a project, so if you make any subsequent changes to your project, you will have to Share your project again to create a new link with the changes. There is also no way to remove or “unpublish” an anonymous share link, except through the “Report Abuse” function (see below for more information).
+
+## Persistent Share Link
+
+If you sign-in to MakeCode, you can create a persistent share link for your project. This means that you can create one link to a project, share it with others or include it in curriculum, and for any subsequent changes you make to the project, you can keep the same link.  For more information on signing in to MakeCode, see [Online Accounts and MakeCode](https://makecode.microbit.org/share/sign-in).
+
+Persistent share links start with an “S” followed by a series of numbers.
+
+![Persistent share link](/static/share/persist-share-link.png)
+
+If you want to update, or publish changes to a shared project, click to share it again and select the "Update existing share link for this project" checkbox.
+
+![Update link](/static/share/update-link.png)
+
+## Sharing to Google Classroom or Microsoft Teams
+
+As well as being able to share projects to popular social media sites, users can also share their projects to Learning Management Systems (LMS) like Google Classroom or Microsoft Teams.  In the Share Project window, click on the appropriate icon and you will be prompted to sign into the LMS and select where you want to share to.
+
+![Share project using LMS](/static/share/share-lms.png)
+
+![Share project to MS Teams](/static/share/share-teams.png)
+
+## Sharing to Mobile devices
+
+For sharing projects to phones or other mobile devices, you can use your device’s camera to capture the QR code in the Share Project window.
+
+![Share project with QR code](/static/share/share-qr-code.png)
 
 ## Embedding into a blog or web site
 
-Rather than just sharing the link, you can also embed the project so that your visitors can use the simulator, edit blocks or code, or download the project without having to leave your site.
+MakeCode projects can also be embedded into a blog or web site.  In the Share Project window, click on the Embed icon and copy/paste the HTML content.  You can choose to embed just the project code, a read-only view of the editor, or just the simulator part of the project.
 
-### General instructions
+![Share project with embedded HTML](/static/share/share-embed.png)
 
-Select the kind of embedding you would like.
+## Editing Shared Projects
 
-* **Screenshot** - a lightweight screenshot of the blocks that links to the snippet
-* **Editor** - embedded editor with minimal UI
-* **Simulator** - embedded simulator only
-* **Command line** - specific instructions to unpack the project using the [command line](/cli) tools
+By default, all shared projects in MakeCode can be copied and edited. There is no way to share a read-only project, or a project where people can’t make a copy or can’t see the code. When a user opens a project from a Share Link (either anonymous or persistent), they can see the simulator, the blocks or the text code. And they can download the code onto the micro:bit. They may also make a copy of the project and edit it by pressing the Edit or Edit Code buttons in the top right corner. Any edits they make will not change the original project – if they want to share their changes back, they will have to create a new share link.
 
-Copy the HTML for embedding the page from the publish dialog. It will look like the following:
+![Edit shared project button](/static/share/edit-shared-project.png)
 
-Open the HTML editor for your blog or website and paste it with your content
+## Report Abuse
 
-### Wordpress
+All MakeCode shared projects pass through Microsoft standard scanning for security and safety compliance. In addition, the “Report Abuse” option is available on any shared project if you deem the contents of the project not appropriate (contains unsafe content or includes personally identifiable information).  For these types of projects, the MakeCode Team will remove the project from our databases. 
 
-[wordpress.com][] blogs do not support embedding content from most websites, so you will need to link to your project instead. Alternatively, if you have a Wordpress VIP account you can follow [these instructions][wordpress-vip] to embed an `iframe` into your blog. The URL that you need to add is like `@homeurl@/#pub:PROJECTID`, but replace `PROJECTID` with your project's unique identifier.
-
-If you self host a Wordpress blog you can install the [iframe-plugin][] and then write the following in your blog-post (again, replacing the `PROJECTID` with your project's identifier):
-
-```
-[iframe src="@homeurl@/#pub:PROJECTID"]
-```
-
-### Blogger
-
-* Create a new post
-* Click the 'HTML' button next to 'Compose' and paste in the HTML
-
-### Squarespace
-
-[Squarespace][] allows you to embed HTML code inside a blog post or page. In the editor, click to add a new block.
-
-Scroll to **More** and select **Code**. Paste the embed HTML and click **Apply**.
-
-### Google Sites
-
-Google Sites doesn't currently [support iframes in custom HTML][google-sites-iframes], so you'll have to insert a link to your project's URL instead.
-
-### Office Sway
-
-[Microsoft Office Sway][sway] only allows iframes from [certain websites][sway-restricted], so you'll need to insert a link to your project instead.
-### Embedding in Markdown documents
-
-[Markdown][] is a popular text format supported by many blog editors. As Markdown supports embedded HTML, you should be able to paste the HTML into the document, although some sites may prevent you from doing this.
-
-[wordpress.com]: https://wordpress.com
-[wordpress-vip]: https://vip.wordpress.com/documentation/embedding-rich-media-from-around-the-web-with-protected-embeds/#scripts-iframes-and-objects
-[iframe-plugin]: https://wordpress.org/plugins/iframe/
-[squarespace]: https://squarespace.com
-[google-sites-iframes]: https://support.google.com/sites/answer/2500646?hl=en
-[sway]: https://sway.com/my
-[sway-restricted]: https://support.office.com/en-us/article/Embed-content-in-your-Sway-1e1ab12a-f961-4a26-8afc-77a15f892b1d
-[Markdown]: https://daringfireball.net/projects/markdown/
+![Report abuse link](/static/share/report-abuse.png)


### PR DESCRIPTION
An update for the Identity and Share pages. Images are sourced from the target's static asset path for target specific context.

RE: https://github.com/microsoft/pxt-microbit/issues/5366 and https://github.com/microsoft/pxt-arcade/issues/6105