### PR TITLE
Add partner telemetry flag

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -9,6 +9,7 @@ namespace pxt {
     let analyticsLoaded = false;
     let interactiveConsent = false;
     let isProduction = false;
+    let partnerName: string;
 
     class TelemetryQueue<A, B, C> {
         private q: [A, B, C][] = [];
@@ -185,6 +186,16 @@ namespace pxt {
     }
 
     export function initializeAppInsightsInternal(includeCookie = false) {
+        try {
+            const params = new URLSearchParams(window.location.search);
+            if (params.has("partner")) {
+                partnerName = params.get("partner");
+            }
+        }
+        catch (e) {
+            console.warn("Could not parse search string", e);
+        }
+
         // loadAppInsights is defined in docfiles/tracking.html
         const loadAI = (window as any).loadAppInsights;
         if (loadAI) {
@@ -220,6 +231,10 @@ namespace pxt {
         telemetryItem.properties = telemetryItem.properties || {};
         telemetryItem.properties["target"] = pxtConfig.targetId;
         telemetryItem.properties["stage"] = (pxtConfig.relprefix || "/--").replace(/[^a-z]/ig, '')
+
+        if (partnerName) {
+            telemetryItem.properties["partner"] = partnerName;
+        }
 
         const userAgent = navigator.userAgent.toLowerCase();
         const electronRegexResult = /\belectron\/(\d+\.\d+\.\d+.*?)(?: |$)/i.exec(userAgent); // Example navigator.userAgent: "Mozilla/5.0 Chrome/61.0.3163.100 Electron/2.0.0 Safari/537.36"


### PR DESCRIPTION
Adds a query parameter that lets you add a custom "partner" property to all of the telemetry items that are logged to app insights. The purpose of this feature is to let us differentiate between traffic generated by partners that link to or embed us; think of it as a manual referrer property that can be embedded in a URL. This parameter is added to all tick events.

url should look like this:

```
arcade.makecode.com/?partner=partnerName
```

Right now I am not removing the query parameter from the URL. I can do that, though, if we want.

Here is a test upload:

https://arcade.makecode.com/app/088c007a20a09fcee83221eeda1df6c9dd2a1f5b-590b47925d