### PR TITLE
kiosk: show sim buttons on mobile, and an input tweak

### DIFF
--- a/kiosk/src/Components/PlayingGame.tsx
+++ b/kiosk/src/Components/PlayingGame.tsx
@@ -43,7 +43,7 @@ export default function PlayingGame() {
             return stringifyQueryString(configData.PlayUrlRoot, {
                 id: gameId,
                 // TODO: Show sim buttons on mobile & touch devices.
-                hideSimButtons: 1,
+                hideSimButtons: pxt.BrowserUtils.isMobile() ? undefined : 1,
                 noFooter: 1,
                 single: 1,
                 fullscreen: 1,

--- a/kiosk/src/Services/SimHostService.ts
+++ b/kiosk/src/Services/SimHostService.ts
@@ -103,7 +103,7 @@ export function initialize() {
             case "messagepacket":
                 const channel = event.data.channel;
                 const parts = channel.split("-");
-                if (parts[0] === "keydown" || parts[0] === "keyup") {
+                if ((parts[0] === "keydown" || parts[0] === "keyup") && parts[1] === "Escape") {
                     // This allows us to listen for the Escape key when the
                     // simulator iframe is focused
                     GamepadManager.emitKeyEvent(parts[0], parts[1]);


### PR DESCRIPTION
This change is just enough to enable regression testing of the simulator on touch-only devices. More work is needed to make kiosk functional on mobile.

Also: filter key events from the sim to just the ones we want.

Fixes https://github.com/microsoft/pxt-arcade/issues/6103 (technically)