### PR TITLE
Teacher Tool: Fix Parameters on Criteria Instances that Reference the Same Validator Plans

### DIFF
--- a/teachertool/src/services/loggingService.ts
+++ b/teachertool/src/services/loggingService.ts
@@ -32,8 +32,9 @@ export const logInfo = (message: any) => {
     console.log(timestamp(), message);
 };
 
-export const logDebug = (message: any) => {
+export const logDebug = (message: any, data?: any) => {
     if (pxt.BrowserUtils.isLocalHost() || pxt.options.debug) {
-        console.log(timestamp(), message);
+        console.log(timestamp(), message, data);
     }
 };
+

--- a/teachertool/src/services/makecodeEditorService.ts
+++ b/teachertool/src/services/makecodeEditorService.ts
@@ -21,10 +21,10 @@ export function setEditorRef(ref: HTMLIFrameElement | undefined) {
         driver = new EditorDriver(ref);
 
         driver.addEventListener("message", ev => {
-            logDebug(`Message received from iframe: ${JSON.stringify(ev)}`);
+            logDebug(`Message received from iframe. ID: ${ev?.id}`, ev);
         });
         driver.addEventListener("sent", ev => {
-            logDebug(`Sent message to iframe: ${JSON.stringify(ev)}`);
+            logDebug(`Sent message to iframe. ID: ${ev?.id}`, ev);
         });
         driver.addEventListener("editorcontentloaded", ev => {
             AutorunService.poke();

--- a/teachertool/src/transforms/getRubricFromFileAsync.ts
+++ b/teachertool/src/transforms/getRubricFromFileAsync.ts
@@ -7,7 +7,7 @@ export async function getRubricFromFileAsync(file: File, allowPartial: boolean):
     let rubric = await loadRubricFromFileAsync(file);
 
     if (rubric) {
-        logDebug(`Loading rubric '${rubric.name}' from file...`);
+        logDebug("Loading rubric from file...", {file, rubric});
 
         const rubricVerificationResult = verifyRubricIntegrity(rubric);
 

--- a/teachertool/src/transforms/loadProjectMetadataAsync.ts
+++ b/teachertool/src/transforms/loadProjectMetadataAsync.ts
@@ -34,5 +34,5 @@ export async function loadProjectMetadataAsync(inputText: string, shareLink: str
     };
     dispatch(Actions.setProjectMetadata(projectData));
     initNewProjectResults();
-    logDebug(`Loaded project metadata: ${JSON.stringify(projMeta)}`);
+    logDebug("Loaded project metadata", projMeta);
 }

--- a/teachertool/src/transforms/setActiveTab.ts
+++ b/teachertool/src/transforms/setActiveTab.ts
@@ -1,4 +1,3 @@
-import { logDebug } from "../services/loggingService";
 import { stateAndDispatch } from "../state";
 import * as Actions from "../state/actions";
 import { TabName } from "../types";

--- a/teachertool/src/transforms/tryLoadLastActiveRubricAsync.ts
+++ b/teachertool/src/transforms/tryLoadLastActiveRubricAsync.ts
@@ -9,7 +9,7 @@ export async function tryLoadLastActiveRubricAsync() {
     const lastActiveRubric = await getLastActiveRubricAsync();
 
     if (lastActiveRubric) {
-        logDebug(`Loading last active rubric '${lastActiveRubric.name}'...`);
+        logDebug("Loading last active rubric...", lastActiveRubric);
 
         const rubricVerificationResult = verifyRubricIntegrity(lastActiveRubric);
 


### PR DESCRIPTION
While simplifying the catalog, I noticed parameters were overwriting each other when we had multiple criteria instances that referenced the same validator plan. This was happening because all of them were pointing to the same plan object. To fix it, we can make a deep copy of the validator plan before we modify it.

I also updated the logDebug function to accept a data parameter to help keep our logs a little tidier.

Upload Target: https://makecode.microbit.org/app/cb0809faf5a812b45067c743d1bf2d0c7a3bc799-65bd000c7b--eval?tc=1