### PR TITLE
kiosk: remap esc to the controller's back button

### DIFF
--- a/kiosk/src/Components/PlayingGame.tsx
+++ b/kiosk/src/Components/PlayingGame.tsx
@@ -19,8 +19,7 @@ export default function PlayingGame() {
             playSoundEffect("select");
             escapeGame();
         },
-        GamepadManager.GamepadControl.EscapeButton,
-        GamepadManager.GamepadControl.MenuButton
+        GamepadManager.GamepadControl.EscapeButton
     );
 
     const playUrl = useMemo(() => {

--- a/kiosk/src/config.json
+++ b/kiosk/src/config.json
@@ -12,7 +12,7 @@
     "GamepadOnHeldCooldownMilli": 167,
     "GamepadAButtonPin": 0,
     "GamepadBButtonPin": 1,
-    "GamepadEscapeButtonPin": 9,
+    "GamepadEscapeButtonPin": 8,
     "GamepadResetButtonPin": 10,
     "GamepadDpadUpButtonPin": 12,
     "GamepadDpadDownButtonPin": 13,


### PR DESCRIPTION
Exit a game using the controller's back button (view button on newer controllers), not the start button (menu button on newer controllers). Start/view is used by the simulator to open the in-game settings menu.

Fixes https://github.com/microsoft/pxt-arcade/issues/6145
