### PR TITLE
Fix Comparison in Splitter Default Size

### DIFF
--- a/teachertool/src/components/SplitPane.tsx
+++ b/teachertool/src/components/SplitPane.tsx
@@ -26,7 +26,7 @@ export const SplitPane: React.FC<IProps> = ({
     rightMinSize,
     onResizeEnd,
 }) => {
-    const [size, setSize] = React.useState(startingSize ?? defaultSize);
+    const [size, setSize] = React.useState(startingSize || defaultSize);
     const [isResizing, setIsResizing] = React.useState(false);
     const containerRef = React.useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
When the user hasn't set a size directly, we were seeing the panel resize depending on the tab. This was because the startingSize was an empty string and we were doing a nullish check instead of a falsey one for the initial splitter position, so it was using that empty string for the initial flexBasis instead of the default 50%. 