### PR TITLE
Fix MakeCode Editor Service Ready State

### DIFF
--- a/teachertool/src/components/EvalResultDisplay.tsx
+++ b/teachertool/src/components/EvalResultDisplay.tsx
@@ -27,8 +27,8 @@ export const EvalResultDisplay: React.FC<IProps> = ({}) => {
                     {teacherTool.evalResults.length === 0 && <div className="common-spinner" />}
                     {Object.keys(teacherTool.evalResults ?? {}).map(criteriaInstanceId => {
                         const result = teacherTool.evalResults[criteriaInstanceId];
-
-                        return (
+                        const label = getTemplateStringFromCriteriaInstanceId(criteriaInstanceId);
+                        return label && (
                             <div className="result-block-id" key={criteriaInstanceId}>
                                 <p className="block-id-label">
                                     {getTemplateStringFromCriteriaInstanceId(criteriaInstanceId)}:

--- a/teachertool/src/components/MakecodeFrame.tsx
+++ b/teachertool/src/components/MakecodeFrame.tsx
@@ -1,6 +1,6 @@
 /// <reference path="../../../built/pxteditor.d.ts" />
-import { useContext } from "react";
-import { setEditorRef } from "../services/makecodeEditorService";
+import { useContext, useEffect } from "react";
+import { clearReady, setEditorRef } from "../services/makecodeEditorService";
 import { AppStateContext } from "../state/appStateContext";
 import { getEditorUrl } from "../utils";
 
@@ -8,6 +8,11 @@ interface MakeCodeFrameProps {}
 
 export const MakeCodeFrame: React.FC<MakeCodeFrameProps> = () => {
     const { state: teacherTool } = useContext(AppStateContext);
+
+    // Clear iframe state when the iframe url is changed
+    useEffect(() => {
+        clearReady();
+    }, [teacherTool.projectMetadata?.id]);
 
     function createIFrameUrl(shareId: string): string {
         const editorUrl: string = pxt.BrowserUtils.isLocalHost()

--- a/teachertool/src/services/makecodeEditorService.ts
+++ b/teachertool/src/services/makecodeEditorService.ts
@@ -65,8 +65,11 @@ function validateResponse(result: pxt.editor.EditorMessageResponse, expectRespon
     }
 }
 
-export function setEditorRef(ref: HTMLIFrameElement | undefined) {
+export function clearReady() {
     readyForMessages = false;
+}
+
+export function setEditorRef(ref: HTMLIFrameElement | undefined) {
     makecodeEditorRef = ref ?? undefined;
     window.removeEventListener("message", onMessageReceived);
     if (ref) {

--- a/teachertool/src/transforms/loadProjectMetadataAsync.ts
+++ b/teachertool/src/transforms/loadProjectMetadataAsync.ts
@@ -22,6 +22,7 @@ export async function loadProjectMetadataAsync(shareLink: string) {
         return;
     }
 
+    dispatch(Actions.clearAllEvalResults());
     dispatch(Actions.setProjectMetadata(projMeta));
     logDebug(`Loaded project metadata: ${JSON.stringify(projMeta)}`);
 }


### PR DESCRIPTION
Fixes a bug where you couldn't run eval multiple times. (In fact, messaging to the iframe was totally breaking down.)

Before this change, the `makecodeEditorService` unset its `readyForMessages` flag anytime the iframe ref was updated. This was done under the assumption that the ref updating also means the iframe would reload, which turns out to be untrue. As a result, we end up setting `readyForMessages` to `false` and get stuck because the editor inside the iframe does *not* send its `editorcontentloaded` event again, since it already did so a while ago.

I basically took the simplest approach to fixing this, which is to make the `readyForMessages` reset an intentional action, and only call that when we change the iframe url. It seems to work in my testing and I'm struggling to find a scenario where we'd get into a bad state again, but it's possible I'm missing something.

An alternative approach would be to send an "are you ready?" ping any time we want to send a message but `readyForMessages` is false, then switch to ready and clear the queue if the editor responds to that ping successfully (as we do currently when we get an `editorcontentloaded` event)...but that feels like it may be unnecessary at this stage.

I've also included a few UI touch-ups for when you are running eval multiple times and/or changing the rubric after eval has run.

Upload target: https://makecode.microbit.org/app/f3f1b4e65ff5b1c8a233beb71cf0024757ea5b4a-aff29c0756