### PR TITLE
Fix target blocks test runner (and slider field)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -739,6 +739,8 @@ const karma = gulp.series(buildKarmaRunner, browserifyKarma, runKarma);
 const buildBlocksTestRunner = () => compileTsProject("tests/blocks-test", "built/", true);
 const browserifyBlocksTestRunner = () =>
     exec('node node_modules/browserify/bin/cmd built/tests/blocks-test/blocksrunner.js -o built/tests/blocksrunner.js --debug');
+const browserifyBlocksPrep = () =>
+    exec('node node_modules/browserify/bin/cmd built/tests/blocks-test/blockssetup.js -o built/tests/blockssetup.js --debug');
 
 const testAll = gulp.series(
     testdecompiler,
@@ -824,7 +826,7 @@ const buildAll = gulp.series(
     browserifyAssetEditor,
     gulp.parallel(semanticjs, copyJquery, copyWebapp, copySemanticFonts, copyMonaco),
     buildBlocksTestRunner,
-    browserifyBlocksTestRunner,
+    gulp.parallel(browserifyBlocksTestRunner, browserifyBlocksPrep),
     runUglify
 );
 

--- a/tests/blocks-test/blocksrunner.ts
+++ b/tests/blocks-test/blocksrunner.ts
@@ -157,7 +157,7 @@ function testXmlAsync(blocksfile: string) {
                 fail(e.message);
             }
 
-            const err = compareBlocklyTrees(xml, Blockly.Xml.workspaceToDom(workspace));
+            const err = compareBlocklyTrees(xml, pxtblockly.workspaceToDom(workspace));
             if (err) {
                 fail(`XML mismatch (${err.reason}) ${err.chain} \n See https://makecode.com/develop/blockstests for more info`);
             }

--- a/tests/blocks-test/blockssetup.ts
+++ b/tests/blocks-test/blockssetup.ts
@@ -1,0 +1,8 @@
+/// <reference path="..\..\localtypings\pxteditor.d.ts" />
+/// <reference path="..\..\built\pxtcompiler.d.ts" />
+
+import * as Blockly from "blockly";
+import * as pxtblockly from "../../pxtblocks";
+
+pxt.blocks.requireBlockly = () => Blockly;
+pxt.blocks.requirePxtBlockly = () => pxtblockly;

--- a/tests/blocks-test/karma.conf.js
+++ b/tests/blocks-test/karma.conf.js
@@ -26,6 +26,7 @@ module.exports = function(config) {
       'node_modules/pxt-core/built/pxtblocks.js',
       'node_modules/pxt-core/built/pxtcompiler.js',
       'node_modules/pxt-core/built/pxteditor.js',
+      'node_modules/pxt-core/built/tests/blockssetup.js',
       'built/target.js',
       'built/fieldeditors.js',
 


### PR DESCRIPTION
This PR fixes the blocks test runner that we use to prevent breaking changes in target blocks.

These tests are only used in pxt-microbit AFAIK

Also fixed a bug that the tests actually caught, which is that the slider field was constraining values more aggressively than it should.