### PR TITLE
Teacher tool: updated iframe url to be readonly

### DIFF
--- a/teachertool/src/components/DebugInput.tsx
+++ b/teachertool/src/components/DebugInput.tsx
@@ -10,7 +10,7 @@ import { runEvaluateAsync } from "../transforms/runEvaluateAsync";
 interface IProps {}
 
 const DebugInput: React.FC<IProps> = ({}) => {
-    const [shareLink, setShareLink] = useState("https://arcade.makecode.com/S50644-45891-08403-36583");
+    const [shareLink, setShareLink] = useState("https://arcade.makecode.com/S70821-26848-68192-30094");
     const [rubric, setRubric] = useState("");
 
     const evaluate = async () => {

--- a/teachertool/src/components/MakecodeFrame.tsx
+++ b/teachertool/src/components/MakecodeFrame.tsx
@@ -15,7 +15,7 @@ export const MakeCodeFrame: React.FC<MakeCodeFrameProps> = () => {
         if (editorUrl.charAt(editorUrl.length - 1) === "/" && !pxt.BrowserUtils.isLocalHost()) {
             url = editorUrl.substr(0, editorUrl.length - 1);
         }
-        url += `#pub:${shareId}?controller=1&teachertool=1&readonly=1&ws=browser&nocookiebanner=1`;
+        url += `?controller=1&teachertool=1&readonly=1&ws=browser&nocookiebanner=1#pub:${shareId}`;
         return url;
     }
 

--- a/teachertool/src/components/MakecodeFrame.tsx
+++ b/teachertool/src/components/MakecodeFrame.tsx
@@ -15,7 +15,7 @@ export const MakeCodeFrame: React.FC<MakeCodeFrameProps> = () => {
         if (editorUrl.charAt(editorUrl.length - 1) === "/" && !pxt.BrowserUtils.isLocalHost()) {
             url = editorUrl.substr(0, editorUrl.length - 1);
         }
-        url += `?controller=1&ws=browser&nocookiebanner=1#pub:${shareId}`;
+        url += `#pub:${shareId}?controller=1&teachertool=1&readonly=1&ws=browser&nocookiebanner=1`;
         return url;
     }
 

--- a/teachertool/src/components/MakecodeFrame.tsx
+++ b/teachertool/src/components/MakecodeFrame.tsx
@@ -15,7 +15,7 @@ export const MakeCodeFrame: React.FC<MakeCodeFrameProps> = () => {
         if (editorUrl.charAt(editorUrl.length - 1) === "/" && !pxt.BrowserUtils.isLocalHost()) {
             url = editorUrl.substr(0, editorUrl.length - 1);
         }
-        url += `?controller=1&teachertool=1&readonly=1&ws=browser&nocookiebanner=1#pub:${shareId}`;
+        url += `?controller=1&teachertool=1&readonly=1&ws=mem&nocookiebanner=1#pub:${shareId}`;
         return url;
     }
 


### PR DESCRIPTION
Changed the url query parameters to include `readonly=1` and `teachertool=1`. 

Relies on https://github.com/microsoft/pxt-arcade/pull/6327 for the `teachertool=1` styling.

This is what the iframe looks like with the current changes:
![image](https://github.com/microsoft/pxt/assets/49178322/57815a8c-0d45-4c4c-a962-2c9b8f615120)

And here's an upload target (updated, with the mem flag, so projects in iframe in teacher tool should not show up in your project list): https://arcade.makecode.com/app/10ca0330285532cd740f0c3893c6f8850eb544c6-133a36c7a3--eval

