### PR TITLE
Teacher Tool: Consolidate Calls to SetRubric

### DIFF
--- a/teachertool/src/transforms/addCriteriaToRubric.ts
+++ b/teachertool/src/transforms/addCriteriaToRubric.ts
@@ -1,11 +1,10 @@
 import { stateAndDispatch } from "../state";
-import * as Actions from "../state/actions";
 import { getCatalogCriteriaWithId } from "../state/helpers";
 import { logDebug, logError } from "../services/loggingService";
 import { CriteriaInstance, CriteriaParameterValue } from "../types/criteria";
 import { nanoid } from "nanoid";
 import { ErrorCode } from "../types/errorCode";
-import * as AutorunService from "../services/autorunService";
+import { setRubric } from "./setRubric";
 
 export function addCriteriaToRubric(catalogCriteriaIds: string[]) {
     const { state: teacherTool, dispatch } = stateAndDispatch();
@@ -45,8 +44,7 @@ export function addCriteriaToRubric(catalogCriteriaIds: string[]) {
         newRubric.criteria.push(criteriaInstance);
     }
 
-    dispatch(Actions.setRubric(newRubric));
-    AutorunService.poke();
+    setRubric(newRubric);
 
     pxt.tickEvent("teachertool.addcriteria", {
         ids: JSON.stringify(catalogCriteriaIds),

--- a/teachertool/src/transforms/removeCriteriaFromRubric.ts
+++ b/teachertool/src/transforms/removeCriteriaFromRubric.ts
@@ -1,8 +1,7 @@
 import { stateAndDispatch } from "../state";
-import * as Actions from "../state/actions";
 import { logDebug } from "../services/loggingService";
 import { CriteriaInstance } from "../types/criteria";
-import * as AutorunService from "../services/autorunService";
+import { setRubric } from "./setRubric";
 
 export function removeCriteriaFromRubric(instance: CriteriaInstance) {
     const { state: teacherTool, dispatch } = stateAndDispatch();
@@ -14,8 +13,7 @@ export function removeCriteriaFromRubric(instance: CriteriaInstance) {
         criteria: teacherTool.rubric.criteria.filter(c => c.instanceId !== instance.instanceId),
     };
 
-    dispatch(Actions.setRubric(newRubric));
-    AutorunService.poke();
+    setRubric(newRubric);
 
     pxt.tickEvent("teachertool.removecriteria", { catalogCriteriaId: instance.catalogCriteriaId });
 }

--- a/teachertool/src/transforms/setRubricName.ts
+++ b/teachertool/src/transforms/setRubricName.ts
@@ -1,8 +1,8 @@
 import { stateAndDispatch } from "../state";
-import * as Actions from "../state/actions";
+import { setRubric } from "./setRubric";
 
 export function setRubricName(name: string) {
-    const { state: teacherTool, dispatch } = stateAndDispatch();
+    const { state: teacherTool } = stateAndDispatch();
 
     const oldName = teacherTool.rubric.name;
 
@@ -14,5 +14,5 @@ export function setRubricName(name: string) {
         ...teacherTool.rubric,
         name,
     };
-    dispatch(Actions.setRubric(newRubric));
+    setRubric(newRubric);
 }


### PR DESCRIPTION
This change sends all `setRubric` calls through the `setRubric` transform (https://github.com/microsoft/pxt/blob/master/teachertool/src/transforms/setRubric.ts), so they don't call into the action directly. This is just a refactor; there is no change in functionality.

I didn't do this originally because the setRubric transform was doing a bunch of validation that would have been redundant, but I refactored that out and forgot to go in and change these calls. Now with this change, we can rely on the transform to poke autorun and we don't need to call that separately every time.