### PR TITLE
Teacher tool: field value validator added

### DIFF
--- a/common-docs/teachertool/catalog-shared.json
+++ b/common-docs/teachertool/catalog-shared.json
@@ -51,7 +51,7 @@
         {
             "id": "DC564060-F177-46CC-A3AC-890CD8545972",
             "use": "num_compare_eq",
-            "template": "Check that two numbers are equal",
+            "template": "Compare two numbers for equality",
             "docPath": "/teachertool"
         }
     ]

--- a/common-docs/teachertool/catalog-shared.json
+++ b/common-docs/teachertool/catalog-shared.json
@@ -47,6 +47,12 @@
             "use": "device_random_used",
             "template": "The math random number generator block is used",
             "docPath": "/teachertool"
+        },
+        {
+            "id": "DC564060-F177-46CC-A3AC-890CD8545972",
+            "use": "num_compare_eq",
+            "template": "Check that two numbers are equal",
+            "docPath": "/teachertool"
         }
     ]
 }

--- a/common-docs/teachertool/validator-plans-shared.json
+++ b/common-docs/teachertool/validator-plans-shared.json
@@ -123,6 +123,33 @@
                     }
                 }
             ]
+        },
+        {
+            ".desc": "make sure two numbers are equal",
+            "name": "num_compare_eq",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blockFieldValueExists",
+                    "fieldType": "OP",
+                    "fieldValue": "EQ",
+                    "blockType": "logic_compare",
+                    "childValidatorPlans": ["two_nums_exist"]
+                }
+            ]
+        },
+        {
+            ".desc": "two numbers exist",
+            "name": "two_nums_exist",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "math_number": 2
+                    }
+                }
+            ]
         }
     ]
 }

--- a/localtypings/validatorPlan.d.ts
+++ b/localtypings/validatorPlan.d.ts
@@ -39,4 +39,11 @@ declare namespace pxt.blocks {
     export interface EvaluationResult {
         result: boolean;
     }
+
+    export interface BlockFieldValueExistsCheck extends ValidatorCheckBase {
+        validator: "blockFieldValueExists";
+        fieldType: string;
+        fieldValue: string;
+        blockType: string;
+    }
 }

--- a/pxteditor/code-validation/runValidatorPlan.ts
+++ b/pxteditor/code-validation/runValidatorPlan.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../localtypings/validatorPlan.d.ts" />
 
+import { validateBlockFieldValueExists } from "./validateBlockFieldValueExists";
 import { validateBlocksExist } from "./validateBlocksExist";
 import { validateBlocksInSetExist } from "./validateBlocksInSetExist";
 import { validateBlockCommentsExist } from "./validateCommentsExist";
@@ -24,6 +25,9 @@ export function runValidatorPlan(usedBlocks: Blockly.Block[], plan: pxt.blocks.V
                 break;
             case "blocksInSetExist":
                 [successfulBlocks, checkPassed] = [...runBlocksInSetExistValidation(usedBlocks, check as pxt.blocks.BlocksInSetExistValidatorCheck)];
+                break;
+            case "blockFieldValueExists":
+                [successfulBlocks, checkPassed] = [...runBlockFieldValueExistsValidation(usedBlocks, check as pxt.blocks.BlockFieldValueExistsCheck)];
                 break;
             default:
                 pxt.debug(`Unrecognized validator: ${check.validator}`);
@@ -80,5 +84,15 @@ function runValidateSpecificBlockCommentsExist(usedBlocks: Blockly.Block[], inpu
 
 function runBlocksInSetExistValidation(usedBlocks: Blockly.Block[], inputs: pxt.blocks.BlocksInSetExistValidatorCheck): [Blockly.Block[], boolean] {
     const blockResults = validateBlocksInSetExist({ usedBlocks, blockIdsToCheck: inputs.blocks, count: inputs.count });
+    return  [blockResults.successfulBlocks, blockResults.passed];
+}
+
+function runBlockFieldValueExistsValidation(usedBlocks: Blockly.Block[], inputs: pxt.blocks.BlockFieldValueExistsCheck): [Blockly.Block[], boolean] {
+    const blockResults = validateBlockFieldValueExists({
+        usedBlocks,
+        fieldType: inputs.fieldType,
+        fieldValue: inputs.fieldValue,
+        specifiedBlock: inputs.blockType
+    });
     return  [blockResults.successfulBlocks, blockResults.passed];
 }

--- a/pxteditor/code-validation/validateBlockFieldValueExists.ts
+++ b/pxteditor/code-validation/validateBlockFieldValueExists.ts
@@ -1,0 +1,21 @@
+// validates that one or more blocks comments are in the project
+// returns the blocks that have comments for teacher tool scenario
+export function validateBlockFieldValueExists({ usedBlocks, fieldType, fieldValue, specifiedBlock }: {
+    usedBlocks: Blockly.Block[],
+    fieldType: string,
+    fieldValue: string,
+    specifiedBlock: string,
+}): {
+    successfulBlocks: Blockly.Block[],
+    passed: boolean
+} {
+    const enabledSpecifiedBlocks = usedBlocks.filter((block) =>
+        block.isEnabled() && block.type === specifiedBlock
+    );
+
+    const successfulBlocks = enabledSpecifiedBlocks.filter((block) =>
+        block.getFieldValue(fieldType) === fieldValue
+    );
+
+    return { successfulBlocks, passed: successfulBlocks.length > 0 };
+}


### PR DESCRIPTION
A validator that checks the field values of a block has been added to our validator library. Field values are a specific type of input for a block. The easiest type that I can demonstrate is the different operators that are associated with the `math_arithmetic` block. In this case, the field value _type_ is "OP" or, I'm guessing, the shorthand for operation. Some others that I've seen in `blocklycompiler.ts` are: `TEXT, EXPRESSION, VAR, BOOL, NAME, VALUE` and more. The "OP" field value for the `math_arithmetic` block can be `ADD, MINUS, MULTIPLY, DIVIDE` and more.

You'll see that the validation I made for `logic_compare` is looking for something very specific. The `logic_compare` blocks in the following program don't pass because the one that has the `EQ` "OP" type doesn't have two `math_number` blocks, and the other that has two numbers has a different "OP" type.

![nums-equal](https://github.com/microsoft/pxt/assets/49178322/a15a7ce1-c551-45e6-a89c-6b8b69b339d9)

Edit: And to show that it can pass lol
![nums-equal-pass](https://github.com/microsoft/pxt/assets/49178322/abc98b36-05a7-441c-9bc9-af034a211a14)

One thing to note about this approach is that if we want to support any type of field value, we need to know that field value's name and possible values it can be before we can create the validator for it. @riknoll chatted with me and let me know that this will require quite a bit of work because all of our custom blocks have field value names that are going to be tricky to find. He recommended a way for me to find the different field values, which isn't hard, just tedious. I'm planning on making a table in OneNote that will have the relationship between a block, it's field value names, and the variations that a specific field value can have. For now, I'm planning to build this table as I go, but we might reach a time when we'll want to just fill the table as earnestly as possible.