### PR TITLE
kiosk: set color of "loading" text in run.html

### DIFF
--- a/kiosk/src/Components/PlayingGame.tsx
+++ b/kiosk/src/Components/PlayingGame.tsx
@@ -34,6 +34,7 @@ export default function PlayingGame() {
                 single: 1,
                 fullscreen: 1,
                 autofocus: 1,
+                loadingColor: "white",
                 // If we have the built game cached, we will send it to the
                 // simulator once it loads. The `server` flag inhibits the
                 // simulator from trying to build it.

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -121,6 +121,7 @@
         var codeFromSrc = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
         var additionalSimParams = /simParams(?:[:=])([^&?]+)/i.exec(window.location.href)?.[1];
         var sendBuilt = !!/sendBuilt(?:[:=])1/i.test(window.location.href);
+        var loadingColor = /[\&\?]loadingColor=(#[0-9A-Fa-f]{3}|#[0-9A-Fa-f]{6}|[A-Za-z]+)\b/i.test(window.location.href)?.[1];
         var codeFromData = undefined;
         var assetJsonFromData = undefined;
         try {
@@ -134,6 +135,9 @@
         }
         var code = codeFromData || (codeFromSrc ? codeFromSrc[1] : undefined);
 
+        if (loading && loadingColor) {
+            loading.style.color = loadingColor;
+        }
 
         if (additionalSimParams) {
             additionalSimParams = decodeURIComponent(additionalSimParams);


### PR DESCRIPTION
.. and added support setting color of "loading" text in run.html

Fixes https://github.com/microsoft/pxt-arcade/issues/5407
Fixes https://github.com/microsoft/pxt-arcade/issues/6137
