### PR TITLE
Teacher Tool: Remove rubric name from header bar

### DIFF
--- a/teachertool/src/components/HeaderBar.tsx
+++ b/teachertool/src/components/HeaderBar.tsx
@@ -74,15 +74,6 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
         );
     };
 
-    const getRubricName = (): JSX.Element | null => {
-        const rubricName = getSafeRubricName(teacherTool);
-        return rubricName ? (
-            <div className={css["rubric-name"]}>
-                <span>{rubricName}</span>
-            </div>
-        ) : null;
-    };
-
     const onHomeClicked = () => {
         pxt.tickEvent(Ticks.HomeLink);
 
@@ -103,7 +94,6 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
             <div className={css["left-menu"]}>
                 {getOrganizationLogo()}
                 {getTargetLogo()}
-                {getRubricName()}
             </div>
 
             <div className={css["right-menu"]}>


### PR DESCRIPTION
Potential branding concerns about having user content beside logo, and we have a bug on it. Just removing it for now.

Fixes https://github.com/microsoft/pxt-microbit/issues/5634.