### PR TITLE
Include prefix when marking scripts as already migrated

### DIFF
--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -132,7 +132,7 @@ async function migratePouchAsync() {
             continue;
         }
 
-        alreadyMigratedList.setAsync(table, { id: migrationDbKey(prefix, id) });
+        await alreadyMigratedList.setAsync(table, { id: migrationDbKey(prefix, id) });
 
         const db = await getDbAsync(prefix)
         const existing = await db.getAsync(table, id);

--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -83,8 +83,6 @@ async function migratePouchAsync() {
     const entries = await oldDb.getAllAsync<any>(POUCH_OBJECT_STORE);
     const alreadyMigratedList = await getMigrationDbAsync();
 
-    const migrated: [string, string][] = [];
-
     for (const entry of entries) {
         // format is (prefix-)?tableName--id::rev
         const docId: string = entry._doc_id_rev;
@@ -135,8 +133,6 @@ async function migratePouchAsync() {
         }
 
         alreadyMigratedList.setAsync(table, { id: migrationDbKey(prefix, id) });
-
-        migrated.push([table, id]);
 
         const db = await getDbAsync(prefix)
         const existing = await db.getAsync(table, id);


### PR DESCRIPTION
When going to pxt-microbit beta the other day, I noticed a few of my scripts being left behind. Turns out I didn't account for the possibility of the same header existing multiple times in different versions of the pouch db!

This corrects that by prepending the browser prefix to the id we use for checking if something has been migrated.