### PR TITLE
re-cache json docs on request

### DIFF
--- a/teachertool/src/services/backendRequests.ts
+++ b/teachertool/src/services/backendRequests.ts
@@ -4,7 +4,9 @@ import { logError } from "./loggingService";
 
 export async function fetchJsonDocAsync<T = any>(url: string): Promise<T | undefined> {
     try {
-        const response = await fetch(url);
+        const response = await fetch(url, {
+            cache: "no-cache",
+        });
         if (!response.ok) {
             throw new Error("Unable to fetch the json file");
         } else {
@@ -70,7 +72,9 @@ export async function loadTestableCollectionFromDocsAsync<T>(fileNames: string[]
     let allResults: T[] = [];
     for (const planFile of files) {
         try {
-            const response = await fetch(planFile);
+            const response = await fetch(planFile, {
+                cache: "no-cache",
+            });
 
             if (response.ok) {
                 const content = await response.json();


### PR DESCRIPTION
I was getting old versions of validator-plans and catalog.json. Turns out they're getting cached by the browser. Specifying `no-cache` on the fetch request so that the files, if cached, will still work offline, but the cache will be refreshed after each new request.
