### PR TITLE
Teacher tool: icon in sharelink input now clickable

### DIFF
--- a/teachertool/src/components/ShareLinkInput.tsx
+++ b/teachertool/src/components/ShareLinkInput.tsx
@@ -42,6 +42,7 @@ export const ShareLinkInput: React.FC<IProps> = () => {
                 icon={icon}
                 onChange={onTextChange}
                 onEnterKey={onEnterKey}
+                onIconClick={onEnterKey}
                 preserveValueOnBlur={true}
                 autoComplete={false}
             ></Input>

--- a/teachertool/src/components/ShareLinkInput.tsx
+++ b/teachertool/src/components/ShareLinkInput.tsx
@@ -40,6 +40,7 @@ export const ShareLinkInput: React.FC<IProps> = () => {
                 placeholder={lf("Enter Project Link or Share ID")}
                 ariaLabel={lf("Project Link or Share ID")}
                 icon={icon}
+                iconTitle={lf("Submit project link or share ID")}
                 onChange={onTextChange}
                 onEnterKey={onEnterKey}
                 onIconClick={onEnterKey}

--- a/teachertool/src/components/styling/ShareLinkInput.module.scss
+++ b/teachertool/src/components/styling/ShareLinkInput.module.scss
@@ -18,4 +18,9 @@
             }
         }
     }
+
+    button[class~="common-button"] {
+        border-radius: 99px;
+        margin-right: -1rem;
+    }
 }

--- a/teachertool/src/style.overrides/Button.scss
+++ b/teachertool/src/style.overrides/Button.scss
@@ -40,3 +40,8 @@
 .common-button.disabled {
     opacity: 0.8;
 }
+
+.common-input-group>.common-button {
+    border-radius: 99px;
+    margin-right: -1rem;
+}

--- a/teachertool/src/style.overrides/Button.scss
+++ b/teachertool/src/style.overrides/Button.scss
@@ -40,8 +40,3 @@
 .common-button.disabled {
     opacity: 0.8;
 }
-
-.common-input-group>.common-button {
-    border-radius: 99px;
-    margin-right: -1rem;
-}


### PR DESCRIPTION
https://makecode.microbit.org/app/8064d90149396080f7266d4f8935b133be8e7173-7d530bca36--eval

Just a note that the styling is a bit off in the upload target, even though I built the css, the upload target is using `-0.75rem` for the margin instead of `-1rem` to get the button hugging the right side more like in our design right now. 

This is what it looks like with `margin-right: -1rem` 
<img width="641" alt="image" src="https://github.com/microsoft/pxt/assets/49178322/91ea4a6c-8f43-4311-bd69-b5823f61a968">
