### PR TITLE
Add URL Parameter to Show Block IDs in Tooltip

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -716,7 +716,8 @@ namespace pxt.blocks {
         block.setPreviousStatement(!(hasHandlers && !fn.attributes.handlerStatement) && fn.retType == "void");
         block.setNextStatement(!(hasHandlers && !fn.attributes.handlerStatement) && fn.retType == "void");
 
-        block.setTooltip(/^__/.test(fn.namespace) ? "" : fn.attributes.jsDoc);
+        block.setTooltip((/^__/.test(fn.namespace) ? "" : fn.attributes.jsDoc) + (pxt.blocks.showBlockIdInTooltip ? " (id: '" + fn.attributes.blockId + "')" : ""));
+
         function buildBlockFromDef(def: pxtc.ParsedBlockDef, expanded = false) {
             let anonIndex = 0;
             let firstParam = !expanded && !!comp.thisParameter;

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -3,6 +3,8 @@
 namespace pxt.blocks {
     const THIS_NAME = "this";
 
+    export let showBlockIdInTooltip: boolean = false;
+
     // The JS Math functions supported in the blocks. The order of this array
     // determines the order of the dropdown in the math_js_op block
     export const MATH_FUNCTIONS = {
@@ -805,6 +807,21 @@ namespace pxt.blocks {
                     })
                 )
             })
+        }
+
+        if (pxt.blocks.showBlockIdInTooltip) {
+            for (const id of Object.keys(_blockDefinitions)) {
+                const tooltip = _blockDefinitions[id].tooltip;
+                if (typeof tooltip === "object" && tooltip !== null) {
+                    for (const innerKey in tooltip) {
+                        if (tooltip.hasOwnProperty(innerKey)) {
+                            (_blockDefinitions[id].tooltip as any)[innerKey] = `${tooltip[innerKey]} (id: ${id})`;
+                        }
+                    }
+                } else {
+                    _blockDefinitions[id].tooltip = `${_blockDefinitions[id].tooltip} (id: ${id})`;
+                }
+            }
         }
     }
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5735,6 +5735,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     } else if (optsQuery["consoleticks"] == "2" || optsQuery["consoleticks"] == "short") {
         pxt.analytics.consoleTicks = pxt.analytics.ConsoleTickOptions.Short;
     }
+    if (optsQuery["tooltipblockids"] == "1") {
+        pxt.blocks.showBlockIdInTooltip = true;
+    }
 
     pxt.perf.measureStart("setAppTarget");
     pkg.setupAppTarget((window as any).pxtTargetBundle);


### PR DESCRIPTION
This adds the tooltipBlockIds URL parameter. When set to 1 in the URL (?tooltipBlockIds=1), blocks will include their block id in the tooltip when you hover over them.

I'm doubtful that an exported bool directly inside pxt.blocks is the best way to store this, but I figured I'd send the PR anyway and get feedback. If anyone has thoughts on a better approach, please let me know!