### PR TITLE
restore qname support for image editor and default preview in flyout

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -40,6 +40,8 @@ export abstract class FieldAssetEditor<U extends FieldAssetEditorOptions, V exte
     protected pendingEdit = false;
     protected isEmpty = false;
 
+    protected qName?: string;
+
     // If input is invalid, the subclass can set this to be true. The field will instead
     // render as a grey block and preserve the decompiled code
     public isGreyBlock: boolean;
@@ -417,7 +419,7 @@ export abstract class FieldAssetEditor<U extends FieldAssetEditorOptions, V exte
 
     protected parseValueText(newText: string) {
         newText = pxt.Util.htmlUnescape(newText);
-        if (this.sourceBlock_ && !this.sourceBlock_.isInFlyout) {
+        if (this.sourceBlock_) {
             const project = pxt.react.getTilemapProject();
 
             const id = this.getBlockData();

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -48,13 +48,21 @@ export class FieldSpriteEditor extends FieldAssetEditor<FieldSpriteEditorOptions
 
         const bmp = text ? pxt.sprite.imageLiteralToBitmap(text) : new pxt.sprite.Bitmap(this.params.initWidth, this.params.initHeight);
 
+        let data: pxt.sprite.BitmapData;
+
         if (!bmp) {
-            this.isGreyBlock = true;
-            this.valueText = text;
-            return undefined;
+            // check for qualified name
+            data = qNameToBitmapData(text);
+            if (!data) {
+                this.isGreyBlock = true;
+                this.valueText = text;
+                return undefined;
+            } else {
+                this.qName = text;
+            }
         }
 
-        const data = bmp.data();
+        if (!data) data = bmp.data();
 
         const newAsset: pxt.ProjectImage = {
             internalID: -1,
@@ -73,6 +81,12 @@ export class FieldSpriteEditor extends FieldAssetEditor<FieldSpriteEditorOptions
         if (!this.asset) return this.valueText || "";
         if (this.asset && !this.isTemporaryAsset()) {
             return pxt.getTSReferenceForAsset(this.asset);
+        } else if (this.qName) {
+            // check if image has been edited
+            const data = qNameToBitmapData(this.qName);
+            if (data && pxt.sprite.bitmapEquals(data, (this.asset as pxt.ProjectImage).bitmap)) {
+                return this.qName;
+            }
         }
         return pxt.sprite.bitmapToImageLiteral(this.asset && pxt.sprite.Bitmap.fromData((this.asset as pxt.ProjectImage).bitmap), pxt.editor.FileType.TypeScript);
     }
@@ -150,4 +164,15 @@ function parseFieldOptions(opts: FieldSpriteEditorOptions) {
         }
         return res;
     }
+}
+
+
+function qNameToBitmapData(qName: string): pxt.sprite.BitmapData {
+    const project = pxt.react.getTilemapProject();
+    const images = project.getGalleryAssets(pxt.AssetType.Image).filter(asset => asset.id === qName);
+    const img = images.length && images[0];
+    if (img) {
+        return img.bitmap;
+    }
+    return undefined;
 }

--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -49,6 +49,8 @@ export class FieldTilemap extends FieldAssetEditor<FieldTilemapOptions, ParsedFi
         const existing = pxt.lookupProjectAssetByTSReference(newText, project);
         if (existing) return existing;
 
+        if (this.sourceBlock_?.isInFlyout) return undefined;
+
         const tilemap = pxt.sprite.decodeTilemap(newText, "typescript", project) || project.blankTilemap(this.params.tileWidth, this.params.initWidth, this.params.initHeight);
         let newAsset: pxt.ProjectTilemap;
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6296
Fixes https://github.com/microsoft/pxt-arcade/issues/5942

So, turns out we always supported default values for assets in block definitions; the only thing that was broken was the preview in the flyout. This fixes that flyout and also restores the qname change that @kimprice made a while back that got lost in the blockly merge.

Here is an example of setting default values for an image three different ways:

```typescript
namespace custom {
    /**
     * This version sets the default using an image literal. Note that
     * newlines need to be replaced by \n
     */
    //% blockId=screen_image_picker2 block="$img"
    //% shim=TD_ID
    //% img.fieldEditor="sprite"
    //% img.fieldOptions.taggedTemplate="img"
    //% img.fieldOptions.decompileIndirectFixedInstances="true"
    //% img.fieldOptions.decompileArgumentAsString="true"
    //% img.fieldOptions.filter="!tile !dialog !background"
    //% duplicateShadowOnDrag
    //% img.defl="img`123\n231\n312`"
    export function _spriteImage2(img: Image) {
        return img
    }

    /**
     * This version uses the qualified name of an image
     */
    //% blockId=screen_image_picker3 block="$img"
    //% shim=TD_ID
    //% img.fieldEditor="sprite"
    //% img.fieldOptions.taggedTemplate="img"
    //% img.fieldOptions.decompileIndirectFixedInstances="true"
    //% img.fieldOptions.decompileArgumentAsString="true"
    //% img.fieldOptions.filter="!tile !dialog !background"
    //% duplicateShadowOnDrag
    //% img.defl="sprites.duck.duck1"
    export function _spriteImage3(img: Image) {
        return img
    }

    /**
     * This version uses an asset in the user's project
     */
    //% blockId=screen_image_picker4 block="$img"
    //% shim=TD_ID
    //% img.fieldEditor="sprite"
    //% img.fieldOptions.taggedTemplate="img"
    //% img.fieldOptions.decompileIndirectFixedInstances="true"
    //% img.fieldOptions.decompileArgumentAsString="true"
    //% img.fieldOptions.filter="!tile !dialog !background"
    //% duplicateShadowOnDrag
    //% img.defl="assets.image`blorraine`"
    export function _spriteImage4(img: Image) {
        return img
    }
}
```