### PR TITLE
Added `onIconClick` to extension search input

### DIFF
--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -517,6 +517,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                         placeholder={lf("Search or enter project URL...")}
                         ariaLabel={lf("Search or enter project URL...")}
                         onEnterKey={onSearchBarChange}
+                        onIconClick={onSearchBarChange}
                         preserveValueOnBlur={true}
                         icon="fas fa-search"
                     />


### PR DESCRIPTION
When searching for extensions in the Minecraft target, clicking on the magnifying glass icon on the right of the search bar wouldn't do anything. It was unclear to me why it was behaving differently. As far as I could tell, there weren't any flags that would set this in the target itself and when inspecting the html, everything looked the same as it does in arcade, where clicking the icon will kick off a search as expected. 

Adding the `onIconClick` field to the input _does_ change the icon into a button, but I think this is a fine change. I actually think that this modification makes it clearer that the icon can be clicked since it comes with the css that we have defined for common-buttons (pointer and darker background color on hover). 

This is a quick video showing how it looks as only an icon and then now as a button: 

https://github.com/microsoft/pxt/assets/49178322/0c0a67a5-bf2d-4c0d-acf9-a8b61e2375ed


Here's a target in Minecraft: https://minecraft.makecode.com/app/cc86807a84f344ed00a69ca22a3c95f31105b02f-3cdea2d8d6#
This includes some css changes that I made to the button to make it look the same as the other targets. I'm opening another PR in Minecraft to get those changes.

Fixes https://github.com/microsoft/pxt-minecraft/issues/2392