### PR TITLE
Automatically adjust block colors to have a contrast ratio of 4.5

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -506,6 +506,7 @@ declare namespace pxt {
         timeMachineQueryParams?: string[]; // An array of query params to pass to timemachine iframe embed
         timeMachineDiffInterval?: number; // An interval in milliseconds at which to take diffs to store in project history. Defaults to 5 minutes
         timeMachineSnapshotInterval?: number; // An interval in milliseconds at which to take full project snapshots in project history. Defaults to 15 minutes
+        adjustBlockContrast?: boolean; // If set to true, all block colors will automatically be adjusted to have a contrast ratio of 4.5 with text
     }
 
     interface DownloadDialogTheme {

--- a/pxtblocks/builtins/misc.ts
+++ b/pxtblocks/builtins/misc.ts
@@ -8,6 +8,12 @@ export function initOnStart() {
     const onStartDef = pxt.blocks.getBlockDefinition(ts.pxtc.ON_START_TYPE);
     Blockly.Blocks[ts.pxtc.ON_START_TYPE] = {
         init: function () {
+            let colorOverride = pxt.appTarget.runtime?.onStartColor;
+
+            if (colorOverride) {
+                colorOverride = pxt.toolbox.getAccessibleBackground(colorOverride);
+            }
+
             this.jsonInit({
                 "message0": onStartDef.block["message0"],
                 "args0": [
@@ -19,7 +25,7 @@ export function initOnStart() {
                         "name": "HANDLER"
                     }
                 ],
-                "colour": (pxt.appTarget.runtime ? pxt.appTarget.runtime.onStartColor : '') || pxt.toolbox.getNamespaceColor('loops')
+                "colour": colorOverride || pxt.toolbox.getNamespaceColor('loops')
             });
 
             setHelpResources(this,
@@ -27,7 +33,7 @@ export function initOnStart() {
                 onStartDef.name,
                 onStartDef.tooltip,
                 onStartDef.url,
-                String((pxt.appTarget.runtime ? pxt.appTarget.runtime.onStartColor : '') || pxt.toolbox.getNamespaceColor('loops')),
+                colorOverride || pxt.toolbox.getNamespaceColor('loops'),
                 undefined, undefined,
                 pxt.appTarget.runtime ? pxt.appTarget.runtime.onStartUnDeletable : false
             );

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -217,7 +217,7 @@ function initBlock(block: Blockly.Block, info: pxtc.BlocksInfo, fn: pxtc.SymbolI
     const helpUrl = pxt.blocks.getHelpUrl(fn);
     if (helpUrl) block.setHelpUrl(helpUrl)
 
-    block.setColour(color);
+    block.setColour(typeof color === "string" ? pxt.toolbox.getAccessibleBackground(color) : color);
     let blockShape = provider.SHAPES.ROUND;
     if (fn.retType == "boolean") {
         blockShape = provider.SHAPES.HEXAGONAL;

--- a/pxtlib/color.ts
+++ b/pxtlib/color.ts
@@ -1,0 +1,115 @@
+namespace pxt {
+    export function getWhiteContrastingBackground(color: string) {
+        if (contrastRatio("#ffffff", color) >= 4.5) return color;
+
+        const hslColor = hsl(color);
+
+        // There is probably a "smart" way to calculate this, but a cursory search
+        // didn't turn up anything so we're just going to decrease the luminosity
+        // until we get a contrasting color
+        const luminosityStep = 0.05;
+
+        let l = hslColor.l - luminosityStep;
+        while (l > 0) {
+            const newColor = hslToHex({ h: hslColor.h, s: hslColor.s, l });
+            if (contrastRatio("#ffffff", newColor) >= 4.5) return newColor;
+            l -= luminosityStep;
+        }
+
+        // We couldn't find one, so just return the original
+        console.warn(`Couldn't find a contrasting background for color ${color}`);
+        return color;
+    }
+
+    function hsl(color: string): { h: number, s: number, l: number } {
+        const rgb = pxt.toolbox.convertColor(color);
+
+        const r = parseInt(rgb.slice(1, 3), 16) / 255;
+        const g = parseInt(rgb.slice(3, 5), 16) / 255;
+        const b = parseInt(rgb.slice(5, 7), 16) / 255;
+
+        const max = Math.max(Math.max(r, g), b);
+        const min = Math.min(Math.min(r, g), b);
+
+        const diff = max - min;
+        let h;
+        if (diff === 0)
+            h = 0;
+        else if (max === r)
+            h = ((((g - b) / diff) % 6) + 6) % 6;
+        else if (max === g)
+            h = (b - r) / diff + 2;
+        else if (max === b)
+            h = (r - g) / diff + 4;
+
+        let l = (min + max) / 2;
+        let s = diff === 0
+            ? 0
+            : diff / (1 - Math.abs(2 * l - 1));
+
+        return {
+            h: h * 60,
+            s,
+            l
+        }
+    }
+
+
+    function relativeLuminance(color: string) {
+        const rgb = pxt.toolbox.convertColor(color);
+
+        const r = parseInt(rgb.slice(1, 3), 16) / 255;
+        const g = parseInt(rgb.slice(3, 5), 16) / 255;
+        const b = parseInt(rgb.slice(5, 7), 16) / 255;
+
+        const r2 = (r <= 0.03928) ? r / 12.92 : Math.pow((r + 0.055) / 1.055, 2.4);
+        const g2 = (g <= 0.03928) ? g / 12.92 : Math.pow((g + 0.055) / 1.055, 2.4);
+        const b2 = (b <= 0.03928) ? b / 12.92 : Math.pow((b + 0.055) / 1.055, 2.4);
+
+        return 0.2126 * r2 + 0.7152 * g2 + 0.0722 * b2;
+    }
+
+    function contrastRatio(fg: string, bg: string) {
+        return (relativeLuminance(fg) + 0.05) / (relativeLuminance(bg) + 0.05)
+    }
+
+    function hslToHex(color: { h: number, s: number, l: number }) {
+        const chroma = (1 - Math.abs(2 * color.l - 1)) * color.s;
+        const hp = color.h / 60.0;
+        // second largest component of this color
+        const x = chroma * (1 - Math.abs((hp % 2) - 1));
+
+        // 'point along the bottom three faces of the RGB cube'
+        let rgb1: number[];
+        if (color.h === undefined)
+            rgb1 = [0, 0, 0];
+        else if (hp <= 1)
+            rgb1 = [chroma, x, 0];
+        else if (hp <= 2)
+            rgb1 = [x, chroma, 0];
+        else if (hp <= 3)
+            rgb1 = [0, chroma, x];
+        else if (hp <= 4)
+            rgb1 = [0, x, chroma];
+        else if (hp <= 5)
+            rgb1 = [x, 0, chroma];
+        else if (hp <= 6)
+            rgb1 = [chroma, 0, x];
+
+        // lightness match component
+        let m = color.l - chroma * 0.5;
+        return toHexString(
+            Math.round(255 * (rgb1[0] + m)),
+            Math.round(255 * (rgb1[1] + m)),
+            Math.round(255 * (rgb1[2] + m))
+        );
+    }
+
+    function toHexString(r: number, g: number, b: number) {
+        return "#" + toHex(r) + toHex(g) + toHex(b);
+    }
+
+    function toHex(n: number) {
+        return ("0" + n.toString(16)).slice(-2)
+    }
+}

--- a/pxtlib/toolbox.ts
+++ b/pxtlib/toolbox.ts
@@ -207,6 +207,8 @@ namespace pxt.toolbox {
      * concern since we only cache colors that are used in the toolbox.
      */
     export function getAccessibleBackground(color: string) {
+        if (!pxt.appTarget?.appTheme?.adjustBlockContrast) return color;
+
         if (!cachedAccessibleColors[color]) {
             cachedAccessibleColors[color] = pxt.getWhiteContrastingBackground(color);
         }

--- a/pxtlib/toolbox.ts
+++ b/pxtlib/toolbox.ts
@@ -1,4 +1,6 @@
 namespace pxt.toolbox {
+    const cachedAccessibleColors: pxt.Map<string> = {};
+
     export const blockColors: Map<number | string> = {
         loops: '#107c10',
         logic: '#006970',
@@ -63,10 +65,18 @@ namespace pxt.toolbox {
 
     export function getNamespaceColor(ns: string): string {
         ns = ns.toLowerCase();
-        if (pxt.appTarget.appTheme.blockColors && pxt.appTarget.appTheme.blockColors[ns])
-            return pxt.appTarget.appTheme.blockColors[ns] as string;
-        if (pxt.toolbox.blockColors[ns])
-            return pxt.toolbox.blockColors[ns] as string;
+
+        let color: string;
+        if (pxt.appTarget.appTheme.blockColors && pxt.appTarget.appTheme.blockColors[ns]) {
+            color = pxt.appTarget.appTheme.blockColors[ns] as string;
+        }
+        else if (pxt.toolbox.blockColors[ns]) {
+            color = pxt.toolbox.blockColors[ns] as string;
+        }
+
+        if (color) {
+            return getAccessibleBackground(color);
+        }
         return "";
     }
 
@@ -189,5 +199,18 @@ namespace pxt.toolbox {
         }
 
         return rgb;
+    }
+
+    /**
+     * Calculates an accessible background color assuming a foreground color of white and
+     * caches the result. Does not clear the cache, but this shouldn't be much of a memory
+     * concern since we only cache colors that are used in the toolbox.
+     */
+    export function getAccessibleBackground(color: string) {
+        if (!cachedAccessibleColors[color]) {
+            cachedAccessibleColors[color] = pxt.getWhiteContrastingBackground(color);
+        }
+
+        return cachedAccessibleColors[color];
     }
 }

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -351,7 +351,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
 
         const snippet = isPython ? block.pySnippet : block.snippet;
         const params = block.parameters;
-        const blockColor = block.attributes.color || color;
+        const blockColor = pxt.toolbox.getAccessibleBackground(block.attributes.color || color);
         const blockDescription = this.getBlockDescription(block, params ? params.slice() : null);
         const helpUrl = block.attributes.help;
 
@@ -404,7 +404,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
 
     renderCore() {
         const { name, ns, color, icon, groups } = this.state;
-        const rgb = pxt.toolbox.convertColor(color || (ns && pxt.toolbox.getNamespaceColor(ns)) || "255");
+        const rgb = pxt.toolbox.getAccessibleBackground(pxt.toolbox.convertColor(color || (ns && pxt.toolbox.getNamespaceColor(ns)) || "255"));
         const iconClass = `blocklyTreeIcon${icon ? (ns || icon).toLowerCase() : "Default"}`.replace(/\s/g, "");
         return <div id="monacoFlyoutWidget" className="monacoFlyout" style={this.getFlyoutStyle()}>
             <div id="monacoFlyoutWrapper" onScroll={this.scrollHandler} onWheel={this.wheelHandler} role="list">

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -731,7 +731,9 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
 
     getMetaColor() {
         const { color } = this.props.treeRow;
-        return pxt.toolbox.convertColor(color) || pxt.toolbox.getNamespaceColor('default');
+        return pxt.toolbox.getAccessibleBackground(
+            pxt.toolbox.convertColor(color) || pxt.toolbox.getNamespaceColor('default')
+        );
     }
 
     handleTreeRowRef = (c: HTMLDivElement) => {


### PR DESCRIPTION
Motivated by: https://github.com/microsoft/pxt-arcade/issues/4870

This PR adds a little code to automatically adjust all block background colors to have a contrast ratio of at least 4.5 with white foreground text. The algorithm I'm using is pretty dumb: I just lower the luminosity until a color with the correct contrast ratio is generated and cache the result.

I placed this behind a feature flag for now because the general consensus is that this makes all the blocks look duller/uglier and creates a breaking change with old screenshots. The goal should be for us to eventually turn this on in all targets; we might have to adjust the base colors of some categories to make them more visually appealing though (arrays is particularly ugly).

Here is an upload target in micro:bit with the feature turned on:

https://makecode.microbit.org/app/36f327a321d404020e3804ed55f5a3567b2e929f-3d8dd326ca