### PR TITLE
Don't start sim when toggling file explorer in headless

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3538,8 +3538,9 @@ export class ProjectView
     toggleSimulatorCollapse() {
         const state = this.state;
         pxt.tickEvent("simulator.toggleCollapse", { view: 'computer', collapsedTo: '' + !state.collapseEditorTools }, { interactiveConsent: true });
-        if (state.simState == pxt.editor.SimState.Stopped && state.collapseEditorTools)
+        if (state.simState == pxt.editor.SimState.Stopped && state.collapseEditorTools && !pxt.appTarget.simulator.headless) {
             this.startStopSimulator();
+        }
 
         if (state.collapseEditorTools) {
             this.expandSimulator();


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2386

Just adding a check for headless when expanding the collapsed side panel