### PR TITLE
[Stable8.5] Cherry pick https://github.com/microsoft/pxt/pull/9886 to arcade stable

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -417,7 +417,7 @@ namespace pxtblockly {
 
         protected parseValueText(newText: string) {
             newText = pxt.Util.htmlUnescape(newText);
-            if (this.sourceBlock_ && !this.sourceBlock_.isInFlyout) {
+            if (this.sourceBlock_) {
                 const project = pxt.react.getTilemapProject();
 
                 const id = this.getBlockData();

--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -48,6 +48,8 @@ namespace pxtblockly {
             const existing = pxt.lookupProjectAssetByTSReference(newText, project);
             if (existing) return existing;
 
+            if (this.sourceBlock_?.isInFlyout) return undefined;
+
             const tilemap = pxt.sprite.decodeTilemap(newText, "typescript", project) || project.blankTilemap(this.params.tileWidth, this.params.initWidth, this.params.initHeight);
             let newAsset: pxt.ProjectTilemap;
 


### PR DESCRIPTION
Cherry picking https://github.com/microsoft/pxt/pull/9886 to the stable branch used by arcade.

The diff looks different than the original pr because in that pr i was also restoring some code that accidentally was lost in the blockly merge. that code was already cherry picked to this branch a while ago, so no need to replicate it.