### PR TITLE
Don't give a ridiculously high pouchdb version

### DIFF
--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -50,7 +50,7 @@ async function performMigrationsAsync() {
 
 async function migratePouchAsync() {
     const POUCH_OBJECT_STORE = "by-sequence";
-    const oldDb = new pxt.BrowserUtils.IDBWrapper("_pouch_pxt-" + pxt.storage.storageId(), 99999, () => {});
+    const oldDb = new pxt.BrowserUtils.IDBWrapper("_pouch_pxt-" + pxt.storage.storageId(), 5, () => {});
     await oldDb.openAsync();
     const entries = await oldDb.getAllAsync<any>(POUCH_OBJECT_STORE);
 


### PR DESCRIPTION
I originally did this so that I wouldn't have to worry about accidentally giving too low a version, but this ends up bricking the old pouchdb database and making it inaccessible. 5 is the value that pouchDB uses internally.