### PR TITLE
[stable8.5] Cherry pick: Check for qualified name in sprite editor (#9789)

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -38,6 +38,8 @@ namespace pxtblockly {
         protected pendingEdit = false;
         protected isEmpty = false;
 
+        protected qName?: string;
+
         // If input is invalid, the subclass can set this to be true. The field will instead
         // render as a grey block and preserve the decompiled code
         public isGreyBlock: boolean;


### PR DESCRIPTION
* check for qualified name in sprite editor

* check qName for sprite when converting back to js