### PR TITLE
add tick events for perf measurements

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -106,14 +106,21 @@ namespace pxt {
             }
         }
         export function report(filter: string = null) {
+            perfReportLogged = true;
+
             if (enabled) {
+                const milestones: {[index: string]: number} = {};
+                const durations: {[index: string]: number} = {};
+
                 let report = `performance report:\n`
                 for (let [msg, time] of stats.milestones) {
                     if (!filter || msg.indexOf(filter) >= 0) {
                         let pretty = prettyStr(time)
                         report += `\t\t${msg} @ ${pretty}\n`
+                        milestones[msg] = time;
                     }
                 }
+
                 report += `\n`
                 for (let [msg, start, duration] of stats.durations) {
                     let filterIncl = filter && msg.indexOf(filter) >= 0
@@ -125,10 +132,12 @@ namespace pxt {
                         }
                         report += `\n`
                     }
+                    durations[msg] = duration;
                 }
                 console.log(report)
+                return { milestones, durations };
             }
-            perfReportLogged = true
+            return undefined;
         }
         (function () {
             init()

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -93,4 +93,16 @@ namespace pxt.analytics {
             }
         };
     }
+
+    export function trackPerformanceReport() {
+        if (pxt.perf.perfReportLogged) return;
+
+        const data = pxt.perf.report();
+
+        if (data) {
+            const { durations, milestones } = data;
+            pxt.tickEvent("performance.milestones", milestones);
+            pxt.tickEvent("performance.durations", durations);
+        }
+    }
 }

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -9,7 +9,7 @@
 namespace pxt.perf {
     // These functions are defined in docfiles/pxtweb/cookieCompliance.ts
     export declare let perfReportLogged: boolean;
-    export declare function report(): void;
+    export declare function report(): { milestones: {[index: string]: number}, durations: {[index: string]: number} } | undefined;
     export declare function recordMilestone(msg: string, time?: number): void;
     export declare function measureStart(name: string): void;
     export declare function measureEnd(name: string): void;
@@ -18,7 +18,7 @@ namespace pxt.perf {
     // Sometimes these aren't initialized, for example in tests. We only care about them
     // doing anything in the browser.
     if (!pxt.perf.report)
-        pxt.perf.report = () => { }
+        pxt.perf.report = () => undefined
     if (!pxt.perf.recordMilestone)
         pxt.perf.recordMilestone = () => { }
     if (!pxt.perf.measureStart)

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -501,6 +501,7 @@ namespace pxsim {
         }
 
         public preload(aspectRatio: number, clearRuntime?: boolean) {
+            this.addEventListeners();
             if (clearRuntime) {
                 this._currentRuntime = undefined;
                 this.container.textContent = "";

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1097,6 +1097,9 @@ export class ProjectView
                 }
             },
             onSimulatorReady: () => {
+                if (this.autoRunOnStart()) {
+                    pxt.analytics.trackPerformanceReport();
+                }
             },
             onMuteButtonStateChange: state => this.setMute(state),
             setState: (k, v) => {
@@ -4475,7 +4478,7 @@ export class ProjectView
 
     private hintManager: HintManager = new HintManager();
 
-    private loadActivityFromMarkdownAsync(path: string, title?: string, editorProjectName?: string): Promise<{
+    private async loadActivityFromMarkdownAsync(path: string, title?: string, editorProjectName?: string): Promise<{
         reportId: string;
         filename: string;
         autoChooseBoard: boolean;
@@ -4495,71 +4498,80 @@ export class ProjectView
         let features: string[] = undefined;
         let temporary = false;
 
-        let p: Promise<string>;
-        if (/^\//.test(path)) {
-            filename = title || path.split('/').reverse()[0].replace('-', ' '); // drop any kind of sub-paths
-            p = pxt.Cloud.markdownAsync(path)
-                .then(md => {
-                    autoChooseBoard = true;
-                    return processMarkdown(md);
-                });
-        } else if (scriptId) {
-            pxt.tickEvent("tutorial.shared", { tutorial: scriptId });
-            p = workspace.downloadFilesByIdAsync(scriptId)
-                .then(files => {
-                    const pxtJson = pxt.Package.parseAndValidConfig(files["pxt.json"]);
-                    pxt.Util.jsonMergeFrom(dependencies, pxtJson.dependencies);
-                    filename = pxtJson.name || lf("Untitled");
-                    autoChooseBoard = false;
-                    reportId = scriptId;
-                    const md = files["README.md"];
-                    return processMarkdown(md);
-                });
-        } else if (!!ghid && ghid.owner && ghid.project) {
-            pxt.tickEvent("tutorial.github");
-            pxt.log(`loading tutorial from ${ghid.fullName}`)
-            p = pxt.packagesConfigAsync()
-                .then(config => {
-                    const status = pxt.github.repoStatus(ghid, config);
-                    switch (status) {
-                        case pxt.github.GitRepoStatus.Banned:
-                            throw lf("This GitHub repository has been banned.");
-                        case pxt.github.GitRepoStatus.Approved:
-                            reportId = undefined;
-                            break;
-                        default:
-                            reportId = "https://github.com/" + ghid.slug;
-                            break;
-                    }
-                    return (ghid.tag ? Promise.resolve(ghid.tag) : pxt.github.latestVersionAsync(ghid.slug, config, true))
-                        .then(tag => {
-                            if (!tag) {
-                                pxt.log(`tutorial github tag not found at ${ghid.fullName}`);
-                                return undefined;
-                            }
-                            ghid.tag = tag;
-                            pxt.log(`tutorial ${ghid.fullName} tag: ${tag}`);
-                            return pxt.github.downloadPackageAsync(`${ghid.slug}#${ghid.tag}`, config);
-                        });
-                }).then(gh => {
-                    let p = Promise.resolve();
-                    // check for cached tutorial info, save into IndexedDB if found
-                    if (gh.files[pxt.TUTORIAL_INFO_FILE]) {
-                        p.then(() => pxt.tutorial.parseCachedTutorialInfo(gh.files[pxt.TUTORIAL_INFO_FILE], path));
-                    }
-                    return p.then(() => gh && resolveMarkdown(ghid, gh.files));
-                });
-        } else if (header) {
-            pxt.tickEvent("tutorial.header");
-            temporary = true;
-            const hghid = pxt.github.parseRepoId(header.githubId);
-            const hfileName = path.split(':')[1] || "README";
-            p = workspace.getTextAsync(header.id)
-                .then(script => resolveMarkdown(hghid, script, hfileName))
-        } else {
-            p = Promise.resolve(undefined);
-        }
-        return p.then(md => {
+        let markdown: string;
+
+        try {
+            if (/^\//.test(path)) {
+                filename = title || path.split('/').reverse()[0].replace('-', ' '); // drop any kind of sub-paths
+                pxt.perf.measureStart("downloadMarkdown");
+                const rawMarkdown = await pxt.Cloud.markdownAsync(path);
+                pxt.perf.measureEnd("downloadMarkdown");
+                autoChooseBoard = true;
+                markdown = await processMarkdown(rawMarkdown);
+            } else if (scriptId) {
+                pxt.tickEvent("tutorial.shared", { tutorial: scriptId });
+                const files = await workspace.downloadFilesByIdAsync(scriptId)
+                const pxtJson = pxt.Package.parseAndValidConfig(files["pxt.json"]);
+                pxt.Util.jsonMergeFrom(dependencies, pxtJson.dependencies);
+                filename = pxtJson.name || lf("Untitled");
+                autoChooseBoard = false;
+                reportId = scriptId;
+                const md = files["README.md"];
+                markdown = processMarkdown(md);
+            } else if (!!ghid && ghid.owner && ghid.project) {
+                pxt.tickEvent("tutorial.github");
+                pxt.log(`loading tutorial from ${ghid.fullName}`)
+                pxt.perf.measureStart("downloadGitHubTutorial");
+                const config = await pxt.packagesConfigAsync();
+
+                const status = pxt.github.repoStatus(ghid, config);
+                switch (status) {
+                    case pxt.github.GitRepoStatus.Banned:
+                        throw lf("This GitHub repository has been banned.");
+                    case pxt.github.GitRepoStatus.Approved:
+                        reportId = undefined;
+                        break;
+                    default:
+                        reportId = "https://github.com/" + ghid.slug;
+                        break;
+                }
+
+                let githubTag: string;
+                if (ghid.tag) {
+                    githubTag = ghid.tag;
+                }
+                else {
+                    githubTag = await pxt.github.latestVersionAsync(ghid.slug, config, true);
+                }
+
+                let gh: pxt.github.CachedPackage;
+                if (!githubTag) {
+                    pxt.log(`tutorial github tag not found at ${ghid.fullName}`);
+                    gh = undefined;
+                }
+                else {
+                    ghid.tag = githubTag;
+                    pxt.log(`tutorial ${ghid.fullName} tag: ${githubTag}`);
+                    gh = await pxt.github.downloadPackageAsync(`${ghid.slug}#${ghid.tag}`, config);
+                }
+                pxt.perf.measureEnd("downloadGitHubTutorial");
+
+                // check for cached tutorial info, save into IndexedDB if found
+                if (gh?.files[pxt.TUTORIAL_INFO_FILE]) {
+                    await pxt.tutorial.parseCachedTutorialInfo(gh.files[pxt.TUTORIAL_INFO_FILE], path);
+                }
+                if (gh) {
+                    markdown = await resolveMarkdown(ghid, gh.files);
+                }
+            } else if (header) {
+                pxt.tickEvent("tutorial.header");
+                temporary = true;
+                const hghid = pxt.github.parseRepoId(header.githubId);
+                const hfileName = path.split(':')[1] || "README";
+                const script = await workspace.getTextAsync(header.id);
+                markdown = await resolveMarkdown(ghid, script, hfileName)
+            }
+
             return {
                 reportId,
                 filename,
@@ -4567,14 +4579,15 @@ export class ProjectView
                 dependencies,
                 features,
                 temporary,
-                md
+                md: markdown
             };
-        }).catch(e => {
+        }
+        catch (e) {
             core.handleNetworkError(e);
             core.errorNotification(lf("Oops, we could not load this activity."));
             this.openHome(); // don't stay stranded
             return undefined;
-        });
+        }
 
         function processMarkdown(md: string) {
             if (!md) return md;
@@ -4668,6 +4681,8 @@ export class ProjectView
     async startActivity(opts: pxt.editor.StartActivityOptions) {
         const { activity, path, editor, title, focus, importOptions, previousProjectHeaderId, carryoverPreviousCode } = opts;
 
+        pxt.perf.measureStart("startActivity");
+
         this.textEditor.giveFocusOnLoading = focus;
         switch (activity) {
             case "tutorial":
@@ -4683,6 +4698,8 @@ export class ProjectView
                 await this.importExampleAsync({ name: title, path, preferredEditor: editor, ...importOptions });
                 break;
         }
+
+        pxt.perf.measureEnd("startActivity")
     }
 
     completeTutorialAsync(): Promise<void> {
@@ -4790,6 +4807,10 @@ export class ProjectView
         if (this.isTutorial()) {
             pxt.tickEvent("tutorial.editorLoaded")
             this.postTutorialLoaded();
+
+            if (!this.autoRunOnStart()) {
+                pxt.analytics.trackPerformanceReport();
+            }
         }
 
         if (this.pendingImport) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4507,7 +4507,7 @@ export class ProjectView
                 const rawMarkdown = await pxt.Cloud.markdownAsync(path);
                 pxt.perf.measureEnd("downloadMarkdown");
                 autoChooseBoard = true;
-                markdown = await processMarkdown(rawMarkdown);
+                markdown = processMarkdown(rawMarkdown);
             } else if (scriptId) {
                 pxt.tickEvent("tutorial.shared", { tutorial: scriptId });
                 const files = await workspace.downloadFilesByIdAsync(scriptId)
@@ -4561,7 +4561,7 @@ export class ProjectView
                     await pxt.tutorial.parseCachedTutorialInfo(gh.files[pxt.TUTORIAL_INFO_FILE], path);
                 }
                 if (gh) {
-                    markdown = await resolveMarkdown(ghid, gh.files);
+                    markdown = resolveMarkdown(ghid, gh.files);
                 }
             } else if (header) {
                 pxt.tickEvent("tutorial.header");
@@ -4569,7 +4569,7 @@ export class ProjectView
                 const hghid = pxt.github.parseRepoId(header.githubId);
                 const hfileName = path.split(':')[1] || "README";
                 const script = await workspace.getTextAsync(header.id);
-                markdown = await resolveMarkdown(ghid, script, hfileName)
+                markdown = resolveMarkdown(ghid, script, hfileName)
             }
 
             return {
@@ -4808,6 +4808,7 @@ export class ProjectView
             pxt.tickEvent("tutorial.editorLoaded")
             this.postTutorialLoaded();
 
+            pxt.perf.recordMilestone("editorContentLoaded");
             if (!this.autoRunOnStart()) {
                 pxt.analytics.trackPerformanceReport();
             }

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -183,9 +183,7 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
         },
         onSimulatorReady: function () {
             pxt.perf.recordMilestone("simulator ready")
-            if (!pxt.perf.perfReportLogged) {
-                pxt.perf.report()
-            }
+            cfg.onSimulatorReady();
         },
         onSimulatorCommand: (msg: pxsim.SimulatorCommandMessage): void => {
             switch (msg.command) {


### PR DESCRIPTION
This adds two tick events that contain all of the info from the performance report that we print out to the console:

* `performance.milestones` - a map of event names to the elapsed time since page load for when that event occurred. For example, if blockly loaded 2 seconds after page load you'd get an entry like this: `loadBlockly: 2000`
* `performance.durations` - a map of task names to the amount of elapsed time that task took to complete

These ticks are only sent once per session! That makes them most useful for activities that are loaded directly from a URL, as the minecraft tutorials are.

I also added three new duration measures:

* `startActivity` - this is the overall time it takes for a tutorial or example to load into the editor
* `downloadMarkdown` - this is the time it takes to download markdown for a tutorial
* `downloadGitHubTutorial` - this is the time it takes to fetch a GitHub repo that contains a tutorial

and one new milestone:

* `editorContentLoaded` - the time at which the tutorial has fully loaded (you can interact with the Blockly workspace)


Other things I did:

1. Fixed a bug where the simulator ready event was never firing for the first time the editor was loaded (we weren't registering the message event listener in simdriver for preloaded iframes)
2. Converted loadActivityFromMarkdownAsync to async/await
3. Changed where the reporting happens for targets that do not autorun the simulator. Instead of in the simulator ready event, it fires once the content has loaded in the editor