### PR TITLE
Set valid help paths for built-in number blocks

### DIFF
--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -415,26 +415,26 @@ namespace pxt.blocks {
             },
             'math_number': {
                 name: Util.lf("{id:block}number"),
-                url: '/blocks/math/random',
+                url: '/types/number',
                 category: 'math',
                 tooltip: (pxt.appTarget && pxt.appTarget.compile) ?
                     Util.lf("a decimal number") : Util.lf("an integer number")
             },
             'math_integer': {
                 name: Util.lf("{id:block}number"),
-                url: '/blocks/math/random',
+                url: '/types/number',
                 category: 'math',
                 tooltip: Util.lf("an integer number")
             },
             'math_whole_number': {
                 name: Util.lf("{id:block}number"),
-                url: '/blocks/math/random',
+                url: '/types/number',
                 category: 'math',
                 tooltip: Util.lf("a whole number")
             },
             'math_number_minmax': {
                 name: Util.lf("{id:block}number"),
-                url: '/blocks/math/random',
+                url: '/blocks/math',
                 category: 'math'
             },
             'math_arithmetic': {


### PR DESCRIPTION
Change the old help paths for the built-in number blocks to something valid.

RE: https://github.com/microsoft/pxt-arcade/issues/6231