### PR TITLE
Fix exception when disposing sim sequencers

### DIFF
--- a/pxtsim/sound/sequencer.ts
+++ b/pxtsim/sound/sequencer.ts
@@ -41,6 +41,7 @@ namespace pxsim.music {
 
         dispose() {
             if (this.metronome) this.metronome.dispose();
+            this.metronome = undefined
             this.stop();
             this.currentlyPlaying = undefined;
             this.listeners = {};
@@ -88,7 +89,7 @@ namespace pxsim.music {
         stop(sustainCurrentSounds = false) {
             if (this._state === "stop") return;
             this._state = "stop";
-            this.metronome.stop();
+            if (this.metronome) this.metronome.stop();
             this.fireStateChange();
 
             if (!sustainCurrentSounds) this.currentCancelToken.cancelled = true;


### PR DESCRIPTION
This is an exception we ran into on stream today. The dispose function in music sequencers was throwing an exception when it tried to communicate with the metronome after the metronome was already disposed of.