### PR TITLE
Fix blockly sound effects and add volume option

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -492,6 +492,7 @@ declare namespace pxt {
         condenseProfile?: boolean; // if set, will make the profile dialog smaller
         cloudProfileIcon?: string; // the file path for added imagery on smaller profile dialogs
         timeMachine?: boolean; // Save/restore old versions of a project experiment
+        blocklySoundVolume?: number; // A number between 0 and 1 that sets the volume for blockly sounds (e.g. connect, disconnect, click)
     }
 
     interface DownloadDialogTheme {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -483,7 +483,19 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         const oldAudioPlay = (Blockly as any).WorkspaceAudio.prototype.play;
         (Blockly as any).WorkspaceAudio.prototype.play = function (name: string, opt_volume?: number) {
-            if (editor && editor.parent.state.mute) opt_volume = 0;
+            const themeVolume = pxt.appTarget?.appTheme?.blocklySoundVolume;
+
+            if (editor?.parent.state.mute === pxt.editor.MuteState.Muted) {
+                opt_volume = 0;
+            }
+            else if (themeVolume != undefined) {
+                if (opt_volume != undefined) {
+                    opt_volume *= themeVolume;
+                }
+                else {
+                    opt_volume = themeVolume;
+                }
+            }
             oldAudioPlay.call(this, name, opt_volume);
         };
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5350

Also adds an option to pxtarget.json that lets you control the volume of the sounds for a target (e.g. if they've been overridden)