### PR TITLE
Re-enable crowdin stats command

### DIFF
--- a/cli/crowdinApi.ts
+++ b/cli/crowdinApi.ts
@@ -98,11 +98,14 @@ export async function getFileProgressAsync(file: string, languages?: string[]) {
     return results;
 }
 
-export async function listFilesAsync(directory: string): Promise<string[]> {
-    directory = normalizePath(directory);
+export async function listFilesAsync(directory?: string): Promise<string[]> {
     const files = (await getAllFiles()).map(file => normalizePath(file.path));
 
-    return files.filter(file => file.startsWith(directory));
+    if (directory) {
+        directory = normalizePath(directory);
+        return files.filter(file => file.startsWith(directory));
+    }
+    return files;
 }
 
 export async function downloadTranslationsAsync(directory?: string) {
@@ -380,6 +383,7 @@ function crowdinCredentials(): Credentials {
 // calls path.normalize and removes leading slash
 function normalizePath(p: string) {
     p = path.normalize(p);
+    p = p.replace(/\\/g, "/");
     if (/^[\/\\]/.test(p)) p = p.slice(1)
 
     return p;


### PR DESCRIPTION
Re-implementing the crowdin stats command with the v2 APIs.

FYI, I tweaked the behavior somewhat. The previous version of the command always checked translations for all targets even if it was run from within a target repo. I assume this was a mistake, so I made it so that it now filters the translations to only include core and the strings from the target repo it's run within (e.g. running within pxt-arcade will only check for translations of strings in pxt-arcade and pxt-core). Running the command within pxt-core will go back to the old behavior and collect stats for all targets at the same time. @abchatra FYI

Also, this will probably take a lot longer to run then the old version. The new APIs require us to make many separate requests as opposed to the old API's single request.