### PR TITLE
teacher tool: initial homescreen

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -145,5 +145,7 @@ module.exports = {
         "@microsoft/sdl/react-iframe-missing-sandbox": "error",
         "@typescript-eslint/no-implied-eval": "error",
         "react/no-danger": "error",
+        "import/no-unassigned-import": "off",
+        "import/no-internal-modules": "off",
     }
 };

--- a/teachertool/package-lock.json
+++ b/teachertool/package-lock.json
@@ -14,6 +14,7 @@
         "nanoid": "^4.0.2",
         "react-scripts": "5.0.1",
         "sass": "^1.70.0",
+        "swiper": "^8.4.4",
         "tslib": "^2.6.2",
         "typescript": "^4.6.4"
       },
@@ -6804,6 +6805,14 @@
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom7": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
+      "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
+      "dependencies": {
+        "ssr-window": "^4.0.0"
       }
     },
     "node_modules/domain-browser": {
@@ -16104,6 +16113,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "node_modules/ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -16662,6 +16676,29 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dependencies": {
         "boolbase": "~1.0.0"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.7.tgz",
+      "integrity": "sha512-VwO/KU3i9IV2Sf+W2NqyzwWob4yX9Qdedq6vBtS0rFqJ6Fa5iLUJwxQkuD4I38w0WDJwmFl8ojkdcRFPHWD+2g==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "hasInstallScript": true,
+      "dependencies": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -23157,6 +23194,14 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
         "entities": "^2.0.0"
+      }
+    },
+    "dom7": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
+      "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
+      "requires": {
+        "ssr-window": "^4.0.0"
       }
     },
     "domain-browser": {
@@ -29759,6 +29804,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -30191,6 +30241,15 @@
             "boolbase": "~1.0.0"
           }
         }
+      }
+    },
+    "swiper": {
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.7.tgz",
+      "integrity": "sha512-VwO/KU3i9IV2Sf+W2NqyzwWob4yX9Qdedq6vBtS0rFqJ6Fa5iLUJwxQkuD4I38w0WDJwmFl8ojkdcRFPHWD+2g==",
+      "requires": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
       }
     },
     "symbol-tree": {

--- a/teachertool/package.json
+++ b/teachertool/package.json
@@ -9,6 +9,7 @@
     "nanoid": "^4.0.2",
     "react-scripts": "5.0.1",
     "sass": "^1.70.0",
+    "swiper": "^8.4.4",
     "tslib": "^2.6.2",
     "typescript": "^4.6.4"
   },

--- a/teachertool/src/App.tsx
+++ b/teachertool/src/App.tsx
@@ -38,7 +38,7 @@ export const App = () => {
                     ...makeToast("success", "🎓", 2000),
                     hideIcon: true,
                     hideDismissBtn: true,
-                    textContainerClass: "app-large-toast",
+                    className: "app-large-toast",
                 });
 
                 setInited(true);

--- a/teachertool/src/App.tsx
+++ b/teachertool/src/App.tsx
@@ -34,7 +34,12 @@ export const App = () => {
                 await tryLoadLastActiveRubricAsync();
 
                 // Test notification
-                showToast(makeToast("success", "🎓", 2000));
+                showToast({
+                    ...makeToast("success", "🎓", 2000),
+                    hideIcon: true,
+                    hideDismissBtn: true,
+                    textContainerClass: "app-large-toast",
+                });
 
                 setInited(true);
                 logDebug("App initialized");

--- a/teachertool/src/components/HeaderBar.tsx
+++ b/teachertool/src/components/HeaderBar.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { useContext } from "react";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/HeaderBar.module.scss";
 import { Button } from "react-common/components/controls/Button";
 import { MenuBar } from "react-common/components/controls/MenuBar";
 import { AppStateContext } from "../state/appStateContext";
 import { getSafeRubricName } from "../state/helpers";
+import { Ticks } from "../constants";
 
 interface HeaderBarProps {}
 
@@ -15,7 +15,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
     const appTheme = pxt.appTarget?.appTheme;
 
     const brandIconClick = () => {
-        pxt.tickEvent("teachertool.brandicon");
+        pxt.tickEvent(Ticks.BrandIcon);
         // TODO: Link this
     };
 
@@ -75,7 +75,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
     };
 
     const onHomeClicked = () => {
-        pxt.tickEvent("teachertool.home");
+        pxt.tickEvent(Ticks.HomeTab);
 
         // relprefix looks like "/beta---", need to chop off the hyphens and slash
         let rel = pxt.webConfig?.relprefix.substr(0, pxt.webConfig.relprefix.length - 3);

--- a/teachertool/src/components/HeaderBar.tsx
+++ b/teachertool/src/components/HeaderBar.tsx
@@ -14,7 +14,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
 
     const appTheme = pxt.appTarget?.appTheme;
 
-    const brandIconClick = () => {
+    const onBrandIconClick = () => {
         pxt.tickEvent(Ticks.BrandLink);
         if (appTheme?.logoUrl) {
             window.open(appTheme.logoUrl);
@@ -50,7 +50,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
                 className={css["brand"]}
                 aria-label={lf("{0} Logo", appTheme.boardName)}
                 role="menuitem"
-                onClick={brandIconClick}
+                onClick={onBrandIconClick}
             >
                 {appTheme.useTextLogo ? (
                     [

--- a/teachertool/src/components/HeaderBar.tsx
+++ b/teachertool/src/components/HeaderBar.tsx
@@ -15,13 +15,22 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
     const appTheme = pxt.appTarget?.appTheme;
 
     const brandIconClick = () => {
-        pxt.tickEvent(Ticks.BrandIcon);
-        // TODO: Link this
+        pxt.tickEvent(Ticks.BrandLink);
+        if (appTheme?.logoUrl) {
+            window.open(appTheme.logoUrl);
+        }
     };
+
+    const onOrgClick = () => {
+        pxt.tickEvent(Ticks.OrgLink);
+        if (appTheme?.organizationUrl) {
+            window.open(appTheme.organizationUrl);
+        }
+    }
 
     const getOrganizationLogo = () => {
         return (
-            <div className={css["org"]}>
+            <div className={css["org"]} onClick={onOrgClick}>
                 {appTheme.organizationWideLogo || appTheme.organizationLogo ? (
                     <img
                         className={css["logo"]}
@@ -75,7 +84,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
     };
 
     const onHomeClicked = () => {
-        pxt.tickEvent(Ticks.HomeTab);
+        pxt.tickEvent(Ticks.HomeLink);
 
         // relprefix looks like "/beta---", need to chop off the hyphens and slash
         let rel = pxt.webConfig?.relprefix.substr(0, pxt.webConfig.relprefix.length - 3);
@@ -101,7 +110,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
                 <Button
                     className="menu-button"
                     leftIcon="fas fa-home large"
-                    title={lf("Return to the editor homepage")}
+                    title={lf("Open the MakeCode editor")}
                     onClick={onHomeClicked}
                 />
             </div>

--- a/teachertool/src/components/HeaderBar.tsx
+++ b/teachertool/src/components/HeaderBar.tsx
@@ -1,15 +1,23 @@
 import * as React from "react";
+import { useContext } from "react";
 // eslint-disable-next-line import/no-internal-modules
 import css from "./styling/HeaderBar.module.scss";
 import { Button } from "react-common/components/controls/Button";
 import { MenuBar } from "react-common/components/controls/MenuBar";
+import { AppStateContext } from "../state/appStateContext";
+import { getSafeRubricName } from "../state/helpers";
 
 interface HeaderBarProps {}
 
 export const HeaderBar: React.FC<HeaderBarProps> = () => {
+    const { state: teacherTool } = useContext(AppStateContext);
+
     const appTheme = pxt.appTarget?.appTheme;
 
-    const brandIconClick = () => {};
+    const brandIconClick = () => {
+        pxt.tickEvent("teachertool.brandicon");
+        // TODO: Link this
+    };
 
     const getOrganizationLogo = () => {
         return (
@@ -57,8 +65,17 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
         );
     };
 
+    const getRubricName = (): JSX.Element | null => {
+        const rubricName = getSafeRubricName(teacherTool);
+        return rubricName ? (
+            <div className={css["rubric-name"]}>
+                <span>{rubricName}</span>
+            </div>
+        ) : null;
+    };
+
     const onHomeClicked = () => {
-        pxt.tickEvent("teacherTool.home");
+        pxt.tickEvent("teachertool.home");
 
         // relprefix looks like "/beta---", need to chop off the hyphens and slash
         let rel = pxt.webConfig?.relprefix.substr(0, pxt.webConfig.relprefix.length - 3);
@@ -77,6 +94,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
             <div className={css["left-menu"]}>
                 {getOrganizationLogo()}
                 {getTargetLogo()}
+                {getRubricName()}
             </div>
 
             <div className={css["right-menu"]}>

--- a/teachertool/src/components/HeaderBar.tsx
+++ b/teachertool/src/components/HeaderBar.tsx
@@ -26,7 +26,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
         if (appTheme?.organizationUrl) {
             window.open(appTheme.organizationUrl);
         }
-    }
+    };
 
     const getOrganizationLogo = () => {
         return (

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -81,7 +81,7 @@ const Carousel: React.FC<CarouselProps> = ({ children }) => {
 const GetStarted: React.FC = () => {
     const onNewRubricClickedAsync = async () => {
         pxt.tickEvent(Ticks.NewRubric);
-        await resetRubricAsync(true);
+        await resetRubricAsync();
     };
 
     const onImportRubricClicked = () => {

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -9,6 +9,7 @@ import { resetRubricAsync } from "../transforms/resetRubricAsync";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Mousewheel, Navigation } from "swiper";
 
+// eslint-disable import/no-internal-modules
 import "swiper/scss";
 import "swiper/scss/navigation";
 import "swiper/scss/mousewheel";
@@ -60,13 +61,12 @@ const Carousel: React.FC<CarouselProps> = ({ children }) => {
 
     return (
         <Swiper
-            spaceBetween={16}
+            spaceBetween={10}
             slidesPerView={"auto"}
             allowTouchMove={true}
             slidesOffsetBefore={32}
             navigation={true}
             mousewheel={true}
-            scrollbar={{ draggable: true }}
             modules={[Navigation, Mousewheel]}
             className={css.swiperCarousel}
         >

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/HomeScreen.module.scss";
 import { Link } from "react-common/components/controls/Link";
 import { Button } from "react-common/components/controls/Button";
@@ -8,11 +7,9 @@ import { showModal } from "../transforms/showModal";
 import { resetRubricAsync } from "../transforms/resetRubricAsync";
 import Constants from "../constants";
 
-// eslint-disable-next-line import/no-internal-modules
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Mousewheel, Navigation } from "swiper";
 
-// eslint-disable import/no-unassigned-import
 import "swiper/scss";
 import "swiper/scss/navigation";
 import "swiper/scss/mousewheel";

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -5,7 +5,7 @@ import { Button } from "react-common/components/controls/Button";
 import { classList } from "react-common/components/util";
 import { showModal } from "../transforms/showModal";
 import { resetRubricAsync } from "../transforms/resetRubricAsync";
-import Constants from "../constants";
+import Constants, { Ticks } from "../constants";
 
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Mousewheel, Navigation } from "swiper";
@@ -81,12 +81,12 @@ const Carousel: React.FC<CarouselProps> = ({ children }) => {
 
 const GetStarted: React.FC = () => {
     const onNewRubricClickedAsync = async () => {
-        pxt.tickEvent("teachertool.newrubric");
+        pxt.tickEvent(Ticks.NewRubric);
         await resetRubricAsync(true);
     };
 
     const onImportRubricClicked = () => {
-        pxt.tickEvent("teachertool.importrubric");
+        pxt.tickEvent(Ticks.ImportRubric);
         showModal("import-rubric");
     };
 

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -1,0 +1,89 @@
+import * as React from "react";
+// eslint-disable-next-line import/no-internal-modules
+import css from "./styling/HomeScreen.module.scss";
+import { Link } from "react-common/components/controls/Link";
+import { Button } from "react-common/components/controls/Button";
+import { classList } from "react-common/components/util";
+import { showModal } from "../transforms/showModal";
+import { resetRubricAsync } from "../transforms/resetRubricAsync";
+
+const Welcome: React.FC = () => {
+    return (
+        <div className={css.welcome}>
+            <h1>{lf("Welcome to MakeCode Project Insights!")}</h1>
+            <p>
+                {lf("This tool is designed to help you evaluate student projects using a rubric.")}{" "}
+                <Link target="_blank" href="https://makecode.com/teachertool">
+                    {lf("Learn More.")}
+                </Link>
+            </p>
+        </div>
+    );
+};
+
+interface CardProps {
+    title: string;
+    className?: string;
+    icon?: string;
+    onClick: () => void;
+}
+
+const Card: React.FC<CardProps> = ({ title, className, icon, onClick }) => {
+    return (
+        <Button className={classList(css.cardButton, className)} title={title} onClick={onClick}>
+            <div className={css.cardDiv}>
+                {icon && (
+                    <div className={css.cardIcon}>
+                        <i className={icon}></i>
+                    </div>
+                )}
+                <div className={css.cardTitle}>
+                    <h3>{title}</h3>
+                </div>
+            </div>
+        </Button>
+    );
+};
+
+const GetStarted: React.FC = () => {
+    const onNewRubricClickedAsync = async () => {
+        pxt.tickEvent("teachertool.newrubric");
+        await resetRubricAsync(true);
+    };
+
+    const onImportRubricClicked = () => {
+        pxt.tickEvent("teachertool.importrubric");
+        showModal("import-rubric");
+    };
+
+    return (
+        <div className={css.getStarted}>
+            <h2>{lf("Get Started")}</h2>
+            {/* TODO: Replace with carousel */}
+            <div className={css.cards}>
+                <Card
+                    title={lf("New Rubric")}
+                    icon={"fas fa-plus-circle"}
+                    className={css.newRubric}
+                    onClick={onNewRubricClickedAsync}
+                />
+                <Card
+                    title={lf("Import Rubric")}
+                    icon={"fas fa-file-upload"}
+                    className={css.importRubric}
+                    onClick={onImportRubricClicked}
+                />
+            </div>
+        </div>
+    );
+};
+
+export const HomeScreen: React.FC = () => {
+    return (
+        <div className={css.page}>
+            <div className={css.top} />
+            <Welcome />
+            <GetStarted />
+        </div>
+    );
+};

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -6,10 +6,11 @@ import { Button } from "react-common/components/controls/Button";
 import { classList } from "react-common/components/util";
 import { showModal } from "../transforms/showModal";
 import { resetRubricAsync } from "../transforms/resetRubricAsync";
+// eslint-disable-next-line import/no-internal-modules
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Mousewheel, Navigation } from "swiper";
 
-// eslint-disable import/no-internal-modules
+// eslint-disable import/no-unassigned-import
 import "swiper/scss";
 import "swiper/scss/navigation";
 import "swiper/scss/mousewheel";

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -5,7 +5,7 @@ import { Button } from "react-common/components/controls/Button";
 import { classList } from "react-common/components/util";
 import { showModal } from "../transforms/showModal";
 import { resetRubricAsync } from "../transforms/resetRubricAsync";
-import Constants, { Ticks } from "../constants";
+import { Constants, Strings, Ticks } from "../constants";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Mousewheel, Navigation } from "swiper";
 
@@ -60,7 +60,7 @@ const Carousel: React.FC<CarouselProps> = ({ children }) => {
 
     return (
         <Swiper
-            spaceBetween={10}
+            spaceBetween={0}
             slidesPerView={"auto"}
             allowTouchMove={true}
             slidesOffsetBefore={32}
@@ -96,13 +96,13 @@ const GetStarted: React.FC = () => {
             </div>
             <Carousel>
                 <Card
-                    title={lf("New Rubric")}
+                    title={Strings.NewRubric}
                     icon={"fas fa-plus-circle"}
                     className={css.newRubric}
                     onClick={onNewRubricClickedAsync}
                 />
                 <Card
-                    title={lf("Import Rubric")}
+                    title={Strings.ImportRubric}
                     icon={"fas fa-file-upload"}
                     className={css.importRubric}
                     onClick={onImportRubricClicked}

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -6,7 +6,6 @@ import { classList } from "react-common/components/util";
 import { showModal } from "../transforms/showModal";
 import { resetRubricAsync } from "../transforms/resetRubricAsync";
 import Constants, { Ticks } from "../constants";
-
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Mousewheel, Navigation } from "swiper";
 

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -115,7 +115,6 @@ const GetStarted: React.FC = () => {
 export const HomeScreen: React.FC = () => {
     return (
         <div className={css.page}>
-            <div className={css.top} />
             <Welcome />
             <GetStarted />
         </div>

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -6,6 +6,12 @@ import { Button } from "react-common/components/controls/Button";
 import { classList } from "react-common/components/util";
 import { showModal } from "../transforms/showModal";
 import { resetRubricAsync } from "../transforms/resetRubricAsync";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Mousewheel, Navigation } from "swiper";
+
+import "swiper/scss";
+import "swiper/scss/navigation";
+import "swiper/scss/mousewheel";
 
 const Welcome: React.FC = () => {
     return (
@@ -30,18 +36,46 @@ interface CardProps {
 
 const Card: React.FC<CardProps> = ({ title, className, icon, onClick }) => {
     return (
-        <Button className={classList(css.cardButton, className)} title={title} onClick={onClick}>
-            <div className={css.cardDiv}>
-                {icon && (
-                    <div className={css.cardIcon}>
-                        <i className={icon}></i>
+        <div className={css.cardContainer}>
+            <Button className={classList(css.cardButton, className)} title={title} onClick={onClick}>
+                <div className={css.cardDiv}>
+                    {icon && (
+                        <div className={css.cardIcon}>
+                            <i className={icon}></i>
+                        </div>
+                    )}
+                    <div className={css.cardTitle}>
+                        <h3>{title}</h3>
                     </div>
-                )}
-                <div className={css.cardTitle}>
-                    <h3>{title}</h3>
                 </div>
-            </div>
-        </Button>
+            </Button>
+        </div>
+    );
+};
+
+interface CarouselProps extends React.PropsWithChildren<{}> {}
+
+const Carousel: React.FC<CarouselProps> = ({ children }) => {
+    const cards = React.Children.toArray(children);
+
+    return (
+        <Swiper
+            spaceBetween={16}
+            slidesPerView={"auto"}
+            allowTouchMove={true}
+            slidesOffsetBefore={32}
+            navigation={true}
+            mousewheel={true}
+            scrollbar={{ draggable: true }}
+            modules={[Navigation, Mousewheel]}
+            className={css.swiperCarousel}
+        >
+            {cards.map((card, index) => (
+                <SwiperSlide key={index} className={css.swiperSlide}>
+                    {card}
+                </SwiperSlide>
+            ))}
+        </Swiper>
     );
 };
 
@@ -57,10 +91,11 @@ const GetStarted: React.FC = () => {
     };
 
     return (
-        <div className={css.getStarted}>
-            <h2>{lf("Get Started")}</h2>
-            {/* TODO: Replace with carousel */}
-            <div className={css.cards}>
+        <div className={css.carouselRow}>
+            <div className={css.rowTitle}>
+                <h2>{lf("Get Started")}</h2>
+            </div>
+            <Carousel>
                 <Card
                     title={lf("New Rubric")}
                     icon={"fas fa-plus-circle"}
@@ -73,7 +108,7 @@ const GetStarted: React.FC = () => {
                     className={css.importRubric}
                     onClick={onImportRubricClicked}
                 />
-            </div>
+            </Carousel>
         </div>
     );
 };

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -6,6 +6,8 @@ import { Button } from "react-common/components/controls/Button";
 import { classList } from "react-common/components/util";
 import { showModal } from "../transforms/showModal";
 import { resetRubricAsync } from "../transforms/resetRubricAsync";
+import Constants from "../constants";
+
 // eslint-disable-next-line import/no-internal-modules
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Mousewheel, Navigation } from "swiper";
@@ -21,7 +23,7 @@ const Welcome: React.FC = () => {
             <h1>{lf("Welcome to MakeCode Project Insights!")}</h1>
             <p>
                 {lf("This tool is designed to help you evaluate student projects using a rubric.")}{" "}
-                <Link target="_blank" href="https://makecode.com/teachertool">
+                <Link target="_blank" href={Constants.LearnMoreLink}>
                     {lf("Learn More.")}
                 </Link>
             </p>

--- a/teachertool/src/components/ImportRubricModal.tsx
+++ b/teachertool/src/components/ImportRubricModal.tsx
@@ -2,7 +2,6 @@ import { useContext, useEffect, useState } from "react";
 import { AppStateContext } from "../state/appStateContext";
 import { Modal } from "react-common/components/controls/Modal";
 import { hideModal } from "../transforms/hideModal";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/ImportRubricModal.module.scss";
 import { getRubricFromFileAsync } from "../transforms/getRubricFromFileAsync";
 import { NoticeLabel } from "./NoticeLabel";

--- a/teachertool/src/components/MainPanel.tsx
+++ b/teachertool/src/components/MainPanel.tsx
@@ -1,8 +1,5 @@
 import * as React from "react";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/MainPanel.module.scss";
-
-import { MakeCodeFrame } from "./MakecodeFrame";
 import { SplitPane } from "./SplitPane";
 import { RubricWorkspace } from "./RubricWorkspace";
 import { ProjectWorkspace } from "./ProjectWorkspace";

--- a/teachertool/src/components/MainPanel.tsx
+++ b/teachertool/src/components/MainPanel.tsx
@@ -9,16 +9,13 @@ interface IProps {}
 export const MainPanel: React.FC<IProps> = () => {
     return (
         <div className={css["main-panel"]}>
-            <SplitPane split={"vertical"} defaultSize={"80%"} primary={"left"}>
-                {/* Left side */}
-                <>
-                    <RubricWorkspace />
-                </>
-                {/* Right side */}
-                <>
-                    <ProjectWorkspace />
-                </>
-            </SplitPane>
+            <SplitPane
+                split={"vertical"}
+                defaultSize={"80%"}
+                primary={"left"}
+                left={<RubricWorkspace />}
+                right={<ProjectWorkspace />}
+            />
         </div>
     );
 };

--- a/teachertool/src/components/MakecodeFrame.tsx
+++ b/teachertool/src/components/MakecodeFrame.tsx
@@ -1,8 +1,6 @@
 /// <reference path="../../../localtypings/pxteditor.d.ts" />
 
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/MakeCodeFrame.module.scss";
-
 import { useContext, useEffect } from "react";
 import { clearReady, setEditorRef } from "../services/makecodeEditorService";
 import { AppStateContext } from "../state/appStateContext";

--- a/teachertool/src/components/NoticeLabel.tsx
+++ b/teachertool/src/components/NoticeLabel.tsx
@@ -1,5 +1,4 @@
 import { classList } from "react-common/components/util";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/NoticeLabel.module.scss";
 
 export type NoticeLabelSeverity = "info" | "warning" | "error" | "neutral";

--- a/teachertool/src/components/ProjectWorkspace.tsx
+++ b/teachertool/src/components/ProjectWorkspace.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/ProjectWorkspace.module.scss";
-
 import { useContext } from "react";
 import { AppStateContext } from "../state/appStateContext";
 import { getSafeProjectName } from "../state/helpers";

--- a/teachertool/src/components/ProjectWorkspace.tsx
+++ b/teachertool/src/components/ProjectWorkspace.tsx
@@ -2,16 +2,23 @@ import * as React from "react";
 // eslint-disable-next-line import/no-internal-modules
 import css from "./styling/ProjectWorkspace.module.scss";
 
+import { useContext } from "react";
+import { AppStateContext } from "../state/appStateContext";
+import { getSafeProjectName } from "../state/helpers";
 import { Toolbar } from "./Toolbar";
 import { ShareLinkInput } from "./ShareLinkInput";
 import { MakeCodeFrame } from "./MakecodeFrame";
 
-interface IProps {}
+const ProjectName: React.FC = () => {
+    const { state: teacherTool } = useContext(AppStateContext);
+    const projectName = getSafeProjectName(teacherTool);
+    return projectName ? <div className={css.projectName}>{projectName}</div> : null;
+};
 
-export const ProjectWorkspace: React.FC<IProps> = () => {
+export const ProjectWorkspace: React.FC = () => {
     return (
         <div className={css.panel}>
-            <Toolbar />
+            <Toolbar center={<ProjectName />} />
             <ShareLinkInput />
             <MakeCodeFrame />
         </div>

--- a/teachertool/src/components/RubricPreview.tsx
+++ b/teachertool/src/components/RubricPreview.tsx
@@ -1,6 +1,5 @@
 import { getCatalogCriteriaWithId } from "../state/helpers";
 import { Rubric } from "../types/rubric";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/RubricPreview.module.scss";
 
 export interface IRubricPreviewProps {

--- a/teachertool/src/components/RubricWorkspace.tsx
+++ b/teachertool/src/components/RubricWorkspace.tsx
@@ -31,7 +31,7 @@ function handleExportRubricClicked() {
 
 async function handleNewRubricClickedAsync() {
     pxt.tickEvent(Ticks.NewRubric);
-    await resetRubricAsync(true);
+    await resetRubricAsync();
 }
 
 async function handleEvaluateClickedAsync() {

--- a/teachertool/src/components/RubricWorkspace.tsx
+++ b/teachertool/src/components/RubricWorkspace.tsx
@@ -15,7 +15,8 @@ import { writeRubricToFile } from "../services/fileSystemService";
 import { showModal } from "../transforms/showModal";
 import { isProjectLoaded } from "../state/helpers";
 import { setAutorun } from "../transforms/setAutorun";
-import { Ticks } from "../constants";
+import { Strings, Ticks } from "../constants";
+import { resetRubricAsync } from "../transforms/resetRubricAsync";
 
 function handleImportRubricClicked() {
     pxt.tickEvent(Ticks.ImportRubric);
@@ -26,6 +27,11 @@ function handleExportRubricClicked() {
     pxt.tickEvent(Ticks.ExportRubric);
     const { state: teacherTool } = stateAndDispatch();
     writeRubricToFile(teacherTool.rubric);
+}
+
+async function handleNewRubricClickedAsync() {
+    pxt.tickEvent(Ticks.NewRubric);
+    await resetRubricAsync(true);
 }
 
 async function handleEvaluateClickedAsync() {
@@ -70,15 +76,21 @@ function getActionMenuItems(tab: TabName): MenuItem[] {
         case "rubric":
             items.push(
                 {
-                    title: lf("Import Rubric"),
-                    label: lf("Import Rubric"),
-                    ariaLabel: lf("Import Rubric"),
+                    title: Strings.NewRubric,
+                    label: Strings.NewRubric,
+                    ariaLabel: Strings.NewRubric,
+                    onClick: handleNewRubricClickedAsync,
+                },
+                {
+                    title: Strings.ImportRubric,
+                    label: Strings.ImportRubric,
+                    ariaLabel: Strings.ImportRubric,
                     onClick: handleImportRubricClicked,
                 },
                 {
-                    title: lf("Export Rubric"),
-                    label: lf("Export Rubric"),
-                    ariaLabel: lf("Export Rubric"),
+                    title: Strings.ExportRubric,
+                    label: Strings.ExportRubric,
+                    ariaLabel: Strings.ExportRubric,
                     onClick: handleExportRubricClicked,
                 }
             );

--- a/teachertool/src/components/RubricWorkspace.tsx
+++ b/teachertool/src/components/RubricWorkspace.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/RubricWorkspace.module.scss";
-
 import { useContext } from "react";
 import { AppStateContext, stateAndDispatch } from "../state/appStateContext";
 import { Toolbar } from "./Toolbar";
@@ -17,20 +15,21 @@ import { writeRubricToFile } from "../services/fileSystemService";
 import { showModal } from "../transforms/showModal";
 import { isProjectLoaded } from "../state/helpers";
 import { setAutorun } from "../transforms/setAutorun";
+import { Ticks } from "../constants";
 
 function handleImportRubricClicked() {
-    pxt.tickEvent("teachertool.importrubric");
+    pxt.tickEvent(Ticks.ImportRubric);
     showModal("import-rubric");
 }
 
 function handleExportRubricClicked() {
-    pxt.tickEvent("teachertool.exportrubric");
+    pxt.tickEvent(Ticks.ExportRubric);
     const { state: teacherTool } = stateAndDispatch();
     writeRubricToFile(teacherTool.rubric);
 }
 
 async function handleEvaluateClickedAsync() {
-    pxt.tickEvent("teachertool.evaluate");
+    pxt.tickEvent(Ticks.Evaluate);
     await runEvaluateAsync(true);
 }
 
@@ -97,7 +96,7 @@ const WorkspaceToolbarButtons: React.FC = () => {
     const actionItems = getActionMenuItems(activeTab);
 
     const onAutorunChange = (checked: boolean) => {
-        pxt.tickEvent("teachertool.autorun", { checked: checked ? "true" : "false" });
+        pxt.tickEvent(Ticks.Autorun, { checked: checked ? "true" : "false" });
         setAutorun(checked);
     };
 

--- a/teachertool/src/components/ShareLinkInput.tsx
+++ b/teachertool/src/components/ShareLinkInput.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/ShareLinkInput.module.scss";
-
 import { useContext, useState, useMemo, useCallback, useEffect } from "react";
 import { AppStateContext } from "../state/appStateContext";
 import { classList } from "react-common/components/util";

--- a/teachertool/src/components/ShareLinkInput.tsx
+++ b/teachertool/src/components/ShareLinkInput.tsx
@@ -45,6 +45,7 @@ export const ShareLinkInput: React.FC<IProps> = () => {
                 onChange={onTextChange}
                 onEnterKey={onEnterKey}
                 preserveValueOnBlur={true}
+                autoComplete={false}
             ></Input>
         </div>
     );

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -7,12 +7,11 @@ interface IProps {
     split: "horizontal" | "vertical";
     defaultSize: number | string;
     primary: "left" | "right";
-    children: React.ReactNode;
+    left: React.ReactNode;
+    right: React.ReactNode;
 }
 
-export const SplitPane: React.FC<IProps> = ({ className, split, children }) => {
-    const [left, right] = React.Children.toArray(children);
-
+export const SplitPane: React.FC<IProps> = ({ className, split, left, right }) => {
     return (
         <div className={classList(css[`split-pane-${split}`], className)}>
             <div className={css[`left-${split}`]}>{left}</div>

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/SplitPane.module.scss";
 import { classList } from "react-common/components/util";
 

--- a/teachertool/src/components/TabGroup.tsx
+++ b/teachertool/src/components/TabGroup.tsx
@@ -6,7 +6,6 @@ import { Button } from "react-common/components/controls/Button";
 import { AppStateContext } from "../state/appStateContext";
 import { TabName } from "../types";
 import { setActiveTab } from "../transforms/setActiveTab";
-import { Ticks } from "../constants";
 
 interface ITabProps extends React.PropsWithChildren<{}> {
     name: TabName;
@@ -17,7 +16,6 @@ export const TabButton: React.FC<ITabProps> = ({ children, name, disabled }) => 
     const { state: teacherTool } = useContext(AppStateContext);
 
     const onClick = () => {
-        pxt.tickEvent(Ticks.TabClicked, { tab: name });
         setActiveTab(name);
     };
 

--- a/teachertool/src/components/TabGroup.tsx
+++ b/teachertool/src/components/TabGroup.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/TabGroup.module.scss";
-
 import { useContext } from "react";
 import { classList } from "react-common/components/util";
 import { Button } from "react-common/components/controls/Button";

--- a/teachertool/src/components/TabGroup.tsx
+++ b/teachertool/src/components/TabGroup.tsx
@@ -8,6 +8,7 @@ import { Button } from "react-common/components/controls/Button";
 import { AppStateContext } from "../state/appStateContext";
 import { TabName } from "../types";
 import { setActiveTab } from "../transforms/setActiveTab";
+import { Ticks } from "../constants";
 
 interface ITabProps extends React.PropsWithChildren<{}> {
     name: TabName;
@@ -18,6 +19,7 @@ export const TabButton: React.FC<ITabProps> = ({ children, name, disabled }) => 
     const { state: teacherTool } = useContext(AppStateContext);
 
     const onClick = () => {
+        pxt.tickEvent(Ticks.TabClicked, { tab: name });
         setActiveTab(name);
     };
 

--- a/teachertool/src/components/TabPanel.tsx
+++ b/teachertool/src/components/TabPanel.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/TabPanel.module.scss";
-
 import { useContext } from "react";
 import { classList } from "react-common/components/util";
 import { AppStateContext } from "../state/appStateContext";

--- a/teachertool/src/components/Toasts.tsx
+++ b/teachertool/src/components/Toasts.tsx
@@ -44,15 +44,15 @@ const ToastNotification: React.FC<IToastNotificationProps> = ({ toast }) => {
     }, [sliderActive]);
 
     return (
-        <div className={classList(css["toast"], css[toast.type])}>
+        <div className={classList(css["toast"], css[toast.type], toast.className)}>
             <div className={css["toast-content"]}>
                 {!toast.hideIcon && (
                     <div className={classList(css["icon-container"], css[toast.type])}>
                         {toast.icon ?? icons[toast.type]}
                     </div>
                 )}
-                <div className={classList(css["text-container"], "tt-toast-text-container", toast.textContainerClass)}>
-                    {toast.text && <div className={classList(css["text"], "tt-toast-text")}>{toast.text}</div>}
+                <div className={css["text-container"]}>
+                    {toast.text && <div className={css["text"]}>{toast.text}</div>}
                     {toast.detail && <div className={css["detail"]}>{toast.detail}</div>}
                     {toast.jsx && <div>{toast.jsx}</div>}
                 </div>

--- a/teachertool/src/components/Toasts.tsx
+++ b/teachertool/src/components/Toasts.tsx
@@ -52,8 +52,8 @@ const ToastNotification: React.FC<IToastNotificationProps> = ({ toast }) => {
                         {toast.icon ?? icons[toast.type]}
                     </div>
                 )}
-                <div className={css["text-container"]}>
-                    {toast.text && <div className={css["text"]}>{toast.text}</div>}
+                <div className={classList(css["text-container"], "tt-toast-text-container", toast.textContainerClass)}>
+                    {toast.text && <div className={classList(css["text"], "tt-toast-text")}>{toast.text}</div>}
                     {toast.detail && <div className={css["detail"]}>{toast.detail}</div>}
                     {toast.jsx && <div>{toast.jsx}</div>}
                 </div>

--- a/teachertool/src/components/Toasts.tsx
+++ b/teachertool/src/components/Toasts.tsx
@@ -52,7 +52,7 @@ const ToastNotification: React.FC<IToastNotificationProps> = ({ toast }) => {
                     </div>
                 )}
                 <div className={css["text-container"]}>
-                    {toast.text && <div className={css["text"]}>{toast.text}</div>}
+                    {toast.text && <div className={classList(css["text"], "tt-toast-text")}>{toast.text}</div>}
                     {toast.detail && <div className={css["detail"]}>{toast.detail}</div>}
                     {toast.jsx && <div>{toast.jsx}</div>}
                 </div>

--- a/teachertool/src/components/Toasts.tsx
+++ b/teachertool/src/components/Toasts.tsx
@@ -4,7 +4,6 @@ import { ToastType, ToastWithId } from "../types";
 import { AnimatePresence, motion } from "framer-motion";
 import { dismissToast } from "../state/actions";
 import { classList } from "react-common/components/util";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/Toasts.module.scss";
 
 const icons: { [type in ToastType]: string } = {

--- a/teachertool/src/components/Toolbar.tsx
+++ b/teachertool/src/components/Toolbar.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
-// eslint-disable-next-line import/no-internal-modules
 import css from "./styling/Toolbar.module.scss";
-
 import { classList } from "react-common/components/util";
 import { Button, ButtonProps } from "react-common/components/controls/Button";
 import { MenuDropdown, MenuDropdownProps } from "react-common/components/controls/MenuDropdown";

--- a/teachertool/src/components/styling/HeaderBar.module.scss
+++ b/teachertool/src/components/styling/HeaderBar.module.scss
@@ -20,6 +20,7 @@
     .org {
         display: flex;
         align-items: center;
+        cursor: pointer;
         .logo {
             height: 1.4rem;
             margin: 0 1rem;
@@ -29,6 +30,7 @@
     .brand {
         display: flex;
         align-items: center;
+        cursor: pointer;
         &:before {
             height: 1.5rem;
             border-left: 2px solid var(--pxt-headerbar-foreground);

--- a/teachertool/src/components/styling/HeaderBar.module.scss
+++ b/teachertool/src/components/styling/HeaderBar.module.scss
@@ -39,4 +39,17 @@
             margin: 0 1rem;
         }
     }
+
+    .rubric-name {
+        display: flex;
+        align-items: center;
+        &:before {
+            height: 1.5rem;
+            border-left: 2px solid var(--pxt-headerbar-foreground);
+            content: " ";
+        }
+        span {
+            margin: 0 1rem;
+        }
+    }
 }

--- a/teachertool/src/components/styling/HomeScreen.module.scss
+++ b/teachertool/src/components/styling/HomeScreen.module.scss
@@ -1,3 +1,5 @@
+@import "swiper/css/bundle";
+
 $pageGutter: 2rem;
 
 div.page {
@@ -32,20 +34,23 @@ div.page {
         padding: 0 $pageGutter;
     }
 
-    div.getStarted {
-        padding: 0 0 0 $pageGutter;
+    div.carouselRow {
+        display: flex;
+        flex-direction: column;
     }
 
-    div.cards {
+    div.rowTitle {
+        padding: 0 0 0.75rem $pageGutter;
+    }
+
+    div.cardContainer {
         display: flex;
-        flex-direction: row;
-        gap: 0.5rem;
     }
 
     button.cardButton {
         border: solid black 1px;
         border-radius: 0.5rem;
-        margin:0;
+        margin: 0;
         padding: 0;
         min-width: 17.5rem;
         min-height: 12rem;
@@ -106,5 +111,18 @@ div.page {
                 outline-color: var(--pxt-button-primary-foreground);
             }
         }
+    }
+
+    .swiperCarousel {
+        display: flex;
+        min-height: 0;
+        min-width: 0;
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    .swiperSlide {
+        display: flex;
+        width: fit-content !important;
     }
 }

--- a/teachertool/src/components/styling/HomeScreen.module.scss
+++ b/teachertool/src/components/styling/HomeScreen.module.scss
@@ -138,7 +138,7 @@ div.page {
         height: 100%;
         top: 0;
         background-color: var(--pxt-page-background);
-        filter: opacity(0.5);
+        filter: opacity(0.75);
         padding: 10px;
         width: fit-content;
         margin: 0;

--- a/teachertool/src/components/styling/HomeScreen.module.scss
+++ b/teachertool/src/components/styling/HomeScreen.module.scss
@@ -24,12 +24,8 @@ div.page {
         font-weight: 600;
     }
 
-    div.top {
-        height: 0;
-    }
-
     div.welcome {
-        padding: 0 $pageGutter;
+        padding: $pageGutter 0 0 $pageGutter;
     }
 
     div.carouselRow {

--- a/teachertool/src/components/styling/HomeScreen.module.scss
+++ b/teachertool/src/components/styling/HomeScreen.module.scss
@@ -46,7 +46,6 @@ div.page {
     }
 
     button.cardButton {
-        border: solid black 1px;
         border-radius: 0.5rem;
         margin: 0;
         padding: 0;

--- a/teachertool/src/components/styling/HomeScreen.module.scss
+++ b/teachertool/src/components/styling/HomeScreen.module.scss
@@ -124,5 +124,52 @@ div.page {
     .swiperSlide {
         display: flex;
         width: fit-content !important;
+        transform: scale(0.95);
+        transition: transform 0.1s ease;
+
+        &:focus-visible,
+        &:focus-within,
+        &:active,
+        &:hover {
+            transform: scale(1);
+        }
+    }
+
+    div[class*="swiper-button-prev"],
+    div[class*="swiper-button-next"] {
+        height: 100%;
+        top: 0;
+        background-color: var(--pxt-page-background);
+        filter: opacity(0.5);
+        padding: 10px;
+        width: fit-content;
+        margin: 0;
+        transition: filter 0.1s ease;
+
+        &:hover {
+            filter: opacity(0.95);
+
+            &::after {
+                transform: scale(1.1);
+            }
+        }
+        
+        &::after {
+            transform: scale(0.9);
+            color: var(--pxt-headerbar-background);
+            font-weight: bolder;
+        }
+    }
+
+    div[class*="swiper-button-prev"] {
+        left: 0;
+    }
+
+    div[class*="swiper-button-next"] {
+        right: 0;
+    }
+
+    div[class*="swiper-button-disabled"] {
+        display: none;
     }
 }

--- a/teachertool/src/components/styling/HomeScreen.module.scss
+++ b/teachertool/src/components/styling/HomeScreen.module.scss
@@ -1,5 +1,3 @@
-@import "swiper/css/bundle";
-
 $pageGutter: 2rem;
 
 div.page {

--- a/teachertool/src/components/styling/HomeScreen.module.scss
+++ b/teachertool/src/components/styling/HomeScreen.module.scss
@@ -1,0 +1,110 @@
+$pageGutter: 2rem;
+
+div.page {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: $pageGutter;
+    background-color: var(--pxt-page-background);
+    color: var(--pxt-page-foreground);
+
+    h1 {
+        font-size: 1.75rem;
+        font-weight: 600;
+    }
+
+    h2 {
+        font-size: 1.25rem;
+        font-weight: 600;
+    }
+
+    h3 {
+        font-size: 1.1rem;
+        font-weight: 600;
+    }
+
+    div.top {
+        height: 0;
+    }
+
+    div.welcome {
+        padding: 0 $pageGutter;
+    }
+
+    div.getStarted {
+        padding: 0 0 0 $pageGutter;
+    }
+
+    div.cards {
+        display: flex;
+        flex-direction: row;
+        gap: 0.5rem;
+    }
+
+    button.cardButton {
+        border: solid black 1px;
+        border-radius: 0.5rem;
+        margin:0;
+        padding: 0;
+        min-width: 17.5rem;
+        min-height: 12rem;
+
+        div.cardDiv {
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
+            height: 100%;
+
+            div.cardIcon {
+                height: 100%;
+                width: 100%;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                position: absolute;
+
+                i {
+                    margin: 0;
+                    font-size: 5.5rem;
+                    width: auto;
+                    height: auto;
+                    padding-bottom: 1.75rem;
+                }
+            }
+
+            div.cardTitle {
+                display: flex;
+                padding: 0.75rem 0.625rem;
+                justify-content: center;
+                align-items: center;
+                gap: 0.625rem;
+                align-self: stretch;
+
+                h3 {
+                    font-size: 1.25rem;
+                    font-weight: normal;
+                    padding-bottom: 0.25rem;
+                }
+            }
+        }
+
+        &.newRubric {
+            background-color: var(--pxt-button-primary-background);
+            color: var(--pxt-button-primary-foreground);
+
+            &:focus-visible::after {
+                outline-color: var(--pxt-button-primary-foreground);
+            }
+        }
+        &.importRubric {
+            background-color: var(--pxt-headerbar-background);
+            color: var(--pxt-button-primary-foreground);
+
+            &:focus-visible::after {
+                outline-color: var(--pxt-button-primary-foreground);
+            }
+        }
+    }
+}

--- a/teachertool/src/components/styling/MainPanel.module.scss
+++ b/teachertool/src/components/styling/MainPanel.module.scss
@@ -3,7 +3,7 @@
 .main-panel {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    height: calc(100% - 4rem);
     width: 100%;
     background-color: var(--pxt-content-background);
     color: var(--pxt-content-foreground);

--- a/teachertool/src/components/styling/ProjectWorkspace.module.scss
+++ b/teachertool/src/components/styling/ProjectWorkspace.module.scss
@@ -5,6 +5,16 @@
     flex-direction: column;
     background-color: var(--pxt-headerbar-accent-smoke);
 
+    .projectName {
+        height: 100%;
+        font-size: 1.125rem;
+        font-style: normal;
+        font-weight: 700;
+        line-height: normal;
+        display: flex;
+        align-items: center;
+    }
+
     iframe {
         flex: 1 1 0%;
     }

--- a/teachertool/src/components/styling/TabPanel.module.scss
+++ b/teachertool/src/components/styling/TabPanel.module.scss
@@ -3,6 +3,7 @@
     flex-direction: column;
     height: 100%;
     width: 100%;
+    overflow: auto;
     background-color: var(--pxt-page-background);
     color: var(--pxt-page-foreground);
 }

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -2,6 +2,9 @@ export namespace Strings {
     export const ConfirmReplaceRubric = lf("This will replace your current rubric. Continue?");
     export const UntitledProject = lf("Untitled Project");
     export const UntitledRubric = lf("Untitled Rubric");
+    export const NewRubric = lf("New Rubric");
+    export const ImportRubric = lf("Import Rubric");
+    export const ExportRubric = lf("Export Rubric");
 }
 
 export namespace Ticks {
@@ -19,8 +22,8 @@ export namespace Ticks {
     export const RemoveCriteria = "teachertool.removecriteria";
 }
 
-namespace Constants {
+namespace Misc {
     export const LearnMoreLink = "https://makecode.com/teachertool"; // TODO: Replace with gwlink or aka.ms link
 }
 
-export default Constants;
+export const Constants = Object.assign(Misc, { Strings, Ticks });

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -8,14 +8,14 @@ export namespace Strings {
 
 export namespace Ticks {
     export const Loaded = "teachertool.loaded";
+    export const HomeLink = "teachertool.homelink";
+    export const BrandLink = "teachertool.brandlink";
+    export const OrgLink = "teachertool.orglink";
     export const Error = "teachertool.error";
     export const NewRubric = "teachertool.newrubric";
     export const ImportRubric = "teachertool.importrubric";
     export const ExportRubric = "teachertool.exportrubric";
-    export const BrandIcon = "teachertool.brandicon";
-    export const HomeTab = "teachertool.hometab";
-    export const RubricTab = "teachertool.rubrictab";
-    export const ResultsTab = "teachertool.resultstab";
+    export const TabClicked = "teachertool.tabclicked";
     export const Evaluate = "teachertool.evaluate";
     export const Autorun = "teachertool.autorun";
     export const AddCriteria = "teachertool.addcriteria";

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -6,6 +6,22 @@ export namespace Strings {
     export const UntitledRubric = lf("Untitled Rubric");
 }
 
+export namespace Ticks {
+    export const Loaded = "teachertool.loaded";
+    export const Error = "teachertool.error";
+    export const NewRubric = "teachertool.newrubric";
+    export const ImportRubric = "teachertool.importrubric";
+    export const ExportRubric = "teachertool.exportrubric";
+    export const BrandIcon = "teachertool.brandicon";
+    export const HomeTab = "teachertool.hometab";
+    export const RubricTab = "teachertool.rubrictab";
+    export const ResultsTab = "teachertool.resultstab";
+    export const Evaluate = "teachertool.evaluate";
+    export const Autorun = "teachertool.autorun";
+    export const AddCriteria = "teachertool.addcriteria";
+    export const RemoveCriteria = "teachertool.removecriteria";
+}
+
 namespace Constants {
     export const LearnMoreLink = "https://makecode.com/teachertool";    // TODO: Replace with gwlink or aka.ms link
 }

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -3,3 +3,9 @@
 export namespace Strings {
     export const ConfirmReplaceRubric = lf("This will replace your current rubric. Continue?");
 }
+
+namespace Constants {
+    export const LearnMoreLink = "https://makecode.com/teachertool";    // TODO: Replace with gwlink or aka.ms link
+}
+
+export default Constants;

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -15,7 +15,6 @@ export namespace Ticks {
     export const NewRubric = "teachertool.newrubric";
     export const ImportRubric = "teachertool.importrubric";
     export const ExportRubric = "teachertool.exportrubric";
-    export const TabClicked = "teachertool.tabclicked";
     export const Evaluate = "teachertool.evaluate";
     export const Autorun = "teachertool.autorun";
     export const AddCriteria = "teachertool.addcriteria";

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -1,0 +1,5 @@
+
+
+export namespace Strings {
+    export const ConfirmReplaceRubric = lf("This will replace your current rubric. Continue?");
+}

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -2,6 +2,8 @@
 
 export namespace Strings {
     export const ConfirmReplaceRubric = lf("This will replace your current rubric. Continue?");
+    export const UntitledProject = lf("Untitled Project");
+    export const UntitledRubric = lf("Untitled Rubric");
 }
 
 namespace Constants {

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -1,5 +1,3 @@
-
-
 export namespace Strings {
     export const ConfirmReplaceRubric = lf("This will replace your current rubric. Continue?");
     export const UntitledProject = lf("Untitled Project");
@@ -22,7 +20,7 @@ export namespace Ticks {
 }
 
 namespace Constants {
-    export const LearnMoreLink = "https://makecode.com/teachertool";    // TODO: Replace with gwlink or aka.ms link
+    export const LearnMoreLink = "https://makecode.com/teachertool"; // TODO: Replace with gwlink or aka.ms link
 }
 
 export default Constants;

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -23,7 +23,7 @@ export namespace Ticks {
 }
 
 namespace Misc {
-    export const LearnMoreLink = "https://makecode.com/teachertool"; // TODO: Replace with gwlink or aka.ms link
+    export const LearnMoreLink = "https://makecode.com/teachertool"; // TODO: Replace with golink or aka.ms link
 }
 
 export const Constants = Object.assign(Misc, { Strings, Ticks });

--- a/teachertool/src/global.scss
+++ b/teachertool/src/global.scss
@@ -81,8 +81,8 @@ code {
 #root {
     display: flex;
     flex-direction: column;
-    height: 100%;
-    width: 100%;
+    height: 100vh;
+    width: 100vw;
     overflow: hidden;
     isolation: isolate;
 }
@@ -153,6 +153,13 @@ code {
 /*******************************/
 /****  NOTIFICATION STYLING  ***/
 /*******************************/
+
+.app-large-toast {
+    .tt-toast-text {
+        font-size: 1.5rem !important;
+    }
+}
+
 
 .notification-container {
     position: fixed;

--- a/teachertool/src/index.tsx
+++ b/teachertool/src/index.tsx
@@ -10,6 +10,7 @@ import ReactDOM from "react-dom";
 import "./global.scss";
 import { App } from "./App";
 import { AppStateProvider } from "./state/appStateContext";
+import { Ticks } from "./constants";
 
 function enableAnalytics() {
     pxt.analytics.enable(pxt.Util.userLanguage());
@@ -30,7 +31,7 @@ function enableAnalytics() {
             stats["screen.clientHeight"] = body.clientHeight;
         }
     }
-    pxt.tickEvent("teachertool.loaded", stats);
+    pxt.tickEvent(Ticks.Loaded, stats);
 }
 
 window.addEventListener("DOMContentLoaded", () => {

--- a/teachertool/src/services/autorunService.ts
+++ b/teachertool/src/services/autorunService.ts
@@ -12,7 +12,7 @@ export function poke() {
         autorunTimer = null;
         const { state } = stateAndDispatch();
         if (state.autorun && isProjectLoaded(state)) {
-            runEvaluateAsync();
+            runEvaluateAsync(false);
         }
     }, 1000);
 }

--- a/teachertool/src/services/loggingService.ts
+++ b/teachertool/src/services/loggingService.ts
@@ -1,4 +1,5 @@
 import { ErrorCode } from "../types/errorCode";
+import { Ticks } from "../constants";
 
 const timestamp = () => {
     const time = new Date();
@@ -20,7 +21,7 @@ export const logError = (errorCode: ErrorCode, message?: any, data: pxt.Map<stri
             dataObj.message = message;
         }
     }
-    pxt.tickEvent("teachertool.error", {
+    pxt.tickEvent(Ticks.Error, {
         ...dataObj,
         errorCode,
     });

--- a/teachertool/src/state/helpers.ts
+++ b/teachertool/src/state/helpers.ts
@@ -47,6 +47,20 @@ export function isProjectLoaded(state: AppState) {
     return !!state.projectMetadata;
 }
 
+export function isRubricLoaded(state: AppState): boolean {
+    return !!(state.rubric.criteria.length || state.rubric.name);
+}
+
+export function getSafeProjectName(state: AppState): string | undefined {
+    if (state.projectMetadata) {
+        return state.projectMetadata.name ?? lf("Untitled Project");
+    }
+}
+
+export function getSafeRubricName(state: AppState): string {
+    return state.rubric.name || lf("Untitled Rubric");
+}
+
 export function getSelectableCatalogCriteria(state: AppState): CatalogCriteria[] {
     const usedCatalogCriteria = state.rubric.criteria.map(c => c.catalogCriteriaId) ?? [];
 

--- a/teachertool/src/state/helpers.ts
+++ b/teachertool/src/state/helpers.ts
@@ -4,6 +4,7 @@ import { ErrorCode } from "../types/errorCode";
 import { Rubric } from "../types/rubric";
 import { stateAndDispatch } from "./appStateContext";
 import { AppState } from "./state";
+import { Strings } from "../constants";
 
 export function getCatalogCriteriaWithId(id: string): CatalogCriteria | undefined {
     const { state } = stateAndDispatch();
@@ -53,12 +54,12 @@ export function isRubricLoaded(state: AppState): boolean {
 
 export function getSafeProjectName(state: AppState): string | undefined {
     if (state.projectMetadata) {
-        return state.projectMetadata.name ?? lf("Untitled Project");
+        return state.projectMetadata.name ?? Strings.UntitledProject;
     }
 }
 
 export function getSafeRubricName(state: AppState): string | undefined {
-    return state.rubric.name || lf("Untitled Rubric");
+    return state.rubric.name || Strings.UntitledRubric;
 }
 
 export function getSelectableCatalogCriteria(state: AppState): CatalogCriteria[] {

--- a/teachertool/src/state/helpers.ts
+++ b/teachertool/src/state/helpers.ts
@@ -43,7 +43,7 @@ export function verifyRubricIntegrity(rubric: Rubric): {
     return { valid: invalidCriteria.length === 0, validCriteria, invalidCriteria };
 }
 
-export function isProjectLoaded(state: AppState) {
+export function isProjectLoaded(state: AppState): boolean {
     return !!state.projectMetadata;
 }
 
@@ -57,7 +57,7 @@ export function getSafeProjectName(state: AppState): string | undefined {
     }
 }
 
-export function getSafeRubricName(state: AppState): string {
+export function getSafeRubricName(state: AppState): string | undefined {
     return state.rubric.name || lf("Untitled Rubric");
 }
 

--- a/teachertool/src/state/state.ts
+++ b/teachertool/src/state/state.ts
@@ -1,6 +1,7 @@
 import { ModalType, ToastWithId, TabName } from "../types";
 import { CatalogCriteria, CriteriaEvaluationResult, CriteriaInstance } from "../types/criteria";
 import { Rubric } from "../types/rubric";
+import { makeRubric } from "../utils";
 
 export type AppState = {
     targetConfig?: pxt.TargetConfig;
@@ -23,9 +24,9 @@ export const initialAppState: AppState = {
     evalResults: {},
     projectMetadata: undefined,
     catalog: undefined,
-    rubric: { name: "", criteria: [] },
+    rubric: makeRubric(),
     modal: undefined,
-    activeTab: "rubric",
+    activeTab: "home",
     validatorPlans: undefined,
     autorun: false,
     flags: {

--- a/teachertool/src/transforms/addCriteriaToRubric.ts
+++ b/teachertool/src/transforms/addCriteriaToRubric.ts
@@ -5,6 +5,7 @@ import { CriteriaInstance, CriteriaParameterValue } from "../types/criteria";
 import { nanoid } from "nanoid";
 import { ErrorCode } from "../types/errorCode";
 import { setRubric } from "./setRubric";
+import { Ticks } from "../constants";
 
 export function addCriteriaToRubric(catalogCriteriaIds: string[]) {
     const { state: teacherTool, dispatch } = stateAndDispatch();
@@ -46,7 +47,7 @@ export function addCriteriaToRubric(catalogCriteriaIds: string[]) {
 
     setRubric(newRubric);
 
-    pxt.tickEvent("teachertool.addcriteria", {
+    pxt.tickEvent(Ticks.AddCriteria, {
         ids: JSON.stringify(catalogCriteriaIds),
     });
 }

--- a/teachertool/src/transforms/confirmAsync.ts
+++ b/teachertool/src/transforms/confirmAsync.ts
@@ -1,0 +1,7 @@
+export async function confirmAsync(prompt: string) {
+    // TODO: Replace with our own confirmation dialog.
+    if (!confirm(prompt)) {
+        return false;
+    }
+    return true;
+}

--- a/teachertool/src/transforms/confirmClearRubricAsync.ts
+++ b/teachertool/src/transforms/confirmClearRubricAsync.ts
@@ -1,7 +1,0 @@
-export async function confirmClearRubricAsync() {
-    // TODO: Replace with our own confirmation dialog.
-    if (!confirm(lf("This will clear your current rubric. Continue?"))) {
-        return false;
-    }
-    return true;
-}

--- a/teachertool/src/transforms/confirmClearRubricAsync.ts
+++ b/teachertool/src/transforms/confirmClearRubricAsync.ts
@@ -1,0 +1,7 @@
+export async function confirmClearRubricAsync() {
+    // TODO: Replace with our own confirmation dialog.
+    if (!confirm(lf("This will clear your current rubric. Continue?"))) {
+        return false;
+    }
+    return true;
+}

--- a/teachertool/src/transforms/loadProjectMetadataAsync.ts
+++ b/teachertool/src/transforms/loadProjectMetadataAsync.ts
@@ -22,6 +22,12 @@ export async function loadProjectMetadataAsync(shareLink: string) {
         return;
     }
 
+    if (projMeta.target !== pxt.appTarget.id) {
+        showToast(makeToast("error", lf("That project was built with a different MakeCode editor")));
+        dispatch(Actions.setProjectMetadata(undefined));
+        return;
+    }
+
     dispatch(Actions.clearAllEvalResults());
     dispatch(Actions.setProjectMetadata(projMeta));
     logDebug(`Loaded project metadata: ${JSON.stringify(projMeta)}`);

--- a/teachertool/src/transforms/removeCriteriaFromRubric.ts
+++ b/teachertool/src/transforms/removeCriteriaFromRubric.ts
@@ -2,6 +2,7 @@ import { stateAndDispatch } from "../state";
 import { logDebug } from "../services/loggingService";
 import { CriteriaInstance } from "../types/criteria";
 import { setRubric } from "./setRubric";
+import { Ticks } from "../constants";
 
 export function removeCriteriaFromRubric(instance: CriteriaInstance) {
     const { state: teacherTool, dispatch } = stateAndDispatch();
@@ -15,5 +16,5 @@ export function removeCriteriaFromRubric(instance: CriteriaInstance) {
 
     setRubric(newRubric);
 
-    pxt.tickEvent("teachertool.removecriteria", { catalogCriteriaId: instance.catalogCriteriaId });
+    pxt.tickEvent(Ticks.RemoveCriteria, { catalogCriteriaId: instance.catalogCriteriaId });
 }

--- a/teachertool/src/transforms/resetRubricAsync.ts
+++ b/teachertool/src/transforms/resetRubricAsync.ts
@@ -2,14 +2,15 @@ import { stateAndDispatch } from "../state";
 import { isRubricLoaded } from "../state/helpers";
 import * as Actions from "../state/actions";
 import { setRubric } from "./setRubric";
-import { confirmClearRubricAsync } from "./confirmClearRubricAsync";
+import { confirmAsync } from "./confirmAsync";
 import { makeRubric } from "../utils";
+import { Strings } from "../constants";
 
 export async function resetRubricAsync(fromUserInteraction: boolean) {
     const { state: teachertool, dispatch } = stateAndDispatch();
 
     if (fromUserInteraction && isRubricLoaded(teachertool)) {
-        if (!await confirmClearRubricAsync()) {
+        if (!await confirmAsync(Strings.ConfirmReplaceRubric)) {
             return;
         }
     }

--- a/teachertool/src/transforms/resetRubricAsync.ts
+++ b/teachertool/src/transforms/resetRubricAsync.ts
@@ -1,0 +1,23 @@
+import { stateAndDispatch } from "../state";
+import { isRubricLoaded } from "../state/helpers";
+import * as Actions from "../state/actions";
+import { setRubric } from "./setRubric";
+import { confirmClearRubricAsync } from "./confirmClearRubricAsync";
+import { makeRubric } from "../utils";
+
+export async function resetRubricAsync(fromUserInteraction: boolean) {
+    const { state: teachertool, dispatch } = stateAndDispatch();
+
+    if (fromUserInteraction && isRubricLoaded(teachertool)) {
+        if (!await confirmClearRubricAsync()) {
+            return;
+        }
+    }
+
+    dispatch(Actions.clearAllEvalResults());
+    setRubric(makeRubric());
+
+    if (fromUserInteraction) {
+        dispatch(Actions.setActiveTab("rubric"));
+    }
+}

--- a/teachertool/src/transforms/resetRubricAsync.ts
+++ b/teachertool/src/transforms/resetRubricAsync.ts
@@ -6,10 +6,10 @@ import { confirmAsync } from "./confirmAsync";
 import { makeRubric } from "../utils";
 import { Strings } from "../constants";
 
-export async function resetRubricAsync(fromUserInteraction: boolean) {
+export async function resetRubricAsync() {
     const { state: teachertool, dispatch } = stateAndDispatch();
 
-    if (fromUserInteraction && isRubricLoaded(teachertool)) {
+    if (isRubricLoaded(teachertool)) {
         if (!(await confirmAsync(Strings.ConfirmReplaceRubric))) {
             return;
         }
@@ -18,7 +18,5 @@ export async function resetRubricAsync(fromUserInteraction: boolean) {
     dispatch(Actions.clearAllEvalResults());
     setRubric(makeRubric());
 
-    if (fromUserInteraction) {
-        dispatch(Actions.setActiveTab("rubric"));
-    }
+    dispatch(Actions.setActiveTab("rubric"));
 }

--- a/teachertool/src/transforms/resetRubricAsync.ts
+++ b/teachertool/src/transforms/resetRubricAsync.ts
@@ -10,7 +10,7 @@ export async function resetRubricAsync(fromUserInteraction: boolean) {
     const { state: teachertool, dispatch } = stateAndDispatch();
 
     if (fromUserInteraction && isRubricLoaded(teachertool)) {
-        if (!await confirmAsync(Strings.ConfirmReplaceRubric)) {
+        if (!(await confirmAsync(Strings.ConfirmReplaceRubric))) {
             return;
         }
     }

--- a/teachertool/src/transforms/runEvaluateAsync.ts
+++ b/teachertool/src/transforms/runEvaluateAsync.ts
@@ -1,3 +1,4 @@
+import { from } from "form-data";
 import { logError } from "../services/loggingService";
 import { runValidatorPlanAsync } from "../services/makecodeEditorService";
 import { stateAndDispatch } from "../state";
@@ -7,6 +8,7 @@ import { CriteriaEvaluationResult, CriteriaInstance } from "../types/criteria";
 import { ErrorCode } from "../types/errorCode";
 import { makeToast } from "../utils";
 import { showToast } from "./showToast";
+import { setActiveTab } from "./setActiveTab";
 
 function generateValidatorPlan(criteriaInstance: CriteriaInstance): pxt.blocks.ValidatorPlan | undefined {
     const { state: teacherTool } = stateAndDispatch();
@@ -32,8 +34,12 @@ function generateValidatorPlan(criteriaInstance: CriteriaInstance): pxt.blocks.V
     return plan;
 }
 
-export async function runEvaluateAsync() {
+export async function runEvaluateAsync(fromUserInteraction: boolean) {
     const { state: teacherTool, dispatch } = stateAndDispatch();
+
+    if (fromUserInteraction) {
+        setActiveTab("results");
+    }
 
     // Clear all existing results.
     dispatch(Actions.clearAllEvalResults());
@@ -68,6 +74,10 @@ export async function runEvaluateAsync() {
                 }
             })
     );
+
+    if (evalRequests.length === 0) {
+        return;
+    }
 
     const results = await Promise.all(evalRequests);
     const errorCount = results.filter(r => !r).length;

--- a/teachertool/src/transforms/runEvaluateAsync.ts
+++ b/teachertool/src/transforms/runEvaluateAsync.ts
@@ -1,4 +1,3 @@
-import { from } from "form-data";
 import { logError } from "../services/loggingService";
 import { runValidatorPlanAsync } from "../services/makecodeEditorService";
 import { stateAndDispatch } from "../state";

--- a/teachertool/src/types/index.ts
+++ b/teachertool/src/types/index.ts
@@ -14,7 +14,7 @@ export type Toast = {
     showSpinner?: boolean; // if true, will show a spinner icon
     hideIcon?: boolean; // if true, will hide the type-specific icon
     icon?: string; // if provided, will override the type-specific icon
-    textContainerClass?: string; // if provided, will be appended to the text container class list
+    className?: string; // if provided, will be appended to the toast's class list
 };
 
 export type ToastWithId = Toast & {

--- a/teachertool/src/types/index.ts
+++ b/teachertool/src/types/index.ts
@@ -14,6 +14,7 @@ export type Toast = {
     showSpinner?: boolean; // if true, will show a spinner icon
     hideIcon?: boolean; // if true, will hide the type-specific icon
     icon?: string; // if provided, will override the type-specific icon
+    textContainerClass?: string; // if provided, will be appended to the text container class list
 };
 
 export type ToastWithId = Toast & {
@@ -22,4 +23,4 @@ export type ToastWithId = Toast & {
 
 export type ModalType = "catalog-display" | "import-rubric";
 
-export type TabName = "rubric" | "results";
+export type TabName = "home" | "rubric" | "results";

--- a/teachertool/src/utils/index.ts
+++ b/teachertool/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { nanoid } from "nanoid";
 import { ToastType, ToastWithId } from "../types";
+import { Rubric } from "../types/rubric";
 import { classList } from "react-common/components/util";
 
 export function makeToast(type: ToastType, text: string, timeoutMs: number = 5000): ToastWithId {
@@ -26,4 +27,11 @@ export const getEditorUrl = (embedUrl: string) => {
 
 export function classes(css: { [name: string]: string }, ...names: string[]) {
     return classList(...names.map(n => css[n]));
+}
+
+export function makeRubric(): Rubric {
+    return {
+        name: "",
+        criteria: [],
+    };
 }


### PR DESCRIPTION
Adds initial home screen, with two cards: New Rubric and Import Rubric. Home screen is set up for additional carousels.

Also did some tidying and refinement:
- Extracted ticks to a central area
- Extracted shared `lf` strings to a central area
- Disabled the lint warnings about unassigned imports
- Added rubric name to header bar
- Made org and brand logos in header bar clickable
- Added project name to project toolbar
- Sorted out scrolling issues in rubric panel
- Check loaded project matches target
- Made the startup 🎓 toast a bit bigger


![image](https://github.com/microsoft/pxt/assets/12176807/ad81d0d5-baa0-47da-8344-22b899cd3bd5)

