### PR TITLE
Correct the Serbian locale name field

### DIFF
--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1236,7 +1236,7 @@ namespace ts.pxtc.Util {
         "sk": { englishName: "Slovak", localizedName: "Slovenčina" },
         "sl": { englishName: "Slovenian", localizedName: "Slovenski" },
         "sq": { englishName: "Albanian", localizedName: "shqip" },
-        "sr": { englishName: "Serbian (Latin)", localizedName: "Srpski" },
+        "sr": { englishName: "Serbian (Cyrillic)", localizedName: "Srpski" },
         "su": { englishName: "Sundanese", localizedName: "ᮘᮞ ᮞᮥᮔ᮪ᮓ" },
         "sv-SE": { englishName: "Swedish", localizedName: "Svenska" },
         "sw": { englishName: "Swahili", localizedName: "Kiswahili" },


### PR DESCRIPTION
The locale name for `sr` should be `Serbian (Cyrillic)` and not `Serbian (Latin)`. The locale names in the [Crowdin Language Codes](https://developer.crowdin.com/language-codes/) list them as:

Crowdin Code | Name
-- | --
sr | Serbian (Cyrillic)
sr-CS | Serbian (Latin)

Naming it as "Serbian (Latin)" is a bit misleading to users seeing Cyrillic while expecting Latin script.