### PR TITLE
Change Expected Web App Name from TeacherTool to Eval

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -28,7 +28,7 @@ let serveOptions: ServeOptions;
 const webappNames = [
     "kiosk",
     "multiplayer",
-    "teachertool"
+    "eval"
     // TODO: Add other webapp names here: "skillmap", "authcode"
 ];
 

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -393,7 +393,7 @@ namespace pxt {
         authcodeUrl?: string; // "/beta---authcode"
         multiplayerUrl?: string; // "/beta---multiplayer"
         kioskUrl?: string; // "/beta---kiosk"
-        teachertoolUrl?: string; // "/beta---teachertool"
+        teachertoolUrl?: string; // "/beta---eval"
         isStatic?: boolean;
         verprefix?: string; // "v1"
     }


### PR DESCRIPTION
We already have this set to eval in the backend. Just changing it here so it works locally too.