### PR TITLE
Teacher Tool: Make Splitter Functional

### DIFF
--- a/teachertool/src/components/MainPanel.tsx
+++ b/teachertool/src/components/MainPanel.tsx
@@ -16,8 +16,7 @@ export const MainPanel: React.FC<IProps> = () => {
 
     const lastSavedSplitPosition = getLastSplitPosition() ?? defaultSize;
 
-    // TODO still:
-    // Min and Max sizes.
+    // TODO : fix horizontal (offset within the view?)
 
     return (
         <div className={css["main-panel"]}>
@@ -28,6 +27,8 @@ export const MainPanel: React.FC<IProps> = () => {
                 primary={"left"}
                 left={<RubricWorkspace />}
                 right={<ProjectWorkspace />}
+                leftMinSize="5rem"
+                rightMinSize="5rem"
                 onResizeEnd={handleResizeEnd}
             />
         </div>

--- a/teachertool/src/components/MainPanel.tsx
+++ b/teachertool/src/components/MainPanel.tsx
@@ -8,13 +8,15 @@ import { getSplitPosition as getLastSplitPosition, setSplitPosition as setLastSp
 interface IProps {}
 
 export const MainPanel: React.FC<IProps> = () => {
-    function handleResize(size: number | string) {
+    function handleResizeEnd(size: number | string) {
         setLastSplitPosition(size.toString());
     }
 
     const lastSavedSplitPosition = getLastSplitPosition() ?? "50%";
 
-    // TODO still - fix arrow mouse display, figure out why it isn't working with the iframe loaded. Maybe test local storage more (does it redraw a bunch because of this changing after the change in SplitPane?)...
+    // TODO still:
+    // figure out why it isn't working with the iframe loaded.
+    // Double click to restore defaults.
 
     return (
         <div className={css["main-panel"]}>
@@ -24,7 +26,7 @@ export const MainPanel: React.FC<IProps> = () => {
                 primary={"left"}
                 left={<RubricWorkspace />}
                 right={<ProjectWorkspace />}
-                onResize={handleResize}
+                onResizeEnd={handleResizeEnd}
             />
         </div>
     );

--- a/teachertool/src/components/MainPanel.tsx
+++ b/teachertool/src/components/MainPanel.tsx
@@ -3,7 +3,7 @@ import css from "./styling/MainPanel.module.scss";
 import { SplitPane } from "./SplitPane";
 import { RubricWorkspace } from "./RubricWorkspace";
 import { ProjectWorkspace } from "./ProjectWorkspace";
-import { getSplitPosition as getLastSplitPosition, setSplitPosition as setLastSplitPosition } from "../services/storageService";
+import { getLastSplitPosition, setLastSplitPosition } from "../services/storageService";
 
 interface IProps {}
 

--- a/teachertool/src/components/MainPanel.tsx
+++ b/teachertool/src/components/MainPanel.tsx
@@ -15,7 +15,6 @@ export const MainPanel: React.FC<IProps> = () => {
     const lastSavedSplitPosition = getLastSplitPosition() ?? "50%";
 
     // TODO still:
-    // figure out why it isn't working with the iframe loaded.
     // Double click to restore defaults.
 
     return (

--- a/teachertool/src/components/MainPanel.tsx
+++ b/teachertool/src/components/MainPanel.tsx
@@ -11,7 +11,7 @@ export const MainPanel: React.FC<IProps> = () => {
         <div className={css["main-panel"]}>
             <SplitPane
                 split={"vertical"}
-                defaultSize={"80%"}
+                defaultSize={"50%"}
                 primary={"left"}
                 left={<RubricWorkspace />}
                 right={<ProjectWorkspace />}

--- a/teachertool/src/components/MainPanel.tsx
+++ b/teachertool/src/components/MainPanel.tsx
@@ -16,8 +16,6 @@ export const MainPanel: React.FC<IProps> = () => {
 
     const lastSavedSplitPosition = getLastSplitPosition() ?? defaultSize;
 
-    // TODO : fix horizontal (offset within the view?)
-
     return (
         <div className={css["main-panel"]}>
             <SplitPane

--- a/teachertool/src/components/MainPanel.tsx
+++ b/teachertool/src/components/MainPanel.tsx
@@ -3,18 +3,28 @@ import css from "./styling/MainPanel.module.scss";
 import { SplitPane } from "./SplitPane";
 import { RubricWorkspace } from "./RubricWorkspace";
 import { ProjectWorkspace } from "./ProjectWorkspace";
+import { getSplitPosition as getLastSplitPosition, setSplitPosition as setLastSplitPosition } from "../services/storageService";
 
 interface IProps {}
 
 export const MainPanel: React.FC<IProps> = () => {
+    function handleResize(size: number | string) {
+        setLastSplitPosition(size.toString());
+    }
+
+    const lastSavedSplitPosition = getLastSplitPosition() ?? "50%";
+
+    // TODO still - fix arrow mouse display, figure out why it isn't working with the iframe loaded. Maybe test local storage more (does it redraw a bunch because of this changing after the change in SplitPane?)...
+
     return (
         <div className={css["main-panel"]}>
             <SplitPane
                 split={"vertical"}
-                defaultSize={"50%"}
+                defaultSize={lastSavedSplitPosition}
                 primary={"left"}
                 left={<RubricWorkspace />}
                 right={<ProjectWorkspace />}
+                onResize={handleResize}
             />
         </div>
     );

--- a/teachertool/src/components/MainPanel.tsx
+++ b/teachertool/src/components/MainPanel.tsx
@@ -8,20 +8,23 @@ import { getSplitPosition as getLastSplitPosition, setSplitPosition as setLastSp
 interface IProps {}
 
 export const MainPanel: React.FC<IProps> = () => {
+    const defaultSize = "50%";
+
     function handleResizeEnd(size: number | string) {
         setLastSplitPosition(size.toString());
     }
 
-    const lastSavedSplitPosition = getLastSplitPosition() ?? "50%";
+    const lastSavedSplitPosition = getLastSplitPosition() ?? defaultSize;
 
     // TODO still:
-    // Double click to restore defaults.
+    // Min and Max sizes.
 
     return (
         <div className={css["main-panel"]}>
             <SplitPane
                 split={"vertical"}
-                defaultSize={lastSavedSplitPosition}
+                defaultSize={defaultSize}
+                startingSize={lastSavedSplitPosition}
                 primary={"left"}
                 left={<RubricWorkspace />}
                 right={<ProjectWorkspace />}

--- a/teachertool/src/components/MainPanel.tsx
+++ b/teachertool/src/components/MainPanel.tsx
@@ -14,8 +14,7 @@ export const MainPanel: React.FC<IProps> = () => {
         setLastSplitPosition(size.toString());
     }
 
-    const lastSavedSplitPosition = getLastSplitPosition() ?? defaultSize;
-
+    const lastSavedSplitPosition = getLastSplitPosition();
     return (
         <div className={css["main-panel"]}>
             <SplitPane

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -16,6 +16,7 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, lef
     const [size, setSize] = React.useState(defaultSize);
     const [isResizing, setIsResizing] = React.useState(false);
     const containerRef = React.useRef<HTMLDivElement>(null);
+    const overlayRef = React.useRef<HTMLDivElement>(null);
 
     React.useEffect(() => {
         if (!isResizing) {
@@ -70,14 +71,16 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, lef
             <div className={css[`left-${split}`]} style={{ flexBasis: size }}>
                 {left}
             </div>
-            <div
-                className={css[`splitter-${split}`]}
-                onMouseDown={startResizing}
-                onTouchStart={startResizing}
-            >
+            <div className={css[`splitter-${split}`]} onMouseDown={startResizing} onTouchStart={startResizing}>
                 <div className={css[`splitter-${split}-inner`]} />
             </div>
             <div className={css[`right-${split}`]}>{right}</div>
+
+            {/*
+                This overlay hack is necessary to prevent any other parts of the page (particularly iframes)
+                from intercepting the mouse events while resizing. We simply add a transparent div over everything.
+            */}
+            <div ref={overlayRef} className={classList(css["resizing-overlay"], isResizing ? "" : "hidden")} />
         </div>
     );
 };

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -5,15 +5,16 @@ import { classList } from "react-common/components/util";
 interface IProps {
     className?: string;
     split: "horizontal" | "vertical";
-    defaultSize: number | string;
+    defaultSize: number | string; // The size to reset to when double clicking the splitter.
+    startingSize?: number | string; // The size to use initially when creating the splitter. Defaults to `defaultSize`.
     primary: "left" | "right";
     left: React.ReactNode;
     right: React.ReactNode;
     onResizeEnd?: (size: number | string) => void;
 }
 
-export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, left, right, onResizeEnd }) => {
-    const [size, setSize] = React.useState(defaultSize);
+export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, startingSize, left, right, onResizeEnd }) => {
+    const [size, setSize] = React.useState(startingSize ?? defaultSize);
     const [isResizing, setIsResizing] = React.useState(false);
     const containerRef = React.useRef<HTMLDivElement>(null);
     const overlayRef = React.useRef<HTMLDivElement>(null);
@@ -66,12 +67,17 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, lef
         setIsResizing(false);
     }
 
+    function setToDefaultSize() {
+        setSize(defaultSize);
+        onResizeEnd?.(defaultSize);
+    }
+
     return (
         <div ref={containerRef} className={classList(css[`split-pane-${split}`], className)}>
             <div className={css[`left-${split}`]} style={{ flexBasis: size }}>
                 {left}
             </div>
-            <div className={css[`splitter-${split}`]} onMouseDown={startResizing} onTouchStart={startResizing}>
+            <div className={css[`splitter-${split}`]} onMouseDown={startResizing} onTouchStart={startResizing} onDoubleClick={setToDefaultSize}>
                 <div className={css[`splitter-${split}-inner`]} />
             </div>
             <div className={css[`right-${split}`]}>{right}</div>

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -87,14 +87,14 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, sta
     }
 
     return (
-        <div ref={containerRef} className={classList(css[`split-pane-${split}`], className)}>
-            <div className={css[`left-${split}`]} style={leftStyle}>
+        <div ref={containerRef} className={classList(css["split-pane"], css[`split-${split}`], className)}>
+            <div className={css[`left`]} style={leftStyle}>
                 {left}
             </div>
-            <div className={css[`splitter-${split}`]} onMouseDown={startResizing} onTouchStart={startResizing} onDoubleClick={setToDefaultSize}>
-                <div className={css[`splitter-${split}-inner`]} />
+            <div className={css[`splitter`]} onMouseDown={startResizing} onTouchStart={startResizing} onDoubleClick={setToDefaultSize}>
+                <div className={css[`splitter-inner`]} />
             </div>
-            <div className={css[`right-${split}`]}>{right}</div>
+            <div className={css[`right`]}>{right}</div>
 
             {/*
                 This overlay hack is necessary to prevent any other parts of the page (particularly iframes)

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -42,8 +42,8 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, sta
         if (containerRect) {
             const newSize =
                 split === "vertical"
-                    ? `${(clientX / containerRect.width) * 100}%`
-                    : `${(clientY / containerRect.height) * 100}%`;
+                    ? `${((clientX - containerRect.left) / containerRect.width) * 100}%`
+                    : `${((clientY - containerRect.top) / containerRect.height) * 100}%`;
 
             console.log("newSize", newSize);
             setSize(newSize);
@@ -100,7 +100,7 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, sta
                 This overlay hack is necessary to prevent any other parts of the page (particularly iframes)
                 from intercepting the mouse events while resizing. We simply add a transparent div over everything.
             */}
-            <div ref={overlayRef} className={classList(css["resizing-overlay"], isResizing ? "" : "hidden")} />
+            <div ref={overlayRef} className={classList(css["resizing-overlay"], isResizing ? undefined : "hidden")} />
         </div>
     );
 };

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -15,7 +15,17 @@ interface IProps {
     onResizeEnd?: (size: number | string) => void;
 }
 
-export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, startingSize, left, right, leftMinSize, rightMinSize, onResizeEnd }) => {
+export const SplitPane: React.FC<IProps> = ({
+    className,
+    split,
+    defaultSize,
+    startingSize,
+    left,
+    right,
+    leftMinSize,
+    rightMinSize,
+    onResizeEnd,
+}) => {
     const [size, setSize] = React.useState(startingSize ?? defaultSize);
     const [isResizing, setIsResizing] = React.useState(false);
     const containerRef = React.useRef<HTMLDivElement>(null);
@@ -44,6 +54,7 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, sta
                     ? `${((clientX - containerRect.left) / containerRect.width) * 100}%`
                     : `${((clientY - containerRect.top) / containerRect.height) * 100}%`;
 
+            setIsResizing(true); // Do this here rather than inside startResizing to prevent interference with double click detection.
             setSize(newSize);
         }
     }
@@ -54,8 +65,6 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, sta
         document.addEventListener("mouseup", endResizing);
         document.addEventListener("touchmove", handleResizeTouch);
         document.addEventListener("touchend", endResizing);
-
-        setIsResizing(true);
     }
 
     function endResizing() {
@@ -88,21 +97,23 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, sta
         <div ref={containerRef} className={classList(css["split-pane"], css[`split-${split}`], className)}>
             <div className={css[`left`]} style={leftStyle}>
                 {left}
-
-                {/*
-                    This overlay is necessary to prevent any other parts of the page (particularly iframes)
-                    from intercepting the mouse events while resizing. We simply add a transparent div over the
-                    left and right sections.
-                */}
-                <div className={classList(css["resizing-overlay"], isResizing ? undefined : "hidden")} />
             </div>
-            <div className={css[`splitter`]} onMouseDown={startResizing} onTouchStart={startResizing} onDoubleClick={setToDefaultSize}>
+            <div
+                className={css[`splitter`]}
+                onMouseDown={startResizing}
+                onTouchStart={startResizing}
+                onDoubleClick={setToDefaultSize}
+            >
                 <div className={css[`splitter-inner`]} />
             </div>
-            <div className={css[`right`]}>
-                {right}
-                <div className={classList(css["resizing-overlay"], isResizing ? undefined : "hidden")} />
-            </div>
+            <div className={css[`right`]}>{right}</div>
+
+            {/*
+                This overlay is necessary to prevent any other parts of the page (particularly iframes)
+                from intercepting the mouse events while resizing. We simply add a transparent div over the
+                left and right sections.
+            */}
+            <div className={classList(css["resizing-overlay"], isResizing ? undefined : "hidden")} />
         </div>
     );
 };

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -10,8 +10,8 @@ interface IProps {
     primary: "left" | "right";
     left: React.ReactNode;
     right: React.ReactNode;
-    leftMinSize?: number | string;
-    rightMinSize?: number | string;
+    leftMinSize: number | string;
+    rightMinSize: number | string;
     onResizeEnd?: (size: number | string) => void;
 }
 

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -11,11 +11,53 @@ interface IProps {
     right: React.ReactNode;
 }
 
-export const SplitPane: React.FC<IProps> = ({ className, split, left, right }) => {
+export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, left, right }) => {
+    const [size, setSize] = React.useState(defaultSize);
+    const leftRef = React.useRef<HTMLDivElement>(null);
+
+    function handleResizeMouse(event: MouseEvent) {
+        handleResize(event.clientX, event.clientY);
+    }
+
+    function handleResizeTouch(event: TouchEvent) {
+        if (event.touches.length >= 1) {
+            handleResize(event.touches[0].clientX, event.touches[0].clientY);
+        }
+    }
+
+    function handleResize(clientX: number, clientY: number) {
+        const paneRect = leftRef.current?.getBoundingClientRect();
+        if (paneRect) {
+            const newSize = split === "vertical" ? clientX - paneRect.left : clientY - paneRect.top;
+            setSize(newSize);
+        }
+    }
+
+    function addResizeListeners(event: React.MouseEvent | React.TouchEvent) {
+        event.preventDefault();
+        document.addEventListener("mousemove", handleResizeMouse);
+        document.addEventListener("mouseup", removeResizeListeners);
+        document.addEventListener("touchmove", handleResizeTouch);
+        document.addEventListener("touchend", removeResizeListeners);
+    }
+
+    function removeResizeListeners() {
+        document.removeEventListener("mousemove", handleResizeMouse);
+        document.removeEventListener("mouseup", removeResizeListeners);
+        document.removeEventListener("touchmove", handleResizeTouch);
+        document.removeEventListener("touchend", removeResizeListeners);
+    }
+
     return (
         <div className={classList(css[`split-pane-${split}`], className)}>
-            <div className={css[`left-${split}`]}>{left}</div>
-            <div className={css[`splitter-${split}`]}>
+            <div ref={leftRef} className={css[`left-${split}`]} style={{ flexBasis: size }}>
+                {left}
+            </div>
+            <div
+                className={css[`splitter-${split}`]}
+                onMouseDown={addResizeListeners}
+                onTouchStart={addResizeListeners}
+            >
                 <div className={css[`splitter-${split}-inner`]} />
             </div>
             <div className={css[`right-${split}`]}>{right}</div>

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -19,7 +19,6 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, sta
     const [size, setSize] = React.useState(startingSize ?? defaultSize);
     const [isResizing, setIsResizing] = React.useState(false);
     const containerRef = React.useRef<HTMLDivElement>(null);
-    const overlayRef = React.useRef<HTMLDivElement>(null);
 
     React.useEffect(() => {
         if (!isResizing) {
@@ -45,7 +44,6 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, sta
                     ? `${((clientX - containerRect.left) / containerRect.width) * 100}%`
                     : `${((clientY - containerRect.top) / containerRect.height) * 100}%`;
 
-            console.log("newSize", newSize);
             setSize(newSize);
         }
     }
@@ -90,17 +88,21 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, sta
         <div ref={containerRef} className={classList(css["split-pane"], css[`split-${split}`], className)}>
             <div className={css[`left`]} style={leftStyle}>
                 {left}
+
+                {/*
+                    This overlay is necessary to prevent any other parts of the page (particularly iframes)
+                    from intercepting the mouse events while resizing. We simply add a transparent div over the
+                    left and right sections.
+                */}
+                <div className={classList(css["resizing-overlay"], isResizing ? undefined : "hidden")} />
             </div>
             <div className={css[`splitter`]} onMouseDown={startResizing} onTouchStart={startResizing} onDoubleClick={setToDefaultSize}>
                 <div className={css[`splitter-inner`]} />
             </div>
-            <div className={css[`right`]}>{right}</div>
-
-            {/*
-                This overlay hack is necessary to prevent any other parts of the page (particularly iframes)
-                from intercepting the mouse events while resizing. We simply add a transparent div over everything.
-            */}
-            <div ref={overlayRef} className={classList(css["resizing-overlay"], isResizing ? undefined : "hidden")} />
+            <div className={css[`right`]}>
+                {right}
+                <div className={classList(css["resizing-overlay"], isResizing ? undefined : "hidden")} />
+            </div>
         </div>
     );
 };

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -13,7 +13,7 @@ interface IProps {
 
 export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, left, right }) => {
     const [size, setSize] = React.useState(defaultSize);
-    const leftRef = React.useRef<HTMLDivElement>(null);
+    const containerRef = React.useRef<HTMLDivElement>(null);
 
     function handleResizeMouse(event: MouseEvent) {
         handleResize(event.clientX, event.clientY);
@@ -26,9 +26,12 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, lef
     }
 
     function handleResize(clientX: number, clientY: number) {
-        const paneRect = leftRef.current?.getBoundingClientRect();
-        if (paneRect) {
-            const newSize = split === "vertical" ? clientX - paneRect.left : clientY - paneRect.top;
+        const containerRect = containerRef.current?.getBoundingClientRect();
+        if (containerRect) {
+            const newSize =
+                split === "vertical"
+                    ? `${(clientX / containerRect.width) * 100}%`
+                    : `${(clientY / containerRect.height) * 100}%`;
             setSize(newSize);
         }
     }
@@ -49,8 +52,8 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, lef
     }
 
     return (
-        <div className={classList(css[`split-pane-${split}`], className)}>
-            <div ref={leftRef} className={css[`left-${split}`]} style={{ flexBasis: size }}>
+        <div ref={containerRef} className={classList(css[`split-pane-${split}`], className)}>
+            <div className={css[`left-${split}`]} style={{ flexBasis: size }}>
                 {left}
             </div>
             <div

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -10,10 +10,12 @@ interface IProps {
     primary: "left" | "right";
     left: React.ReactNode;
     right: React.ReactNode;
+    leftMinSize?: number | string;
+    rightMinSize?: number | string;
     onResizeEnd?: (size: number | string) => void;
 }
 
-export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, startingSize, left, right, onResizeEnd }) => {
+export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, startingSize, left, right, leftMinSize, rightMinSize, onResizeEnd }) => {
     const [size, setSize] = React.useState(startingSize ?? defaultSize);
     const [isResizing, setIsResizing] = React.useState(false);
     const containerRef = React.useRef<HTMLDivElement>(null);
@@ -72,9 +74,21 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, sta
         onResizeEnd?.(defaultSize);
     }
 
+    const leftStyle: React.CSSProperties = { flexBasis: size };
+    if (split === "vertical") {
+        leftStyle.minWidth = leftMinSize;
+
+        // Setting right's minWidth doesn't work because left is still allowed
+        // to expand beyond it. Instead, set left's maxWidth.
+        leftStyle.maxWidth = `calc(100% - ${rightMinSize})`;
+    } else {
+        leftStyle.minHeight = leftMinSize;
+        leftStyle.maxHeight = `calc(100% - ${rightMinSize})`;
+    }
+
     return (
         <div ref={containerRef} className={classList(css[`split-pane-${split}`], className)}>
-            <div className={css[`left-${split}`]} style={{ flexBasis: size }}>
+            <div className={css[`left-${split}`]} style={leftStyle}>
                 {left}
             </div>
             <div className={css[`splitter-${split}`]} onMouseDown={startResizing} onTouchStart={startResizing} onDoubleClick={setToDefaultSize}>

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -9,9 +9,10 @@ interface IProps {
     primary: "left" | "right";
     left: React.ReactNode;
     right: React.ReactNode;
+    onResize?: (size: number | string) => void;
 }
 
-export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, left, right }) => {
+export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, left, right, onResize }) => {
     const [size, setSize] = React.useState(defaultSize);
     const containerRef = React.useRef<HTMLDivElement>(null);
 
@@ -33,6 +34,7 @@ export const SplitPane: React.FC<IProps> = ({ className, split, defaultSize, lef
                     ? `${(clientX / containerRect.width) * 100}%`
                     : `${(clientY / containerRect.height) * 100}%`;
             setSize(newSize);
+            onResize?.(newSize);
         }
     }
 

--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -49,12 +49,11 @@ export const SplitPane: React.FC<IProps> = ({
     function handleResize(clientX: number, clientY: number) {
         const containerRect = containerRef.current?.getBoundingClientRect();
         if (containerRect) {
+            setIsResizing(true); // Do this here rather than inside startResizing to prevent interference with double click detection.
             const newSize =
                 split === "vertical"
                     ? `${((clientX - containerRect.left) / containerRect.width) * 100}%`
                     : `${((clientY - containerRect.top) / containerRect.height) * 100}%`;
-
-            setIsResizing(true); // Do this here rather than inside startResizing to prevent interference with double click detection.
             setSize(newSize);
         }
     }

--- a/teachertool/src/components/styling/SplitPane.module.scss
+++ b/teachertool/src/components/styling/SplitPane.module.scss
@@ -1,75 +1,58 @@
+.split-pane {
+    display: flex;
+    height: 100%;
+    width: 100%;
 
-// TODO make this scssy
+    .left {
+        flex-grow: 0;
+        flex-shrink: 0;
+        overflow: auto;
+    }
 
-.split-pane-vertical {
-  display: flex;
-  flex-direction: row;
-  height: 100%;
-  width: 100%;
+    .right {
+        flex-grow: 1;
+        flex-shrink: 1;
+        overflow: auto;
+    }
 }
 
-.left-vertical {
-  flex-grow: 0;
-  flex-shrink: 0;
-  overflow: auto;
+.split-vertical {
+    flex-direction: row;
+
+    .splitter {
+        background-color: var(--pxt-content-accent);
+        width: 1px;
+
+        .splitter-inner {
+            position: relative;
+            background-color: transparent;
+            transition: background-color 0.2s ease;
+            left: -2.5px;
+            width: 5px;
+            height: 100%;
+            cursor: ew-resize;
+
+            &:hover {
+                background-color: var(--pxt-content-foreground);
+                transition: background-color 0.2s ease;
+                transition-delay: 0.2s;
+            }
+        }
+    }
 }
 
-.right-vertical {
-  flex-grow: 1;
-  flex-shrink: 1;
-  overflow: auto;
-}
+.split-horizontal {
+    flex-direction: column;
 
-.splitter-vertical {
-  background-color: var(--pxt-content-accent);
-  width: 1px;
-}
-
-.splitter-vertical-inner {
-  position: relative;
-  background-color: transparent;
-  transition: background-color 0.2s ease;
-  left: -2.5px;
-  width: 5px;
-  height: 100%;
-  cursor: ew-resize;
-}
-
-.splitter-vertical-inner:hover {
-  background-color: var(--pxt-content-foreground);
-  transition: background-color 0.2s ease;
-  transition-delay: 0.2s;
-}
-
-/* Horizontal split pane */
-
-.split-pane-horizontal {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  width: 100%;
-}
-
-.left-horizontal {
-  flex-grow: 0;
-  flex-shrink: 0;
-  overflow: auto;
-}
-
-.right-horizontal {
-  flex-grow: 1;
-  flex-shrink: 1;
-  overflow: auto;
-}
-
-.splitter-horizontal {
-  flex: 0 0 1px;
-  background-color: var(--pxt-headerbar-background);
-  height: 5px;
-  cursor: ns-resize;
+    .splitter {
+        flex: 0 0 1px;
+        background-color: var(--pxt-headerbar-background);
+        height: 5px;
+        cursor: ns-resize;
+    }
 }
 
 .resizing-overlay {
-  position: 'absolute';
-  inset: 0;
+    position: absolute;
+    inset: 0;
 }

--- a/teachertool/src/components/styling/SplitPane.module.scss
+++ b/teachertool/src/components/styling/SplitPane.module.scss
@@ -4,18 +4,24 @@
     width: 100%;
 
     .left {
-        position: relative;
         flex-grow: 0;
         flex-shrink: 0;
         overflow: auto;
     }
 
     .right {
-        position: relative;
         flex-grow: 1;
         flex-shrink: 1;
         overflow: auto;
     }
+
+  .resizing-overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 }
 
 .split-vertical {
@@ -52,9 +58,4 @@
         height: 5px;
         cursor: ns-resize;
     }
-}
-
-.resizing-overlay {
-    position: absolute;
-    inset: 0;
 }

--- a/teachertool/src/components/styling/SplitPane.module.scss
+++ b/teachertool/src/components/styling/SplitPane.module.scss
@@ -9,12 +9,14 @@
 }
 
 .left-vertical {
-  flex: 1;
+  flex-grow: 0;
+  flex-shrink: 0;
   overflow: auto;
 }
 
 .right-vertical {
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
   overflow: auto;
 }
 

--- a/teachertool/src/components/styling/SplitPane.module.scss
+++ b/teachertool/src/components/styling/SplitPane.module.scss
@@ -66,3 +66,8 @@
   height: 5px;
   cursor: ns-resize;
 }
+
+.resizing-overlay {
+  position: 'absolute';
+  inset: 0;
+}

--- a/teachertool/src/components/styling/SplitPane.module.scss
+++ b/teachertool/src/components/styling/SplitPane.module.scss
@@ -51,12 +51,14 @@
 }
 
 .left-horizontal {
-  flex: 1;
+  flex-grow: 0;
+  flex-shrink: 0;
   overflow: auto;
 }
 
 .right-horizontal {
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
   overflow: auto;
 }
 

--- a/teachertool/src/components/styling/SplitPane.module.scss
+++ b/teachertool/src/components/styling/SplitPane.module.scss
@@ -4,12 +4,14 @@
     width: 100%;
 
     .left {
+        position: relative;
         flex-grow: 0;
         flex-shrink: 0;
         overflow: auto;
     }
 
     .right {
+        position: relative;
         flex-grow: 1;
         flex-shrink: 1;
         overflow: auto;
@@ -27,8 +29,8 @@
             position: relative;
             background-color: transparent;
             transition: background-color 0.2s ease;
-            left: -2.5px;
-            width: 5px;
+            left: -3px;
+            width: 6px;
             height: 100%;
             cursor: ew-resize;
 

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -149,7 +149,7 @@ export function setLastActiveRubricName(name: string) {
     }
 }
 
-export function getSplitPosition(): string {
+export function getLastSplitPosition(): string {
     try {
         return getValue(SPLIT_POSITION_KEY) ?? "";
     } catch (e) {
@@ -158,7 +158,7 @@ export function getSplitPosition(): string {
     }
 }
 
-export function setSplitPosition(position: string) {
+export function setLastSplitPosition(position: string) {
     try {
         setValue(SPLIT_POSITION_KEY, position);
     } catch (e) {

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -10,6 +10,7 @@ import { Rubric } from "../types/rubric";
 const KEY_PREFIX = "teachertool";
 const AUTORUN_KEY = [KEY_PREFIX, "autorun"].join("/");
 const LAST_ACTIVE_RUBRIC_KEY = [KEY_PREFIX, "lastActiveRubric"].join("/");
+const SPLIT_POSITION_KEY = [KEY_PREFIX, "splitPosition"].join("/");
 
 function getValue(key: string, defaultValue?: string): string | undefined {
     return localStorage.getItem(key) || defaultValue;
@@ -143,6 +144,23 @@ export function getLastActiveRubricName(): string {
 export function setLastActiveRubricName(name: string) {
     try {
         setValue(LAST_ACTIVE_RUBRIC_KEY, name);
+    } catch (e) {
+        logError(ErrorCode.localStorageWriteError, e);
+    }
+}
+
+export function getSplitPosition(): string {
+    try {
+        return getValue(SPLIT_POSITION_KEY) ?? "";
+    } catch (e) {
+        logError(ErrorCode.localStorageReadError, e);
+        return "";
+    }
+}
+
+export function setSplitPosition(position: string) {
+    try {
+        setValue(SPLIT_POSITION_KEY, position);
     } catch (e) {
         logError(ErrorCode.localStorageWriteError, e);
     }

--- a/teachertool/src/state/helpers.ts
+++ b/teachertool/src/state/helpers.ts
@@ -71,7 +71,7 @@ export function getSelectableCatalogCriteria(state: AppState): CatalogCriteria[]
         state.catalog?.filter(
             catalogCriteria =>
                 ((catalogCriteria.parameters && catalogCriteria.parameters.length > 0) ||
-                !usedCatalogCriteria.includes(catalogCriteria.id)) &&
+                    !usedCatalogCriteria.includes(catalogCriteria.id)) &&
                 !catalogCriteria.hideInCatalog
         ) ?? []
     );


### PR DESCRIPTION
This makes it so the splitter can actually be used to resize the windows. I've also made it so you can double-click the split to reset it to its original position.

I intentionally did not tie the split position into app state, so the control will be more reusable in the future, if we move it to react common.

It'd be nice to merge this and the existing VerticalResizeContainer, but they've approached the problem from two somewhat different angles that makes the refactor a bit messy. The VerticalResizeContainer is a single window that can have its height changed, but it doesn't care what's shrinking/expanding below it. Meanwhile, this is a container for two different panels that manages both sides. In the future, I think it'd make sense to move this SplitPanel into React Common and take anything that's using the VerticalResizeContainer and have it use the SplitPanel instead, but I wanted to save that for another change.

Upload Target: https://makecode.microbit.org/app/50d4b45ccb39db5b42fee1e5cacc60776082aa3c-32ad1744d7--eval