### PR TITLE
Fix asset editor for non-arcade targets

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -833,10 +833,8 @@ namespace pxt {
             await loadDepsRecursive(null, this);
 
             // get paletter config loading deps, so the more higher level packages take precedence
-            if (this.config.palette && appTarget.runtime) {
-                appTarget.runtime.palette = U.clone(this.config.palette);
-                if (this.config.paletteNames) appTarget.runtime.paletteNames = this.config.paletteNames;
-            }
+            this.patchAppTargetPalette();
+
             // get screen size loading deps, so the more higher level packages take precedence
             if (this.config.screenSize && appTarget.runtime)
                 appTarget.runtime.screenSize = U.clone(this.config.screenSize);
@@ -996,6 +994,13 @@ namespace pxt {
             }
 
             return r;
+        }
+
+        protected patchAppTargetPalette() {
+            if (this.config.palette && appTarget.runtime) {
+                appTarget.runtime.palette = U.clone(this.config.palette);
+                if (this.config.paletteNames) appTarget.runtime.paletteNames = this.config.paletteNames;
+            }
         }
     }
 
@@ -1288,6 +1293,8 @@ namespace pxt {
             opts.jres = this.getJRes()
             const functionOpts = pxt.appTarget.runtime && pxt.appTarget.runtime.functionsOptions;
             opts.allowedArgumentTypes = functionOpts && functionOpts.extraFunctionEditorTypes && functionOpts.extraFunctionEditorTypes.map(info => info.typeName).concat("number", "boolean", "string");
+
+            this.patchAppTargetPalette();
             return opts;
         }
 

--- a/webapp/src/components/ImageEditor/BottomBar.tsx
+++ b/webapp/src/components/ImageEditor/BottomBar.tsx
@@ -22,6 +22,7 @@ export interface BottomBarProps {
 
     aspectRatioLocked: boolean;
     onionSkinEnabled: boolean;
+    hideAssetName: boolean;
 
     dispatchUndoImageEdit: () => void;
     dispatchRedoImageEdit: () => void;
@@ -67,7 +68,8 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
             singleFrame,
             onDoneClick,
             assetName,
-            hideDoneButton
+            hideDoneButton,
+            hideAssetName
         } = this.props;
 
         const { assetNameMessage } = this.state;
@@ -124,19 +126,23 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
                     {cursorLocation && `${cursorLocation[0]}, ${cursorLocation[1]}`}
                 </div>
                 <div className="image-editor-change-name">
-                    <input className="image-editor-input"
-                        title={lf("Asset Name")}
-                        value={assetNameState}
-                        placeholder={lf("Asset Name")}
-                        tabIndex={0}
-                        onChange={this.handleAssetNameChange}
-                        onFocus={this.disableShortcutsOnFocus}
-                        onBlur={this.handleAssetNameBlur}
-                        onKeyDown={this.handleDimensionalKeydown}
-                    />
-                    {assetNameMessage && <div className="ui pointing below red basic label">
-                        {assetNameMessage}
-                    </div>}
+                    {!hideAssetName &&
+                        <>
+                            <input className="image-editor-input"
+                                title={lf("Asset Name")}
+                                value={assetNameState}
+                                placeholder={lf("Asset Name")}
+                                tabIndex={0}
+                                onChange={this.handleAssetNameChange}
+                                onFocus={this.disableShortcutsOnFocus}
+                                onBlur={this.handleAssetNameBlur}
+                                onKeyDown={this.handleDimensionalKeydown}
+                            />
+                            {assetNameMessage && <div className="ui pointing below red basic label">
+                                {assetNameMessage}
+                            </div>}
+                        </>
+                    }
                 </div>
                 <div className="image-editor-undo-redo">
                     <IconButton

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -37,6 +37,7 @@ export interface ImageEditorProps {
     nested?: boolean;
     lightMode?: boolean;
     hideDoneButton?: boolean;
+    hideAssetName?: boolean;
 }
 
 export interface ImageEditorState {
@@ -76,7 +77,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
     }
 
     render(): JSX.Element {
-        const { singleFrame, lightMode, hideDoneButton } = this.props;
+        const { singleFrame, lightMode, hideDoneButton, hideAssetName } = this.props;
         const instanceStore = this.getStore();
 
         const { tileToEdit, editingTile, alert } = this.state;
@@ -92,11 +93,21 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
                         <ImageCanvas suppressShortcuts={editingTile} lightMode={lightMode} />
                         {isAnimationEditor && !singleFrame ? <Timeline /> : undefined}
                     </div>
-                    <BottomBar singleFrame={singleFrame} onDoneClick={this.onDoneClick} hideDoneButton={!!hideDoneButton} />
+                    <BottomBar singleFrame={singleFrame} onDoneClick={this.onDoneClick} hideDoneButton={!!hideDoneButton} hideAssetName={!!hideAssetName} />
                     {alert && alert.title && <Alert title={alert.title} text={alert.text} options={alert.options} />}
                 </div>
             </Provider>
-            {editingTile && <ImageEditor store={tileEditorStore} ref="nested-image-editor" onDoneClicked={this.onTileEditorFinished} asset={tileToEdit} singleFrame={true} nested={true} />}
+            {editingTile &&
+                <ImageEditor
+                    store={tileEditorStore}
+                    ref="nested-image-editor"
+                    onDoneClicked={this.onTileEditorFinished}
+                    asset={tileToEdit}
+                    singleFrame={true}
+                    nested={true}
+                    hideAssetName={hideAssetName}
+                />
+            }
         </div>
     }
 

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -87,11 +87,15 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
 
         let showHeader = headerVisible;
         // If there is no asset, show the gallery to prevent changing shape when it's added
-        const showGallery = !this.props.isMusicEditor && (!this.asset || editingTile || this.asset.type !== pxt.AssetType.Tilemap);
+        let showGallery = !this.props.isMusicEditor && (!this.asset || editingTile || this.asset.type !== pxt.AssetType.Tilemap);
         const showMyAssets = !hideMyAssets && !editingTile;
 
         if (this.asset && !this.galleryAssets && showGallery) {
             this.updateGalleryAssets();
+        }
+
+        if (!this.galleryAssets?.length) {
+            showGallery = false;
         }
 
         const specialTags = this.props.includeSpecialTagsInFilter ? [] : ["tile", "dialog", "background"];
@@ -181,6 +185,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                             onTileEditorOpenClose={this.onTileEditorOpenClose}
                             lightMode={this.lightMode}
                             hideDoneButton={this.props.hideDoneButton}
+                            hideAssetName={!pxt.appTarget?.appTheme?.assetEditor}
                         />
                     }
                     <ImageEditorGallery

--- a/webapp/src/components/TilemapFieldEditor.tsx
+++ b/webapp/src/components/TilemapFieldEditor.tsx
@@ -30,7 +30,7 @@ export class TilemapFieldEditor extends React.Component<TilemapFieldEditorProps,
     render() {
         return <div className="image-editor-wrapper">
             <div className="image-editor-gallery-content">
-                <ImageEditor ref="image-editor" singleFrame={true} onDoneClicked={this.onDoneClick} />
+                <ImageEditor ref="image-editor" singleFrame={true} onDoneClicked={this.onDoneClick} hideAssetName={!pxt.appTarget?.appTheme?.assetEditor} />
             </div>
         </div>
     }


### PR DESCRIPTION
This fixes the image editor for non-arcade targets like micro:bit and minecraft (the pixel art extension)

Includes three fixes:
1. Removes the name field from the bottom bar of the asset editor when assetEditor isn't set in pxtarget.json
2. Fixes palettes loading from pxt.json when using compile variants (i.e. in micro:bit)
3. Hides the gallery tab in the image editor when there are no gallery assets