### PR TITLE
Bug fix: global config snippets in tutorials no longer rendering on docs pages

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -1254,44 +1254,37 @@ function renderTypeScript(options?: ClientRenderOptions) {
     });
 }
 
-function renderGhost(options: ClientRenderOptions) {
-    let c = $('code.lang-ghost');
+function removeSnippet(c: JQuery<HTMLElement>, options: ClientRenderOptions) {
     if (options.snippetReplaceParent)
         c = c.parent();
     c.remove();
+}
+
+function renderGhost(options: ClientRenderOptions) {
+    let c = $('code.lang-ghost');
+    removeSnippet(c, options);
 }
 
 function renderTemplate(options: ClientRenderOptions) {
     let c = $('code.lang-template');
-    if (options.snippetReplaceParent)
-        c = c.parent();
-    c.remove();
+    removeSnippet(c, options);
+}
+
+function removeScopedConfig(type: string, scope: "local" | "global", options: ClientRenderOptions) {
+    $(`code.lang-${type}\\.${scope}`).each((i, c) => {
+        let $c = $(c);
+        removeSnippet($c, options);
+    });
 }
 
 function renderBlockConfig(options: ClientRenderOptions) {
-    function render(scope: "local" | "global") {
-        $(`code.lang-blockconfig\\.${scope}`).each((i, c) => {
-            let $c = $(c);
-            if (options.snippetReplaceParent)
-                $c = $c.parent();
-            $c.remove();
-        });
-    }
-    render("local");
-    render("global");
+    removeScopedConfig("blockconfig", "local", options);
+    removeScopedConfig("blockconfig", "global", options);
 }
 
 function renderValidation(options: ClientRenderOptions) {
-    function render(scope: "local" | "global") {
-        $(`code.lang-validation\\.${scope}`).each((i, c) => {
-            let $c = $(c);
-            if (options.snippetReplaceParent)
-                $c = $c.parent();
-            $c.remove();
-        });
-    }
-    render("local");
-    render("global");
+    removeScopedConfig("validation", "local", options);
+    removeScopedConfig("validation", "global", options);
 }
 
 function renderSims(options: ClientRenderOptions) {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -1274,6 +1274,19 @@ function renderBlockConfig(options: ClientRenderOptions) {
     render("global");
 }
 
+function renderValidation(options: ClientRenderOptions) {
+    function render(scope: "local" | "global") {
+        $(`code.lang-validation\\.${scope}`).each((i, c) => {
+            let $c = $(c);
+            if (options.snippetReplaceParent)
+                $c = $c.parent();
+            $c.remove();
+        });
+    }
+    render("local");
+    render("global");
+}
+
 function renderSims(options: ClientRenderOptions) {
     if (!options.simulatorClass) return;
     // simulators
@@ -1313,6 +1326,7 @@ export function renderAsync(options?: ClientRenderOptions): Promise<void> {
     renderQueue = [];
     renderGhost(options);
     renderBlockConfig(options);
+    renderValidation(options);
     renderSims(options);
     renderTypeScript(options);
     renderDirectPython(options);

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -1263,7 +1263,7 @@ function renderGhost(options: ClientRenderOptions) {
 
 function renderBlockConfig(options: ClientRenderOptions) {
     function render(scope: "local" | "global") {
-        $(`code.lang-blockconfig.${scope}`).each((i, c) => {
+        $(`code.lang-blockconfig\\.${scope}`).each((i, c) => {
             let $c = $(c);
             if (options.snippetReplaceParent)
                 $c = $c.parent();

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -1260,6 +1260,13 @@ function removeSnippet(c: JQuery<HTMLElement>, options: ClientRenderOptions) {
     c.remove();
 }
 
+function removeScopedConfig(type: string, scope: "local" | "global", options: ClientRenderOptions) {
+    $(`code.lang-${type}\\.${scope}`).each((i, c) => {
+        let $c = $(c);
+        removeSnippet($c, options);
+    });
+}
+
 function renderGhost(options: ClientRenderOptions) {
     let c = $('code.lang-ghost');
     removeSnippet(c, options);
@@ -1268,13 +1275,6 @@ function renderGhost(options: ClientRenderOptions) {
 function renderTemplate(options: ClientRenderOptions) {
     let c = $('code.lang-template');
     removeSnippet(c, options);
-}
-
-function removeScopedConfig(type: string, scope: "local" | "global", options: ClientRenderOptions) {
-    $(`code.lang-${type}\\.${scope}`).each((i, c) => {
-        let $c = $(c);
-        removeSnippet($c, options);
-    });
 }
 
 function renderBlockConfig(options: ClientRenderOptions) {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -1261,6 +1261,13 @@ function renderGhost(options: ClientRenderOptions) {
     c.remove();
 }
 
+function renderTemplate(options: ClientRenderOptions) {
+    let c = $('code.lang-template');
+    if (options.snippetReplaceParent)
+        c = c.parent();
+    c.remove();
+}
+
 function renderBlockConfig(options: ClientRenderOptions) {
     function render(scope: "local" | "global") {
         $(`code.lang-blockconfig\\.${scope}`).each((i, c) => {
@@ -1326,6 +1333,7 @@ export function renderAsync(options?: ClientRenderOptions): Promise<void> {
     renderQueue = [];
     renderGhost(options);
     renderBlockConfig(options);
+    renderTemplate(options);
     renderValidation(options);
     renderSims(options);
     renderTypeScript(options);


### PR DESCRIPTION
There were three code snippets that were rendering on docs pages when we don't want them to:

1. Template snippets that are used to define the starting blocks of a tutorial
2. Global and local block configs so that blocks in tutorials could be given different default values in the toolbox (this was just a bug with the selector string we were using in JQuery)
3. Tutorial validation snippets

This change leverages what we already did for `renderGhost` and `renderBlockConfig`, and just creates new functions for the other cases. I was thinking about making two functions to cover all of the different cases where we need to remove the snippet, one for the snippets that also have the scoping and one for the rest (ghost, template), but I found that it didn't add any clarity to the code and actually made `renderAsync` look more cluttered.

Fixes https://github.com/microsoft/pxt-microbit/issues/5380