### PR TITLE
Fix indices check for pop operation in Python

### DIFF
--- a/libs/pxt-python/pxt-python-helpers.ts
+++ b/libs/pxt-python/pxt-python-helpers.ts
@@ -361,7 +361,7 @@ namespace _py {
         if (index == undefined) {
             return arr.pop();
         }
-        else if (index > 0 && index < arr.length) {
+        else if (index >= 0 && index < arr.length) {
             return arr.removeAt(index | 0);
         }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2024

We were throwing an Index Error when trying to pop the 0th element because our check didn't include 0 as a valid index.