### PR TITLE
kiosk: fixes for carousel touch nav, storage exceptions

### DIFF
--- a/kiosk/src/Components/GameList.tsx
+++ b/kiosk/src/Components/GameList.tsx
@@ -109,17 +109,18 @@ const GameList: React.FC<IProps> = ({}) => {
         GamepadManager.GamepadControl.AButton
     );
 
-    const transitionStart = () => {
+    const slideChangeTransitionStart = () => {
         if (userInitiatedTransition) {
-            syncSelectedGame();
             playSoundEffect("swipe");
-            setUserInitiatedTransition(false);
         }
     };
 
-    const onTouchEnd = () => {
-        syncSelectedGame();
-    };
+    const slideChangeTransitionEnd = () => {
+        if (userInitiatedTransition) {
+            syncSelectedGame();
+            setUserInitiatedTransition(false);
+        }
+    }
 
     if (!kiosk.allGames?.length) {
         return (
@@ -142,8 +143,9 @@ const GameList: React.FC<IProps> = ({}) => {
                 onSwiper={handleLocalSwiper}
                 allowTouchMove={true}
                 modules={[Pagination]}
-                onSlideChangeTransitionStart={() => transitionStart()}
-                onTouchEnd={() => onTouchEnd()}
+                onSlideChangeTransitionStart={() => slideChangeTransitionStart()}
+                onSlideChangeTransitionEnd={() => slideChangeTransitionEnd()}
+                onTouchStart={() => setUserInitiatedTransition(true)}
             >
                 {kiosk.allGames.map((game, index) => {
                     return (

--- a/kiosk/src/Services/LocalStorage.ts
+++ b/kiosk/src/Services/LocalStorage.ts
@@ -126,6 +126,9 @@ function getBuiltJsInfo(gameId: string): ts.pxtc.BuiltSimJsInfo | undefined {
 }
 
 function setBuiltJsInfo(gameId: string, builtJs: ts.pxtc.BuiltSimJsInfo) {
+    // Need to switch to indexdb. We're hitting local storage size limit with just a few games.
+    return;
+    /*
     try {
         const ver = pxt.appTarget?.versions?.target;
         if (!ver) return;
@@ -134,6 +137,7 @@ function setBuiltJsInfo(gameId: string, builtJs: ts.pxtc.BuiltSimJsInfo) {
     } catch (e) {
         console.error(e);
     }
+    */
 }
 
 export {

--- a/kiosk/src/Services/LocalStorage.ts
+++ b/kiosk/src/Services/LocalStorage.ts
@@ -14,17 +14,6 @@ function delValue(key: string) {
     localStorage.removeItem(key);
 }
 
-function matchingKeys(pattern: RegExp): string[] {
-    const keys: string[] = [];
-    for (let i = 0; i < localStorage.length; i++) {
-        const key = localStorage.key(i);
-        if (key && pattern.test(key)) {
-            keys.push(key);
-        }
-    }
-    return keys;
-}
-
 function getJsonValue<T>(key: string, defaultValue?: T): T | undefined {
     var value = getValue(key);
     if (value) {
@@ -50,7 +39,11 @@ function getUserAddedGames(): GamesById {
 }
 
 function setUserAddedGames(games: GamesById) {
-    setJsonValue(Constants.addedGamesLocalStorageKey, games);
+    try {
+        setJsonValue(Constants.addedGamesLocalStorageKey, games);
+    } catch (e) {
+        console.error(e);
+    }
 }
 
 function getHighScores(): AllHighScores {
@@ -91,8 +84,12 @@ function resetHighScores() {
 }
 
 function setKioskCode(code: string, expiration: number) {
-    setValue(Constants.kioskCodeStorageKey, code);
-    setValue(Constants.kioskCodeExpirationStorageKey, expiration.toString());
+    try {
+        setValue(Constants.kioskCodeStorageKey, code);
+        setValue(Constants.kioskCodeExpirationStorageKey, expiration.toString());
+    } catch (e) {
+        console.error(e);
+    }
 }
 
 function getKioskCode(): { code: string; expiration: number } | undefined {
@@ -123,22 +120,19 @@ function clearKioskCode() {
 function getBuiltJsInfo(gameId: string): ts.pxtc.BuiltSimJsInfo | undefined {
     const ver = pxt.appTarget?.versions?.target;
     if (!ver) return undefined;
-    const key = `builtjs:${ver}:${gameId}`;
+    const key = `kiosk/builtjs:${ver}:${gameId}`;
     const rec = getJsonValue<ts.pxtc.BuiltSimJsInfo>(key);
     return rec;
 }
 
 function setBuiltJsInfo(gameId: string, builtJs: ts.pxtc.BuiltSimJsInfo) {
-    const ver = pxt.appTarget?.versions?.target;
-    if (!ver) return;
-    const key = `builtjs:${ver}:${gameId}`;
-    setJsonValue(key, builtJs);
-}
-
-function clearBuiltJsInfo() {
-    const keys = matchingKeys(/^builtjs:/);
-    for (const key of keys) {
-        delValue(key);
+    try {
+        const ver = pxt.appTarget?.versions?.target;
+        if (!ver) return;
+        const key = `kiosk/builtjs:${ver}:${gameId}`;
+        setJsonValue(key, builtJs);
+    } catch (e) {
+        console.error(e);
     }
 }
 
@@ -155,5 +149,4 @@ export {
     clearKioskCode,
     getBuiltJsInfo,
     setBuiltJsInfo,
-    clearBuiltJsInfo,
 };


### PR DESCRIPTION
* The compiled js for games can exceed local storage quota. Added protection for that.
* Fixed a bug where carousel touch/scroll could result in app state confusion around which game is the currently selected game.
