### PR TITLE
Refactor iframe communication and use MessageChannel

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,6 +48,7 @@ const cli = () => compileTsProject("cli", "built", true);
 const webapp = () => compileTsProject("webapp", "built", true);
 const reactCommon = () => compileTsProject("react-common", "built/react-common", true);
 const pxtblocks = () => compileTsProject("pxtblocks", "built/pxtblocks", true);
+const pxtservices = () => compileTsProject("pxtservices", "built/pxtservices", true);
 
 const pxtapp = () => gulp.src([
     "node_modules/lzma/src/lzma_worker-min.js",
@@ -118,7 +119,7 @@ function initWatch() {
         pxtlib,
         gulp.parallel(pxtcompiler, pxtsim, backendutils),
         pxtpy,
-        gulp.parallel(pxtblocks, pxteditor),
+        gulp.parallel(pxtblocks, pxteditor, pxtservices),
         gulp.parallel(pxtrunner, cli, pxtcommon),
         gulp.parallel(updatestrings, browserifyEmbed),
         gulp.parallel(pxtjs, pxtdts, pxtapp, pxtworker, pxtembed),
@@ -139,6 +140,7 @@ function initWatch() {
 
     gulp.watch("./pxtpy/**/*", gulp.series(pxtpy, ...tasks.slice(3)));
     gulp.watch("./pxtblocks/**/*", gulp.series(pxtblocks, ...tasks.slice(4)));
+    gulp.watch("./pxtservices/**/*", gulp.series(pxtservices, ...tasks.slice(4)));
 
     gulp.watch("./pxteditor/**/*", gulp.series(pxteditor, ...tasks.slice(4)));
 
@@ -219,6 +221,7 @@ function updatestrings() {
     return buildStrings("built/strings.json", [
         "cli",
         "pxtblocks",
+        "pxtservices",
         "pxtcompiler",
         "pxteditor",
         "pxtlib",
@@ -610,8 +613,9 @@ const maybeBuildWebapps = () => {
 
 const lintWithEslint = () => Promise.all(
     ["cli", "pxtblocks", "pxteditor", "pxtlib", "pxtcompiler",
-        "pxtpy", "pxtrunner", "pxtsim", "webapp",
-        "docfiles/pxtweb", "skillmap", "authcode", "multiplayer"/*, "kiosk"*/, "teachertool", "docs/static/streamer"].map(dirname =>
+        "pxtpy", "pxtrunner", "pxtsim", "webapp", "pxtservices",
+        "docfiles/pxtweb", "skillmap", "authcode",
+        "multiplayer"/*, "kiosk"*/, "teachertool", "docs/static/streamer"].map(dirname =>
             exec(`node node_modules/eslint/bin/eslint.js -c .eslintrc.js --ext .ts,.tsx ./${dirname}/`, true)))
     .then(() => console.log("linted"))
 const lint = lintWithEslint
@@ -723,7 +727,7 @@ const buildAll = gulp.series(
     gulp.parallel(pxtlib, pxtweb),
     gulp.parallel(pxtcompiler, pxtsim, backendutils),
     pxtpy,
-    gulp.parallel(pxteditor, pxtblocks),
+    gulp.parallel(pxteditor, pxtblocks, pxtservices),
     gulp.parallel(pxtrunner, cli, pxtcommon),
     browserifyEmbed,
     gulp.parallel(pxtjs, pxtdts, pxtapp, pxtworker, pxtembed),
@@ -747,7 +751,7 @@ exports.clean = clean;
 exports.build = buildAll;
 
 exports.webapp = gulp.series(
-    gulp.parallel(reactCommon, pxtblocks, pxteditor),
+    gulp.parallel(reactCommon, pxtblocks, pxteditor, pxtservices),
     webapp,
     browserifyWebapp,
     browserifyAssetEditor

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -16,6 +16,11 @@ declare namespace pxt.editor {
          * flag to request response
          */
         response?: boolean;
+
+        /**
+         * Frame identifier that can be passed to the iframe by adding the frameId query parameter
+         */
+        frameId?: string;
     }
 
     export interface EditorMessageResponse extends EditorMessage {
@@ -1237,6 +1242,71 @@ declare namespace pxt.editor {
          */
         blockId?: string;
     }
+
+    interface BaseAssetEditorRequest {
+        id?: number;
+        files: pxt.Map<string>;
+        palette?: string[];
+    }
+
+    interface OpenAssetEditorRequest extends BaseAssetEditorRequest {
+        type: "open";
+        assetId: string;
+        assetType: pxt.AssetType;
+    }
+
+    interface CreateAssetEditorRequest extends BaseAssetEditorRequest {
+        type: "create";
+        assetType: pxt.AssetType;
+        displayName?: string;
+    }
+
+    interface SaveAssetEditorRequest extends BaseAssetEditorRequest {
+        type: "save";
+    }
+
+    interface DuplicateAssetEditorRequest extends BaseAssetEditorRequest {
+        type: "duplicate";
+        assetId: string;
+        assetType: pxt.AssetType;
+    }
+
+    type AssetEditorRequest = OpenAssetEditorRequest | CreateAssetEditorRequest | SaveAssetEditorRequest | DuplicateAssetEditorRequest | SetMessagePortAssetEditorRequest;
+
+    interface BaseAssetEditorResponse {
+        id?: number;
+    }
+
+    interface OpenAssetEditorResponse extends BaseAssetEditorResponse {
+        type: "open";
+    }
+
+    interface CreateAssetEditorResponse extends BaseAssetEditorResponse {
+        type: "create";
+    }
+
+    interface SaveAssetEditorResponse extends BaseAssetEditorResponse {
+        type: "save";
+        files: pxt.Map<string>;
+    }
+
+    interface DuplicateAssetEditorResponse extends BaseAssetEditorResponse {
+        type: "duplicate";
+    }
+
+    type AssetEditorResponse = OpenAssetEditorResponse | CreateAssetEditorResponse | SaveAssetEditorResponse | DuplicateAssetEditorResponse | SetMessagePortAssetEditorResponse;
+
+    interface AssetEditorRequestSaveEvent {
+        type: "event";
+        kind: "done-clicked";
+    }
+
+    interface AssetEditorReadyEvent {
+        type: "event";
+        kind: "ready";
+    }
+
+    type AssetEditorEvent = AssetEditorRequestSaveEvent | AssetEditorReadyEvent;
 }
 
 declare namespace pxt.workspace {

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -1271,7 +1271,7 @@ declare namespace pxt.editor {
         assetType: pxt.AssetType;
     }
 
-    type AssetEditorRequest = OpenAssetEditorRequest | CreateAssetEditorRequest | SaveAssetEditorRequest | DuplicateAssetEditorRequest | SetMessagePortAssetEditorRequest;
+    type AssetEditorRequest = OpenAssetEditorRequest | CreateAssetEditorRequest | SaveAssetEditorRequest | DuplicateAssetEditorRequest;
 
     interface BaseAssetEditorResponse {
         id?: number;
@@ -1294,7 +1294,7 @@ declare namespace pxt.editor {
         type: "duplicate";
     }
 
-    type AssetEditorResponse = OpenAssetEditorResponse | CreateAssetEditorResponse | SaveAssetEditorResponse | DuplicateAssetEditorResponse | SetMessagePortAssetEditorResponse;
+    type AssetEditorResponse = OpenAssetEditorResponse | CreateAssetEditorResponse | SaveAssetEditorResponse | DuplicateAssetEditorResponse;
 
     interface AssetEditorRequestSaveEvent {
         type: "event";

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -3,10 +3,15 @@
 import { runValidatorPlan } from "./code-validation/runValidatorPlan";
 import IProjectView = pxt.editor.IProjectView;
 
+import { IFrameEmbeddedClient } from "../pxtservices/iframeEmbeddedClient";
+
 const pendingRequests: pxt.Map<{
     resolve: (res?: pxt.editor.EditorMessageResponse | PromiseLike<pxt.editor.EditorMessageResponse>) => void;
     reject: (err: any) => void;
 }> = {};
+
+let iframeClient: IFrameEmbeddedClient;
+
 /**
  * Binds incoming window messages to the project view.
  * Requires the "allowParentController" flag in the pxtarget.json/appTheme object.
@@ -24,7 +29,7 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
 
     if (!allowEditorMessages && !allowExtensionMessages && !allowSimTelemetry) return;
 
-    window.addEventListener("message", (msg: MessageEvent) => {
+    const handleMessage = (msg: MessageEvent) => {
         const data = msg.data as pxt.editor.EditorMessage;
         if (!data || !/^pxt(host|editor|pkgext|sim)$/.test(data.type)) return false;
 
@@ -154,7 +159,7 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                         })
                                     });
                             }
-                            case "renderxml": {
+case "renderxml": {
                                 const rendermsg = data as pxt.editor.EditorMessageRenderXmlRequest;
                                 return Promise.resolve()
                                     .then(() => {
@@ -186,7 +191,7 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                         resp = { result: results };
                                     });
                             }
-                            case "gettoolboxcategories": {
+case "gettoolboxcategories": {
                                 const msg = data as pxt.editor.EditorMessageGetToolboxCategoriesRequest;
                                 return Promise.resolve()
                                     .then(() => {
@@ -289,7 +294,9 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
         }
 
         return true;
-    }, false)
+    };
+
+    iframeClient = new IFrameEmbeddedClient(handleMessage);
 }
 
 /**
@@ -343,13 +350,20 @@ export function enableControllerAnalytics() {
 
 function sendResponse(request: pxt.editor.EditorMessage, resp: any, success: boolean, error: any) {
     if (request.response) {
-        window.parent.postMessage({
+        const toSend = {
             type: request.type,
             id: request.id,
             resp,
             success,
             error
-        }, "*");
+        };
+
+        if (iframeClient) {
+            iframeClient.postMessage(toSend)
+        }
+        else {
+            window.parent.postMessage(toSend, "*");
+        }
     }
 }
 
@@ -369,7 +383,14 @@ export function postHostMessageAsync(msg: pxt.editor.EditorMessageRequest): Prom
         env.id = ts.pxtc.Util.guidGen();
         if (msg.response)
             pendingRequests[env.id] = { resolve, reject };
-        window.parent.postMessage(env, "*");
+
+        if (iframeClient) {
+            iframeClient.postMessage(env);
+        }
+        else {
+            window.parent.postMessage(env, "*");
+        }
+
         if (!msg.response)
             resolve(undefined)
     })

--- a/pxtservices/.eslintrc.js
+++ b/pxtservices/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    "parserOptions": {
+        "project": "pxtservices/tsconfig.json",
+    }
+}

--- a/pxtservices/assetEditorDriver.ts
+++ b/pxtservices/assetEditorDriver.ts
@@ -1,0 +1,65 @@
+import { IframeDriver } from "./iframeDriver";
+
+export class AssetEditorDriver extends IframeDriver {
+    constructor(frame: HTMLIFrameElement) {
+        super(frame);
+    }
+
+    async openAsset(assetId: string, assetType: pxt.AssetType, files: pxt.Map<string>, palette?: string[]) {
+        await this.sendRequest(
+            {
+                type: "open",
+                assetId,
+                assetType,
+                files,
+                palette
+            } as pxt.editor.OpenAssetEditorRequest
+        );
+    }
+
+    async createAsset(assetType: pxt.AssetType, files: pxt.Map<string>, displayName?: string, palette?: string[]) {
+        await this.sendRequest({
+            type: "create",
+            assetType,
+            files,
+            displayName,
+            palette
+        } as pxt.editor.CreateAssetEditorRequest);
+    }
+
+    async saveAsset() {
+        const resp = await this.sendRequest({
+            type: "save"
+        } as pxt.editor.SaveAssetEditorRequest);
+
+        return (resp as pxt.editor.SaveAssetEditorResponse).files;
+    }
+
+    async duplicateAsset(assetId: string, assetType: pxt.AssetType, files: pxt.Map<string>, palette?: string[]) {
+        await this.sendRequest({
+            type: "duplicate",
+            assetId,
+            assetType,
+            files,
+            palette
+        } as pxt.editor.DuplicateAssetEditorRequest);
+    }
+
+    addEventListener(event: "ready", handler: (ev: pxt.editor.AssetEditorReadyEvent) => void): void;
+    addEventListener(event: "done-clicked", handler: (ev: pxt.editor.AssetEditorRequestSaveEvent) => void): void;
+    addEventListener(event: string, handler: (ev: any) => void): void {
+        super.addEventListener(event, handler);
+    }
+
+    protected handleMessage(event: MessageEvent<any>): void {
+        const data = event.data;
+        if (!data) return;
+
+        if (data.type === "event") {
+            this.fireEvent((data as pxt.editor.AssetEditorEvent).kind, data);
+        }
+        else {
+            this.resolvePendingMessage(event);
+        }
+    }
+}

--- a/pxtservices/editorDriver.ts
+++ b/pxtservices/editorDriver.ts
@@ -1,0 +1,502 @@
+/// <reference path="../localtypings/pxteditor.d.ts" />
+
+import { IframeDriver } from "./iframeDriver";
+
+const MessageReceivedEvent = "message";
+const MessageSentEvent = "sent";
+
+export interface IframeWorkspaceStatus {
+    projects: pxt.workspace.Project[];
+    editor?: pxt.editor.EditorSyncState;
+    controllerId?: string;
+}
+
+export interface IFrameWorkspaceHost {
+    saveProject(project: pxt.workspace.Project): Promise<void>;
+    getWorkspaceProjects(): Promise<IframeWorkspaceStatus>;
+    resetWorkspace(): Promise<void>;
+    onWorkspaceLoaded?(): Promise<void>;
+}
+
+/**
+ * Manages communication with the editor iframe.
+ */
+export class EditorDriver extends IframeDriver {
+    constructor(public iframe: HTMLIFrameElement, public host?: IFrameWorkspaceHost) {
+        super(iframe);
+    }
+
+    async switchEditorLanguage(lang: "typescript" | "blocks" | "python") {
+        let action;
+        switch (lang) {
+            case "blocks":
+                action = "switchblocks";
+                break;
+            case "typescript":
+                action = "switchjavascript";
+                break;
+            case "python":
+                action = "switchpython";
+                break;
+        }
+
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async setLanguageRestriction(restriction: pxt.editor.LanguageRestriction) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "setlanguagerestriction",
+                restriction
+            } as pxt.editor.EditorSetLanguageRestriction
+        );
+    }
+
+    async startSimulator() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "startsimulator"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async stopSimulator(unload = false) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "stopsimulator",
+                unload
+            } as pxt.editor.EditorMessageStopRequest
+        );
+    }
+
+    async restartSimulator() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "restartsimulator"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async hideSimulator() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "hidesimulator"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async showSimulator() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "showsimulator"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async setSimulatorFullscreen(on: boolean) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "setsimulatorfullscreen",
+                enabled: on
+            } as pxt.editor.EditorMessageSetSimulatorFullScreenRequest
+        );
+    }
+
+    async closeFlyout() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "closeflyout"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async unloadProject() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "unloadproject"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async saveProject() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "saveproject"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async undo() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "undo"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async redo() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "redo"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async setHighContrast(on: boolean) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "sethighcontrast",
+                on
+            } as pxt.editor.EditorMessageSetHighContrastRequest
+        );
+    }
+
+    async toggleHighContrast() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "togglehighcontrast"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async toggleGreenScreen() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "togglegreenscreen"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async toggleSloMo(intervalSpeed?: number) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "toggletrace",
+                intervalSpeed
+            } as pxt.editor.EditorMessageToggleTraceRequest
+        );
+    }
+
+    async setSloMoEnabled(enabled: boolean, intervalSpeed?: number) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "settracestate",
+                enabled,
+                intervalSpeed
+            } as pxt.editor.EditorMessageSetTraceStateRequest
+        );
+    }
+
+    async printProject() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "print"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async getInfo(): Promise<pxt.editor.InfoMessage> {
+        const resp = await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "info"
+            } as pxt.editor.EditorMessageRequest
+        ) as pxt.editor.EditorMessageResponse;
+
+        return (resp.resp as pxt.editor.InfoMessage);
+    }
+
+    async newProject(options: pxt.editor.ProjectCreationOptions) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "newproject",
+                options
+            } as pxt.editor.EditorMessageNewProjectRequest
+        );
+    }
+
+    async importProject(project: pxt.workspace.Project, filters?: pxt.editor.ProjectFilters, searchBar?: boolean) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "importproject",
+                project,
+                filters,
+                searchBar
+            } as pxt.editor.EditorMessageImportProjectRequest
+        );
+    }
+
+    async openHeader(headerId: string) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "openheader",
+                headerId
+            } as pxt.editor.EditorMessageOpenHeaderRequest
+        );
+    }
+
+    async shareHeader(headerId: string, projectName: string) {
+        const resp = await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "shareproject",
+                headerId,
+                projectName
+            } as pxt.editor.EditorShareRequest
+        ) as pxt.editor.EditorMessageResponse;
+
+        return resp.resp as pxt.editor.ShareData;
+    }
+
+    async startActivity(activityType: "tutorial" | "example" | "recipe", path: string, title?: string, previousProjectHeaderId?: string, carryoverPreviousCode?: boolean) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "startactivity",
+                activityType,
+                path,
+                title,
+                previousProjectHeaderId,
+                carryoverPreviousCode
+            } as pxt.editor.EditorMessageStartActivity
+        );
+    }
+
+    async importTutorial(markdown: string) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "importtutorial",
+                markdown
+            } as pxt.editor.EditorMessageImportTutorialRequest
+        );
+    }
+
+    async pair() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "pair"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async decompileToBlocks(ts: string, snippetMode?: boolean, layout?: pxt.editor.BlockLayout) {
+        const resp = await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "renderblocks",
+                ts,
+                snippetMode,
+                layout
+            } as pxt.editor.EditorMessageRenderBlocksRequest
+        ) as pxt.editor.EditorMessageResponse;
+
+        return resp.resp as pxt.editor.EditorMessageRenderBlocksResponse;
+    }
+
+    async decompileToPython(ts: string) {
+        const resp = await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "renderpython",
+                ts
+            } as pxt.editor.EditorMessageRenderPythonRequest
+        ) as pxt.editor.EditorMessageResponse;
+
+        return (resp.resp as pxt.editor.EditorMessageRenderPythonResponse).python;
+    }
+
+    async renderXml(xml: string) {
+        const resp = await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "renderxml",
+                xml
+            } as pxt.editor.EditorMessageRenderXmlRequest
+        ) as pxt.editor.EditorMessageResponse;
+
+        return resp.resp;
+    }
+
+    async renderByBlockId(blockId: string) {
+        const resp = await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "renderbyblockid",
+                blockId: blockId
+            } as pxt.editor.EditorMessageRenderByBlockIdRequest
+        ) as pxt.editor.EditorMessageResponse;
+
+        return resp.resp;
+    }
+
+    async getToolboxCategories(advanced?: boolean): Promise<pxt.editor.ToolboxCategoryDefinition[]> {
+        const resp = await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "gettoolboxcategories",
+                advanced
+            } as pxt.editor.EditorMessageGetToolboxCategoriesRequest
+        ) as pxt.editor.EditorMessageResponse;
+
+        return (resp.resp as pxt.editor.EditorMessageGetToolboxCategoriesResponse).categories;
+    }
+
+    async runValidatorPlan(validatorPlan: pxt.blocks.ValidatorPlan, planLib: pxt.blocks.ValidatorPlan[]) {
+        const resp = await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "runeval",
+                validatorPlan,
+                planLib,
+            } as pxt.editor.EditorMessageRunEvalRequest
+        ) as pxt.editor.EditorMessageResponse;
+
+        return resp.resp as pxt.blocks.EvaluationResult;
+    }
+
+    async saveLocalProjectsToCloud(headerIds: string[]) {
+        const resp = await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "savelocalprojectstocloud",
+                headerIds
+            } as pxt.editor.EditorMessageSaveLocalProjectsToCloud
+        ) as pxt.editor.EditorMessageResponse;
+
+        return resp.resp as pxt.editor.EditorMessageSaveLocalProjectsToCloudResponse;
+    }
+
+    async convertCloudProjectsToLocal(userId: string) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "convertcloudprojectstolocal",
+                userId
+            } as pxt.editor.EditorMessageConvertCloudProjectsToLocal
+        );
+    }
+
+    async requestProjectCloudStatus(headerIds: string[]) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "requestprojectcloudstatus",
+                headerIds
+            } as pxt.editor.EditorMessageRequestProjectCloudStatus
+        );
+    }
+
+    addEventListener(event: typeof MessageSentEvent, handler: (ev: pxt.editor.EditorMessage) => void): void;
+    addEventListener(event: typeof MessageReceivedEvent, handler: (ev: pxt.editor.EditorMessage) => void): void;
+    addEventListener(event: "event", handler: (ev: pxt.editor.EditorMessageEventRequest) => void): void;
+    addEventListener(event: "simevent", handler: (ev: pxt.editor.EditorSimulatorEvent) => void): void;
+    addEventListener(event: "tutorialevent", handler: (ev: pxt.editor.EditorMessageTutorialEventRequest) => void): void;
+    addEventListener(event: "workspacesave", handler: (ev: pxt.editor.EditorWorkspaceSaveRequest) => void): void;
+    addEventListener(event: "workspaceevent", handler: (ev: pxt.editor.EditorWorkspaceEvent) => void): void;
+    addEventListener(event: "workspacereset", handler: (ev: pxt.editor.EditorWorkspaceSyncRequest) => void): void;
+    addEventListener(event: "workspacesync", handler: (ev: pxt.editor.EditorWorkspaceSyncRequest) => void): void;
+    addEventListener(event: "workspaceloaded", handler: (ev: pxt.editor.EditorWorkspaceSyncRequest) => void): void;
+    addEventListener(event: "workspacediagnostics", handler: (ev: pxt.editor.EditorWorkspaceDiagnostics) => void): void;
+    addEventListener(event: "editorcontentloaded", handler: (ev: pxt.editor.EditorContentLoadedRequest) => void): void;
+    addEventListener(event: "projectcloudstatus", handler: (ev: pxt.editor.EditorMessageProjectCloudStatus) => void): void;
+    addEventListener(event: string, handler: (ev: any) => void): void {
+        super.addEventListener(event, handler);
+    }
+
+    sendMessage(message: pxt.editor.EditorMessageRequest): Promise<pxt.editor.EditorMessageResponse> {
+        return this.sendRequest(message) as Promise<pxt.editor.EditorMessageResponse>;
+    }
+
+    protected handleMessage(event: MessageEvent) {
+        const data = event.data as pxt.editor.EditorMessageRequest;
+        if (!data || !/^pxt(host|editor|pkgext|sim)$/.test(data.type)) return;
+
+        if (data.type === "pxteditor") {
+            this.resolvePendingMessage(event);
+        }
+        else if (data.type === "pxthost") {
+            if (data.action === "editorcontentloaded") {
+                this.readyForMessages = true;
+                this.sendMessageCore(); // flush message queue.
+            }
+            else if (data.action === "workspacesync" || data.action === "workspacesave" || data.action === "workspacereset" || data.action === "workspaceloaded") {
+                this.handleWorkspaceSync(data as pxt.editor.EditorWorkspaceSyncRequest);
+            }
+
+            this.fireEvent(data.action, data);
+        }
+
+        this.fireEvent(MessageReceivedEvent, data);
+    }
+
+    protected async handleWorkspaceSync(event: pxt.editor.EditorWorkspaceSyncRequest | pxt.editor.EditorWorkspaceSaveRequest) {
+        if (!this.host) return;
+
+        let error: any = undefined;
+        try {
+            if (event.action === "workspacesync") {
+                const status = await this.host.getWorkspaceProjects();
+                this.sendMessageCore({
+                    type: "pxthost",
+                    id: event.id,
+                    success: !!status,
+                    projects: status?.projects,
+                    editor: status?.editor,
+                    controllerId: status?.controllerId
+                } as pxt.editor.EditorWorkspaceSyncResponse);
+            }
+            else if (event.action === "workspacereset") {
+                await this.host.resetWorkspace();
+            }
+            else if (event.action === "workspacesave") {
+                await this.host.saveProject(event.project);
+            }
+            else if (event.action === "workspaceloaded") {
+                if (this.host.onWorkspaceLoaded) {
+                    await this.host.onWorkspaceLoaded();
+                }
+            }
+        }
+        catch (e) {
+            error = e;
+            console.error(e);
+        }
+        finally {
+            if (event.response) {
+                this.sendMessageCore({
+                    type: "pxthost",
+                    id: event.id,
+                    success: !error,
+                    error
+                } as pxt.editor.EditorMessageResponse);
+            }
+        }
+    }
+}

--- a/pxtservices/iframeEmbeddedClient.ts
+++ b/pxtservices/iframeEmbeddedClient.ts
@@ -19,6 +19,17 @@ export class IFrameEmbeddedClient {
         this.sendReadyMessage();
     }
 
+    dispose() {
+        window.removeEventListener("message", this.onMessageReceived);
+        if (this.port) {
+            this.port.close();
+        }
+    }
+
+    postMessage(message: any) {
+        this.postMessageCore(message);
+    }
+
     protected onMessageReceived = (event: MessageEvent) => {
         const data = event.data;
 
@@ -39,10 +50,6 @@ export class IFrameEmbeddedClient {
         }
 
         this.messageHandler(event);
-    }
-
-    postMessage(message: any) {
-        this.postMessageCore(message);
     }
 
     protected postMessageCore(message: any) {

--- a/pxtservices/iframeEmbeddedClient.ts
+++ b/pxtservices/iframeEmbeddedClient.ts
@@ -1,0 +1,79 @@
+type IframeClientSetMessagePortRequest = {
+    type: "iframeclientsetmessageport";
+};
+
+type IFrameClientReadyMessage = {
+    type: "iframeclientready";
+};
+
+export type IframeClientMessage = IframeClientSetMessagePortRequest | IFrameClientReadyMessage;
+
+export class IFrameEmbeddedClient {
+    protected frameId: string;
+    protected port: MessagePort;
+
+    constructor(protected messageHandler: (message: MessageEvent) => void) {
+        this.frameId = frameId();
+
+        window.addEventListener("message", this.onMessageReceived);
+        this.sendReadyMessage();
+    }
+
+    protected onMessageReceived = (event: MessageEvent) => {
+        const data = event.data;
+
+        if (data) {
+            if (data.type === "iframeclientsetmessageport") {
+                this.port = event.ports[0];
+                this.port.onmessage = this.onMessageReceived;
+
+                this.postMessage({
+                    type: "iframeclientsetmessageport"
+                } as IframeClientSetMessagePortRequest);
+                return;
+            }
+            else if (data.type === "iframeclientready") {
+                this.sendReadyMessage();
+                return;
+            }
+        }
+
+        this.messageHandler(event);
+    }
+
+    postMessage(message: any) {
+        this.postMessageCore(message);
+    }
+
+    protected postMessageCore(message: any) {
+        if (this.frameId) {
+            message.frameId = this.frameId;
+        }
+
+        if (this.port) {
+            this.port.postMessage(message);
+        }
+        else if ((window as any).acquireVsCodeApi) {
+            (window as any).acquireVsCodeApi().postMessage(message)
+        }
+        else {
+            window.parent.postMessage(message, "*");
+        }
+    }
+
+    protected sendReadyMessage() {
+        this.postMessage({
+            type: "iframeclientready"
+        });
+    }
+}
+
+function frameId(): string {
+    const match = /frameid=([a-zA-Z0-9\-]+)/i.exec(window.location.href);
+
+    if (match) {
+        return match[1];
+    }
+
+    return undefined;
+}

--- a/teachertool/src/services/makecodeEditorService.ts
+++ b/teachertool/src/services/makecodeEditorService.ts
@@ -3,10 +3,10 @@
 import { ErrorCode } from "../types/errorCode";
 import { logDebug, logError } from "./loggingService";
 import * as AutorunService from "./autorunService";
-import { IframeDriver } from "pxtservices/iframeDriver";
+import { EditorDriver } from "pxtservices/editorDriver";
 import { loadToolboxCategoriesAsync } from "../transforms/loadToolboxCategoriesAsync";
 
-let driver: IframeDriver | undefined;
+let driver: EditorDriver | undefined;
 let highContrast: boolean = false;
 
 export function setEditorRef(ref: HTMLIFrameElement | undefined) {
@@ -18,7 +18,7 @@ export function setEditorRef(ref: HTMLIFrameElement | undefined) {
     }
 
     if (ref) {
-        driver = new IframeDriver(ref);
+        driver = new EditorDriver(ref);
 
         driver.addEventListener("message", ev => {
             logDebug(`Message received from iframe: ${JSON.stringify(ev)}`);


### PR DESCRIPTION
This PR does a few things:

1. Refactors the IFrameDriver into a base class and adds a new EditorDriver that takes the place of the old class
2. Adds another IFrameDriver that can be used to drive the asset editor embed (arcade.makecode.com/--asseteditor)
3. Adds a new IFrameEmbeddedClient that can be used within the embedded iframe to handle communication with the parent frame
4. Refactors our messaging protocol to use a MessageChannel so that we can support multiple iframe embeds at the same time

This is all 100% backwards compatible with old embeds. To use the new MessageChannel stuff, you need to add `?frameid=<some-unique-id>` to the iframe's src url, then everything will just work and it will automatically switch to using the MessageChannel. If you don't add that, the new code falls back to using the good old `postMessage` for communication. I went ahead and added it to the embed for the teacher tool and everything is working fine.

We still have a few iframe embeds that I'll want to eventually switch over to this new stuff:
* pxtrunner (both --docs and --run)
* the simulator (this will involve refactoring the existing pxsim SimDriver class)