### PR TITLE
Editor tour: add play button for Minecraft

### DIFF
--- a/webapp/src/onboarding.ts
+++ b/webapp/src/onboarding.ts
@@ -29,6 +29,9 @@ function getTargetMap(target: string): querySelector {
         "download": {
             targetQuery: "#downloadArea",
         },
+        "play button" : {
+            targetQuery: ".big-play-button",
+        },
         "everything" : {
             targetQuery: "#root",
         },


### PR DESCRIPTION
To enable the editor tour in Minecraft, we need to include the play button which is specific to Minecraft.