### PR TITLE
Fix link to package spec reference in tutorial docs.

### DIFF
--- a/docs/writing-docs/tutorials/basics.md
+++ b/docs/writing-docs/tutorials/basics.md
@@ -376,4 +376,10 @@ Click ``|Download|`` to transfer your code in your @boardname@!
 
 ## Dependencies
 
-If your tutorial requires the use of an extension, you can add it using the [package macro](https://makecode.com/writing-docs/macros#dependencies).
+If your tutorial requires the use of an extension, you can add it using the [package](/writing-docs/snippets#package) macro.
+
+````
+```package
+microturtle=github:microsoft/pxt-microturtle
+```
+````


### PR DESCRIPTION
Link to the reference for ```` ```package```` broke in the last redo of the tutorial docs.