### PR TITLE
kiosk: Fix for clean=1 param

### DIFF
--- a/kiosk/src/App.tsx
+++ b/kiosk/src/App.tsx
@@ -46,11 +46,11 @@ function App() {
                 if (cfg) {
                     dispatch(Actions.setTargetConfig(cfg));
                     if (cfg.kiosk) {
-                        dispatch(Actions.setGameList(cfg.kiosk.games));
+                        if (!state.clean) {
+                            dispatch(Actions.setGameList(cfg.kiosk.games));
+                        }
                         // Load user-added games from local storage.
                         dispatch(Actions.loadUserAddedGames());
-                        // Select the first game in the list.
-                        dispatch(Actions.setSelectedGameId(cfg.kiosk.games[0].id));
                     }
                 } else {
                     // TODO: Handle this better

--- a/kiosk/src/Components/GameList.tsx
+++ b/kiosk/src/Components/GameList.tsx
@@ -23,6 +23,7 @@ const GameList: React.FC<IProps> = ({}) => {
     const [userInitiatedTransition, setUserInitiatedTransition] =
         React.useState(false);
     const [pageInited, setPageInited] = React.useState(false);
+    const [generation, setGeneration] = React.useState(0);
 
     const handleLocalSwiper = (swiper: SwiperClass) => {
         setLocalSwiper(swiper);
@@ -116,11 +117,12 @@ const GameList: React.FC<IProps> = ({}) => {
     };
 
     const slideChangeTransitionEnd = () => {
+        setGeneration(generation + 1); // This will force GameSlides to re-render
         if (userInitiatedTransition) {
             syncSelectedGame();
             setUserInitiatedTransition(false);
         }
-    }
+    };
 
     if (!kiosk.allGames?.length) {
         return (
@@ -134,7 +136,6 @@ const GameList: React.FC<IProps> = ({}) => {
         <div className="carouselWrap">
             <Swiper
                 focusableElements="div"
-                slideActiveClass="swiper-slide-active"
                 tabIndex={0}
                 loop={true}
                 slidesPerView={1.8}
@@ -143,14 +144,16 @@ const GameList: React.FC<IProps> = ({}) => {
                 onSwiper={handleLocalSwiper}
                 allowTouchMove={true}
                 modules={[Pagination]}
-                onSlideChangeTransitionStart={() => slideChangeTransitionStart()}
+                onSlideChangeTransitionStart={() =>
+                    slideChangeTransitionStart()
+                }
                 onSlideChangeTransitionEnd={() => slideChangeTransitionEnd()}
                 onTouchStart={() => setUserInitiatedTransition(true)}
             >
                 {kiosk.allGames.map((game, index) => {
                     return (
                         <SwiperSlide key={index}>
-                            <GameSlide game={game} />
+                            <GameSlide game={game} generation={generation} />
                         </SwiperSlide>
                     );
                 })}

--- a/kiosk/src/Kiosk.css
+++ b/kiosk/src/Kiosk.css
@@ -552,19 +552,26 @@ h2 {
 
 .swiper-slide {
     position: relative;
-    width: var(--swiper-width);
     transform: scale(0.75);
     top: -10%;
 }
 
-.swiper-slide-active {
-    cursor: pointer;
-    transform: scale(1) !important;
-    top: 0;
+.swiper-slide.swiper-slide-next {
+    position: relative;
+    transform: scale(0.75) !important;
+    top: -10%;
 }
 
-.swiper-slide-active .deleted {
-    animation: 1s shrink;
+.swiper-slide.swiper-slide-prev {
+    position: relative;
+    transform: scale(0.75) !important;
+    top: -10%;
+}
+
+.swiper-slide.swiper-slide-active {
+    cursor: pointer;
+    transform: scale(1);
+    top: 0;
 }
 
 .gameTile {

--- a/kiosk/src/State/Reducer.ts
+++ b/kiosk/src/State/Reducer.ts
@@ -93,7 +93,7 @@ export default function reducer(state: AppState, action: Action): AppState {
             if (state.selectedGameId === action.gameId) {
                 // Get the index of the now-deleted game in the original list.
                 const selectedGameIndex = state.allGames.findIndex(g => g.id === action.gameId);
-                if (selectedGameIndex >= 0) {
+                if (selectedGameIndex >= 0 && remainingGames.length) {
                     if (selectedGameIndex > remainingGames.length - 1) {
                         // The index of the deleted game is beyond the bounds of the updated list. Select the last game in the updated list.
                         selectedGameId = remainingGames[remainingGames.length - 1].id;

--- a/kiosk/src/State/State.ts
+++ b/kiosk/src/State/State.ts
@@ -18,10 +18,10 @@ export type AppState = {
     kioskCodeExpiration?: number;
     notifications: Notifications;
     modal?: ModalConfig;
-    clean: boolean;
-    locked: boolean;
-    time?: string;
-    volume?: number;
+    clean: boolean; // if true, don't load built-in games
+    locked: boolean; // if true, hide the add games button
+    time?: string; // lifetime of kiosk code, in minutes
+    volume?: number; // volume level of kiosk UI sounds, in [0..1]
     targetConfig?: pxt.TargetConfig;
 };
 


### PR DESCRIPTION
More fun with Swiper idiosyncrasies. When Swiper's `loop` option is enabled, it will duplicate slides until there are three, but it won't distinguish between them when rendering, so you won't know which is actually selected. Transitioning between these duplicated slides doesn't reliably trigger a React re-render. I had to work around this behavior to get the carousel rendering correctly when there were less than three games uploaded and clean=1. @srietkerk this probably sounds familiar to you! :)

Fixes https://github.com/microsoft/pxt-arcade/issues/6169
Fixes https://github.com/microsoft/pxt-arcade/issues/6136, incidentally
