### PR TITLE
[stable9.0] cherry-pick: Add index of the source iframe to the broadcast message (#9790)

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -83,6 +83,7 @@ namespace pxsim {
     export interface SimulatorBroadcastMessage extends SimulatorMessage {
         broadcast: boolean;
         toParentIFrameOnly?: boolean;
+        srcFrameIndex?: number;
     }
 
     export interface SimulatorControlMessage extends SimulatorBroadcastMessage {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -319,6 +319,8 @@ namespace pxsim {
 
             const broadcastmsg = msg as pxsim.SimulatorBroadcastMessage;
             if (source && broadcastmsg?.broadcast) {
+                // include index of the source iframe
+                broadcastmsg.srcFrameIndex = this.simFrames().findIndex((item) => item.contentWindow === source)
                 // if the editor is hosted in a multi-editor setting
                 // don't start extra frames
                 const single = !!this._currentRuntime?.single;


### PR DESCRIPTION
* Add index of the source iframe to the broadcast message

* avoid using potentially filtered frame array