### PR TITLE
teacher tool: add home screen carousels

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -33,6 +33,7 @@ declare namespace pxt {
         electronManifest?: pxt.electron.ElectronManifest;
         profileNotification?: ProfileNotification;
         kiosk?: KioskConfig;
+        teachertool?: TeacherToolConfig;
     }
 
     interface PackagesConfig {
@@ -86,6 +87,15 @@ declare namespace pxt {
         name: string;
         description: string;
         highScoreMode: string;
+    }
+
+    interface TeacherToolConfig {
+        carousels?: TeacherToolCarouselConfig[];
+    }
+
+    interface TeacherToolCarouselConfig {
+        title: string;
+        cardsUrl: string;
     }
 
     interface AppTarget {

--- a/teachertool/public/index.html
+++ b/teachertool/public/index.html
@@ -33,8 +33,6 @@
     <script type="text/javascript" src="/blb/target.js"></script>
     <script type="text/javascript" src="/blb/pxtlib.js"></script>
     <script type="text/javascript" src="/blb/pxtsim.js"></script>
-    <script type="text/javascript" src="/blb/pxtblockly.js"></script>
-    <script type="text/javascript" src="/blb/pxtblocks.js"></script>
 
     <div id="root"></div>
   </body>

--- a/teachertool/src/App.tsx
+++ b/teachertool/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useContext, useState } from "react";
 import { AppStateContext, AppStateReady } from "./state/appStateContext";
-import { usePromise } from "./hooks";
+import { usePromise } from "./hooks/usePromise";
 import { makeToast } from "./utils";
 import * as Actions from "./state/actions";
 import { downloadTargetConfigAsync } from "./services/backendRequests";

--- a/teachertool/src/components/styling/HomeScreen.module.scss
+++ b/teachertool/src/components/styling/HomeScreen.module.scss
@@ -47,6 +47,7 @@ div.page {
         padding: 0;
         min-width: 17.5rem;
         min-height: 12rem;
+        overflow: hidden;
 
         div.cardDiv {
             display: flex;
@@ -104,6 +105,38 @@ div.page {
                 outline-color: var(--pxt-button-primary-foreground);
             }
         }
+        &.loadingGradient {
+            background: linear-gradient(45deg, var(--pxt-content-background), var(--pxt-content-foreground));
+            opacity: 0.2;
+            background-size: 400% 200%;
+            animation: loading 3s ease infinite;
+
+            @keyframes loading {
+                0% {
+                    background-position: 0 0;
+                }
+                50% {
+                    background-position: 100% 50%;
+                }
+                100% {
+                    background-position: 0 0;
+                }
+            }
+            &.loadingGradientDelay {
+                animation-delay: 0.3s;
+            }
+        }
+        &.rubricResource {
+            background-size: 100% 100%;
+            background-repeat: no-repeat;
+            grid-area: 1 / 1 / 2 / 5;
+            border: 1px solid var(--pxt-content-background);
+
+            .rubricResourceCardTitle {
+                background-color: rgba(228, 231, 241, 0.9);
+                color: var(--pxt-page-foreground);
+            }
+        }
     }
 
     .swiperCarousel {
@@ -146,7 +179,7 @@ div.page {
                 transform: scale(1.1);
             }
         }
-        
+
         &::after {
             transform: scale(0.9);
             color: var(--pxt-headerbar-background);

--- a/teachertool/src/components/styling/SplitPane.module.scss
+++ b/teachertool/src/components/styling/SplitPane.module.scss
@@ -31,6 +31,7 @@
   width: 5px;
   height: 100%;
   cursor: ew-resize;
+  z-index: 1;
 }
 
 .splitter-vertical-inner:hover {

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -1,5 +1,6 @@
 export namespace Strings {
-    export const ConfirmReplaceRubric = lf("This will replace your current rubric. Continue?");
+    export const ErrorLoadingRubricMsg = lf("That wasn't a valid rubric.");
+    export const ConfirmReplaceRubricMsg = lf("This will replace your current rubric. Continue?");
     export const UntitledProject = lf("Untitled Project");
     export const UntitledRubric = lf("Untitled Rubric");
     export const NewRubric = lf("New Rubric");
@@ -22,6 +23,7 @@ export namespace Ticks {
     export const NewRubric = "teachertool.newrubric";
     export const ImportRubric = "teachertool.importrubric";
     export const ExportRubric = "teachertool.exportrubric";
+    export const LoadRubric = "teachertool.loadrubric";
     export const Evaluate = "teachertool.evaluate";
     export const Autorun = "teachertool.autorun";
     export const AddCriteria = "teachertool.addcriteria";

--- a/teachertool/src/hooks/index.ts
+++ b/teachertool/src/hooks/index.ts
@@ -1,1 +1,0 @@
-export { usePromise } from "./usePromise";

--- a/teachertool/src/hooks/useJsonDocRequest.ts
+++ b/teachertool/src/hooks/useJsonDocRequest.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { RequestStatus } from "../types";
+import { fetchJsonDocAsync } from "../services/backendRequests";
+
+export function useJsonDocRequest<T>(
+    url: string,
+    statusCb: (status: RequestStatus) => void,
+    jsonCb: (data: T) => void
+) {
+    const [status, setStatus] = useState<RequestStatus | undefined>();
+
+    useEffect(() => {
+        if (!status) {
+            setStatus("loading");
+            statusCb("loading");
+            Promise.resolve().then(async () => {
+                const json = await fetchJsonDocAsync(url);
+                if (!json) {
+                    setStatus("error");
+                    statusCb("error");
+                } else {
+                    setStatus("success");
+                    statusCb("success");
+                    jsonCb(json as T);
+                }
+            });
+        }
+    }, []);
+}

--- a/teachertool/src/services/backendRequests.ts
+++ b/teachertool/src/services/backendRequests.ts
@@ -2,6 +2,21 @@ import { stateAndDispatch } from "../state";
 import { ErrorCode } from "../types/errorCode";
 import { logError } from "./loggingService";
 
+export async function fetchJsonDocAsync<T = any>(url: string): Promise<T | undefined> {
+    try {
+        // TODO: Prepend CDN origin if not localhost
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error("Unable to fetch the json file from CDN");
+        } else {
+            const json = await response.json();
+            return json;
+        }
+    } catch (e) {
+        logError(ErrorCode.fetchJsonDocAsync, e);
+    }
+}
+
 export async function getProjectTextAsync(projectId: string): Promise<pxt.Cloud.JsonText | undefined> {
     try {
         const projectTextUrl = `${pxt.Cloud.apiRoot}/${projectId}/text`;

--- a/teachertool/src/transforms/loadRubricAsync.ts
+++ b/teachertool/src/transforms/loadRubricAsync.ts
@@ -1,0 +1,32 @@
+import { Strings } from "../constants";
+import { fetchJsonDocAsync } from "../services/backendRequests";
+import { verifyRubricIntegrity } from "../state/helpers";
+import { Rubric } from "../types/rubric";
+import { makeToast } from "../utils";
+import { confirmAsync } from "./confirmAsync";
+import { setActiveTab } from "./setActiveTab";
+import { setRubric } from "./setRubric";
+import { showToast } from "./showToast";
+
+export async function loadRubricAsync(rubricUrl: string) {
+    if (!(await confirmAsync(Strings.ConfirmReplaceRubricMsg))) {
+        return;
+    }
+
+    const json = await fetchJsonDocAsync<Rubric | undefined>(rubricUrl);
+
+    if (!json) {
+        showToast(makeToast("error", Strings.ErrorLoadingRubricMsg));
+        return;
+    }
+
+    const { valid } = verifyRubricIntegrity(json);
+
+    if (!valid) {
+        showToast(makeToast("error", Strings.ErrorLoadingRubricMsg));
+        return;
+    }
+
+    setRubric(json);
+    setActiveTab("rubric");
+}

--- a/teachertool/src/transforms/resetRubricAsync.ts
+++ b/teachertool/src/transforms/resetRubricAsync.ts
@@ -10,7 +10,7 @@ export async function resetRubricAsync() {
     const { state: teachertool, dispatch } = stateAndDispatch();
 
     if (isRubricLoaded(teachertool)) {
-        if (!(await confirmAsync(Strings.ConfirmReplaceRubric))) {
+        if (!(await confirmAsync(Strings.ConfirmReplaceRubricMsg))) {
             return;
         }
     }

--- a/teachertool/src/types/errorCode.ts
+++ b/teachertool/src/types/errorCode.ts
@@ -16,4 +16,6 @@ export enum ErrorCode {
     localStorageReadError = "localStorageReadError",
     localStorageWriteError = "localStorageWriteError",
     validatorPlansNotFound = "validatorPlansNotFound",
+    fetchRequestFailed = "fetchRequestFailed",
+    fetchJsonDocAsync = "fetchJsonDocAsync",
 }

--- a/teachertool/src/types/index.ts
+++ b/teachertool/src/types/index.ts
@@ -25,13 +25,15 @@ export type ModalType = "catalog-display" | "import-rubric";
 
 export type TabName = "home" | "rubric" | "results";
 
+export type CardType = "rubric-resource";
+
 // Rubric Card types that can be appear in the carousel
 export type CarouselCard = {
-    cardType: string;
+    cardType: CardType;
 };
 
 export type CarouselRubricResourceCard = CarouselCard & {
-    cardType: "rubric-card";
+    cardType: "rubric-resource";
     cardTitle: string;
     imageUrl: string;
     rubricUrl: string;

--- a/teachertool/src/types/index.ts
+++ b/teachertool/src/types/index.ts
@@ -24,3 +24,21 @@ export type ToastWithId = Toast & {
 export type ModalType = "catalog-display" | "import-rubric";
 
 export type TabName = "home" | "rubric" | "results";
+
+// Rubric Card types that can be appear in the carousel
+export type CarouselCard = {
+    cardType: string;
+};
+
+export type CarouselRubricResourceCard = CarouselCard & {
+    cardType: "rubric-card";
+    cardTitle: string;
+    imageUrl: string;
+    rubricUrl: string;
+};
+
+export type CarouselCardSet = {
+    cards: CarouselCard[];
+};
+
+export type RequestStatus = "init" | "loading" | "error" | "success";

--- a/teachertool/tsconfig.json
+++ b/teachertool/tsconfig.json
@@ -15,7 +15,10 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "noEmit": true,
-        "jsx": "react-jsx"
+        "jsx": "react-jsx",
+        "types": [
+          "../localtypings/pxtarget.d.ts"
+        ]
     },
     "include": ["src"]
 }


### PR DESCRIPTION
Adds additional carousels to the teacher tool home screen. I will also open a companion PR in the microbit repo.

There are a few TODOs remaining that I'll address in a future PR:
- [ ] Refactor HomeScreen.tsx. I will pull the Cards out into their own files.
- [ ] backendRequests.fetchJsonDocAsync may need additional work to point at the correct CDN origin in production. But maybe not. The backend may already route it properly.
- [ ] I added a lot of cards to the carousels! I did this to get a sense of what it will feel like when filled out. We will need to whittle them down to the ones we can implement in time.


![image](https://github.com/microsoft/pxt/assets/12176807/cacb71fd-2bcf-4682-8eaf-e87604774874)
