### PR TITLE
Add pxtarget.json options for tuning time machine intervals

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -494,6 +494,8 @@ declare namespace pxt {
         timeMachine?: boolean; // Save/restore old versions of a project experiment
         blocklySoundVolume?: number; // A number between 0 and 1 that sets the volume for blockly sounds (e.g. connect, disconnect, click)
         timeMachineQueryParams?: string[]; // An array of query params to pass to timemachine iframe embed
+        timeMachineDiffInterval?: number; // An interval in milliseconds at which to take diffs to store in project history. Defaults to 5 minutes
+        timeMachineSnapshotInterval?: number; // An interval in milliseconds at which to take full project snapshots in project history. Defaults to 15 minutes
     }
 
     interface DownloadDialogTheme {

--- a/pxteditor/history.ts
+++ b/pxteditor/history.ts
@@ -443,7 +443,7 @@ namespace pxt.workspace {
     }
 
     function diffInterval() {
-        if (pxt.appTarget?.appTheme.timeMachineDiffInterval != undefined) {
+        if (pxt.appTarget?.appTheme?.timeMachineDiffInterval != undefined) {
             return pxt.appTarget.appTheme.timeMachineDiffInterval;
         }
 
@@ -451,7 +451,7 @@ namespace pxt.workspace {
     }
 
     function snapshotInterval() {
-        if (pxt.appTarget?.appTheme.timeMachineSnapshotInterval != undefined) {
+        if (pxt.appTarget?.appTheme?.timeMachineSnapshotInterval != undefined) {
             return pxt.appTarget.appTheme.timeMachineSnapshotInterval;
         }
 

--- a/pxteditor/history.ts
+++ b/pxteditor/history.ts
@@ -50,11 +50,11 @@ namespace pxt.workspace {
         maxTime?: number;
     }
 
-    // 5 minutes
-    const DIFF_HISTORY_INTERVAL = 1000 * 60 * 5;
+    // 5 minutes. This is overridden in pxtarget.json
+    const DEFAULT_DIFF_HISTORY_INTERVAL = 1000 * 60 * 5;
 
-    // 15 minutes
-    const SNAPSHOT_HISTORY_INTERVAL = 1000 * 60 * 15;
+    // 15 minutes. This is overridden in pxtarget.json
+    const DEFAULT_SNAPSHOT_HISTORY_INTERVAL = 1000 * 60 * 15;
 
     const ONE_DAY = 1000 * 60 * 60 * 24;
 
@@ -324,7 +324,7 @@ namespace pxt.workspace {
             const topTime = history.entries[history.entries.length - 1].timestamp;
             const prevTime = history.entries[history.entries.length - 2].timestamp;
 
-            if (currentTime - topTime < DIFF_HISTORY_INTERVAL && topTime - prevTime < DIFF_HISTORY_INTERVAL) {
+            if (currentTime - topTime < diffInterval() && topTime - prevTime < diffInterval()) {
                 shouldCombine = true;
             }
         }
@@ -352,7 +352,7 @@ namespace pxt.workspace {
         if (history.snapshots.length == 0) {
             history.snapshots.push(takeSnapshot(previousText, currentTime - 1));
         }
-        else if (currentTime - history.snapshots[history.snapshots.length - 1].timestamp >= SNAPSHOT_HISTORY_INTERVAL) {
+        else if (currentTime - history.snapshots[history.snapshots.length - 1].timestamp >= snapshotInterval()) {
             history.snapshots.push(takeSnapshot(previousText, currentTime));
 
             const trimmed: pxt.workspace.SnapshotEntry[] = [];
@@ -440,5 +440,21 @@ namespace pxt.workspace {
         }
 
         return true;
+    }
+
+    function diffInterval() {
+        if (pxt.appTarget?.appTheme.timeMachineDiffInterval != undefined) {
+            return pxt.appTarget.appTheme.timeMachineDiffInterval;
+        }
+
+        return DEFAULT_DIFF_HISTORY_INTERVAL;
+    }
+
+    function snapshotInterval() {
+        if (pxt.appTarget?.appTheme.timeMachineSnapshotInterval != undefined) {
+            return pxt.appTarget.appTheme.timeMachineSnapshotInterval;
+        }
+
+        return DEFAULT_SNAPSHOT_HISTORY_INTERVAL;
     }
 }


### PR DESCRIPTION
I'm a little worried about accidentally making projects too big in arcade and messing with cloud sync. Adding a couple of pxtarget.json options to increase the project history interval so that we can start with a higher interval and lower it if all goes well.