### PR TITLE
Delete the _doc_id_rev when migrating entries

### DIFF
--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -138,6 +138,7 @@ async function migratePouchAsync() {
         const existing = await db.getAsync(table, id);
 
         if (!existing) {
+            delete entry._doc_id_rev
             await db.setAsync(table, entry);
         }
     }


### PR DESCRIPTION
This fixes one of the issues I mentioned in standup with cloud sync and the pouchDB migration.

This is an internal property that pouchDB uses as its primary key. We have no reason to keep it around, and if it goes out of sync with the other project metadata it prevents a project from being synchronized on older versions of the editor.