### PR TITLE
Fix post message loop

### DIFF
--- a/pxtservices/iframeEmbeddedClient.ts
+++ b/pxtservices/iframeEmbeddedClient.ts
@@ -63,7 +63,7 @@ export class IFrameEmbeddedClient {
         else if ((window as any).acquireVsCodeApi) {
             (window as any).acquireVsCodeApi().postMessage(message)
         }
-        else {
+        else if (window.parent && window.parent !== window) {
             window.parent.postMessage(message, "*");
         }
     }


### PR DESCRIPTION
I *think* this is the culprit for what we saw in testing today.

If the editor is not embedded, then window.parent points to the window itself. This meant we were posting the ready message on the window which caused us to fire another ready message and so on and so forth.