### PR TITLE
Check for qualified name in sprite editor

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -38,6 +38,8 @@ namespace pxtblockly {
         protected pendingEdit = false;
         protected isEmpty = false;
 
+        protected qName?: string;
+
         // If input is invalid, the subclass can set this to be true. The field will instead
         // render as a grey block and preserve the decompiled code
         public isGreyBlock: boolean;

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -51,14 +51,13 @@ namespace pxtblockly {
 
             if (!bmp) {
                 // check for qualified name
-                const images = project.getGalleryAssets(pxt.AssetType.Image).filter(asset => asset.id === text);
-                const img = images.length && images[0];
-                if (!img) {
+                data = qNameToBitmapData(text);
+                if (!data) {
                     this.isGreyBlock = true;
                     this.valueText = text;
                     return undefined;
                 } else {
-                    data = img.bitmap;
+                    this.qName = text;
                 }
             }
 
@@ -80,6 +79,12 @@ namespace pxtblockly {
         protected getValueText(): string {
             if (this.asset && !this.isTemporaryAsset()) {
                 return pxt.getTSReferenceForAsset(this.asset);
+            } else if (this.qName) {
+                // check if image has been edited
+                const data = qNameToBitmapData(this.qName);
+                if (data && pxt.sprite.bitmapEquals(data, (this.asset as pxt.ProjectImage).bitmap)) {
+                    return this.qName;
+                }
             }
             return pxt.sprite.bitmapToImageLiteral(this.asset && pxt.sprite.Bitmap.fromData((this.asset as pxt.ProjectImage).bitmap), pxt.editor.FileType.TypeScript);
         }
@@ -157,5 +162,16 @@ namespace pxtblockly {
             }
             return res;
         }
+
+    }
+
+    function qNameToBitmapData(qName: string): pxt.sprite.BitmapData {
+        const project = pxt.react.getTilemapProject();
+        const images = project.getGalleryAssets(pxt.AssetType.Image).filter(asset => asset.id === qName);
+        const img = images.length && images[0];
+        if (img) {
+            return img.bitmap;
+        }
+        return undefined;
     }
 }

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -47,13 +47,22 @@ namespace pxtblockly {
 
             const bmp = text ? pxt.sprite.imageLiteralToBitmap(text) : new pxt.sprite.Bitmap(this.params.initWidth, this.params.initHeight);
 
+            let data: pxt.sprite.BitmapData;
+
             if (!bmp) {
-                this.isGreyBlock = true;
-                this.valueText = text;
-                return undefined;
+                // check for qualified name
+                const images = project.getGalleryAssets(pxt.AssetType.Image).filter(asset => asset.id === text);
+                const img = images.length && images[0];
+                if (!img) {
+                    this.isGreyBlock = true;
+                    this.valueText = text;
+                    return undefined;
+                } else {
+                    data = img.bitmap;
+                }
             }
 
-            const data = bmp.data();
+            if (!data) data = bmp.data();
 
             const newAsset: pxt.ProjectImage = {
                 internalID: -1,


### PR DESCRIPTION
The sprite editor will now check for qualified names such as "sprites.food.smallBurger" when converting to blocks from JS and maintain those names when converting back to JS.

This change in combination with https://github.com/microsoft/pxt-common-packages/pull/1459 is a fix for the image picker problem that @kiki-lee was having in which using a qualified name resulted in the block having an image picker instead of the sprite editor.

Before:
![image](https://github.com/microsoft/pxt/assets/15070078/98570b0d-3a4b-4406-9f67-8c209caf6c5b)

After:
![image](https://github.com/microsoft/pxt/assets/15070078/d0b8ecaf-ea47-497d-870b-f7c925687387)
![image](https://github.com/microsoft/pxt/assets/15070078/b4b87b1e-6599-43b8-bef4-49fa5c2e6292)
