### PR TITLE
[stable8.5] Cherry-pick built sim JS changes

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -116,6 +116,25 @@ namespace pxt.Cloud {
         })
     }
 
+    export function downloadScriptMetaAsync(id: string): Promise<JsonScriptMeta> {
+        return privateRequestAsync({
+            url: id + (id.startsWith("S") ? `?time=${Date.now()}` : ""),
+            forceLiveEndpoint: true,
+        }).then(resp => {
+            return JSON.parse(resp.text).meta;
+        })
+    }
+
+    export async function downloadBuiltSimJsInfoAsync(id: string): Promise<pxtc.BuiltSimJsInfo> {
+        const targetVersion = pxt.appTarget.versions && pxt.appTarget.versions.target || "";
+        const url = pxt.U.stringifyQueryString(id + "/js", { v: "v" + targetVersion }) + (id.startsWith("S") ? `&time=${Date.now()}` : "");
+        const resp = await privateRequestAsync({
+            url,
+            forceLiveEndpoint: true,
+        });
+        return resp.json;
+    }
+
     export async function markdownAsync(docid: string, locale?: string): Promise<string> {
         // 1h check on markdown content if not on development server
         const MARKDOWN_EXPIRATION = pxt.BrowserUtils.isLocalHostDev() ? 0 : 1 * 60 * 60 * 1000;

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -375,7 +375,7 @@ namespace pxt.runner {
     }
 
     export async function simulateAsync(container: HTMLElement, simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {
-        const builtSimJS = simOptions.builtJsInfo || await buildSimJsInfo(simOptions);
+        const builtSimJS = simOptions.builtJsInfo || await fetchSimJsInfo(simOptions) || await buildSimJsInfo(simOptions);
         const { js } = builtSimJS;
 
         if (!js) {
@@ -464,6 +464,16 @@ namespace pxt.runner {
     }
     export function postSimMessage(msg: pxsim.SimulatorMessage) {
         simDriver?.postMessage(msg);
+    }
+
+    export async function fetchSimJsInfo(simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {
+        try {
+            return await pxt.Cloud.downloadBuiltSimJsInfoAsync(simOptions.id);
+        } catch (e) {
+            // This exception will happen in the majority of cases, so we don't want to log it unless for debugging.
+            pxt.debug(e.toString());
+            return undefined;
+        }
     }
 
     export async function buildSimJsInfo(simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -213,6 +213,7 @@ namespace pxt.runner {
 
     function initInnerAsync() {
         pxt.setAppTarget((window as any).pxtTargetBundle)
+        pxt.analytics.enable(pxt.Util.userLanguage());
         Util.assert(!!pxt.appTarget);
 
         const href = window.location.href;
@@ -468,7 +469,13 @@ namespace pxt.runner {
 
     export async function fetchSimJsInfo(simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {
         try {
-            return await pxt.Cloud.downloadBuiltSimJsInfoAsync(simOptions.id);
+            const start = Date.now();
+            const result = await pxt.Cloud.downloadBuiltSimJsInfoAsync(simOptions.id);
+            pxt.tickEvent("perfMeasurement", {
+              durationMs: Date.now() - start,
+              operation: "fetchSimJsInfo",
+            });
+            return result;
         } catch (e) {
             // This exception will happen in the majority of cases, so we don't want to log it unless for debugging.
             pxt.debug(e.toString());
@@ -477,6 +484,7 @@ namespace pxt.runner {
     }
 
     export async function buildSimJsInfo(simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {
+        const start = Date.now();
         await loadPackageAsync(simOptions.id, simOptions.code, simOptions.dependencies);
 
         let didUpgrade = false;
@@ -539,6 +547,10 @@ namespace pxt.runner {
 
         const res = pxtc.buildSimJsInfo(compileResult);
         res.parts = compileResult.usedParts;
+        pxt.tickEvent("perfMeasurement", {
+          durationMs: Date.now() - start,
+          operation: "buildSimJsInfo",
+        });
         return res;
     }
 


### PR DESCRIPTION
* Before compiling, try to fetch built js from backend (#9778)]
* Track js compilation time (#9794)

#### Validation
- Ran these changes locally with `pxt-arcade` on the `stable1.12` branch.
- Hit the http://localhost:3232/68336-13291-41085-56601 endpoint and confirmed the already compiled JS was downloaded.
- Confirmed the new `perfMeasurement` event was sent via the network tab.