### PR TITLE
Update Blocks Exist Json Schema for JsonPath Friendliness

### DIFF
--- a/common-docs/teachertool/test/validator-plans-shared.json
+++ b/common-docs/teachertool/test/validator-plans-shared.json
@@ -9,7 +9,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "",
+                            "blockId": "",
                             "count": 0
                         }
                     ]

--- a/common-docs/teachertool/test/validator-plans-shared.json
+++ b/common-docs/teachertool/test/validator-plans-shared.json
@@ -7,9 +7,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "": 0
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "",
+                            "count": 0
+                        }
+                    ]
                 }
             ]
         }

--- a/common-docs/teachertool/validator-plans-shared.json
+++ b/common-docs/teachertool/validator-plans-shared.json
@@ -9,7 +9,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "controls_repeat_ext",
+                            "blockId": "controls_repeat_ext",
                             "count": 1
                         }
                     ]
@@ -18,7 +18,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "device_while",
+                            "blockId": "device_while",
                             "count": 1
                         }
                     ]
@@ -27,7 +27,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "pxt_controls_for",
+                            "blockId": "pxt_controls_for",
                             "count": 1
                         }
                     ]
@@ -36,7 +36,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "pxt_controls_for_of",
+                            "blockId": "pxt_controls_for_of",
                             "count": 1
                         }
                     ]
@@ -79,7 +79,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "function_definition",
+                            "blockId": "function_definition",
                             "count": 1
                         }
                     ]
@@ -95,7 +95,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "variables_set",
+                            "blockId": "variables_set",
                             "count": 1
                         }
                     ]
@@ -111,7 +111,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "variables_get",
+                            "blockId": "variables_get",
                             "count": 1
                         }
                     ]
@@ -127,7 +127,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "argument_reporter_string",
+                            "blockId": "argument_reporter_string",
                             "count": 1
                         }
                     ]
@@ -136,7 +136,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "argument_reporter_number",
+                            "blockId": "argument_reporter_number",
                             "count": 1
                         }
                     ]
@@ -145,7 +145,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "argument_reporter_boolean",
+                            "blockId": "argument_reporter_boolean",
                             "count": 1
                         }
                     ]
@@ -154,7 +154,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "argument_reporter_array",
+                            "blockId": "argument_reporter_array",
                             "count": 1
                         }
                     ]
@@ -163,7 +163,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "argument_reporter_custom",
+                            "blockId": "argument_reporter_custom",
                             "count": 1
                         }
                     ]
@@ -172,7 +172,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "variables_get_reporter",
+                            "blockId": "variables_get_reporter",
                             "count": 1
                         }
                     ]
@@ -188,7 +188,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "argument_reporter_number",
+                            "blockId": "argument_reporter_number",
                             "count": 1
                         }
                     ]
@@ -204,7 +204,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "variables_set",
+                            "blockId": "variables_set",
                             "count": 1
                         }
                     ],
@@ -221,7 +221,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "device_random",
+                            "blockId": "device_random",
                             "count": 1
                         }
                     ]
@@ -251,7 +251,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "math_number",
+                            "blockId": "math_number",
                             "count": 2
                         }
                     ]
@@ -267,7 +267,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "math_number",
+                            "blockId": "math_number",
                             "count": 1
                         }
                     ]

--- a/common-docs/teachertool/validator-plans-shared.json
+++ b/common-docs/teachertool/validator-plans-shared.json
@@ -7,27 +7,39 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "controls_repeat_ext": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "controls_repeat_ext",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_while": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "device_while",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "pxt_controls_for": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "pxt_controls_for",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "pxt_controls_for_of": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "pxt_controls_for_of",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -65,9 +77,12 @@
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "function_definition": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "function_definition",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -78,9 +93,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "variables_set": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "variables_set",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -91,9 +109,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "variables_get": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "variables_get",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -104,39 +125,57 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "argument_reporter_string": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "argument_reporter_string",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "argument_reporter_number": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "argument_reporter_number",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "argument_reporter_boolean": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "argument_reporter_boolean",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "argument_reporter_array": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "argument_reporter_array",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "argument_reporter_custom": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "argument_reporter_custom",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "variables_get_reporter": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "variables_get_reporter",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -147,9 +186,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "argument_reporter_number": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "argument_reporter_number",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -160,9 +202,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "variables_set": 1
-                    },
+                    "blockCounts": [
+                        {
+                            "block_id": "variables_set",
+                            "count": 1
+                        }
+                    ],
                     "childValidatorPlans": ["device_random_used"]
                 }
             ]
@@ -174,9 +219,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_random": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "device_random",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -201,9 +249,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "math_number": 2
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "math_number",
+                            "count": 2
+                        }
+                    ]
                 }
             ]
         },
@@ -214,9 +265,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "math_number": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "math_number",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         }

--- a/localtypings/validatorPlan.d.ts
+++ b/localtypings/validatorPlan.d.ts
@@ -16,9 +16,13 @@ declare namespace pxt.blocks {
     }
 
     // Inputs for "Blocks Exist" validation.
+    export interface BlocksExistCountInfo extends ValidatorCheckBase {
+        blockId: string;
+        count: number;
+    }
     export interface BlocksExistValidatorCheck extends ValidatorCheckBase {
         validator: "blocksExist";
-        blockCounts: pxt.Map<number>;
+        blockCounts: BlocksExistCountInfo[];
     }
 
     export interface BlockCommentsExistValidatorCheck extends ValidatorCheckBase {

--- a/pxteditor/code-validation/runValidatorPlan.ts
+++ b/pxteditor/code-validation/runValidatorPlan.ts
@@ -65,7 +65,11 @@ export function runValidatorPlan(usedBlocks: Blockly.Block[], plan: pxt.blocks.V
 }
 
 function runBlocksExistValidation(usedBlocks: Blockly.Block[], inputs: pxt.blocks.BlocksExistValidatorCheck): [Blockly.Block[], boolean] {
-    const blockResults = validateBlocksExist({ usedBlocks, requiredBlockCounts: inputs.blockCounts });
+    const requiredBlockCounts = inputs.blockCounts.reduce((acc, info) => {
+        acc[info.blockId] = info.count;
+        return acc;
+    }, {} as pxt.Map<number>);
+    const blockResults = validateBlocksExist({ usedBlocks, requiredBlockCounts });
     let successfulBlocks: Blockly.Block[] = [];
     if (blockResults.passed) {
         const blockIdsFromValidator = Object.keys(inputs.blockCounts)


### PR DESCRIPTION
The structure of the `blockCounts` input for `blocksExist` validator plans was not JsonPath friendly, as the customizable `blockId` was treated as a property and it was also a part of the path for count. This change adjusts the schema so both `blockId` and `count` can be referenced more easily by [JsonPath](https://github.com/json-path/JsonPath), which we will need for parameterized criteria.

No user-facing functionality changes.