### PR TITLE
Add `--noauth` option to `pxt serve`

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2854,7 +2854,8 @@ export function serveAsync(parsed: commandParser.ParsedCommand) {
             wsPort: parsed.flags["wsport"] as number || 0,
             hostname: parsed.flags["hostname"] as string || "",
             browser: parsed.flags["browser"] as string,
-            serial: !parsed.flags["noSerial"] && !globalConfig.noSerial
+            serial: !parsed.flags["noSerial"] && !globalConfig.noSerial,
+            noauth: parsed.flags["noauth"] as boolean || false,
         }))
 }
 
@@ -6922,6 +6923,10 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
                 aliases: ["w"],
                 type: "number",
                 argument: "wsport"
+            },
+            noauth: {
+                description: "disable localtoken-based authentication",
+                aliases: ["na"],
             }
         }
     }, serveAsync);

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -808,6 +808,7 @@ export interface ServeOptions {
     hostname?: string;
     wsPort?: number;
     serial?: boolean;
+    noauth?: boolean;
 }
 
 // can use http://localhost:3232/streams/nnngzlzxslfu for testing
@@ -1089,7 +1090,7 @@ export function serveAsync(options: ServeOptions) {
                     })
             }
 
-            if (!isAuthorizedLocalRequest(req)) {
+            if (!options.noauth && !isAuthorizedLocalRequest(req)) {
                 error(403);
                 return null;
             }


### PR DESCRIPTION
Add option to disable request authentication when running `pxt serve`. This is a security feature for external users that might be running pxt serve in production, but it was getting in the way for me when connecting to pxt serve remotely during local development (connecting from Xbox to my dev PC, in this case).
