### PR TITLE
Teacher tool: Added hidden flag for catalog criteria

### DIFF
--- a/teachertool/src/state/helpers.ts
+++ b/teachertool/src/state/helpers.ts
@@ -70,8 +70,9 @@ export function getSelectableCatalogCriteria(state: AppState): CatalogCriteria[]
     return (
         state.catalog?.filter(
             catalogCriteria =>
-                (catalogCriteria.parameters && catalogCriteria.parameters.length > 0) ||
-                !usedCatalogCriteria.includes(catalogCriteria.id)
+                ((catalogCriteria.parameters && catalogCriteria.parameters.length > 0) ||
+                !usedCatalogCriteria.includes(catalogCriteria.id)) &&
+                !catalogCriteria.hideInCatalog
         ) ?? []
     );
 }

--- a/teachertool/src/types/criteria.ts
+++ b/teachertool/src/types/criteria.ts
@@ -6,6 +6,7 @@ export interface CatalogCriteria {
     description: string | undefined; // More detailed description
     docPath: string | undefined; // Path to documentation
     parameters: CriteriaParameter[] | undefined; // Any parameters that affect the criteria
+    hideInCatalog?: boolean; // Whether the criteria should be hidden in the catalog
 }
 
 // An instance of a criteria in a rubric.

--- a/teachertool/src/types/criteria.ts
+++ b/teachertool/src/types/criteria.ts
@@ -6,7 +6,7 @@ export interface CatalogCriteria {
     description: string | undefined; // More detailed description
     docPath: string | undefined; // Path to documentation
     parameters: CriteriaParameter[] | undefined; // Any parameters that affect the criteria
-    hideInCatalog?: boolean; // Whether the criteria should be hidden in the catalog
+    hideInCatalog?: boolean; // Whether the criteria should be hidden in the user-facing catalog
 }
 
 // An instance of a criteria in a rubric.


### PR DESCRIPTION
As we start to make rubrics for some tutorials, it's going to come up that we don't want those very specific rubric-based criteria to show up in the catalog list. This flag will make it so if you specify `"hideInCatalog": true` in the `catalog__.json` entry, then that criteria will not show up in the modal. 