### PR TITLE
Fixes for image editor in micro:bit

### DIFF
--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -13,6 +13,8 @@ export interface FieldAnimationOptions {
 
     filter?: string;
     lightMode: boolean;
+
+    taggedTemplate?: string;
 }
 
 export interface ParsedFieldAnimationOptions {
@@ -21,6 +23,8 @@ export interface ParsedFieldAnimationOptions {
     disableResize: boolean;
     filter?: string;
     lightMode: boolean;
+
+    taggedTemplate?: string;
 }
 
 // 32 is specifically chosen so that we can scale the images for the default
@@ -73,7 +77,7 @@ export class FieldAnimationEditor extends FieldAssetEditor<FieldAnimationOptions
             const existing = pxt.lookupProjectAssetByTSReference(text, project);
             if (existing) return existing;
 
-            const frames = parseImageArrayString(text);
+            const frames = parseImageArrayString(text, this.params.taggedTemplate);
 
             if (frames && frames.length) {
                 const id = this.sourceBlock_.id;
@@ -117,7 +121,7 @@ export class FieldAnimationEditor extends FieldAssetEditor<FieldAnimationOptions
 
         if (this.isTemporaryAsset()) {
             return "[" + this.asset.frames.map(frame =>
-                pxt.sprite.bitmapToImageLiteral(pxt.sprite.Bitmap.fromData(frame), pxt.editor.FileType.TypeScript)
+                pxt.sprite.bitmapToImageLiteral(pxt.sprite.Bitmap.fromData(frame), pxt.editor.FileType.TypeScript, this.params.taggedTemplate)
             ).join(",") + "]"
         }
 
@@ -239,6 +243,8 @@ function parseFieldOptions(opts: FieldAnimationOptions) {
     parsed.initWidth = withDefault(opts.initWidth, parsed.initWidth);
     parsed.initHeight = withDefault(opts.initHeight, parsed.initHeight);
 
+    parsed.taggedTemplate = opts.taggedTemplate;
+
     return parsed;
 
     function withDefault(raw: string, def: number) {
@@ -250,10 +256,10 @@ function parseFieldOptions(opts: FieldAnimationOptions) {
     }
 }
 
-function parseImageArrayString(str: string): pxt.sprite.BitmapData[] {
+function parseImageArrayString(str: string, templateLiteral?: string): pxt.sprite.BitmapData[] {
     if (str.indexOf("[") === -1) return null;
     str = str.replace(/[\[\]]/mg, "");
-    return str.split(",").map(s => pxt.sprite.imageLiteralToBitmap(s).data()).filter(b => b.height && b.width);
+    return str.split(",").map(s => pxt.sprite.imageLiteralToBitmap(s, templateLiteral).data()).filter(b => b.height && b.width);
 }
 
 function isNumberType(type: string) {

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -18,6 +18,8 @@ export interface FieldSpriteEditorOptions {
 
     filter?: string;
     lightMode: boolean;
+
+    taggedTemplate?: string;
 }
 
 interface ParsedSpriteEditorOptions {
@@ -27,6 +29,8 @@ interface ParsedSpriteEditorOptions {
     disableResize: boolean;
     filter?: string;
     lightMode: boolean;
+
+    taggedTemplate?: string;
 }
 
 export class FieldSpriteEditor extends FieldAssetEditor<FieldSpriteEditorOptions, ParsedSpriteEditorOptions> {
@@ -46,7 +50,7 @@ export class FieldSpriteEditor extends FieldAssetEditor<FieldSpriteEditorOptions
             return project.lookupAsset(pxt.AssetType.Image, this.getBlockData());
         }
 
-        const bmp = text ? pxt.sprite.imageLiteralToBitmap(text) : new pxt.sprite.Bitmap(this.params.initWidth, this.params.initHeight);
+        const bmp = text ? pxt.sprite.imageLiteralToBitmap(text, this.params.taggedTemplate) : new pxt.sprite.Bitmap(this.params.initWidth, this.params.initHeight);
 
         let data: pxt.sprite.BitmapData;
 
@@ -88,7 +92,7 @@ export class FieldSpriteEditor extends FieldAssetEditor<FieldSpriteEditorOptions
                 return this.qName;
             }
         }
-        return pxt.sprite.bitmapToImageLiteral(this.asset && pxt.sprite.Bitmap.fromData((this.asset as pxt.ProjectImage).bitmap), pxt.editor.FileType.TypeScript);
+        return pxt.sprite.bitmapToImageLiteral(this.asset && pxt.sprite.Bitmap.fromData((this.asset as pxt.ProjectImage).bitmap), pxt.editor.FileType.TypeScript, this.params.taggedTemplate);
     }
 
     protected parseFieldOptions(opts: FieldSpriteEditorOptions): ParsedSpriteEditorOptions {
@@ -154,6 +158,8 @@ function parseFieldOptions(opts: FieldSpriteEditorOptions) {
     parsed.initColor = withDefault(opts.initColor, parsed.initColor);
     parsed.initWidth = withDefault(opts.initWidth, parsed.initWidth);
     parsed.initHeight = withDefault(opts.initHeight, parsed.initHeight);
+
+    parsed.taggedTemplate = opts.taggedTemplate;
 
     return parsed;
 

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -996,7 +996,7 @@ namespace pxt {
             return r;
         }
 
-        protected patchAppTargetPalette() {
+        patchAppTargetPalette() {
             if (this.config.palette && appTarget.runtime) {
                 appTarget.runtime.palette = U.clone(this.config.palette);
                 if (this.config.paletteNames) appTarget.runtime.paletteNames = this.config.paletteNames;
@@ -1293,6 +1293,10 @@ namespace pxt {
             opts.jres = this.getJRes()
             const functionOpts = pxt.appTarget.runtime && pxt.appTarget.runtime.functionsOptions;
             opts.allowedArgumentTypes = functionOpts && functionOpts.extraFunctionEditorTypes && functionOpts.extraFunctionEditorTypes.map(info => info.typeName).concat("number", "boolean", "string");
+
+            for (const dep of this.sortedDeps()) {
+                dep.patchAppTargetPalette();
+            }
 
             this.patchAppTargetPalette();
             return opts;

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -603,11 +603,12 @@ namespace pxt.sprite {
         return result;
     }
 
-    export function imageLiteralToBitmap(text: string): Bitmap {
+    export function imageLiteralToBitmap(text: string, templateLiteral = "img"): Bitmap {
         // Strip the tagged template string business and the whitespace. We don't have to exhaustively
         // replace encoded characters because the compiler will catch any disallowed characters and throw
         // an error before the decompilation happens. 96 is backtick and 9 is tab
         text = text.replace(/[ `]|(?:&#96;)|(?:&#9;)|(?:img)/g, "").trim();
+        text = text.replaceAll(templateLiteral, "");
         text = text.replace(/^["`\(\)]*/, '').replace(/["`\(\)]*$/, '');
         text = text.replace(/&#10;/g, "\n");
 
@@ -735,14 +736,14 @@ namespace pxt.sprite {
         pxt.sprite.trimTilemapTileset(result);
     }
 
-    function imageLiteralPrologue(fileType: "typescript" | "python"): string {
+    function imageLiteralPrologue(fileType: "typescript" | "python", templateLiteral = "img"): string {
         let res = '';
         switch (fileType) {
             case "python":
-                res = "img(\"\"\"";
+                res = `${templateLiteral}("""`;
                 break;
             default:
-                res = "img`";
+                res = `${templateLiteral}\``;
                 break;
         }
         return res;
@@ -778,10 +779,10 @@ namespace pxt.sprite {
         return res;
     }
 
-    export function bitmapToImageLiteral(bitmap: Bitmap, fileType: "typescript" | "python"): string {
+    export function bitmapToImageLiteral(bitmap: Bitmap, fileType: "typescript" | "python", templateLiteral = "img"): string {
         if (!bitmap || bitmap.height === 0 || bitmap.width === 0) return "";
 
-        let res = imageLiteralPrologue(fileType);
+        let res = imageLiteralPrologue(fileType, templateLiteral);
 
         if (bitmap) {
             const paddingBetweenPixels = (bitmap.width * bitmap.height > 300) ? "" : " ";

--- a/pxtlib/tsconfig.json
+++ b/pxtlib/tsconfig.json
@@ -13,7 +13,8 @@
             "dom.iterable",
             "scripthost",
             "es2017",
-            "ES2018.Promise"
+            "ES2018.Promise",
+            "ES2021.String"
         ],
         "types": [
             "highlight.js",


### PR DESCRIPTION
This is an addendum to my earlier pr https://github.com/microsoft/pxt/pull/9878 which neglected to fix the palette when it was in the pxt.json of a dependency rather than the top package.

Also adds the ability to configure the image and animation editors to compile/parse different tagged template literals since micro:bit can't use `img`. To use it, simply add it to the field options on the function defining the field editor like so:

```
//% bmp.fieldOptions.taggedTemplate="bmp"
```

it might already be there since this is the same field option we use for configuring the decompiler.