### PR TITLE
kiosk: fix for skipped letters when entering high score

### DIFF
--- a/kiosk/src/Components/HighScoreInitial.tsx
+++ b/kiosk/src/Components/HighScoreInitial.tsx
@@ -21,7 +21,7 @@ const HighScoreInitial: React.FC<IProps> = ({
         (index + 1) % configData.HighScoreInitialAllowedCharacters.length;
 
     const previousInitial = () => {
-                const newIndex = getPreviousIndex();
+        const newIndex = getPreviousIndex();
         setIndex(newIndex);
         onCharacterChanged(
             configData.HighScoreInitialAllowedCharacters[newIndex]
@@ -29,7 +29,7 @@ const HighScoreInitial: React.FC<IProps> = ({
     };
 
     const nextInitial = () => {
-                const newIndex = getNextIndex();
+        const newIndex = getNextIndex();
         setIndex(newIndex);
         onCharacterChanged(
             configData.HighScoreInitialAllowedCharacters[newIndex]

--- a/kiosk/src/Components/HighScoreInitial.tsx
+++ b/kiosk/src/Components/HighScoreInitial.tsx
@@ -21,7 +21,7 @@ const HighScoreInitial: React.FC<IProps> = ({
         (index + 1) % configData.HighScoreInitialAllowedCharacters.length;
 
     const previousInitial = () => {
-        const newIndex = getPreviousIndex();
+                const newIndex = getPreviousIndex();
         setIndex(newIndex);
         onCharacterChanged(
             configData.HighScoreInitialAllowedCharacters[newIndex]
@@ -29,7 +29,7 @@ const HighScoreInitial: React.FC<IProps> = ({
     };
 
     const nextInitial = () => {
-        const newIndex = getNextIndex();
+                const newIndex = getNextIndex();
         setIndex(newIndex);
         onCharacterChanged(
             configData.HighScoreInitialAllowedCharacters[newIndex]
@@ -38,14 +38,14 @@ const HighScoreInitial: React.FC<IProps> = ({
 
     // Handle DPadUp button press
     useOnControlPress(
-        [onCharacterChanged, isSelected, index],
+        [onCharacterChanged, isSelected, setIndex],
         () => isSelected && previousInitial(),
         GamepadManager.GamepadControl.DPadUp
     );
 
     // Handle DPadDown button press
     useOnControlPress(
-        [onCharacterChanged, isSelected, index],
+        [onCharacterChanged, isSelected, setIndex],
         () => isSelected && nextInitial(),
         GamepadManager.GamepadControl.DPadDown
     );


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6134
