### PR TITLE
Update the immersive reader token

### DIFF
--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { MarkedContent } from "../../marked";
 import { Button, Modal, ModalButton } from "../../sui";
-import { ImmersiveReaderButton, launchImmersiveReader } from "../../immersivereader";
+import { ImmersiveReaderButton, launchImmersiveReaderAsync } from "../../immersivereader";
 import { TutorialStepCounter } from "./TutorialStepCounter";
 import { TutorialHint } from "./TutorialHint";
 import { TutorialResetCode } from "./TutorialResetCode";
@@ -229,7 +229,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
     if (showImmersiveReader) {
         modalActions.push({
             className: "immersive-reader-button",
-            onclick: () => { launchImmersiveReader(currentStepInfo.contentMd, tutorialOptions) },
+            onclick: () => { launchImmersiveReaderAsync(currentStepInfo.contentMd, tutorialOptions) },
             ariaLabel: lf("Launch Immersive Reader"),
             title: lf("Launch Immersive Reader")
         })

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -229,7 +229,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
     if (showImmersiveReader) {
         modalActions.push({
             className: "immersive-reader-button",
-            onclick: () => { launchImmersiveReaderAsync(currentStepInfo.contentMd, tutorialOptions) },
+            onclick: async () => { await launchImmersiveReaderAsync(currentStepInfo.contentMd, tutorialOptions) },
             ariaLabel: lf("Launch Immersive Reader"),
             title: lf("Launch Immersive Reader")
         })

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -185,8 +185,8 @@ function beautifyText(content: string): string {
     }
 }
 
+const IMMERSIVE_READER_ID = "immReaderToken";
 function getTokenAsync(): Promise<ImmersiveReaderToken> {
-    const IMMERSIVE_READER_ID = "immReaderToken";
     const storedTokenString = pxt.storage.getLocal(IMMERSIVE_READER_ID);
     const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
@@ -256,6 +256,8 @@ export async function launchImmersiveReaderAsync(content: string, tutorialOption
                 }
                 case "token":
                 default: {
+                    // If the token is invalid, remove it from storage
+                    pxt.storage.removeLocal(IMMERSIVE_READER_ID);
                     core.warningNotification(lf("Immersive Reader could not be launched"));
                     if (typeof e == "string") {
                         pxt.tickEvent("immersiveReader.error", {message: e});

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -186,7 +186,7 @@ function beautifyText(content: string): string {
 }
 
 function getTokenAsync(): Promise<ImmersiveReaderToken> {
-    const IMMERSIVE_READER_ID = "immReader";
+    const IMMERSIVE_READER_ID = "immReaderToken";
     const storedTokenString = pxt.storage.getLocal(IMMERSIVE_READER_ID);
     const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -273,7 +273,7 @@ export async function launchImmersiveReaderAsync(content: string, tutorialOption
     };
 
     async function testConnectionAsync() {
-        // Will except if there is an error we are not expecting
+        // Will throw an exception here if there is an error we are not expecting
         return pxt.Cloud.privateGetAsync("ping", true);
     }
 }
@@ -285,8 +285,8 @@ interface ImmersiveReaderProps {
 }
 
 export class ImmersiveReaderButton extends data.Component<ImmersiveReaderProps, {}> {
-    private buttonClickHandler = () => {
-        /** async */ launchImmersiveReaderAsync(this.props.content, this.props.tutorialOptions);
+    private buttonClickHandler = async () => {
+        await launchImmersiveReaderAsync(this.props.content, this.props.tutorialOptions);
     }
 
     render() {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -367,7 +367,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
             if (immersiveReaderEnabled) {
                 actions.push({
                     className: "immersive-reader-button",
-                    onclick: () => { ImmersiveReader.launchImmersiveReader(fullText, options) },
+                    onclick: () => { ImmersiveReader.launchImmersiveReaderAsync(fullText, options) },
                     ariaLabel: lf("Launch Immersive Reader"),
                     title: lf("Launch Immersive Reader")
                 })

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -367,7 +367,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
             if (immersiveReaderEnabled) {
                 actions.push({
                     className: "immersive-reader-button",
-                    onclick: () => { ImmersiveReader.launchImmersiveReaderAsync(fullText, options) },
+                    onclick: async () => { await ImmersiveReader.launchImmersiveReaderAsync(fullText, options) },
                     ariaLabel: lf("Launch Immersive Reader"),
                     title: lf("Launch Immersive Reader")
                 })


### PR DESCRIPTION
### Problem
A change went live that returned Immersive Reader tokens with invalid expiration dates. Those tokens will effectively never expire; this becomes a problem since we do not remove invalid tokens. Meaning anyone who received the bad token is stuck unless they manually remove the token from local storage themselves.

### Solution
Change the name of the Immersive Reader token so that those with a broken token will pick up a new one. Then make sure to remove the Immersive Reader token if there is a problem using it. That way if something like this happens again, we do not have to worry about old tokens sticking around.

### Validation
[See Arcade build using these changes](https://arcade.staging.pxt.io/app/621989a31abe52ace25e198b1bd7b85d4c7a3f80-acef86db3b#editor).

- Using the above build navigate to the home page and click on the first tutorial. Click on the Immersive Reader button and confirm it works as expected.
- Exit the immersive reader and load the debugger. Set a breakpoint right after `await getTokenAsync();` in `launchImmersiveReaderAsync`. Run the immersive reader again, set the token to gibberish. Confirm that the token is present in local storage. Continue the function, click okay on the Immersive Reader error modal. Confirm that the token has been removed from local storage.

### Notes
This partially addresses https://github.com/microsoft/pxt-microbit/issues/5574, though not until this change is served can we call it closed.
