### PR TITLE
Add Support for Python Upgrade Rules (#9776)

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -738,6 +738,7 @@ declare namespace ts.pxtc {
         flashChecksumAddr?: number;
         ramSize?: number;
         patches?: pxt.Map<UpgradePolicy[]>; // semver range -> upgrade policies
+        pyPatches?: pxt.Map<UpgradePolicy[]>; // semver range -> upgrade policies
         openocdScript?: string;
         uf2Family?: string;
         onStartText?: boolean;

--- a/pxtcompiler/simpledriver.ts
+++ b/pxtcompiler/simpledriver.ts
@@ -172,6 +172,9 @@ namespace pxt {
                 return mainPkg.getCompileOptionsAsync(target)
             }).then(opts => {
                 patchTS(mainPkg.targetVersion(), opts)
+                if (mainPkg.getPreferredEditor() === pxt.PYTHON_PROJECT_NAME) {
+                    patchPY(mainPkg.targetVersion(), opts)
+                }
                 prepPythonOptions(opts)
                 return opts
             })
@@ -204,6 +207,22 @@ namespace pxt {
                 if (ts != ts2) {
                     pxt.debug(`applying TS patch to ${fn}`)
                     opts.fileSystem[fn] = ts2
+                }
+            }
+        }
+    }
+
+    export function patchPY(version: string, opts: pxtc.CompileOptions) {
+        if (!version)
+            return
+        pxt.debug(`applying PY patches relative to ${version}`)
+        for (let fn of Object.keys(opts.fileSystem)) {
+            if (fn.indexOf("/") == -1 && U.endsWith(fn, ".py")) {
+                const initial = opts.fileSystem[fn]
+                const patched = pxt.patching.patchPython(version, initial)
+                if (initial != patched) {
+                    pxt.debug(`applying PY patch to ${fn}`)
+                    opts.fileSystem[fn] = patched
                 }
             }
         }

--- a/pxtlib/patch.ts
+++ b/pxtlib/patch.ts
@@ -2,6 +2,16 @@ namespace pxt.patching {
     export function computePatches(version: string, kind?: string): ts.pxtc.UpgradePolicy[] {
         const patches = pxt.appTarget.compile ? pxt.appTarget.compile.patches : undefined;
         if (!patches) return undefined;
+        return parsePatches(version, patches, kind);
+    }
+
+    export function computePyPatches(version: string, kind?: string): ts.pxtc.UpgradePolicy[] {
+        const patches = pxt.appTarget.compile ? pxt.appTarget.compile.pyPatches : undefined;
+        if (!patches) return undefined;
+        return parsePatches(version, patches, kind);
+    }
+
+    function parsePatches(version: string, patches: Map<ts.pxtc.UpgradePolicy[]>, kind?: string): ts.pxtc.UpgradePolicy[] {
         const v = pxt.semver.tryParse(version || "0.0.0") || pxt.semver.tryParse("0.0.0");
         let r: ts.pxtc.UpgradePolicy[] = [];
         Object.keys(patches)
@@ -30,6 +40,15 @@ namespace pxt.patching {
 
     export function patchJavaScript(pkgTargetVersion: string, fileContents: string): string {
         const upgrades = pxt.patching.computePatches(pkgTargetVersion);
+        return patchTextCode(pkgTargetVersion, fileContents, upgrades);
+    }
+
+    export function patchPython(pkgTargetVersion: string, fileContents: string): string {
+        const upgrades = pxt.patching.computePyPatches(pkgTargetVersion);
+        return patchTextCode(pkgTargetVersion, fileContents, upgrades);
+    }
+
+    function patchTextCode(pkgTargetVersion: string, fileContents: string, upgrades: pxtc.UpgradePolicy[]): string {
         let updatedContents = fileContents;
         if (upgrades) {
             upgrades.filter(u => u.type === "api").forEach(rule => {


### PR DESCRIPTION
Cherry-pick of https://github.com/microsoft/pxt/commit/98cda85365e9eaef2a97c7f52eec030507c2033d

Need this so we can update python code when we make a breaking change. I mostly just copied whatever we were doing for typescript and tried to do it for python as well.