### PR TITLE
Add restore command and keep translations when updating

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -7092,7 +7092,18 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
 
     advancedCommand("augmentdocs", "test markdown docs replacements", augmnetDocsAsync, "<temlate.md> <doc.md>");
 
-    advancedCommand("crowdin", "upload, download, clean, stats files to/from crowdin", pc => crowdin.execCrowdinAsync.apply(undefined, pc.args), "<cmd> <path> [output]")
+    p.defineCommand({
+        name: "crowdin",
+        advanced: true,
+        argString: "<cmd> <path> [output]",
+        help: "upload, download, clean, stats files to/from crowdin",
+        flags: {
+            test: { description: "test run, do not upload files to crowdin" }
+        }
+    }, pc => {
+        if (pc.flags.test) pxt.crowdin.setTestMode();
+        return crowdin.execCrowdinAsync.apply(undefined, pc.args)
+    })
 
     advancedCommand("hidlist", "list HID devices", hid.listAsync)
     advancedCommand("hidserial", "run HID serial forwarding", hid.serialAsync, undefined, true);

--- a/cli/crowdin.ts
+++ b/cli/crowdin.ts
@@ -233,6 +233,9 @@ export async function execCrowdinAsync(cmd: string, ...args: string[]): Promise<
             if (!args[0]) {
                 throw new Error("Time missing");
             }
+            if (args[1] !== "force" && !pxt.crowdin.testMode) {
+                throw new Error(`Refusing to run restore command without 'force' argument. Re-run as 'pxt crowdin restore <date> force' to proceed or use --test flag to test.`);
+            }
             execRestoreFiles(args[0]);
             break;
         default:

--- a/cli/crowdinApi.ts
+++ b/cli/crowdinApi.ts
@@ -299,6 +299,8 @@ async function getAllFiles() {
 }
 
 async function createFile(fileName: string, fileContent: any, directoryId?: number): Promise<void> {
+    if (pxt.crowdin.testMode) return;
+
     const { uploadStorageApi, sourceFilesApi } = getClient();
 
     // This request happens in two parts: first we upload the file to the storage API,
@@ -318,6 +320,8 @@ async function createFile(fileName: string, fileContent: any, directoryId?: numb
 }
 
 async function createDirectory(dirName: string, directoryId?: number): Promise<SourceFilesModel.Directory> {
+    if (pxt.crowdin.testMode) return undefined;
+
     const { sourceFilesApi } = getClient();
 
     const dir = await sourceFilesApi.createDirectory(projectId, {
@@ -392,6 +396,8 @@ async function listFileRevisions(filename: string): Promise<SourceFilesModel.Fil
 
 
 async function updateFile(fileId: number, fileName: string, fileContent: any): Promise<void> {
+    if (pxt.crowdin.testMode) return;
+
     const { uploadStorageApi, sourceFilesApi } = getClient();
 
     const storageResponse = await uploadStorageApi.addStorage(fileName, fileContent);
@@ -403,6 +409,8 @@ async function updateFile(fileId: number, fileName: string, fileContent: any): P
 }
 
 async function restorefile(fileId: number, revisionId: number) {
+    if (pxt.crowdin.testMode) return;
+
     const { sourceFilesApi } = getClient();
 
     await sourceFilesApi.updateOrRestoreFile(projectId, fileId, {


### PR DESCRIPTION
When I was testing out my crowdin changes on pxt-ev3, I realized that I accidentally removed all pre-existing translations on the uploaded files when I pushed new versions (even though the new versions didn't actually change anything). The problem was that I didn't include the [update mode parameter that we used to include](https://github.com/microsoft/pxt/blob/cffd25243efa7b387843943791ac9b9fe7808b3c/pxtlib/crowdin.ts#L150) in our API requests. This PR restores that parameter so that when we upload files pre-existing translations stick around but are marked as unapproved. 

I also figured it was a good idea to restore the old versions of the pxt-ev3 files, so I added a new crowdin command for bulk restoring old file revisions:

```bash
# <date> is either milliseconds since the epoch or a date string
pxt crowdin restore <date> [force]
```

This command restores all files for the target to the most recent revision before the date that is passed in. You can run it with the `--test` flag to see exactly what it's going to do without reverting files.

Because this is a somewhat dangerous command, you also have to specify "force" at the end of the command string or it won't do anything. e.g. `pxt crowdin restore 1712860596984 force`