### PR TITLE
Add info message after saving a copy of a project in time machine

### DIFF
--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -919,6 +919,8 @@ export async function showTurnBackTimeDialogAsync(header: pxt.workspace.Header, 
         await workspace.duplicateAsync(newHeader, `${newHeader.name} ${dateString} ${timeString}`, text);
 
         invalidate("headers:");
+
+        core.infoNotification(lf("Project copy saved to My Projects"))
     }
 
     await core.dialogAsync({


### PR DESCRIPTION
![image](https://github.com/microsoft/pxt/assets/13754588/4c08ba5a-9066-4137-8407-cdde866e3b6e)

Fixes https://github.com/microsoft/pxt-minecraft/issues/2382

Now when you save a copy of a project from version history, a toast shows up telling you it happened.