### PR TITLE
Fix Set High Contrast Error

### DIFF
--- a/teachertool/src/services/makecodeEditorService.ts
+++ b/teachertool/src/services/makecodeEditorService.ts
@@ -7,7 +7,7 @@ import { IframeDriver } from "pxtservices/iframeDriver";
 
 
 let driver: IframeDriver | undefined;
-let highContrast: boolean;
+let highContrast: boolean = false;
 
 export function setEditorRef(ref: HTMLIFrameElement | undefined) {
     if (driver) {


### PR DESCRIPTION
We're seeing intermittent errors in teacher tool where we're trying to call ToString() on undefined. This is happening because, in `setEditorRef()`, we are calling `driver.setHighContrast(highContrast);` without initializing the `highContrast` var to anything. As a result, we were passing in `undefined` which was breaking things down the line.