### PR TITLE
Fix Readonly Mode

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1889,7 +1889,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             }
         });
 
-        this.editor.options.readOnly = debugging;
+        this.editor.options.readOnly = debugging || pxt.shell.isReadOnly();
     }
 
     protected enableBreakpoint(block: Blockly.Block, enabled: boolean) {


### PR DESCRIPTION
Readonly mode wasn't being honored in the blockly workspace because we were resetting the flag based on whether or not we were in debug mode. With this change, we will also account for the original readonly mode in that check.