### PR TITLE
Teacher Tool: Set Block Type for "Block" Used "N" Times

### DIFF
--- a/common-docs/teachertool/test/catalog-shared.json
+++ b/common-docs/teachertool/test/catalog-shared.json
@@ -24,7 +24,7 @@
             "params": [
                 {
                     "name": "block",
-                    "type": "string",
+                    "type": "block",
                     "paths": ["checks[0].blockCounts[0].blockId"]
                 },
                 {


### PR DESCRIPTION
Putting this into a separate change so it can be checked in and used to verify the block picker in an upload target when I send that PR, that way others can see it without needing a local build.