### PR TITLE
kiosk: map controller Y to escapebutton functionality

### DIFF
--- a/kiosk/src/Components/AddingGame.tsx
+++ b/kiosk/src/Components/AddingGame.tsx
@@ -32,11 +32,11 @@ const AddingGame: React.FC<IProps> = ({}) => {
         showMainMenu();
     };
 
-    // Handle Escape button press
+    // Handle Back button press
     useOnControlPress(
         [],
         gotoMainMenu,
-        GamepadManager.GamepadControl.EscapeButton,
+        GamepadManager.GamepadControl.BackButton,
         GamepadManager.GamepadControl.BButton
     );
 

--- a/kiosk/src/Components/AppModal.tsx
+++ b/kiosk/src/Components/AppModal.tsx
@@ -13,7 +13,7 @@ export default function AppModal() {
 
     const hideAppModal = () => {
         GamepadManager.lockControl(GamepadManager.GamepadControl.AButton);
-        GamepadManager.lockControl(GamepadManager.GamepadControl.EscapeButton);
+        GamepadManager.lockControl(GamepadManager.GamepadControl.BackButton);
         dispatch(hideModal());
     };
 

--- a/kiosk/src/Components/GameOver.tsx
+++ b/kiosk/src/Components/GameOver.tsx
@@ -25,11 +25,11 @@ const GameOver: React.FC<IProps> = ({}) => {
         showMainMenu();
     };
 
-    // Handle Escape button press
+    // Handle Back button press
     useOnControlPress(
         [],
         gotoMainMenu,
-        GamepadManager.GamepadControl.EscapeButton
+        GamepadManager.GamepadControl.BackButton
     );
 
     return (

--- a/kiosk/src/Components/Modal.tsx
+++ b/kiosk/src/Components/Modal.tsx
@@ -38,7 +38,7 @@ export const Modal = (props: ModalProps) => {
         () => {
             onClose?.();
         },
-        GamepadManager.GamepadControl.EscapeButton
+        GamepadManager.GamepadControl.BackButton
     );
 
     const classes = classList("common-modal-container", className);

--- a/kiosk/src/Components/NewScoreEntry.tsx
+++ b/kiosk/src/Components/NewScoreEntry.tsx
@@ -42,7 +42,7 @@ const NewScoreEntry: React.FC<IProps> = ({}) => {
         GamepadManager.GamepadControl.BButton
     );
 
-    // Handle Escape button press
+    // Handle Back button press
     useOnControlPress(
         [kiosk],
         () => {
@@ -54,7 +54,7 @@ const NewScoreEntry: React.FC<IProps> = ({}) => {
             );
             navigate(KioskState.GameOver);
         },
-        GamepadManager.GamepadControl.EscapeButton
+        GamepadManager.GamepadControl.BackButton
     );
 
     // Handle all initials entered

--- a/kiosk/src/Components/PlayingGame.tsx
+++ b/kiosk/src/Components/PlayingGame.tsx
@@ -12,15 +12,15 @@ export default function PlayingGame() {
     const { state: kiosk, dispatch } = useContext(AppStateContext);
     const { launchedGameId: gameId } = kiosk;
 
-    // Handle Escape and Menu button presses
+    // Handle Back and Start button presses
     useOnControlPress(
         [],
         () => {
             playSoundEffect("select");
             escapeGame();
         },
-        GamepadManager.GamepadControl.EscapeButton,
-        GamepadManager.GamepadControl.ResetButton
+        GamepadManager.GamepadControl.BackButton,
+        GamepadManager.GamepadControl.StartButton
     );
 
     const playUrl = useMemo(() => {

--- a/kiosk/src/Services/SimHostService.ts
+++ b/kiosk/src/Services/SimHostService.ts
@@ -22,17 +22,17 @@ export function initialize() {
 
         // Look for the high scores reset combo
         if (
-            controlStates[GamepadManager.GamepadControl.ResetButton] &&
-            controlStates[GamepadManager.GamepadControl.EscapeButton] &&
+            controlStates[GamepadManager.GamepadControl.StartButton] &&
+            controlStates[GamepadManager.GamepadControl.BackButton] &&
             controlStates[GamepadManager.GamepadControl.BButton] &&
             controlStates[GamepadManager.GamepadControl.DPadLeft]
         ) {
             // Lock the combo so it doesn't get triggered repeatedly
             GamepadManager.lockControl(
-                GamepadManager.GamepadControl.ResetButton
+                GamepadManager.GamepadControl.StartButton
             );
             GamepadManager.lockControl(
-                GamepadManager.GamepadControl.EscapeButton
+                GamepadManager.GamepadControl.BackButton
             );
             GamepadManager.lockControl(GamepadManager.GamepadControl.BButton);
             GamepadManager.lockControl(GamepadManager.GamepadControl.DPadLeft);

--- a/kiosk/src/Transforms/navigate.ts
+++ b/kiosk/src/Transforms/navigate.ts
@@ -8,9 +8,9 @@ import { playSoundEffect } from "../Services/SoundEffectService";
 export function navigate(nextState: KioskState) {
     const { dispatch } = stateAndDispatch();
     pxt.tickEvent("kiosk.navigate." + nextState.toLowerCase());
-    // Lock the A button and Escape button to prevent accidental navigation upon entering the new state
+    // Lock the A button and Back button to prevent accidental navigation upon entering the new state
     GamepadManager.lockControl(GamepadManager.GamepadControl.AButton);
-    GamepadManager.lockControl(GamepadManager.GamepadControl.EscapeButton);
+    GamepadManager.lockControl(GamepadManager.GamepadControl.BackButton);
     playSoundEffect("select");
     //NavGrid.resetUserInteraction();
     // As a general safety measure, wait one frame before changing screens to allow any pending reducer

--- a/kiosk/src/config.json
+++ b/kiosk/src/config.json
@@ -12,8 +12,10 @@
     "GamepadOnHeldCooldownMilli": 167,
     "GamepadAButtonPin": 0,
     "GamepadBButtonPin": 1,
-    "GamepadEscapeButtonPin": 8,
-    "GamepadResetButtonPin": 10,
+    "GamepadXButtonPin": 2,
+    "GamepadYButtonPin": 3,
+    "GamepadBackButtonPin": 8,
+    "GamepadStartButtonPin": 10,
     "GamepadDpadUpButtonPin": 12,
     "GamepadDpadDownButtonPin": 13,
     "GamepadDpadLeftButtonPin": 14,
@@ -49,8 +51,8 @@
     "GamepadControlToKeyboardKeyMap": {
         "AButton": "Space",
         "BButton": "Enter",
-        "EscapeButton": "Escape",
-        "ResetButton": "2",
+        "BackButton": "Escape",
+        "StartButton": "2",
         "MenuButton": "1",
         "DPadLeft": "ArrowLeft",
         "DPadRight": "ArrowRight",
@@ -72,8 +74,8 @@
         {
             "Space": "AButton",
             "Enter": "BButton",
-            "Escape": "EscapeButton",
-            "2": "ResetButton",
+            "Escape": "BackButton",
+            "2": "StartButton",
             "1": "MenuButton",
             "ArrowLeft": "DPadLeft",
             "ArrowRight": "DPadRight",
@@ -86,7 +88,7 @@
             "Right": "DPadRight",
             "Up": "DPadUp",
             "Down": "DPadDown",
-            "Esc": "EscapeButton"
+            "Esc": "BackButton"
         },
         {
             "z": "AButton",


### PR DESCRIPTION
Change looks bigger than it is due to some symbol renaming. Essential diff is at GamepadManager.ts:507.

Fixes https://github.com/microsoft/pxt-arcade/issues/6149