### PR TITLE
Teacher tool: fixed successful blocks for blocks exist new blocks exist schema

### DIFF
--- a/pxteditor/code-validation/runValidatorPlan.ts
+++ b/pxteditor/code-validation/runValidatorPlan.ts
@@ -72,8 +72,7 @@ function runBlocksExistValidation(usedBlocks: Blockly.Block[], inputs: pxt.block
     const blockResults = validateBlocksExist({ usedBlocks, requiredBlockCounts });
     let successfulBlocks: Blockly.Block[] = [];
     if (blockResults.passed) {
-        const blockIdsFromValidator = Object.keys(inputs.blockCounts)
-        const blockId = blockIdsFromValidator?.[0];
+        const blockId = inputs.blockCounts[0].blockId;
         successfulBlocks = blockResults.successfulBlocks.length ? blockResults.successfulBlocks[0][blockId] : [];
     }
     return [successfulBlocks, blockResults.passed];


### PR DESCRIPTION
The way successful blocks are populated for the blocks exist validator is a bit different from the others, and when we updated the blocks exist schema, the successful blocks list that we get from running the blocksExist validation broke. You'd have only run into this bug with blocksExist validation with children.