### PR TITLE
Pxsim: remove event listeners now a method that can be called from boardview

### DIFF
--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -1089,6 +1089,7 @@ namespace pxsim.visuals {
         getCoord(pinNm: string): Coord;
         getPinDist(): number;
         highlightPin(pinNm: string): void;
+        removeEventListeners?(): void;
     }
 
     //expects rgb from 0,255, gives h in [0,360], s in [0, 100], l in [0, 100]

--- a/pxtsim/visuals/boardhost.ts
+++ b/pxtsim/visuals/boardhost.ts
@@ -134,6 +134,12 @@ namespace pxsim.visuals {
             this.boardView.highlightPin(pinNm);
         }
 
+        public removeEventListeners() {
+            if (this.boardView.removeEventListeners) {
+                this.boardView.removeEventListeners();
+            }
+        }
+
         public highlightBreadboardPin(rowCol: BBLoc) {
             this.breadboard.highlightLoc(rowCol);
         }


### PR DESCRIPTION
This change is needed because the only thing that interacts with the BoardView is the BoardHost, and I need to be able to kill event listeners that were added to the BoardView. Needed for the fix for https://github.com/microsoft/pxt-microbit/issues/5434.

Edit: Part of this PR: https://github.com/microsoft/pxt-microbit/pull/5578