### PR TITLE
Comments on specific blocks validator now fails if no specific blocks exist

### DIFF
--- a/pxteditor/code-validation/validateSpecificBlockCommentsExist.ts
+++ b/pxteditor/code-validation/validateSpecificBlockCommentsExist.ts
@@ -9,5 +9,6 @@ export function validateSpecificBlockCommentsExist({ usedBlocks, blockType }: {
 } {
     const allSpecifcBlocks = usedBlocks.filter((block) => block.type === blockType);
     const uncommentedBlocks = allSpecifcBlocks.filter((block) => !block.getCommentText());
-    return { uncommentedBlocks, passed: uncommentedBlocks.length === 0 };
+    const passed = allSpecifcBlocks.length === 0 ? false : uncommentedBlocks.length === 0;
+    return { uncommentedBlocks, passed };
 }


### PR DESCRIPTION
I noticed a bug for the criteria "all function definitions have comments" where if there were no functions defined, the validator would be successful because of the condition I set for the passed variable. I modified it to make it so if there aren't any blocks of the specified type, passed is just false. 

Through this I learned that filter is totally fine with operating on an empty list. Being that this is the case, I don't feel the need to check the length of `allSpecificBlocks` before filtering for `uncommentedBlocks`. If anyone feels strongly otherwise, I can add a check/optional chain.