### PR TITLE
Send Notification to Parent Frame when Editor Content has Loaded

### DIFF
--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -83,6 +83,7 @@ namespace pxt.editor {
         | "simevent"
         | "info" // return info data`
         | "tutorialevent"
+        | "editorcontentloaded"
 
         // package extension messasges
         | ExtInitializeType
@@ -158,6 +159,10 @@ namespace pxt.editor {
          * Additional optional to create new project
          */
         options?: ProjectCreationOptions;
+    }
+
+    export interface EditorContentLoadedRequest extends EditorMessageRequest {
+        action: "editorcontentloaded";
     }
 
     export interface EditorMessageSetScaleRequest extends EditorMessageRequest {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4814,6 +4814,11 @@ export class ProjectView
             }
         }
 
+        pxt.editor.postHostMessageAsync({
+            type: "pxteditor",
+            action: "editorcontentloaded"
+        } as pxt.editor.EditorContentLoadedRequest)
+
         if (this.pendingImport) {
             this.pendingImport.resolve();
             this.pendingImport = undefined;


### PR DESCRIPTION
This change adds an event that gets sent to the parent when the editor content loads. We need this for the teacher tool app, so we know once the project has finished loading inside the iframe.