### PR TITLE
Fix pouch db migration edge cases

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -835,7 +835,8 @@ namespace pxt.BrowserUtils {
             private name: string,
             private version: number,
             private upgradeHandler?: IDBUpgradeHandler,
-            private quotaExceededHandler?: () => void) {
+            private quotaExceededHandler?: () => void,
+            private skipErrorLog = false) {
         }
 
         private throwIfNotOpened(): void {
@@ -845,6 +846,10 @@ namespace pxt.BrowserUtils {
         }
 
         private errorHandler(err: Error, op: string, reject: (err: Error) => void): void {
+            if (this.skipErrorLog) {
+                reject(err);
+                return;
+            }
             console.error(new Error(`${this.name} IDBWrapper error for ${op}: ${err.message}`));
             reject(err);
             // special case for quota exceeded


### PR DESCRIPTION
This fixes a couple of pouch db migration bugs.

First, I was writing back to the pouchDB db to mark each entry as migrated so that we didn't accidentally re-import them. This was causing problems due to the internal structure of the pouchDB which has some uniqueness constraints that were being violated. Now I just sidestep that issue by storing the ids of the projects that have already been migrated in a separate db. This fixes the issue we were seeing with github projects in testing.

Secondly, I now check to see if the pouchDB actually exists before doing any migrating. This fixes an issue that prevented accessing old versions of the editor if you were in a browser with no pre-existing pouchDB. Figuring out if the db already exists was a little tricky; see the comment in the function for an explanation.