### PR TITLE
teacher tool: add scrollbar styling

### DIFF
--- a/teachertool/src/global.scss
+++ b/teachertool/src/global.scss
@@ -93,6 +93,34 @@ code {
 }
 
 /*******************************/
+/********** SCROLLBAR  *********/
+/*******************************/
+
+// Modeled after the scrollbar in the MakeCode blocks editor
+
+::-webkit-scrollbar {
+    width: 14px;
+    height: 14px;
+    background-color: rgba(0, 0, 0, 0);
+    margin: 2px;
+}
+
+::-webkit-scrollbar-thumb {
+    height: 0;
+    border: 2px solid rgba(0, 0, 0, 0);
+    border-radius: 99px;
+    background-clip: padding-box;
+    background-color: rgb(206, 205, 206);
+    &:hover {
+        // Style matching the standalone editor
+        //background-color: rgb(187, 187, 187);
+        //box-shadow: inset -2px -2px 0px rgb(206, 205, 206), inset 2px 2px 0px rgb(206, 205, 206);
+        // Style matching the embedded editor
+        border-width: 1px;
+    }
+}
+
+/*******************************/
 /******* CATALOG STYLING  ******/
 /*******************************/
 


### PR DESCRIPTION
Just for fun: match app scrollbar style to the blocks editor scrollbar.

![image](https://github.com/microsoft/pxt/assets/12176807/8c6db130-e877-4457-aec8-7b11f40eeb3d)

