### PR TITLE
Fix github accessibility bugs and add an accordion component

### DIFF
--- a/react-common/components/controls/Accordion/Accordion.tsx
+++ b/react-common/components/controls/Accordion/Accordion.tsx
@@ -29,7 +29,6 @@ export const Accordion = (props: AccordionProps) => {
         role,
     } = props;
 
-
     return (
         <AccordionProvider>
             <div
@@ -74,7 +73,6 @@ export const AccordionItem = (props: AccordionItemProps) => {
         }
     }, [isExpanded]);
 
-
     return (
         <div
             className={classList("common-accordion", className)}
@@ -108,7 +106,7 @@ export const AccordionItem = (props: AccordionItemProps) => {
             <div
                 id={panelId}
                 className="common-accordion-panel-outer"
-                style={{ display: expanded ? "block" : "none" }}
+                style={{ display: isExpanded ? "block" : "none" }}
             >
                 {isExpanded && mappedChildren[1]}
             </div>

--- a/react-common/components/controls/Accordion/Accordion.tsx
+++ b/react-common/components/controls/Accordion/Accordion.tsx
@@ -1,0 +1,155 @@
+import * as React from "react";
+import { ContainerProps, classList, fireClickOnEnter } from "../../util";
+import { useId } from "../../../hooks/useId";
+import { AccordionProvider, clearExpanded, setExpanded, useAccordionDispatch, useAccordionState } from "./context";
+
+export interface AccordionProps extends ContainerProps {
+    children?: React.ReactElement<AccordionItemProps>[] | React.ReactElement<AccordionItemProps>;
+}
+
+export interface AccordionItemProps extends ContainerProps {
+    children?: [React.ReactElement<AccordionHeaderProps>, React.ReactElement<AccordionPanelProps>];
+    noChevron?: boolean;
+}
+
+export interface AccordionHeaderProps extends ContainerProps {
+}
+
+export interface AccordionPanelProps extends ContainerProps {
+}
+
+export const Accordion = (props: AccordionProps) => {
+    const {
+        children,
+        id,
+        className,
+        ariaLabel,
+        ariaHidden,
+        ariaDescribedBy,
+        role,
+    } = props;
+
+
+    return (
+        <AccordionProvider>
+            <div
+                className={classList("common-accordion", className)}
+                id={id}
+                aria-label={ariaLabel}
+                aria-hidden={ariaHidden}
+                aria-describedby={ariaDescribedBy}
+                role={role}
+            >
+                {children}
+            </div>
+        </AccordionProvider>
+    );
+};
+
+export const AccordionItem = (props: AccordionItemProps) => {
+    const {
+        children,
+        id,
+        className,
+        ariaLabel,
+        ariaHidden,
+        ariaDescribedBy,
+        role,
+        noChevron
+    } = props;
+
+    const { expanded } = useAccordionState();
+    const dispatch = useAccordionDispatch();
+
+    const panelId = useId();
+    const mappedChildren = React.Children.toArray(children);
+    const isExpanded = expanded === panelId;
+
+    const onHeaderClick = React.useCallback(() => {
+        if (isExpanded) {
+            dispatch(clearExpanded());
+        }
+        else {
+            dispatch(setExpanded(panelId));
+        }
+    }, [isExpanded]);
+
+
+    return (
+        <div
+            className={classList("common-accordion", className)}
+            id={id}
+            aria-label={ariaLabel}
+            aria-hidden={ariaHidden}
+            aria-describedby={ariaDescribedBy}
+            role={role}
+        >
+            <button
+                className="common-accordion-header-outer"
+                aria-expanded={isExpanded}
+                aria-controls={panelId}
+                onClick={onHeaderClick}
+                onKeyDown={fireClickOnEnter}
+            >
+                <div>
+                    {!noChevron &&
+                        <div className="common-accordion-chevron">
+                            <i
+                                className={classList("fas", isExpanded ? "fa-chevron-down" : "fa-chevron-right")}
+                                aria-hidden={true}
+                            />
+                        </div>
+                    }
+                    <div className="common-accordion-header-content">
+                        {mappedChildren[0]}
+                    </div>
+                </div>
+            </button>
+            <div
+                id={panelId}
+                className="common-accordion-panel-outer"
+                style={{ display: expanded ? "block" : "none" }}
+            >
+                {isExpanded && mappedChildren[1]}
+            </div>
+        </div>
+    );
+}
+
+export const AccordionHeader = (props: AccordionHeaderProps) => {
+    const {
+        id,
+        className,
+        ariaLabel,
+        children,
+    } = props;
+
+    return (
+        <div
+            id={id}
+            className={classList("common-accordion-header", className)}
+            aria-label={ariaLabel}
+        >
+            {children}
+        </div>
+    );
+}
+
+export const AccordionPanel = (props: AccordionPanelProps) => {
+    const {
+        id,
+        className,
+        ariaLabel,
+        children,
+    } = props;
+
+    return (
+        <div
+            id={id}
+            className={classList("common-accordion-body", className)}
+            aria-label={ariaLabel}
+        >
+            {children}
+        </div>
+    );
+}

--- a/react-common/components/controls/Accordion/context.tsx
+++ b/react-common/components/controls/Accordion/context.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+
+interface AccordionState {
+    expanded?: string;
+}
+
+const AccordionStateContext = React.createContext<AccordionState>(null);
+const AccordionDispatchContext = React.createContext<(action: Action) => void>(null);
+
+export const AccordionProvider = ({ children }: React.PropsWithChildren<{}>) => {
+    const [state, dispatch] = React.useReducer(
+        accordionReducer,
+        {}
+    );
+
+    return (
+        <AccordionStateContext.Provider value={state}>
+            <AccordionDispatchContext.Provider value={dispatch}>
+                {children}
+            </AccordionDispatchContext.Provider>
+        </AccordionStateContext.Provider>
+    )
+}
+
+type SetExpanded = {
+    type: "SET_EXPANDED";
+    id: string;
+};
+
+type ClearExpanded = {
+    type: "CLEAR_EXPANDED";
+};
+
+type Action = SetExpanded | ClearExpanded;
+
+export const setExpanded = (id: string): SetExpanded => (
+    {
+        type: "SET_EXPANDED",
+        id
+    }
+);
+
+export const clearExpanded = (): ClearExpanded => (
+    {
+        type: "CLEAR_EXPANDED"
+    }
+);
+
+export function useAccordionState() {
+    return React.useContext(AccordionStateContext)
+}
+
+export function useAccordionDispatch() {
+    return React.useContext(AccordionDispatchContext);
+}
+
+function accordionReducer(state: AccordionState, action: Action): AccordionState {
+    switch (action.type) {
+        case "SET_EXPANDED":
+            return {
+                ...state,
+                expanded: action.id
+            };
+        case "CLEAR_EXPANDED":
+            return {
+                ...state,
+                expanded: undefined
+            };
+    }
+}

--- a/react-common/components/controls/Accordion/index.tsx
+++ b/react-common/components/controls/Accordion/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Accordion";

--- a/react-common/components/controls/Accordion/index.tsx
+++ b/react-common/components/controls/Accordion/index.tsx
@@ -1,1 +1,10 @@
-export * from "./Accordion";
+import { Accordion as AccordionControl, AccordionHeader, AccordionItem, AccordionPanel } from "./Accordion";
+
+export const Accordion = Object.assign(
+    AccordionControl,
+    {
+        Header: AccordionHeader,
+        Item: AccordionItem,
+        Panel: AccordionPanel
+    }
+);

--- a/react-common/hooks/useId.ts
+++ b/react-common/hooks/useId.ts
@@ -1,0 +1,5 @@
+import * as React from "react";
+
+export function useId(): string {
+    return React.useMemo(() => pxt.Util.guidGen(), []);
+}

--- a/react-common/styles/controls/Accordion.less
+++ b/react-common/styles/controls/Accordion.less
@@ -1,0 +1,32 @@
+.common-accordion-header-outer {
+	cursor: pointer;
+    background: none;
+	color: inherit;
+	border: none;
+	padding: 0;
+	font: inherit;
+	outline: inherit;
+    text-align: inherit;
+    width: 100%;
+
+    & > div {
+        display: flex;
+        flex-direction: row;
+        width: 100%;
+    }
+
+    .common-accordion-chevron {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        width: 2rem;
+    }
+
+    .common-accordion-header-content {
+        flex-grow: 1;
+    }
+}
+
+.common-accordion-header-outer:focus-visible {
+    outline: @buttonFocusOutlineLightBackground;
+}

--- a/react-common/styles/controls/Accordion.less
+++ b/react-common/styles/controls/Accordion.less
@@ -1,11 +1,11 @@
 .common-accordion-header-outer {
-	cursor: pointer;
+    cursor: pointer;
     background: none;
-	color: inherit;
-	border: none;
-	padding: 0;
-	font: inherit;
-	outline: inherit;
+    color: inherit;
+    border: none;
+    padding: 0;
+    font: inherit;
+    outline: inherit;
     text-align: inherit;
     width: 100%;
 

--- a/react-common/styles/react-common.less
+++ b/react-common/styles/react-common.less
@@ -24,6 +24,7 @@
 @import "controls/Tree.less";
 @import "controls/VerticalResizeContainer.less";
 @import "controls/VerticalSlider.less";
+@import "controls/Accordion.less";
 @import "./react-common-variables.less";
 
 @import "fontawesome-free/less/solid.less";

--- a/theme/github.less
+++ b/theme/github.less
@@ -161,7 +161,6 @@
         }
     }
 
-
     .commit-view:first-child {
         border-top: none;
     }

--- a/theme/github.less
+++ b/theme/github.less
@@ -113,6 +113,64 @@
     }
 }
 
+.history-zone {
+    .commit-day {
+        padding-top: 1rem;
+        padding-bottom: 1rem;
+    }
+
+    .commit-day:first-child {
+        padding-top: 0;
+    }
+
+    .commit-day:last-child {
+        padding-bottom: 0;
+    }
+
+    .commit-day-header {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
+
+    .commit-day-label {
+        font-size: 1.28571429em;
+        font-weight: 700;
+        margin-right: 0.5rem;
+        margin-top: 0.2rem;
+    }
+
+    .commit-time {
+        margin: 0.5rem 0;
+        font-size: 1rem;
+        line-height: 1rem;
+        color: rgba(0, 0, 0, .6);
+    }
+
+    .commit-view {
+        border-top: 1px solid rgba(34, 36, 38, .15);
+        padding-top: 1rem;
+        padding-bottom: 1rem;
+        position: relative;
+
+        .restore-button {
+            position: absolute;
+            right: 0;
+            top: 1.5rem;
+            z-index: 1;
+        }
+    }
+
+
+    .commit-view:first-child {
+        border-top: none;
+    }
+
+    .commit-view:last-child {
+        padding-bottom: 0;
+    }
+}
+
 // inverted style
 .inverted-theme {
     #githubEditor {

--- a/webapp/src/coretsx.tsx
+++ b/webapp/src/coretsx.tsx
@@ -164,7 +164,7 @@ export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogSt
                             aria-label={options.placeholder}
                         />
                     </div>
-                    {!!inputError && <div className="ui error message">{inputError}</div>}
+                    {!!inputError && <div className="ui error message" role="alert">{inputError}</div>}
                 </div>}
                 {options.jsx}
                 {!!options.jsxd && options.jsxd()}

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -1421,7 +1421,7 @@ class ReleaseZone extends sui.StatelessUIElement<GitHubViewProps> {
         const pagesBuilding = pages && pages.status == "building";
         const inverted = !!pxt.appTarget.appTheme.invertedGitHub;
         return <div className={`ui transparent ${inverted ? 'inverted' : ''} segment`}>
-            <div className="ui header">{lf("Release zone")}</div>
+            <h2 className="ui header">{lf("Release zone")}</h2>
             {!needsCommit && !tag && <div className="ui field">
                 <sui.Button
                     className="basic"
@@ -1488,7 +1488,7 @@ class ExtensionZone extends sui.StatelessUIElement<GitHubViewProps> {
 
         const inverted = !!pxt.appTarget.appTheme.invertedGitHub;
         return <div className={`ui transparent ${inverted ? 'inverted' : ''} segment`}>
-            <div className="ui header">{lf("Extension zone")}</div>
+            <h2 className="ui header">{lf("Extension zone")}</h2>
             <div className="ui field">
                 <sui.Link className="basic button"
                     href={testurl}
@@ -1684,7 +1684,7 @@ class HistoryZone extends sui.UIElement<GitHubViewProps, HistoryState> {
             })
 
         return <div className={`ui transparent ${inverted ? 'inverted' : ''} segment`}>
-            <div className="ui header">{lf("History")}</div>
+            <h2 className="ui header">{lf("History")}</h2>
             {(loading || !expanded) && <div className="ui field">
                 <sui.Button loading={loading} className="basic" text={lf("View commits")}
                     onClick={this.handleLoadClick}

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -18,7 +18,7 @@ import * as pxtblockly from "../../pxtblocks";
 import IProjectView = pxt.editor.IProjectView;
 import UserInfo = pxt.editor.UserInfo;
 
-import { Accordion, AccordionItem, AccordionHeader, AccordionPanel } from "../../react-common/components/controls/Accordion/Accordion";
+import { Accordion } from "../../react-common/components/controls/Accordion";
 import { Button } from "../../react-common/components/controls/Button"
 
 const MAX_COMMIT_DESCRIPTION_LENGTH = 70;
@@ -1549,17 +1549,17 @@ const CommitView = (props: CommitViewProps) => {
     const date = new Date(Date.parse(commit.author.date));
 
     return (
-        <AccordionItem noChevron={true} className="commit-view">
-            <AccordionHeader className="commit-view-header">
+        <Accordion.Item noChevron={true} className="commit-view">
+            <Accordion.Header className="commit-view-header">
                 <div className="commit-time">
                     <span>{date.toLocaleTimeString()}</span>
                 </div>
                 <div className="description">{commit.message}</div>
-            </AccordionHeader>
-            <AccordionPanel>
+            </Accordion.Header>
+            <Accordion.Panel>
                 <CommitDiffView {...props} />
-            </AccordionPanel>
-        </AccordionItem>
+            </Accordion.Panel>
+        </Accordion.Item>
     );
 }
 
@@ -1721,16 +1721,16 @@ class HistoryZone extends sui.UIElement<GitHubViewProps, HistoryState> {
             {commits && <div className="history-list">
                 <Accordion>
                     {Object.keys(days).map(day =>
-                        <AccordionItem className="commit-day" key={"commitday" + day} noChevron={true}>
-                            <AccordionHeader className="commit-day-header">
+                        <Accordion.Item className="commit-day" key={"commitday" + day} noChevron={true}>
+                            <Accordion.Header className="commit-day-header">
                                 <span className="commit-day-label">
                                     {day}
                                 </span>
                                 <div className="ui label button">
                                     <i className="long arrow alternate up icon"></i> {days[day].length}
                                 </div>
-                            </AccordionHeader>
-                            <AccordionPanel>
+                            </Accordion.Header>
+                            <Accordion.Panel>
                                 <div className="commit-list">
                                     <Accordion>
                                         {days[day].map(commit =>
@@ -1743,8 +1743,8 @@ class HistoryZone extends sui.UIElement<GitHubViewProps, HistoryState> {
                                         )}
                                     </Accordion>
                                 </div>
-                            </AccordionPanel>
-                        </AccordionItem>
+                            </Accordion.Panel>
+                        </Accordion.Item>
                     )}
                 </Accordion>
             </div>}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5498
Fixes https://github.com/microsoft/pxt-microbit/issues/5503
Fixes https://github.com/microsoft/pxt-microbit/issues/5500

This PR contains two small accessibility fixes for the github integration and one larger one that also adds a new react-common accordion component.

The "History" portion of the GitHub integration is where the accordion is used. This overhauls that section with react-common components and fixes https://github.com/microsoft/pxt-microbit/issues/5500 in the process. The UI is basically unchanged.