### PR TITLE
Add index of the source iframe to the broadcast message

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -83,6 +83,7 @@ namespace pxsim {
     export interface SimulatorBroadcastMessage extends SimulatorMessage {
         broadcast: boolean;
         toParentIFrameOnly?: boolean;
+        srcFrameIndex?: number;
     }
 
     export interface SimulatorControlMessage extends SimulatorBroadcastMessage {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -320,7 +320,7 @@ namespace pxsim {
             const broadcastmsg = msg as pxsim.SimulatorBroadcastMessage;
             if (source && broadcastmsg?.broadcast) {
                 // include index of the source iframe
-                broadcastmsg.srcFrameIndex = frames.findIndex((item) => item.contentWindow === source)
+                broadcastmsg.srcFrameIndex = this.simFrames().findIndex((item) => item.contentWindow === source)
                 // if the editor is hosted in a multi-editor setting
                 // don't start extra frames
                 const single = !!this._currentRuntime?.single;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -319,6 +319,8 @@ namespace pxsim {
 
             const broadcastmsg = msg as pxsim.SimulatorBroadcastMessage;
             if (source && broadcastmsg?.broadcast) {
+                // include index of the source iframe
+                broadcastmsg.srcFrameIndex = frames.findIndex((item) => item.contentWindow === source)
                 // if the editor is hosted in a multi-editor setting
                 // don't start extra frames
                 const single = !!this._currentRuntime?.single;


### PR DESCRIPTION
In the radio scenario, the robot simulator (https://github.com/microsoft/microbit-robot) will receive messages from multiple microbits. The botsim needs know if a message is coming from the primary or secondary microbit.

![image](https://github.com/microsoft/pxt/assets/12176807/f0efb594-b34a-4b8d-9ec1-b814b0d425e4)