### PR TITLE
Fix the keyboard navigation plugin support

### DIFF
--- a/pxtblocks/fields/field_textdropdown.ts
+++ b/pxtblocks/fields/field_textdropdown.ts
@@ -134,7 +134,7 @@ export class BaseFieldTextDropdown extends Blockly.FieldTextInput {
         // Focusing needs to be handled after the menu is rendered and positioned.
         // Otherwise it will cause a page scroll to get the misplaced menu in
         // view. See issue #1329.
-        this.menu_!.focus();
+        // this.menu_!.focus();
 
         if (this.selectedMenuItem) {
             this.menu_!.setHighlighted(this.selectedMenuItem);

--- a/pxtblocks/plugins/flyout/verticalFlyout.ts
+++ b/pxtblocks/plugins/flyout/verticalFlyout.ts
@@ -25,6 +25,8 @@ export class VerticalFlyout implements Blockly.IFlyout {
             return this.element;
         }
 
+        this.dummyWorkspace.createDom();
+
         this.element = Blockly.utils.dom.createSvgElement(
             tagName,
             {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -632,7 +632,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 pxtblockly.FIELD_EDITOR_OPEN_EVENT_TYPE
             ];
 
-            if (ev.type !== "var_create") {
+            if (ev.type !== "var_create" && ev.type !== "marker_move") {
                 this.hideFlyout();
             }
 


### PR DESCRIPTION
Fixing our keyboard navigation. Three small bugs:

1. The dummy workspace was never initialized in the multi-flyout and caused an exception during init
2. We were immediately closing the flyout when the cursor moved because of the workspace event being fired
3. The dropdown portion of the text dropdown field was being focused, which broke typing into the field.