### PR TITLE
Bug fix: Microsoft profile pic not showing

### DIFF
--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -103,7 +103,7 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
     encodedAvatarPic(user: pxt.auth.UserProfile): string {
         const type = user?.idp?.picture?.mimeType;
         const encodedImg = user?.idp?.picture?.encoded;
-        return `data:${type};base64,${encodedImg}`;
+        return type && encodedImg ? `data:${type};base64,${encodedImg}` : "";
     }
 
     avatarPicUrl(): string {

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -100,9 +100,15 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
         this.props.parent.signOutGithub();
     }
 
+    encodedAvatarPic(user: pxt.auth.UserProfile): string {
+        const type = user?.idp?.picture.mimeType;
+        const encodedImg = user?.idp?.picture.encoded;
+        return `data:${type};base64,${encodedImg}`;
+    }
+
     avatarPicUrl(): string {
         const user = this.getUserProfile();
-        return user?.idp?.pictureUrl ?? user?.idp?.picture?.dataUrl;
+        return user?.idp?.pictureUrl ?? this.encodedAvatarPic(user);
     }
 
     hide() {

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -101,8 +101,8 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
     }
 
     encodedAvatarPic(user: pxt.auth.UserProfile): string {
-        const type = user?.idp?.picture.mimeType;
-        const encodedImg = user?.idp?.picture.encoded;
+        const type = user?.idp?.picture?.mimeType;
+        const encodedImg = user?.idp?.picture?.encoded;
         return `data:${type};base64,${encodedImg}`;
     }
 


### PR DESCRIPTION
The data that we receive from the Microsoft auth service is does not have a `dataUrl` anymore, but a whole picture object where the image is encoded. I added a function to handle an encoded image for the avatar picture.

Fixes https://github.com/microsoft/pxt-microbit/issues/5477