### PR TITLE
allow pxt cli to survive css build errors

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2707,8 +2707,12 @@ async function buildAndWatchTargetAsync(includeSourceMaps: boolean, rebundle: bo
             skipFirstCssBuild = false;
         } else {
             console.log("rebuilding css");
-            await buildSemanticUIAsync();
-            console.log("css build complete");
+            try {
+                await buildSemanticUIAsync();
+                console.log("css build complete");
+            } catch (e) {
+                console.error("css build failed", e);
+            }
         }
         return lessFiles;
     };


### PR DESCRIPTION
When `pxt serve` is running and I make the slightest typo in a .less file, the less compiler errors and the cli dies. This adds a lot of friction during development due to the overhead of restarting `pxt serve`.

With this change, the cli will log the build failure and move on.
