### PR TITLE
minimum node version 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you run `npm i` afterwards (in either the target or pxt), you might need to r
 
 ## Build
 
-First, install [Node](https://nodejs.org/en/): minimum version 8.
+First, install [Node](https://nodejs.org/en/): minimum version 16.
 
 To build the PXT command line tools:
 


### PR DESCRIPTION
README states that `node>=8` is needed,
https://github.com/microsoft/pxt/blame/f4e9aad00274ae9b384a9c308d10fa6459a2db50/README.md#L58C66-L58C66
while package.json tells `node>=16` is needed:
https://github.com/microsoft/pxt/blob/f4e9aad00274ae9b384a9c308d10fa6459a2db50/package.json#L59-L62

I myself had a successful build on Node.js 15.

I guess just changing the README to `node>=16` would be okay.