### PR TITLE
Teacher tool: add validator plans for checking a draggable parameter was accessed

### DIFF
--- a/common-docs/teachertool/validator-plans-shared.json
+++ b/common-docs/teachertool/validator-plans-shared.json
@@ -98,6 +98,62 @@
             ]
         },
         {
+            ".desc": "A parameter variable's value is used",
+            "name": "parameter_variable_accessed",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "argument_reporter_string": 1
+                    }
+                },
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "argument_reporter_number": 1
+                    }
+                },
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "argument_reporter_boolean": 1
+                    }
+                },
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "argument_reporter_array": 1
+                    }
+                },
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "argument_reporter_custom": 1
+                    }
+                },
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "variables_get_reporter": 1
+                    }
+                }
+            ]
+        },
+        {
+            ".desc": "A numeric parameter variable's value is used",
+            "name": "numeric_parameter_variable_accessed",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "argument_reporter_number": 1
+                    }
+                }
+            ]
+        },
+        {
             ".desc": "A custom variable's value is set to a random number",
             "name": "variable_set_random",
             "threshold": 1,

--- a/common-docs/teachertool/validator-plans-shared.json
+++ b/common-docs/teachertool/validator-plans-shared.json
@@ -98,7 +98,7 @@
             ]
         },
         {
-            ".desc": "A parameter variable's value is used",
+            ".desc": "A parameter's value is used",
             "name": "parameter_variable_accessed",
             "threshold": 1,
             "checks": [
@@ -141,7 +141,7 @@
             ]
         },
         {
-            ".desc": "A numeric parameter variable's value is used",
+            ".desc": "A numeric parameter's value is used",
             "name": "numeric_parameter_variable_accessed",
             "threshold": 1,
             "checks": [


### PR DESCRIPTION
When you drag a parameter out of a wrapper block (like receivedString in the screenshot below), the resulting accessor blocks have unique ids. This adds a few validator plans to check for them (needed for micro chat rubric work).

![image](https://github.com/microsoft/pxt/assets/69657545/f9ab89c9-c769-41ca-aa97-326822f2dd22)
