### PR TITLE
Teacher tool: Initial validation logic

### DIFF
--- a/pxtblocks/code-validation/evaluationResult.ts
+++ b/pxtblocks/code-validation/evaluationResult.ts
@@ -1,5 +1,5 @@
 namespace pxt.blocks {
   export interface EvaluationResult {
-    passed: boolean;
+   blockIdResults: pxt.Map<boolean>;
   }
 }

--- a/pxtblocks/code-validation/rubricCriteria.ts
+++ b/pxtblocks/code-validation/rubricCriteria.ts
@@ -42,7 +42,7 @@ namespace pxt.blocks {
                 });
             });
         });
-        return { blockIdResults: finalResult} as EvaluationResult;
+        return { blockIdResults: finalResult } as EvaluationResult;
     }
 
 

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -335,7 +335,7 @@ namespace pxt.editor {
         blocksScreenshotAsync(pixelDensity?: number, encodeBlocks?: boolean): Promise<string>;
         renderBlocksAsync(req: EditorMessageRenderBlocksRequest): Promise<EditorMessageRenderBlocksResponse>;
         renderPythonAsync(req: EditorMessageRenderPythonRequest): Promise<EditorMessageRenderPythonResponse>;
-        getBlocksAsync(): Promise<Blockly.Block[]>;
+        getBlocks(): Blockly.Block[];
 
         toggleHighContrast(): void;
         setHighContrast(on: boolean): void;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -335,6 +335,7 @@ namespace pxt.editor {
         blocksScreenshotAsync(pixelDensity?: number, encodeBlocks?: boolean): Promise<string>;
         renderBlocksAsync(req: EditorMessageRenderBlocksRequest): Promise<EditorMessageRenderBlocksResponse>;
         renderPythonAsync(req: EditorMessageRenderPythonRequest): Promise<EditorMessageRenderPythonResponse>;
+        getBlocksAsync(): Promise<Blockly.Block[]>;
 
         toggleHighContrast(): void;
         setHighContrast(on: boolean): void;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -548,9 +548,9 @@ namespace pxt.editor {
                                     const evalmsg = data as EditorMessageRunEvalRequest;
                                     const rubric = evalmsg.rubric;
                                     return Promise.resolve()
-                                        .then(() => (
-                                            // TODO : call into evaluation function.
-                                            { passed: true } as pxt.blocks.EvaluationResult))
+                                        .then(() => projectView.getBlocksAsync())
+                                        .then((blocks) => (
+                                            pxt.blocks.validateProject(blocks, rubric)))
                                         .then (results => {
                                             resp = results;
                                         });

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -548,9 +548,9 @@ namespace pxt.editor {
                                     const evalmsg = data as EditorMessageRunEvalRequest;
                                     const rubric = evalmsg.rubric;
                                     return Promise.resolve()
-                                        .then(() => projectView.getBlocksAsync())
-                                        .then((blocks) => (
-                                            pxt.blocks.validateProject(blocks, rubric)))
+                                        .then(() => {
+                                            const blocks = projectView.getBlocks();
+                                            return pxt.blocks.validateProject(blocks, rubric)})
                                         .then (results => {
                                             resp = results;
                                         });

--- a/teachertool/src/App.tsx
+++ b/teachertool/src/App.tsx
@@ -35,9 +35,11 @@ function App() {
     return (
         <div className="app-container">
             <HeaderBar />
-            <DebugInput />
-            <EvalResultDisplay />
-            <MakeCodeFrame />
+            <div className="inner-app-container">
+                <DebugInput />
+                <EvalResultDisplay />
+                <MakeCodeFrame />
+            </div>
             <Notifications />
         </div>
     );

--- a/teachertool/src/components/EvalResultDisplay.tsx
+++ b/teachertool/src/components/EvalResultDisplay.tsx
@@ -14,8 +14,15 @@ const EvalResultDisplay: React.FC<IProps> = ({}) => {
                 <div className="eval-results-container">
                     <h3>{lf("Project: {0}", teacherTool.projectMetadata.name)}</h3>
                     {teacherTool.currentEvalResult === undefined && <div className="common-spinner" />}
-                    {teacherTool.currentEvalResult?.passed === true && <h4 className="positive-text">Passed!</h4>}
-                    {teacherTool.currentEvalResult?.passed === false && <h4 className="negative-text">Failed!</h4>}
+                    {Object.keys(teacherTool.currentEvalResult?.blockIdResults??{}).map((id) => {
+                        const result = teacherTool.currentEvalResult?.blockIdResults[id];
+                        return (
+                            <div className="result-block-id" key={id}>
+                                <p className="block-id-label">{id}:</p>
+                                <p className={result?"positive-text":"negative-text"}>{result?"passed":"failed"}</p>
+                            </div>
+                        );
+                    })}
                 </div>
             )}
         </>

--- a/teachertool/src/components/EvalResultDisplay.tsx
+++ b/teachertool/src/components/EvalResultDisplay.tsx
@@ -19,7 +19,7 @@ const EvalResultDisplay: React.FC<IProps> = ({}) => {
                         return (
                             <div className="result-block-id" key={id}>
                                 <p className="block-id-label">{id}:</p>
-                                <p className={result?"positive-text":"negative-text"}>{result?"passed":"failed"}</p>
+                                <p className={result ? "positive-text" : "negative-text"}>{result ? "passed" : "failed"}</p>
                             </div>
                         );
                     })}

--- a/teachertool/src/components/EvalResultDisplay.tsx
+++ b/teachertool/src/components/EvalResultDisplay.tsx
@@ -14,7 +14,7 @@ const EvalResultDisplay: React.FC<IProps> = ({}) => {
                 <div className="eval-results-container">
                     <h3>{lf("Project: {0}", teacherTool.projectMetadata.name)}</h3>
                     {teacherTool.currentEvalResult === undefined && <div className="common-spinner" />}
-                    {Object.keys(teacherTool.currentEvalResult?.blockIdResults??{}).map((id) => {
+                    {Object.keys(teacherTool.currentEvalResult?.blockIdResults ?? {}).map((id) => {
                         const result = teacherTool.currentEvalResult?.blockIdResults[id];
                         return (
                             <div className="result-block-id" key={id}>

--- a/teachertool/src/teacherTool.css
+++ b/teachertool/src/teacherTool.css
@@ -76,6 +76,13 @@ code {
     overflow: auto;
 }
 
+.inner-app-container {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+    width: 100%;
+}
+
 .noclick {
     pointer-events: none;
     cursor: default;
@@ -397,6 +404,22 @@ code {
     border-bottom: 1px solid #ddd;
     margin: 1rem 0;
     padding: 1rem;
+    overflow: auto;
+}
+
+.result-block-id {
+    display: flex;
+    padding-left: .5rem;
+    margin: .2rem 0;
+}
+
+.result-block-id p {
+    margin: 0;
+}
+
+.block-id-label {
+    font-weight: 700;
+    padding-right: .5rem;
 }
 
 .positive-text {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4038,6 +4038,14 @@ export class ProjectView
             });
     }
 
+    async getBlocksAsync(): Promise<Blockly.Block[]> {
+        if (!this.isBlocksActive()) {
+            await this.openBlocksAsync();
+        }
+
+        return this.blocksEditor.editor.getAllBlocks(false);
+    }
+
     launchFullEditor() {
         Util.assert(pxt.shell.isSandboxMode());
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4038,9 +4038,10 @@ export class ProjectView
             });
     }
 
-    async getBlocksAsync(): Promise<Blockly.Block[]> {
+    getBlocks(): Blockly.Block[] {
         if (!this.isBlocksActive()) {
-            await this.openBlocksAsync();
+            console.error("Trying to get blocks from a non-blocks editor.");
+            throw new Error("Trying to get blocks from a non-blocks editor.");
         }
 
         return this.blocksEditor.editor.getAllBlocks(false);


### PR DESCRIPTION
Big thanks to @thsparks for helping me get this set up.

Currently, the validation works for `BlockCheckCriteria` only. It takes the rubric and sets the required block counts for each block id. Then it runs the `validateBlocksExist` function for each set of blocks in the rubric.

Upload target: https://arcade.makecode.com/app/5df94cd2b924c898ff9960973789eff8048cc4c5-2776605799--eval
Sample share link: https://arcade.makecode.com/S42128-59682-77192-60950
Sample rubric:
```JSON
{
    "criteria": [
        {
            "displayText": "One or more custom functions that must be called",
            "criteriaId": "blockCheck",
            "blockRequirements": [
                {
                    "blocks": ["function_call", "function_call_output"],
                    "count": 1
                },
                {
                    "blocks": ["function_def"],
                    "count": 1
                }
            ]
        },
        {
            "displayText": "Two different kinds of loops used",
            "criteriaId": "blockCheck",
            "blockRequirements": [
                {
                    "blocks": ["controls_repeat_ext", "device_while", "pxt_controls_for", "pxt_controls_for_of"],
                    "count": 2
                }
            ]
        }
    ]
}
```