### PR TITLE
Accessibility insights fixes

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -525,12 +525,12 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
         }
 
         return (
-            <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`} role="listbox" aria-orientation="horizontal">
+            <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`} role="listbox" aria-orientation="horizontal" aria-label={lf("editor toggle")}>
                 {showSandbox && <SandboxMenuItem parent={parent} />}
                 {showBlocks && <BlocksMenuItem parent={parent} />}
                 {textLanguage}
                 {secondTextLanguage}
-                {showDropdown && <sui.DropdownMenu id="editordropdown" role="menuitem" icon="chevron down" rightIcon title={lf("Select code editor language")} className={`item button attached right ${dropdownActive ? "active" : ""}`}>
+                {showDropdown && <sui.DropdownMenu id="editordropdown" role="option" icon="chevron down" rightIcon title={lf("Select code editor language")} className={`item button attached right ${dropdownActive ? "active" : ""}`}>
                     <JavascriptMenuItem parent={parent} />
                     <PythonMenuItem parent={parent} />
                 </sui.DropdownMenu>}

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -525,7 +525,7 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
         }
 
         return (
-            <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`} role="listbox" aria-orientation="horizontal" aria-label={lf("editor toggle")}>
+            <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`} role="listbox" aria-orientation="horizontal" aria-label={lf("Editor toggle")}>
                 {showSandbox && <SandboxMenuItem parent={parent} />}
                 {showBlocks && <BlocksMenuItem parent={parent} />}
                 {textLanguage}

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -416,7 +416,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         }
 
         return <div id="editortools" className="ui" role="region" aria-label={lf("Editor toolbar")}>
-            <div id="downloadArea" role="menu" className="ui column items">{headless &&
+            <div id="downloadArea" role="menubar" className="ui column items">{headless &&
                 <div className="ui item">
                     <div className="ui icon large buttons">
                         {compileBtn && <EditorToolbarButton icon={downloadIcon} className={`primary large download-button mobile tablet hide ${downloadButtonClasses}`} title={compileTooltip} onButtonClick={this.compile} view='computer' />}
@@ -438,7 +438,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
                         <identity.CloudSaveStatus headerId={header.id} />
                     </div>
                 </div>}
-            <div id="editorToolbarArea" role="menu" className="ui column items">
+            <div id="editorToolbarArea" role="menubar" className="ui column items">
                 {showUndoRedo && <div className="ui icon buttons">{this.getUndoRedo(computer)}</div>}
                 {showZoomControls && <div className="ui icon buttons mobile hide">{this.getZoomControl(computer)}</div>}
                 {targetTheme.bigRunButton && !pxt.shell.isTimeMachineEmbed() &&

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -153,7 +153,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
             readOnly={projectNameReadOnly}
         />)
         if (showSave) {
-            saveInput.push(<EditorToolbarButton icon='save' className={`right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view={this.getViewString(View.Computer)} key={`save${View.Computer}`} />)
+            saveInput.push(<EditorToolbarButton role="button" icon='save' className={`right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view={this.getViewString(View.Computer)} key={`save${View.Computer}`} />)
         }
 
         return saveInput;
@@ -431,7 +431,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
                 </div>}
             </div>
             {(showProjectRename || showGithub || identity.CloudSaveStatus.wouldRender(header.id)) &&
-                <div id="projectNameArea" role="menu" className="ui column items">
+                <div id="projectNameArea" className="ui column items">
                     <div className={`ui right ${showSave ? "labeled" : ""} input projectname-input projectname-computer`}>
                         {showProjectRename && this.getSaveInput(showSave, "fileNameInput2", projectName, showProjectRenameReadonly)}
                         {showGithub && <githubbutton.GithubButton parent={this.props.parent} key={`githubbtn${computer}`} />}

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -178,7 +178,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
                             break;
                     }
                 } else {
-                    return <div className="ui item link editor-menuitem">
+                    return <div className="ui item link editor-menuitem" role="menuitem">
                         <container.EditorSelector parent={this.props.parent} sandbox={view === "sandbox"} python={targetTheme.python} languageRestriction={languageRestriction} headless={pxt.appTarget.simulator?.headless} />
                     </div>
                 }

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -105,7 +105,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
         if (view === "time-machine") {
             return <></>;
         }
-        return <div className="ui item logo organization">
+        return <div className="ui item logo organization" role="menuitem">
             {targetTheme.organizationWideLogo || targetTheme.organizationLogo
                 ? <img className={`ui logo ${view !== "home" ? "mobile hide" : ""}`} src={targetTheme.organizationWideLogo || targetTheme.organizationLogo} alt={lf("{0} Logo", targetTheme.organization)} />
                 : <span className="name">{targetTheme.organization}</span>}

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -189,8 +189,8 @@ export class CloudSaveStatus extends data.Component<CloudSaveStatusProps, {}> {
         const syncing = preparing || cloudStatus.value === "syncing";
 
         return (<div className="cloudstatusarea">
-            {!syncing && <sui.Item className={"ui tiny cloudicon xicon " + cloudStatus.icon} title={cloudStatus.tooltip} tabIndex={-1}></sui.Item>}
-            {syncing && <sui.Item className={"ui tiny inline loader active cloudprogress" + (preparing ? " indeterminate" : "")} title={cloudStatus.tooltip} tabIndex={-1}></sui.Item>}
+            {!syncing && <sui.Item role="presentation" className={"ui tiny cloudicon xicon " + cloudStatus.icon} title={cloudStatus.tooltip} tabIndex={-1}></sui.Item>}
+            {syncing && <sui.Item role="presentation" className={"ui tiny inline loader active cloudprogress" + (preparing ? " indeterminate" : "")} title={cloudStatus.tooltip} tabIndex={-1}></sui.Item>}
             {cloudStatus.value !== "none" && cloudStatus.value !== "synced" && <span className="ui mobile hide no-select cloudtext" role="note">{cloudStatus.shortStatus}</span>}
         </div>);
     }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -149,7 +149,7 @@ export class Projects extends auth.Component<ISettingsProps, ProjectsState> {
             <div key={`mystuff_gallerysegment`} className="ui segment gallerysegment mystuff-segment" role="region" aria-label={lf("My Projects")}>
                 <div className="ui heading">
                     <div className="column" style={{ zIndex: 1 }}
-                        role={scriptManager && "button"} onClick={scriptManager && this.showScriptManager} onKeyDown={scriptManager && fireClickOnEnter}
+                        onClick={scriptManager && this.showScriptManager} onKeyDown={scriptManager && fireClickOnEnter}
                     >
                         {scriptManager ? <h2 className="ui header myproject-header">
                             {lf("My Projects")}

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -500,7 +500,7 @@ export class Item extends data.Component<ItemProps, {}> {
         return (
             <div className={genericClassName("ui item link", this.props, true) + ` ${this.props.active ? 'active' : ''}`}
                 role={this.props.role}
-                aria-label={ariaLabel || title || text}
+                aria-label={(!this.props.role || this.props.role === "presentation") ? "" : ariaLabel || title || text}
                 aria-selected={this.props.active}
                 aria-hidden={ariaHidden}
                 title={title || text}


### PR DESCRIPTION
Mostly fixes https://github.com/microsoft/pxt-microbit/issues/5424

### The meta-viewport failed rule (and why I'm not fixing it)
The "mostly" lies in the fact that I left the `meta-viewport` failed rule. It's failing because we don't allow zooming on mobile. This is something that I can't nicely fix with our single-page app. It would be nice to allow for zooming on the homepage and disable zooming in the editor on mobile, but giving a pattern like that opens a lot of problems. A big one is that when I zoomed in on the home page and then switched over to the editor, the zoom would persist and just cause all sorts of problems. I could try setting the zoom styling when initially visiting the editor, but that property is not supported everywhere and not recommended by MDN. If we want to allow for zooming on mobile, we need to investigate a bit more and have a more sustainable solution.

It was also requested that I use this PR as documentation of sorts, so I'll take some time to explain the changes that I made and why.

### The aria-required-children failed rule
This rule was failing because when a component is set to have `role=menu || menubar`, if that component has children, it is expecting that all of those children have `role=menuitem`. That fixed the problem in this case (the change seen in `headerbar.tsx`).

_**A note about menus and menuitems**_
I wanted to share, though, something that I learned through toying with this and the other "required-children" rule failures. Only specific HTML tags can have the `role=menuitem`. It is expected that if something has `role=menuitem`, it is an interactable element. So if you tried to apply `role=menuitem` directly to the img tag, then you would get another Accessibility Insights rule failure about "allowed aria roles". Allowed aria roles vary per tag and the context of the child. 

### The nested-interactive failed rule
![image](https://github.com/microsoft/pxt/assets/49178322/c1098143-0aed-4ef5-97ba-6eb772c45a53)
This rule was failing because for the 'My Projects' heading, the whole div was set to have `role=button` and  then we also had the 'View All' text have `role=button`. From a high level, it doesn't make sense to have a button nested in a button. Even though it's true that clicking on the whole heading would allow you to see all of your projects, screen readers and using keyboard navigation would only land on the 'View All' "button" since that's the thing that has the tabindex on it. Since that's the case, it doesn't really make sense to have the whole div have the role of button. By removing the `role=button` on the "My Projects" column div, the roles are assigned as expected. This is the change in `webapp/src/projects.tsx`.

Since I was already in Accessibility Insights mode, I also looked at the failures we had in the editor which is where the other changes come from.

### The Project Naming Area
![image](https://github.com/microsoft/pxt/assets/49178322/000f9957-6e89-48c4-9a72-e0f10fe72462)

The fixes here are found in `identity.tsx, sui.tsx, and editortoolbar.tsx`. Pictured above is the "editortoolbar". That whole area is given the aria-role "region", which is just a way to group elements together that landmarks them as an important part of the webpage. Each region in this toolbar was a menu before -- the download button, the project stuff, and the undo/redo/zoom controls. The download and right most controls make sense to be grouped together. However, the naming area is not the same scenario. The input, save button, GitHub button, and (when logged in) the cloud save status don't really have a good grouping. They're already in the "editortoolbar" region, so to try to group them when they're functionally different is a stretch. That's why I removed the `role=menu` from the `projectNameArea` div. Because of that, I needed to change the save button's role (since we assign `role="menuitem" to editortoolbarbuttons when  there is no role assigned. 

The cloud save status also needed to get updated. When there is something on the page that a user cannot interact with, you can give that component `role=presentation` and aria will effectively ignore that component. When there is a component that is strictly visual, though, it should not have an aria-label because it will cause problems for screen readers. Any component that does not have an aria role or doesn't have an implicit aria role based on the html component should not have an aria label. That is where the updates in `sui.tsx` and `identity.tsx` come in. We were applying an aria-label to everything that had text or a title, and if that component doesn't have a role, it will cause problems. 

### The editor toggle
The editor toggle container has `role=listbox`. A listbox is expecting that all of its children have the role `role=option`. The editor dropdown was menuitem, and that is not a possible child of a listbox role parent. This failure was fixed by changing the dropdown's role to `role=option`.