### PR TITLE
Fix importing past scripts when no previous browser prefix is set

### DIFF
--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -172,8 +172,6 @@ async function migratePrefixesAsync() {
     const currentMajor = currentVersion.major;
     const previousMajor = currentMajor - 1;
     const previousDbPrefix = previousMajor < 0 ? "" : pxt.appTarget.appTheme.browserDbPrefixes[previousMajor];
-
-    if (!previousDbPrefix) return;
     const currentDb = await getCurrentDbAsync();
 
     // If headers are already in the new db, migration must have already happened


### PR DESCRIPTION
This fixes the bug we saw when trying to add browser prefixes to arcade yesterday.

If there is no prefix set for a previous version of the editor, we should migrate scripts from the default prefix instead of migrating nothing.