### PR TITLE
Teacher tool: block in set validator added

### DIFF
--- a/docs/teachertool/validator-plans-shared.json
+++ b/docs/teachertool/validator-plans-shared.json
@@ -52,6 +52,24 @@
                     "blockType": "function_definition"
                 }
             ]
+        },
+        {
+            ".desc": "A custom function exists and gets called",
+            "name": "custom_function_called",
+            "threshold": 2,
+            "checks": [
+                {
+                    "validator": "blocksInSetExist",
+                    "blocks": ["function_call", "function_call_output"],
+                    "count": 1
+                },
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "function_definition": 1
+                    }
+                }
+            ]
         }
     ]
 }

--- a/pxtblocks/code-validation/runValidatorPlanAsync.ts
+++ b/pxtblocks/code-validation/runValidatorPlanAsync.ts
@@ -16,6 +16,8 @@ namespace pxt.blocks {
                     return runValidateBlockCommentsExist(usedBlocks, check as BlockCommentsExistValidatorCheck);
                 case "specificBlockCommentsExist":
                     return runValidateSpecificBlockCommentsExist(usedBlocks, check as SpecificBlockCommentsExistValidatorCheck);
+                case "blocksInSetExist":
+                    return runBlocksInSetExistValidation(usedBlocks, check as BlocksInSetExistValidatorCheck);
                 default:
                     pxt.debug(`Unrecognized validator: ${check.validator}`);
                     return false;
@@ -51,6 +53,11 @@ namespace pxt.blocks {
 
     function runValidateSpecificBlockCommentsExist(usedBlocks: Blockly.Block[], inputs: SpecificBlockCommentsExistValidatorCheck): boolean {
         const blockResults = validateSpecificBlockCommentsExist({ usedBlocks, blockType: inputs.blockType });
+        return blockResults.passed;
+    }
+
+    function runBlocksInSetExistValidation(usedBlocks: Blockly.Block[], inputs: BlocksInSetExistValidatorCheck): boolean {
+        const blockResults = validateBlocksInSetExist({ usedBlocks, blocks: inputs.blocks, count: inputs.count });
         return blockResults.passed;
     }
 }

--- a/pxtblocks/code-validation/runValidatorPlanAsync.ts
+++ b/pxtblocks/code-validation/runValidatorPlanAsync.ts
@@ -57,7 +57,7 @@ namespace pxt.blocks {
     }
 
     function runBlocksInSetExistValidation(usedBlocks: Blockly.Block[], inputs: BlocksInSetExistValidatorCheck): boolean {
-        const blockResults = validateBlocksInSetExist({ usedBlocks, blocks: inputs.blocks, count: inputs.count });
+        const blockResults = validateBlocksInSetExist({ usedBlocks, blockIdsToCheck: inputs.blocks, count: inputs.count });
         return blockResults.passed;
     }
 }

--- a/pxtblocks/code-validation/validateBlocksInSetExist.ts
+++ b/pxtblocks/code-validation/validateBlocksInSetExist.ts
@@ -1,0 +1,20 @@
+namespace pxt.blocks {
+    // validates that a combination of blocks in the set satisfies the required count
+    // returns the blocks that make the validator pass
+    export function validateBlocksInSetExist({ usedBlocks, blocks, count }: {
+        usedBlocks: Blockly.Block[],
+        blocks: string[],
+        count: number,
+    }): {
+        successfulBlocks: Blockly.Block[],
+        passed: boolean
+    } {
+        const successfulBlocks = [];
+        const enabledBlocks = usedBlocks.filter((block) => block.isEnabled());
+        for (const block of blocks) {
+            const blockInstances = enabledBlocks.filter((b) => b.type === block);
+            successfulBlocks.push(...blockInstances);
+        }
+        return { successfulBlocks, passed: successfulBlocks.length >= count };
+    }
+}

--- a/pxtblocks/code-validation/validateBlocksInSetExist.ts
+++ b/pxtblocks/code-validation/validateBlocksInSetExist.ts
@@ -1,19 +1,24 @@
 namespace pxt.blocks {
     // validates that a combination of blocks in the set satisfies the required count
     // returns the blocks that make the validator pass
-    export function validateBlocksInSetExist({ usedBlocks, blocks, count }: {
+    export function validateBlocksInSetExist({ usedBlocks, blockIdsToCheck, count, requireUnique }: {
         usedBlocks: Blockly.Block[],
-        blocks: string[],
+        blockIdsToCheck: string[],
         count: number,
+        requireUnique?: boolean
     }): {
         successfulBlocks: Blockly.Block[],
         passed: boolean
     } {
         const successfulBlocks = [];
         const enabledBlocks = usedBlocks.filter((block) => block.isEnabled());
-        for (const block of blocks) {
+        for (const block of blockIdsToCheck) {
             const blockInstances = enabledBlocks.filter((b) => b.type === block);
-            successfulBlocks.push(...blockInstances);
+            if (requireUnique && blockInstances.length >= 1) {
+                successfulBlocks.push(blockInstances[0]);
+            } else {
+                successfulBlocks.push(...blockInstances);
+            }
         }
         return { successfulBlocks, passed: successfulBlocks.length >= count };
     }

--- a/pxtblocks/code-validation/validateSpecificBlockCommentsExist.ts
+++ b/pxtblocks/code-validation/validateSpecificBlockCommentsExist.ts
@@ -8,8 +8,8 @@ namespace pxt.blocks {
         uncommentedBlocks: Blockly.Block[],
         passed: boolean
     } {
-    const allSpecifcBlocks = usedBlocks.filter((block) => block.type === blockType);
-    const uncommentedBlocks = allSpecifcBlocks.filter((block) => !block.getCommentText());
-    return { uncommentedBlocks, passed: uncommentedBlocks.length === 0 };
+        const allSpecifcBlocks = usedBlocks.filter((block) => block.type === blockType);
+        const uncommentedBlocks = allSpecifcBlocks.filter((block) => !block.getCommentText());
+        return { uncommentedBlocks, passed: uncommentedBlocks.length === 0 };
     }
 }

--- a/pxtblocks/code-validation/validatorPlans.ts
+++ b/pxtblocks/code-validation/validatorPlans.ts
@@ -26,4 +26,10 @@ namespace pxt.blocks {
         validator: "specificBlockCommentsExist";
         blockType: string;
     }
+
+    export interface BlocksInSetExistValidatorCheck extends ValidatorCheckBase {
+        validator: "blocksInSetExist";
+        blocks: string[];
+        count: number;
+    }
 }


### PR DESCRIPTION
This PR establishes the block in set validator. I thought the `blocksInSetExist` terminology made more sense than `blockSetExists` since we're not checking that a group of blocks exist. With this validator, we're checking that some kinds of blocks from a set exist, so I'm hoping `blocksInSetExist` is more descriptive. I'm up for changing it, though, if people feel strongly.

For its use for now, I plugged it into the `custom_function_call` validator plan we have in an example in our OneNote. It's a good example of how we'd want to use two different validators together where we want to make sure that a function is made and it is either called and the return function is accessed or it's just called. The `blocksInSetExist` validator is meant to handle this "or" scenario. 

Here are some other possible scenarios that I thought:
- Creating and manipulating a sprite (as in, a teacher wants their student to move the sprite, scale  the sprite, remove the sprite, add effects to the sprite, and it can be any of those)
- Creating and using a variable, although this might be better situated with the `blocksExist` validator
- Maybe something with extensions, like we ensure that an extension was installed and a certain number of blocks from that extension was used, but it doesn't matter which of those blocks were used
- Something with arrays similar to the sprite scenario that I explained above