### PR TITLE
Force version history to update when restoring a version or sharing

### DIFF
--- a/pxteditor/history.ts
+++ b/pxteditor/history.ts
@@ -375,6 +375,51 @@ namespace pxt.workspace {
         toWrite[pxt.HISTORY_FILE] = JSON.stringify(history);
     }
 
+    export function pushSnapshotOnHistory(text: ScriptText, currentTime: number) {
+        let history: pxt.workspace.HistoryFile;
+
+        if (text[pxt.HISTORY_FILE]) {
+            history = pxt.workspace.parseHistoryFile(text[pxt.HISTORY_FILE]);
+        }
+        else {
+            history = {
+                entries: [],
+                snapshots: [],
+                shares: []
+            };
+        }
+
+        history.snapshots.push(takeSnapshot(text, currentTime));
+
+        text[pxt.HISTORY_FILE] = JSON.stringify(history);
+    }
+
+    export function updateShareHistory(text: ScriptText, currentTime: number, shares: PublishVersion[]) {
+        let history: pxt.workspace.HistoryFile;
+
+        if (text[pxt.HISTORY_FILE]) {
+            history = pxt.workspace.parseHistoryFile(text[pxt.HISTORY_FILE]);
+        }
+        else {
+            history = {
+                entries: [],
+                snapshots: [],
+                shares: []
+            };
+        }
+
+        for (const share of shares) {
+            if (!history.shares.some(s => s.id === share.id)) {
+                history.shares.push({
+                    id: share.id,
+                    timestamp: currentTime,
+                });
+            }
+        }
+
+        text[pxt.HISTORY_FILE] = JSON.stringify(history);
+    }
+
     function takeSnapshot(text: ScriptText, time: number) {
         return {
             timestamp: time,

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -872,6 +872,7 @@ export async function showTurnBackTimeDialogAsync(header: pxt.workspace.Header, 
 
         header.targetVersion = editorVersion;
 
+        await workspace.saveSnapshotAsync(header.id);
         await workspace.saveAsync(header, text);
         reloadHeader();
     }

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -456,7 +456,7 @@ export class EditorPackage {
     sortedFiles(): File[] {
         let lst = Util.values(this.files)
         if (!pxt.options.debug)
-            lst = lst.filter(f => f.name != pxt.github.GIT_JSON && f.name != pxt.SIMSTATE_JSON && f.name != pxt.SERIAL_EDITOR_FILE && f.name != pxt.PALETTES_FILE)
+            lst = lst.filter(f => f.name != pxt.github.GIT_JSON && f.name != pxt.SIMSTATE_JSON && f.name != pxt.SERIAL_EDITOR_FILE && f.name != pxt.PALETTES_FILE && f.name !== pxt.HISTORY_FILE)
         lst.sort((a, b) => a.weight() - b.weight() || Util.strcmp(a.name, b.name))
         return lst
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2356

Three version history fixes:

1. Filter the history file out of the file explorer and github diffs
2. Explicitly save a history snapshot before restoring an old version of the project so that we definitely save the old version of the project
3. Save history whenever we do a share so that we don't have to wait for the user to make a change before it shows up in the version history
