### PR TITLE
Track js compilation time

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -471,7 +471,10 @@ namespace pxt.runner {
         try {
             const start = Date.now();
             const result = await pxt.Cloud.downloadBuiltSimJsInfoAsync(simOptions.id);
-            pxt.tickEvent("runner.fetchSimJsInfo", { durationMs: Date.now() - start });
+            pxt.tickEvent("perfMeasurement", {
+              durationMs: Date.now() - start,
+              operation: "fetchSimJsInfo",
+            });
             return result;
         } catch (e) {
             // This exception will happen in the majority of cases, so we don't want to log it unless for debugging.
@@ -544,7 +547,10 @@ namespace pxt.runner {
 
         const res = pxtc.buildSimJsInfo(compileResult);
         res.parts = compileResult.usedParts;
-        pxt.tickEvent("runner.buildSimJsInfo", { durationMs: Date.now() - start });
+        pxt.tickEvent("perfMeasurement", {
+          durationMs: Date.now() - start,
+          operation: "buildSimJsInfo",
+        });
         return res;
     }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -471,7 +471,7 @@ namespace pxt.runner {
         try {
             const start = Date.now();
             const result = await pxt.Cloud.downloadBuiltSimJsInfoAsync(simOptions.id);
-            pxt.tickEvent("runner.fetchSimJsInfo", { durationMs: Date.now() - start});
+            pxt.tickEvent("runner.fetchSimJsInfo", { durationMs: Date.now() - start });
             return result;
         } catch (e) {
             // This exception will happen in the majority of cases, so we don't want to log it unless for debugging.
@@ -544,7 +544,7 @@ namespace pxt.runner {
 
         const res = pxtc.buildSimJsInfo(compileResult);
         res.parts = compileResult.usedParts;
-        pxt.tickEvent("runner.buildSimJsInfo", { durationMs: Date.now() - start});
+        pxt.tickEvent("runner.buildSimJsInfo", { durationMs: Date.now() - start });
         return res;
     }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -471,7 +471,7 @@ namespace pxt.runner {
         try {
             const start = Date.now();
             const result = await pxt.Cloud.downloadBuiltSimJsInfoAsync(simOptions.id);
-            pxt.tickEvent("runner.fetchSimJsInfo", { duration: Date.now() - start});
+            pxt.tickEvent("runner.fetchSimJsInfo", { durationMs: Date.now() - start});
             return result;
         } catch (e) {
             // This exception will happen in the majority of cases, so we don't want to log it unless for debugging.
@@ -544,7 +544,7 @@ namespace pxt.runner {
 
         const res = pxtc.buildSimJsInfo(compileResult);
         res.parts = compileResult.usedParts;
-        pxt.tickEvent("runner.buildSimJsInfo", { duration: Date.now() - start});
+        pxt.tickEvent("runner.buildSimJsInfo", { durationMs: Date.now() - start});
         return res;
     }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -468,7 +468,10 @@ namespace pxt.runner {
 
     export async function fetchSimJsInfo(simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {
         try {
-            return await pxt.Cloud.downloadBuiltSimJsInfoAsync(simOptions.id);
+            const start = Date.now();
+            const result = await pxt.Cloud.downloadBuiltSimJsInfoAsync(simOptions.id);
+            tickEvent("runner.fetchSimJsInfo", { downloadTime: Date.now() - start });
+            return result;
         } catch (e) {
             // This exception will happen in the majority of cases, so we don't want to log it unless for debugging.
             pxt.debug(e.toString());
@@ -477,6 +480,7 @@ namespace pxt.runner {
     }
 
     export async function buildSimJsInfo(simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {
+        const start = Date.now();
         await loadPackageAsync(simOptions.id, simOptions.code, simOptions.dependencies);
 
         let didUpgrade = false;
@@ -539,6 +543,7 @@ namespace pxt.runner {
 
         const res = pxtc.buildSimJsInfo(compileResult);
         res.parts = compileResult.usedParts;
+        tickEvent("runner.buildSimJsInfo", { compileTime: Date.now() - start });
         return res;
     }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -213,6 +213,7 @@ namespace pxt.runner {
 
     function initInnerAsync() {
         pxt.setAppTarget((window as any).pxtTargetBundle)
+        pxt.analytics.enable(pxt.Util.userLanguage());
         Util.assert(!!pxt.appTarget);
 
         const href = window.location.href;
@@ -470,7 +471,7 @@ namespace pxt.runner {
         try {
             const start = Date.now();
             const result = await pxt.Cloud.downloadBuiltSimJsInfoAsync(simOptions.id);
-            tickEvent("runner.fetchSimJsInfo", { downloadTime: Date.now() - start });
+            pxt.tickEvent("runner.fetchSimJsInfo", { duration: Date.now() - start});
             return result;
         } catch (e) {
             // This exception will happen in the majority of cases, so we don't want to log it unless for debugging.
@@ -543,7 +544,7 @@ namespace pxt.runner {
 
         const res = pxtc.buildSimJsInfo(compileResult);
         res.parts = compileResult.usedParts;
-        tickEvent("runner.buildSimJsInfo", { compileTime: Date.now() - start });
+        pxt.tickEvent("runner.buildSimJsInfo", { duration: Date.now() - start});
         return res;
     }
 


### PR DESCRIPTION
Enables telemetry in `runner.ts` to track the time it takes to either download the compiled JS or download and compile the text. These events will help know the impact the pre-compilation step is having.

### Validation
Ran pxt-arcade locally with a local `pxt` on this branched linked. I then changed the InstrumentationKey in [apptracking.html](../blob/master/docfiles/apptracking.html) and [tracking.html](../blob/master/docfiles/tracking.html) to the PPE app insights instance. 
- Visited http://localhost:3232/68336-13291-41085-56601 in an incognito tab a few times. I was then able to confirm the new `runner.fetchSimJsInfo` event was present.
- Visited http://localhost:3232/56776-01920-30861-75662 in an incognito tab a few times. Confirmed that the new `runner.buildSimJsInfo` event was present.

Both these links are the same game just shared twice. For the first one I precompiled the JS to the `fetchSimJsInfo` event would be recorded. After loading each page five times in a new icognito tab each time here is what I found:
- buildSimJsInfo had an average of 1463.4 milliseconds, a min of 1171 milliseconds, and a max of 1748 milliseconds.
- fetchSimJsInfo had an average of 148 milliseconds, a min of 29 milliseconds, a max of 723 milliseconds.

>Note: It's important to note that for fetching the pre-compiled JS the initial page load was the longest. After that, the request was cached by the browser. While the request to grab the share page's text is also cached when compiling the JS, the actual compilation still takes time. Regardless, fetching the compressed pre-compiled JS is faster than fetching the text and then compiling client-side.