### PR TITLE
kiosk: fix for shoebox controller

### DIFF
--- a/kiosk/src/Components/PlayingGame.tsx
+++ b/kiosk/src/Components/PlayingGame.tsx
@@ -20,7 +20,7 @@ export default function PlayingGame() {
             escapeGame();
         },
         GamepadManager.GamepadControl.EscapeButton,
-        GamepadManager.GamepadControl.MenuButton
+        GamepadManager.GamepadControl.ResetButton
     );
 
     const playUrl = useMemo(() => {

--- a/kiosk/src/Services/GamepadManager.ts
+++ b/kiosk/src/Services/GamepadManager.ts
@@ -242,8 +242,7 @@ class GamepadManager {
             gamepad.axes &&
             gamepad.axes.length >= this.minAxisRequired &&
             gamepad.buttons &&
-            gamepad.buttons.length >= this.minButtonPinRequired &&
-            !!gamepad.mapping
+            gamepad.buttons.length >= this.minButtonPinRequired
         );
     }
 


### PR DESCRIPTION
I also bound the reset button to exit game. There isn't a way to do this using only the shoebox controller otherwise.

Fixes https://github.com/microsoft/pxt-arcade/issues/6143
