### PR TITLE
Prevent python snippet enums from being snakified

### DIFF
--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -328,7 +328,7 @@ namespace ts.pxtc.service {
                 }
                 const type = checker?.getTypeAtLocation(param);
                 const typeSymbol = getPxtSymbolFromTsSymbol(type?.symbol, apis, checker);
-                if ((typeSymbol?.attributes.fixedInstances || typeSymbol?.attributes.emitAsConstant) && python) {
+                if ((typeSymbol?.attributes.fixedInstances) && python) {
                     return pxt.Util.snakify(paramDefl);
                 }
                 if (python) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2438

Thanks to @riknoll for pointing me in the right direction.

I'm removing the `emitAsConstant` check which was originally added (https://github.com/microsoft/pxt/pull/8983/files) to address this issue https://github.com/microsoft/pxt-minecraft/issues/2170 that is also regarding python snippets.

The snippet is still correct even with the removal of the `emitAsConstant` check as shown below.
![pythonSnippets](https://github.com/microsoft/pxt/assets/15070078/c1abb42b-7a55-4c6e-8006-c48111eeb3ea)

