### PR TITLE
kiosk: log detected gamepad type to telemetry

### DIFF
--- a/kiosk/src/Services/GamepadManager.ts
+++ b/kiosk/src/Services/GamepadManager.ts
@@ -249,6 +249,7 @@ class GamepadManager {
 
     addGamepad(gamepad: Gamepad) {
         if (this.gamepadFilter(gamepad)) {
+            pxt.tickEvent("kiosk.gamepad.connected", { id: gamepad.id });
             this.gamepads.set(gamepad.index, true);
             this.gamepadStates.set(gamepad.index, {
                 state: { ...this.readGamepad(gamepad) },


### PR DESCRIPTION
This will allow us to answer questions like: "how many kiosks use the shoebox controller?"
