### PR TITLE
Teacher tool: added block comments validators

### DIFF
--- a/docs/teachertool/catalog-shared.json
+++ b/docs/teachertool/catalog-shared.json
@@ -15,13 +15,13 @@
         {
             "id": "76D86387-E3CF-4BEB-B62C-B811F5997631",
             "use": "block_comment_used",
-            "template": "At least one comment was left on a block in the code",
+            "template": "At least one block has comments",
             "docPath": "/teachertool"
         },
         {
             "id": "8F97C9A6-CF16-48B4-A84F-3105C24B20DE",
             "use": "functions_have_comments",
-            "template": "All function definitions have block comments",
+            "template": "All function definitions have comments",
             "docPath": "/teachertool"
         }
     ]

--- a/docs/teachertool/catalog-shared.json
+++ b/docs/teachertool/catalog-shared.json
@@ -13,9 +13,15 @@
             "docPath": "/teachertool"
         },
         {
-            "id": "49262A2B-C02A-43A2-BAD5-FCAC6AE9D465",
+            "id": "76D86387-E3CF-4BEB-B62C-B811F5997631",
             "use": "block_comment_used",
             "template": "At least one comment was left on a block in the code",
+            "docPath": "/teachertool"
+        },
+        {
+            "id": "8F97C9A6-CF16-48B4-A84F-3105C24B20DE",
+            "use": "functions_have_comments",
+            "template": "All function definitions have block comments",
             "docPath": "/teachertool"
         }
     ]

--- a/docs/teachertool/catalog-shared.json
+++ b/docs/teachertool/catalog-shared.json
@@ -11,6 +11,12 @@
             "use": "custom_function_called",
             "template": "A custom function exists and gets called",
             "docPath": "/teachertool"
+        },
+        {
+            "id": "49262A2B-C02A-43A2-BAD5-FCAC6AE9D465",
+            "use": "block_comment_used",
+            "template": "At least one comment was left on a block in the code",
+            "docPath": "/teachertool"
         }
     ]
 }

--- a/docs/teachertool/validator-plans-shared.json
+++ b/docs/teachertool/validator-plans-shared.json
@@ -30,6 +30,16 @@
                     }
                 }
             ]
+        },
+        {
+            ".desc": "A comment exists in a project",
+            "name": "block_comment_used",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blockCommentExists"
+                }
+            ]
         }
     ]
 }

--- a/docs/teachertool/validator-plans-shared.json
+++ b/docs/teachertool/validator-plans-shared.json
@@ -37,7 +37,8 @@
             "threshold": 1,
             "checks": [
                 {
-                    "validator": "blockCommentsExist"
+                    "validator": "blockCommentsExist",
+                    "count": 1
                 }
             ]
         },

--- a/docs/teachertool/validator-plans-shared.json
+++ b/docs/teachertool/validator-plans-shared.json
@@ -37,7 +37,7 @@
             "threshold": 1,
             "checks": [
                 {
-                    "validator": "blockCommentExists"
+                    "validator": "blockCommentsExist"
                 }
             ]
         },
@@ -47,7 +47,7 @@
             "threshold": 1,
             "checks": [
                 {
-                    "validator": "blockCommentExists",
+                    "validator": "specificBlockCommentsExist",
                     "blockType": "function_definition"
                 }
             ]

--- a/docs/teachertool/validator-plans-shared.json
+++ b/docs/teachertool/validator-plans-shared.json
@@ -32,12 +32,23 @@
             ]
         },
         {
-            ".desc": "A comment exists in a project",
+            ".desc": "A block comment exists in a project",
             "name": "block_comment_used",
             "threshold": 1,
             "checks": [
                 {
                     "validator": "blockCommentExists"
+                }
+            ]
+        },
+        {
+            ".desc": "All function definitions have block comments",
+            "name": "functions_have_comments",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blockCommentExists",
+                    "blockType": "function_definition"
                 }
             ]
         }

--- a/pxtblocks/code-validation/runValidatorPlanAsync.ts
+++ b/pxtblocks/code-validation/runValidatorPlanAsync.ts
@@ -15,7 +15,7 @@ namespace pxt.blocks {
                 case "blockCommentsExist":
                     return runValidateBlockCommentsExist(usedBlocks, check as BlockCommentsExistValidatorCheck);
                 case "specificBlockCommentsExist":
-                    return runValidateSpecificBlockCommentsExist(usedBlocks, check as SpecificBlockCommentExistsValidatorCheck);
+                    return runValidateSpecificBlockCommentsExist(usedBlocks, check as SpecificBlockCommentsExistValidatorCheck);
                 default:
                     pxt.debug(`Unrecognized validator: ${check.validator}`);
                     return false;
@@ -49,7 +49,7 @@ namespace pxt.blocks {
         return blockResults.passed;
     }
 
-    function runValidateSpecificBlockCommentsExist(usedBlocks: Blockly.Block[], inputs: SpecificBlockCommentExistsValidatorCheck): boolean {
+    function runValidateSpecificBlockCommentsExist(usedBlocks: Blockly.Block[], inputs: SpecificBlockCommentsExistValidatorCheck): boolean {
         const blockResults = validateSpecificBlockCommentsExist({ usedBlocks, blockType: inputs.blockType });
         return blockResults.passed;
     }

--- a/pxtblocks/code-validation/runValidatorPlanAsync.ts
+++ b/pxtblocks/code-validation/runValidatorPlanAsync.ts
@@ -10,9 +10,9 @@ namespace pxt.blocks {
                 case "blocksExist":
                     return runBlocksExistValidation(usedBlocks, check as BlocksExistValidatorCheck);
                 case "blockCommentsExist":
-                    return runValidateBlockCommentsExist(usedBlocks);
+                    return runValidateBlockCommentsExist(usedBlocks, check as BlockCommentsExistValidatorCheck);
                 case "specificBlockCommentsExist":
-                    return runValidateSpecificBlockCommentsExist(usedBlocks, check as BlockCommentExistsValidatorCheck);
+                    return runValidateSpecificBlockCommentsExist(usedBlocks, check as SpecificBlockCommentExistsValidatorCheck);
                 default:
                     pxt.debug(`Unrecognized validator: ${check.validator}`);
                     return false;
@@ -40,12 +40,12 @@ namespace pxt.blocks {
         return success;
     }
 
-    function runValidateBlockCommentsExist(usedBlocks: Blockly.Block[]): boolean {
-        const blockResults = validateBlockCommentsExist({ usedBlocks });
+    function runValidateBlockCommentsExist(usedBlocks: Blockly.Block[], inputs: BlockCommentsExistValidatorCheck): boolean {
+        const blockResults = validateBlockCommentsExist({ usedBlocks, numRequired: inputs.count });
         return blockResults.passed;
     }
 
-    function runValidateSpecificBlockCommentsExist(usedBlocks: Blockly.Block[], inputs: BlockCommentExistsValidatorCheck): boolean {
+    function runValidateSpecificBlockCommentsExist(usedBlocks: Blockly.Block[], inputs: SpecificBlockCommentExistsValidatorCheck): boolean {
         const blockResults = validateSpecificBlockCommentsExist({ usedBlocks, blockType: inputs.blockType });
         return blockResults.passed;
     }

--- a/pxtblocks/code-validation/runValidatorPlanAsync.ts
+++ b/pxtblocks/code-validation/runValidatorPlanAsync.ts
@@ -10,7 +10,7 @@ namespace pxt.blocks {
                 case "blocksExist":
                     return runBlocksExistValidation(usedBlocks, check as BlocksExistValidatorCheck);
                 case "blockCommentExists":
-                    return validateCommentsExist(usedBlocks);
+                    return runValidateBlockCommentsExist(usedBlocks, check as BlockCommentExistsValidatorCheck);
                 default:
                     pxt.debug(`Unrecognized validator: ${check.validator}`);
                     return false;
@@ -38,9 +38,12 @@ namespace pxt.blocks {
         return success;
     }
 
-    function runValidateCommentsExist(usedBlocks: Blockly.Block[], inputs: BlockCommentExistsValidatorCheck): boolean {
-        const blockResults = validateCommentsExist(usedBlocks);
-
-        return true;
+    function runValidateBlockCommentsExist(usedBlocks: Blockly.Block[], inputs: BlockCommentExistsValidatorCheck): boolean {
+        const blockTypeUsed = inputs.blockType;
+        const blockResults = blockTypeUsed ?
+            validateCommentsOnSpecificBlocksExist({ usedBlocks, blockType: blockTypeUsed }) :
+            validateBlockCommentsExist({ usedBlocks });
+        const success = blockTypeUsed ? blockResults.length === 0 : blockResults.length !== 0;
+        return success;
     }
 }

--- a/pxtblocks/code-validation/runValidatorPlanAsync.ts
+++ b/pxtblocks/code-validation/runValidatorPlanAsync.ts
@@ -9,7 +9,8 @@ namespace pxt.blocks {
             switch (check.validator) {
                 case "blocksExist":
                     return runBlocksExistValidation(usedBlocks, check as BlocksExistValidatorCheck);
-
+                case "blockCommentExists":
+                    return validateCommentsExist(usedBlocks);
                 default:
                     pxt.debug(`Unrecognized validator: ${check.validator}`);
                     return false;
@@ -35,5 +36,11 @@ namespace pxt.blocks {
             blockResults.missingBlocks.length === 0 &&
             blockResults.insufficientBlocks.length === 0;
         return success;
+    }
+
+    function runValidateCommentsExist(usedBlocks: Blockly.Block[], inputs: BlockCommentExistsValidatorCheck): boolean {
+        const blockResults = validateCommentsExist(usedBlocks);
+
+        return true;
     }
 }

--- a/pxtblocks/code-validation/runValidatorPlanAsync.ts
+++ b/pxtblocks/code-validation/runValidatorPlanAsync.ts
@@ -9,8 +9,10 @@ namespace pxt.blocks {
             switch (check.validator) {
                 case "blocksExist":
                     return runBlocksExistValidation(usedBlocks, check as BlocksExistValidatorCheck);
-                case "blockCommentExists":
-                    return runValidateBlockCommentsExist(usedBlocks, check as BlockCommentExistsValidatorCheck);
+                case "blockCommentsExist":
+                    return runValidateBlockCommentsExist(usedBlocks);
+                case "specificBlockCommentsExist":
+                    return runValidateSpecificBlockCommentsExist(usedBlocks, check as BlockCommentExistsValidatorCheck);
                 default:
                     pxt.debug(`Unrecognized validator: ${check.validator}`);
                     return false;
@@ -38,12 +40,13 @@ namespace pxt.blocks {
         return success;
     }
 
-    function runValidateBlockCommentsExist(usedBlocks: Blockly.Block[], inputs: BlockCommentExistsValidatorCheck): boolean {
-        const blockTypeUsed = inputs.blockType;
-        const blockResults = blockTypeUsed ?
-            validateCommentsOnSpecificBlocksExist({ usedBlocks, blockType: blockTypeUsed }) :
-            validateBlockCommentsExist({ usedBlocks });
-        const success = blockTypeUsed ? blockResults.length === 0 : blockResults.length !== 0;
-        return success;
+    function runValidateBlockCommentsExist(usedBlocks: Blockly.Block[]): boolean {
+        const blockResults = validateBlockCommentsExist({ usedBlocks });
+        return blockResults.passed;
+    }
+
+    function runValidateSpecificBlockCommentsExist(usedBlocks: Blockly.Block[], inputs: BlockCommentExistsValidatorCheck): boolean {
+        const blockResults = validateSpecificBlockCommentsExist({ usedBlocks, blockType: inputs.blockType });
+        return blockResults.passed;
     }
 }

--- a/pxtblocks/code-validation/validateCommentsExist.ts
+++ b/pxtblocks/code-validation/validateCommentsExist.ts
@@ -1,7 +1,20 @@
 
 namespace pxt.blocks {
-    export function validateCommentsExist(usedBlocks: Blockly.Block[]): boolean {
-        const commentBlocks = usedBlocks.filter((block) => !!block.comment);
-        return commentBlocks.length > 0;
+    // validates that one or more blocks comments are in the project
+    // returns the blocks that have comments for teacher tool scenario
+    export function validateBlockCommentsExist({ usedBlocks }: { usedBlocks: Blockly.Block[] }): Blockly.Block[] {
+        const commentBlocks = usedBlocks.filter((block) => !!block.getCommentText());
+        return commentBlocks;
+    }
+
+    // validates that all of a specific block type have comments
+    // returns the blocks that do not have comments for a tutorial validation scenario
+    export function validateCommentsOnSpecificBlocksExist({ usedBlocks, blockType }: {
+            usedBlocks: Blockly.Block[],
+            blockType: string,
+        }): Blockly.Block[] {
+        const allSpecifcBlocks = usedBlocks.filter((block) => block.type === blockType);
+        const noncommentBlocks = allSpecifcBlocks.filter((block) => !block.getCommentText());
+        return noncommentBlocks;
     }
 }

--- a/pxtblocks/code-validation/validateCommentsExist.ts
+++ b/pxtblocks/code-validation/validateCommentsExist.ts
@@ -2,13 +2,14 @@
 namespace pxt.blocks {
     // validates that one or more blocks comments are in the project
     // returns the blocks that have comments for teacher tool scenario
-    export function validateBlockCommentsExist({ usedBlocks }: {
-        usedBlocks: Blockly.Block[]
+    export function validateBlockCommentsExist({ usedBlocks, numRequired }: {
+        usedBlocks: Blockly.Block[],
+        numRequired: number,
     }): {
         commentedBlocks: Blockly.Block[],
         passed: boolean
     } {
         const commentedBlocks = usedBlocks.filter((block) => !!block.getCommentText());
-        return { commentedBlocks, passed: commentedBlocks.length !== 0 };
+        return { commentedBlocks, passed: commentedBlocks.length >= numRequired };
     }
 }

--- a/pxtblocks/code-validation/validateCommentsExist.ts
+++ b/pxtblocks/code-validation/validateCommentsExist.ts
@@ -1,0 +1,7 @@
+
+namespace pxt.blocks {
+    export function validateCommentsExist(usedBlocks: Blockly.Block[]): boolean {
+        const commentBlocks = usedBlocks.filter((block) => !!block.comment);
+        return commentBlocks.length > 0;
+    }
+}

--- a/pxtblocks/code-validation/validateCommentsExist.ts
+++ b/pxtblocks/code-validation/validateCommentsExist.ts
@@ -2,19 +2,13 @@
 namespace pxt.blocks {
     // validates that one or more blocks comments are in the project
     // returns the blocks that have comments for teacher tool scenario
-    export function validateBlockCommentsExist({ usedBlocks }: { usedBlocks: Blockly.Block[] }): Blockly.Block[] {
-        const commentBlocks = usedBlocks.filter((block) => !!block.getCommentText());
-        return commentBlocks;
-    }
-
-    // validates that all of a specific block type have comments
-    // returns the blocks that do not have comments for a tutorial validation scenario
-    export function validateCommentsOnSpecificBlocksExist({ usedBlocks, blockType }: {
-            usedBlocks: Blockly.Block[],
-            blockType: string,
-        }): Blockly.Block[] {
-        const allSpecifcBlocks = usedBlocks.filter((block) => block.type === blockType);
-        const noncommentBlocks = allSpecifcBlocks.filter((block) => !block.getCommentText());
-        return noncommentBlocks;
+    export function validateBlockCommentsExist({ usedBlocks }: {
+        usedBlocks: Blockly.Block[]
+    }): {
+        commentedBlocks: Blockly.Block[],
+        passed: boolean
+    } {
+        const commentedBlocks = usedBlocks.filter((block) => !!block.getCommentText());
+        return { commentedBlocks, passed: commentedBlocks.length !== 0 };
     }
 }

--- a/pxtblocks/code-validation/validateSpecificBlockCommentsExist.ts
+++ b/pxtblocks/code-validation/validateSpecificBlockCommentsExist.ts
@@ -1,0 +1,15 @@
+namespace pxt.blocks {
+    // validates that all of a specific block type have comments
+    // returns the blocks that do not have comments for a tutorial validation scenario
+    export function validateSpecificBlockCommentsExist({ usedBlocks, blockType }: {
+        usedBlocks: Blockly.Block[],
+        blockType: string,
+    }): {
+        uncommentedBlocks: Blockly.Block[],
+        passed: boolean
+    } {
+    const allSpecifcBlocks = usedBlocks.filter((block) => block.type === blockType);
+    const uncommentedBlocks = allSpecifcBlocks.filter((block) => !block.getCommentText());
+    return { uncommentedBlocks, passed: uncommentedBlocks.length === 0 };
+    }
+}

--- a/pxtblocks/code-validation/validatorPlans.ts
+++ b/pxtblocks/code-validation/validatorPlans.ts
@@ -22,7 +22,7 @@ namespace pxt.blocks {
         validator: "blockCommentsExist";
         count: number;
     }
-    export interface SpecificBlockCommentExistsValidatorCheck extends ValidatorCheckBase {
+    export interface SpecificBlockCommentsExistValidatorCheck extends ValidatorCheckBase {
         validator: "specificBlockCommentsExist";
         blockType: string;
     }

--- a/pxtblocks/code-validation/validatorPlans.ts
+++ b/pxtblocks/code-validation/validatorPlans.ts
@@ -20,6 +20,6 @@ namespace pxt.blocks {
 
     export interface BlockCommentExistsValidatorCheck extends ValidatorCheckBase {
         validator: "blockCommentExists";
-        onBlocks?: pxt.Map<number>;
+        blockType?: string;
     }
 }

--- a/pxtblocks/code-validation/validatorPlans.ts
+++ b/pxtblocks/code-validation/validatorPlans.ts
@@ -17,4 +17,9 @@ namespace pxt.blocks {
         validator: "blocksExist";
         blockCounts: pxt.Map<number>;
     }
+
+    export interface BlockCommentExistsValidatorCheck extends ValidatorCheckBase {
+        validator: "blockCommentExists";
+        onBlocks?: pxt.Map<number>;
+    }
 }

--- a/pxtblocks/code-validation/validatorPlans.ts
+++ b/pxtblocks/code-validation/validatorPlans.ts
@@ -18,9 +18,12 @@ namespace pxt.blocks {
         blockCounts: pxt.Map<number>;
     }
 
-    export interface BlockCommentExistsValidatorCheck extends ValidatorCheckBase {
-        validator: "blockCommentExists";
-        blockType?: string;
-        count?: number;
+    export interface BlockCommentsExistValidatorCheck extends ValidatorCheckBase {
+        validator: "blockCommentsExist";
+        count: number;
+    }
+    export interface SpecificBlockCommentExistsValidatorCheck extends ValidatorCheckBase {
+        validator: "specificBlockCommentsExist";
+        blockType: string;
     }
 }

--- a/pxtblocks/code-validation/validatorPlans.ts
+++ b/pxtblocks/code-validation/validatorPlans.ts
@@ -21,5 +21,6 @@ namespace pxt.blocks {
     export interface BlockCommentExistsValidatorCheck extends ValidatorCheckBase {
         validator: "blockCommentExists";
         blockType?: string;
+        count?: number;
     }
 }


### PR DESCRIPTION
I added two block comments validators to be used in the teacher tool but should also be usable in tutorials. 


<img width="343" alt="criteria-comments" src="https://github.com/microsoft/pxt/assets/49178322/c02faa37-d4e8-4079-8811-dca2246568c4">


The first is a very rudimentary validator. It's for the use cases that users might not care where or how the comments are used, just that comments exist in the project.

The second is for when a users want to check that a specific type of block has a block comment on it. For example, a common ask I had from my professors was to add comments to every function definition. Users of the teacher tool might want to do the same, so if there is a block type specified, the validator will make sure that all blocks of that type has a comment on it. For teacher tool purposes, this is pre-defined only for function definitions at the moment, but an expansion would be when we introduce user-parameterized criteria, a user can allow the user to choose a block they would like to have comments on.

Some quick notes about decisions for how I wrote this code:
- I really like the idea of having this sort of mapping of one validator to one function run. As in, I like that even though the "any block comments" and "block comments on all this type of block" are pretty different, I like that they both live under the `blockCommentExists` validator and that running the `runValidateBlockCommentsExist` will sort out the more nitty-gritty details. I would love to hear other's thoughts on this, though.
- For validators, I think that we should maintain a common parameter pattern. An object is used in the `validateBlocksExist` function and I asked Joey why this was the choice and he explained that using an object as a parameter lends to "self-documenting" and can make it easier to add flags and the like into the validator down the road. I think these benefits are valuable, so I used this `object parameter` pattern in both of the new validators.
- In the comments above the new validators, I note why I returned the type that I did. Note that the "any block comments" validator returns all blocks that have comments in them. I do this because, in the future of the teacher tool, if we want to return more detail to the user as to why a validator passed or failed (and in this case in particular, passed), we can return all of the blocks where comments exist as an easy access point. The "block comments on all this type of block" scenario returns a list of the blocks that DO NOT have comments on them. This will not only be helpful for the teacher tool scenario, but also a tutorial scenario. If there is a tutorial step that includes having a user put a comment on a block, we would be able to give the hint of what block they're missing the comment on.

In action:
<img width="1269" alt="image" src="https://github.com/microsoft/pxt/assets/49178322/4d41a955-63c0-4eab-98c5-e8b656619a0b">
