### PR TITLE
Allow a Rubric with an Empty Name to be Loaded

### DIFF
--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -152,7 +152,7 @@ export async function getRubric(name: string): Promise<Rubric | undefined> {
     const db = await getDb;
 
     let rubric: Rubric | undefined = undefined;
-    if (name) {
+    if (name !== undefined) {
         rubric = await db.getRubric(name);
     }
 

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -152,9 +152,7 @@ export async function getRubric(name: string): Promise<Rubric | undefined> {
     const db = await getDb;
 
     let rubric: Rubric | undefined = undefined;
-    if (name !== undefined) {
-        rubric = await db.getRubric(name);
-    }
+    rubric = await db.getRubric(name);
 
     return rubric;
 }


### PR DESCRIPTION
Fixes https://github.com/orgs/microsoft/projects/1046/views/1?pane=issue&itemId=53913156 ("bug: criteria don't persist for unnamed rubric.")