### PR TITLE
Fixing a couple of forced reflows in our tutorial components

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -520,8 +520,8 @@
         min-width: inherit;
         max-width: inherit;
         width: @simulatorWidth;
-        height: calc(~'100%' - @mainMenuHeight);
         top: @mainMenuHeight;
+        bottom: 0;
         left: 0;
 
         .simPanel {

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -51,14 +51,15 @@ export function TutorialContainer(props: TutorialContainerProps) {
     const showImmersiveReader = pxt.appTarget.appTheme.immersiveReader;
     const isHorizontal = props.tutorialSimSidebar || pxt.BrowserUtils.isTabletSize();
 
+    const container = React.useRef();
+
     React.useEffect(() => {
         const observer = new ResizeObserver(updateScrollGradient);
         observer.observe(document.body)
 
         // We also want to update the scroll gradient if the tutorial wrapper is resized by the user.
-        const parent = document.querySelector("#tutorialWrapper");
-        if (parent) {
-            observer.observe(parent);
+        if (container.current) {
+            observer.observe(container.current);
         }
 
         return () => observer.disconnect();
@@ -248,7 +249,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
     const hasHint = !!hintMarkdown;
 
 
-    return <div className="tutorial-container">
+    return <div className="tutorial-container" ref={container}>
         {!isHorizontal && stepCounter}
         <div className={classList("tutorial-content", hasHint && "has-hint")} ref={contentRef} onScroll={updateScrollGradient}>
             <div className={"tutorial-content-bkg"}>


### PR DESCRIPTION
Fixes two perf issues for tutorials:

First, the tutorial callout was running it's resize observer even when not visible. The callback for the observer was checking the height of an element, which forces the browser to rerender elements to get an accurate number. I guarded this behind a check to see if the callout is visible and also cleaned up the event listeners in that component a little bit while I was there.

Second, the tutorial container was running a querySelector to get a reference to its container so that it could run a resize observer on it. Query selectors also force reflows, so I changed this to instead use a ref of the container element.

Finally, I fixed a small CSS bug that I noticed when resizing tutorials where the editor sidebar wasn't taking up the whole height of the editor.