### PR TITLE
Update Code Validation Docs to Include Validate-Exists Marker

### DIFF
--- a/docs/writing-docs/snippets.md
+++ b/docs/writing-docs/snippets.md
@@ -47,11 +47,27 @@ you can add the namespace it should open in parentheses after the normal one
 
 This will appear in tutorials as the `variables` category, but clicking it will toggle the `sprites` category.
 
+### validate-exists
+
+The ``@validate-exists`` tag marks the code block following it as subject to validation. This means that, when [code validation](/writing-docs/tutorials/basics.md#code-validation-validationlocal-and-validationglobal-sections) is enabled in a tutorial, the user is warned that their code isn't matching a block that the tutorial intended.
+
+ Use `// @validate-exists` in blocks and TypeScript, and `# @validate-exists`
+in Python.
+
+````
+```blocks
+// @validate-exists
+basic.showString("HELLO!")
+```
+````
+
 ### highlight
 
 When used in snippets, the renderer will higlight the next line of code or block following a comment containing
 **@highlight**. Use `// @highlight` in blocks and TypeScript, and `# @highlight`
 in Python.
+
+Another feature of **@highlight**, like with **@validate-exists**, is that the highlighted block is also validated when [code validation](/writing-docs/tutorials/basics.md#code-validation-validationlocal-and-validationglobal-sections) is enabled.
 
 ````
 ```blocks

--- a/docs/writing-docs/tutorials/basics.md
+++ b/docs/writing-docs/tutorials/basics.md
@@ -275,7 +275,7 @@ Within a validation section, you may specify which validators you want to enable
 
 ### Validators
 
-Currently, only one validator exists: the `BlocksExistValidator`. This validator looks at blocks tagged with `//@validate-exists` or `//@highlight` comments in the answer key and confirms that, for each tagged block, the user's code contains at least one block of the same type. It does *not* validate the parameters passed into the block. For more information on highlighting, see [highlighted blocks](../snippets.md#highlight).
+Currently, only one validator exists, the `BlocksExistValidator`, for [highlight](/writing-docs/snippets.md#highlight) and [validate-exists](/writing-docs/snippets#validate-exists) blocks. This validator looks at blocks tagged with `//@validate-exists` or `//@highlight` comments in the answer key and confirms that, for each tagged block, the user's code contains at least one block of the same type. It does *not* validate the parameters passed into the block.
 
 You can specify whether the `BlocksExistValidator` checks for `//@validate-exists` or `//@highlight` using the `markers` property on the validator. If you specify only `validate-exists`, then highlighted blocks will not be validated. Similarly, if you specify only `highlight`, then blocks marked with `validate-exists` will not be checked. By default, both checks are enabled.
 

--- a/docs/writing-docs/tutorials/basics.md
+++ b/docs/writing-docs/tutorials/basics.md
@@ -275,7 +275,7 @@ Within a validation section, you may specify which validators you want to enable
 
 ### Validators
 
-Currently, only one validator exists, the `BlocksExistValidator`, for [highlight](/writing-docs/snippets.md#highlight) and [validate-exists](/writing-docs/snippets#validate-exists) blocks. This validator looks at blocks tagged with `//@validate-exists` or `//@highlight` comments in the answer key and confirms that, for each tagged block, the user's code contains at least one block of the same type. It does *not* validate the parameters passed into the block.
+Currently, only one validator exists for [highlight](/writing-docs/snippets.md#highlight) and [validate-exists](/writing-docs/snippets#validate-exists) blocks, the `BlocksExistValidator`. This validator looks at blocks tagged with `//@validate-exists` or `//@highlight` comments in the answer key and confirms that, for each tagged block, the user's code contains at least one block of the same type. It does *not* validate the parameters passed into the block.
 
 You can specify whether the `BlocksExistValidator` checks for `//@validate-exists` or `//@highlight` using the `markers` property on the validator. If you specify only `validate-exists`, then highlighted blocks will not be validated. Similarly, if you specify only `highlight`, then blocks marked with `validate-exists` will not be checked. By default, both checks are enabled.
 

--- a/docs/writing-docs/tutorials/basics.md
+++ b/docs/writing-docs/tutorials/basics.md
@@ -275,15 +275,26 @@ Within a validation section, you may specify which validators you want to enable
 
 ### Validators
 
-Currently, only one validator exists: the `BlocksExistValidator`. This validator looks at [highlighted blocks](../snippets.md#highlight) in the answer key and confirms that, for each highlighted block, the user's code contains at least one block of the same type. It does *not* validate the parameters passed into the block.
+Currently, only one validator exists: the `BlocksExistValidator`. This validator looks at blocks tagged with `//@validate-exists` or `//@highlight` comments in the answer key and confirms that, for each tagged block, the user's code contains at least one block of the same type. It does *not* validate the parameters passed into the block. For more information on highlighting, see [highlighted blocks](../snippets.md#highlight).
 
-The only property currently available on the `BlocksExistValidator` is `Enabled`, which determines whether or not the validator runs. This is `true` by default whenever you specify the validator but can be set to `false` if you wish to disable it on a single step.
+You can specify whether the `BlocksExistValidator` checks for `//@validate-exists` or `//@highlight` using the `markers` property on the validator. If you specify only `validate-exists`, then highlighted blocks will not be validated. Similarly, if you specify only `highlight`, then blocks marked with `validate-exists` will not be checked. By default, both checks are enabled.
+
+The `BlocksExistValidator` also has an `Enabled` property that determines whether or not the validator runs at all. This is `true` by default whenever you specify the validator but can be set to `false` if you wish to disable it on a single step.
 
 ### Examples
 **Enable the `BlocksExistValidator` globally**
 ````
 ```validation.global
 # BlocksExistValidator
+```
+````
+
+**Enable the `BlocksExistValidator` globally and ignore highlighted blocks**  
+_Note: highlight is not specified in the markers property._
+````
+```validation.global
+# BlocksExistValidator
+* markers: validate-exists
 ```
 ````
 


### PR DESCRIPTION
Wanted to update the docs to include the changes made in https://github.com/microsoft/pxt/pull/9675.

These can now be utilized in Minecraft to validate non-highlighted blocks, which is nice!