### PR TITLE
Add Tags to Catalog Criteria

### DIFF
--- a/common-docs/teachertool/catalog-shared.json
+++ b/common-docs/teachertool/catalog-shared.json
@@ -6,6 +6,7 @@
             "template": "${Block} used ${count} times",
             "description": "This block was used the specified number of times in your project.",
             "docPath": "/teachertool",
+            "tags": ["General"],
             "params": [
                 {
                     "name": "block",
@@ -27,6 +28,7 @@
             "description": "The project contains at least the specified number of comments.",
             "docPath": "/teachertool",
             "maxCount": 1,
+            "tags": ["General"],
             "params": [
                 {
                     "name": "count",
@@ -43,6 +45,7 @@
             "docPath": "/teachertool",
             "description": "The program uses at least this many loops of any kind (for, repeat, while, or for-of).",
             "maxCount": 1,
+            "tags": ["Code Elements"],
             "params": [
                 {
                     "name": "count",
@@ -59,6 +62,7 @@
             "docPath": "/teachertool",
             "description": "At least this many user-defined functions are created and called.",
             "maxCount": 1,
+            "tags": ["Code Elements"],
             "params": [
                 {
                     "name": "count",
@@ -75,6 +79,7 @@
             "docPath": "/teachertool",
             "description": "The program creates and uses at least this many user-defined variables.",
             "maxCount": 1,
+            "tags": ["Code Elements"],
             "params": [
                 {
                     "name": "count",

--- a/common-docs/teachertool/test/catalog-shared.json
+++ b/common-docs/teachertool/test/catalog-shared.json
@@ -7,6 +7,7 @@
             "description": "Experimental: AI outputs may not be accurate. Use with caution and always review responses.",
             "docPath": "/teachertool",
             "maxCount": 10,
+            "tags": ["General"],
             "params": [
                 {
                     "name": "question",

--- a/react-common/components/controls/Accordion/Accordion.tsx
+++ b/react-common/components/controls/Accordion/Accordion.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 import { ContainerProps, classList, fireClickOnEnter } from "../../util";
 import { useId } from "../../../hooks/useId";
-import { AccordionProvider, clearExpanded, setExpanded, useAccordionDispatch, useAccordionState } from "./context";
+import { AccordionProvider, removeExpanded, setExpanded, useAccordionDispatch, useAccordionState } from "./context";
 
 export interface AccordionProps extends ContainerProps {
+    multiExpand?: boolean;
     children?: React.ReactElement<AccordionItemProps>[] | React.ReactElement<AccordionItemProps>;
 }
 
@@ -27,10 +28,11 @@ export const Accordion = (props: AccordionProps) => {
         ariaHidden,
         ariaDescribedBy,
         role,
+        multiExpand
     } = props;
 
     return (
-        <AccordionProvider>
+        <AccordionProvider multiExpand={multiExpand}>
             <div
                 className={classList("common-accordion", className)}
                 id={id}
@@ -62,11 +64,11 @@ export const AccordionItem = (props: AccordionItemProps) => {
 
     const panelId = useId();
     const mappedChildren = React.Children.toArray(children);
-    const isExpanded = expanded === panelId;
+    const isExpanded = expanded.indexOf(panelId) != -1;
 
     const onHeaderClick = React.useCallback(() => {
         if (isExpanded) {
-            dispatch(clearExpanded());
+            dispatch(removeExpanded(panelId));
         }
         else {
             dispatch(setExpanded(panelId));

--- a/react-common/components/controls/Accordion/Accordion.tsx
+++ b/react-common/components/controls/Accordion/Accordion.tsx
@@ -5,12 +5,14 @@ import { AccordionProvider, removeExpanded, setExpanded, useAccordionDispatch, u
 
 export interface AccordionProps extends ContainerProps {
     multiExpand?: boolean;
+    defaultExpandedIds?: string[];
     children?: React.ReactElement<AccordionItemProps>[] | React.ReactElement<AccordionItemProps>;
 }
 
 export interface AccordionItemProps extends ContainerProps {
     children?: [React.ReactElement<AccordionHeaderProps>, React.ReactElement<AccordionPanelProps>];
     noChevron?: boolean;
+    itemId?: string;
 }
 
 export interface AccordionHeaderProps extends ContainerProps {
@@ -28,11 +30,12 @@ export const Accordion = (props: AccordionProps) => {
         ariaHidden,
         ariaDescribedBy,
         role,
-        multiExpand
+        multiExpand,
+        defaultExpandedIds
     } = props;
 
     return (
-        <AccordionProvider multiExpand={multiExpand}>
+        <AccordionProvider multiExpand={multiExpand} defaultExpandedIds={defaultExpandedIds}>
             <div
                 className={classList("common-accordion", className)}
                 id={id}
@@ -56,13 +59,14 @@ export const AccordionItem = (props: AccordionItemProps) => {
         ariaHidden,
         ariaDescribedBy,
         role,
-        noChevron
+        noChevron,
+        itemId,
     } = props;
 
     const { expanded } = useAccordionState();
     const dispatch = useAccordionDispatch();
 
-    const panelId = useId();
+    const panelId = itemId ?? useId();
     const mappedChildren = React.Children.toArray(children);
     const isExpanded = expanded.indexOf(panelId) != -1;
 

--- a/react-common/components/controls/Accordion/Accordion.tsx
+++ b/react-common/components/controls/Accordion/Accordion.tsx
@@ -13,6 +13,7 @@ export interface AccordionItemProps extends ContainerProps {
     children?: [React.ReactElement<AccordionHeaderProps>, React.ReactElement<AccordionPanelProps>];
     noChevron?: boolean;
     itemId?: string;
+    onExpandToggled?: (expanded: boolean) => void;
 }
 
 export interface AccordionHeaderProps extends ContainerProps {
@@ -61,6 +62,7 @@ export const AccordionItem = (props: AccordionItemProps) => {
         role,
         noChevron,
         itemId,
+        onExpandToggled,
     } = props;
 
     const { expanded } = useAccordionState();
@@ -77,6 +79,7 @@ export const AccordionItem = (props: AccordionItemProps) => {
         else {
             dispatch(setExpanded(panelId));
         }
+        onExpandToggled?.(!isExpanded);
     }, [isExpanded]);
 
     return (

--- a/react-common/components/controls/Accordion/Accordion.tsx
+++ b/react-common/components/controls/Accordion/Accordion.tsx
@@ -70,7 +70,7 @@ export const AccordionItem = (props: AccordionItemProps) => {
 
     const panelId = itemId ?? useId();
     const mappedChildren = React.Children.toArray(children);
-    const isExpanded = expanded.indexOf(panelId) != -1;
+    const isExpanded = expanded.indexOf(panelId) !== -1;
 
     const onHeaderClick = React.useCallback(() => {
         if (isExpanded) {

--- a/react-common/components/controls/Accordion/context.tsx
+++ b/react-common/components/controls/Accordion/context.tsx
@@ -8,11 +8,11 @@ interface AccordionState {
 const AccordionStateContext = React.createContext<AccordionState>(null);
 const AccordionDispatchContext = React.createContext<(action: Action) => void>(null);
 
-export const AccordionProvider = ({ multiExpand, children }: React.PropsWithChildren<{multiExpand?: boolean}>) => {
+export const AccordionProvider = ({ multiExpand, defaultExpandedIds, children }: React.PropsWithChildren<{multiExpand?: boolean, defaultExpandedIds?: string[]}>) => {
     const [state, dispatch] = React.useReducer(
         accordionReducer,
         {
-            expanded: [],
+            expanded: defaultExpandedIds ?? [],
             multiExpand
         }
     );

--- a/react-common/components/controls/Accordion/context.tsx
+++ b/react-common/components/controls/Accordion/context.tsx
@@ -1,16 +1,20 @@
 import * as React from "react";
 
 interface AccordionState {
-    expanded?: string;
+    multiExpand?: boolean;
+    expanded: string[];
 }
 
 const AccordionStateContext = React.createContext<AccordionState>(null);
 const AccordionDispatchContext = React.createContext<(action: Action) => void>(null);
 
-export const AccordionProvider = ({ children }: React.PropsWithChildren<{}>) => {
+export const AccordionProvider = ({ multiExpand, children }: React.PropsWithChildren<{multiExpand?: boolean}>) => {
     const [state, dispatch] = React.useReducer(
         accordionReducer,
-        {}
+        {
+            expanded: [],
+            multiExpand
+        }
     );
 
     return (
@@ -27,15 +31,27 @@ type SetExpanded = {
     id: string;
 };
 
+type RemoveExpanded = {
+    type: "REMOVE_EXPANDED";
+    id: string;
+};
+
 type ClearExpanded = {
     type: "CLEAR_EXPANDED";
 };
 
-type Action = SetExpanded | ClearExpanded;
+type Action = SetExpanded | RemoveExpanded | ClearExpanded;
 
 export const setExpanded = (id: string): SetExpanded => (
     {
         type: "SET_EXPANDED",
+        id
+    }
+);
+
+export const removeExpanded = (id: string): RemoveExpanded => (
+    {
+        type: "REMOVE_EXPANDED",
         id
     }
 );
@@ -59,7 +75,12 @@ function accordionReducer(state: AccordionState, action: Action): AccordionState
         case "SET_EXPANDED":
             return {
                 ...state,
-                expanded: action.id
+                expanded: state.multiExpand ? [...state.expanded, action.id] : [action.id]
+            };
+        case "REMOVE_EXPANDED":
+            return {
+                ...state,
+                expanded: state.expanded.filter(id => id !== action.id)
             };
         case "CLEAR_EXPANDED":
             return {

--- a/react-common/components/controls/Accordion/context.tsx
+++ b/react-common/components/controls/Accordion/context.tsx
@@ -8,14 +8,15 @@ interface AccordionState {
 const AccordionStateContext = React.createContext<AccordionState>(null);
 const AccordionDispatchContext = React.createContext<(action: Action) => void>(null);
 
-export const AccordionProvider = ({ multiExpand, defaultExpandedIds, children }: React.PropsWithChildren<{multiExpand?: boolean, defaultExpandedIds?: string[]}>) => {
-    const [state, dispatch] = React.useReducer(
-        accordionReducer,
-        {
-            expanded: defaultExpandedIds ?? [],
-            multiExpand
-        }
-    );
+export const AccordionProvider = ({
+    multiExpand,
+    defaultExpandedIds,
+    children,
+}: React.PropsWithChildren<{ multiExpand?: boolean; defaultExpandedIds?: string[] }>) => {
+    const [state, dispatch] = React.useReducer(accordionReducer, {
+        expanded: defaultExpandedIds ?? [],
+        multiExpand,
+    });
 
     return (
         <AccordionStateContext.Provider value={state}>
@@ -63,7 +64,7 @@ export const clearExpanded = (): ClearExpanded => (
 );
 
 export function useAccordionState() {
-    return React.useContext(AccordionStateContext)
+    return React.useContext(AccordionStateContext);
 }
 
 export function useAccordionDispatch() {
@@ -75,17 +76,17 @@ function accordionReducer(state: AccordionState, action: Action): AccordionState
         case "SET_EXPANDED":
             return {
                 ...state,
-                expanded: state.multiExpand ? [...state.expanded, action.id] : [action.id]
+                expanded: state.multiExpand ? [...state.expanded, action.id] : [action.id],
             };
         case "REMOVE_EXPANDED":
             return {
                 ...state,
-                expanded: state.expanded.filter(id => id !== action.id)
+                expanded: state.expanded.filter((id) => id !== action.id),
             };
         case "CLEAR_EXPANDED":
             return {
                 ...state,
-                expanded: undefined
+                expanded: undefined,
             };
     }
 }

--- a/react-common/components/controls/Accordion/context.tsx
+++ b/react-common/components/controls/Accordion/context.tsx
@@ -37,11 +37,7 @@ type RemoveExpanded = {
     id: string;
 };
 
-type ClearExpanded = {
-    type: "CLEAR_EXPANDED";
-};
-
-type Action = SetExpanded | RemoveExpanded | ClearExpanded;
+type Action = SetExpanded | RemoveExpanded;
 
 export const setExpanded = (id: string): SetExpanded => (
     {
@@ -54,12 +50,6 @@ export const removeExpanded = (id: string): RemoveExpanded => (
     {
         type: "REMOVE_EXPANDED",
         id
-    }
-);
-
-export const clearExpanded = (): ClearExpanded => (
-    {
-        type: "CLEAR_EXPANDED"
     }
 );
 
@@ -82,11 +72,6 @@ function accordionReducer(state: AccordionState, action: Action): AccordionState
             return {
                 ...state,
                 expanded: state.expanded.filter((id) => id !== action.id),
-            };
-        case "CLEAR_EXPANDED":
-            return {
-                ...state,
-                expanded: undefined,
             };
     }
 }

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -15,7 +15,7 @@ import { FocusTrap } from "react-common/components/controls/FocusTrap";
 import { logError } from "../services/loggingService";
 import { ErrorCode } from "../types/errorCode";
 import {
-    addExandedCatalogTagAsync,
+    addExpandedCatalogTagAsync,
     getExpandedCatalogTags,
     removeExpandedCatalogTagAsync,
 } from "../services/storageService";
@@ -133,7 +133,7 @@ const CatalogList: React.FC = () => {
 
     function onTagExpandToggled(tag: string, expanded: boolean) {
         if (expanded) {
-            /* await */ addExandedCatalogTagAsync(tag);
+            /* await */ addExpandedCatalogTagAsync(tag);
         } else {
             /* await */ removeExpandedCatalogTagAsync(tag);
         }
@@ -147,7 +147,7 @@ const CatalogList: React.FC = () => {
     let expandedTags = getExpandedCatalogTags();
     if (!expandedTags) {
         // If we haven't saved an expanded set, default expand the first one.
-        addExandedCatalogTagAsync(tags[0]);
+        addExpandedCatalogTagAsync(tags[0]);
         expandedTags = [tags[0]];
     }
 

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -14,9 +14,12 @@ import { announceToScreenReader } from "../transforms/announceToScreenReader";
 import { FocusTrap } from "react-common/components/controls/FocusTrap";
 import { logError } from "../services/loggingService";
 import { ErrorCode } from "../types/errorCode";
+import {
+    addExandedCatalogTagAsync,
+    getExpandedCatalogTags,
+    removeExpandedCatalogTagAsync,
+} from "../services/storageService";
 import css from "./styling/CatalogOverlay.module.scss";
-import { addExandedCatalogTagAsync, getExpandedCatalogTags, removeExpandedCatalogTagAsync } from "../services/storageService";
-import exp from "constants";
 
 interface CatalogHeaderProps {
     onClose: () => void;
@@ -152,7 +155,11 @@ const CatalogList: React.FC = () => {
         <Accordion className={css["catalog-list"]} multiExpand={true} defaultExpandedIds={expandedIds}>
             {tags.map(tag => {
                 return (
-                    <Accordion.Item itemId={getItemIdForTag(tag)} onExpandToggled={expanded => onTagExpandToggled(tag, expanded)} key={getItemIdForTag(tag)}>
+                    <Accordion.Item
+                        itemId={getItemIdForTag(tag)}
+                        onExpandToggled={expanded => onTagExpandToggled(tag, expanded)}
+                        key={getItemIdForTag(tag)}
+                    >
                         <Accordion.Header>{tag}</Accordion.Header>
                         <Accordion.Panel>
                             {criteriaGroupedByTag[tag].map(c => {

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -89,7 +89,6 @@ const CatalogItem: React.FC<CatalogItemProps> = ({ catalogCriteria, recentlyAdde
     const isMaxed = catalogCriteria.maxCount !== undefined && existingInstanceCount >= catalogCriteria.maxCount;
     return catalogCriteria.template ? (
         <Button
-            id={`criteria_${catalogCriteria.id}`}
             title={getReadableCriteriaTemplate(catalogCriteria)}
             key={catalogCriteria.id}
             className={css["catalog-item"]}

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -7,7 +7,7 @@ import { ReadOnlyCriteriaDisplay } from "./ReadonlyCriteriaDisplay";
 import { Strings } from "../constants";
 import { Button } from "react-common/components/controls/Button";
 import { Accordion } from "react-common/components/controls/Accordion";
-import { getReadableCriteriaTemplate, makeToast } from "../utils";
+import { getReadableCriteriaTemplate } from "../utils";
 import { setCatalogOpen } from "../transforms/setCatalogOpen";
 import { classList } from "react-common/components/util";
 import { announceToScreenReader } from "../transforms/announceToScreenReader";
@@ -15,7 +15,6 @@ import { FocusTrap } from "react-common/components/controls/FocusTrap";
 import css from "./styling/CatalogOverlay.module.scss";
 import { logError } from "../services/loggingService";
 import { ErrorCode } from "../types/errorCode";
-import { AccordionHeader, AccordionItem, AccordionPanel } from "react-common/components/controls/Accordion/Accordion";
 
 interface CatalogHeaderProps {
     onClose: () => void;

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -75,6 +75,37 @@ const CatalogItemLabel: React.FC<CatalogItemLabelProps> = ({ catalogCriteria, is
     );
 };
 
+interface CatalogItemProps {
+    catalogCriteria: CatalogCriteria;
+    recentlyAddedIds: pxsim.Map<NodeJS.Timeout>;
+    onItemClicked: (c: CatalogCriteria) => void;
+}
+const CatalogItem: React.FC<CatalogItemProps> = ({ catalogCriteria, recentlyAddedIds, onItemClicked }) => {
+    const { state: teacherTool } = useContext(AppStateContext);
+
+    const existingInstanceCount = teacherTool.checklist.criteria.filter(
+        i => i.catalogCriteriaId === catalogCriteria.id
+    ).length;
+    const isMaxed = catalogCriteria.maxCount !== undefined && existingInstanceCount >= catalogCriteria.maxCount;
+    return catalogCriteria.template ? (
+        <Button
+            id={`criteria_${catalogCriteria.id}`}
+            title={getReadableCriteriaTemplate(catalogCriteria)}
+            key={catalogCriteria.id}
+            className={css["catalog-item"]}
+            label={
+                <CatalogItemLabel
+                    catalogCriteria={catalogCriteria}
+                    isMaxed={isMaxed}
+                    recentlyAdded={recentlyAddedIds[catalogCriteria.id] !== undefined}
+                />
+            }
+            onClick={() => onItemClicked(catalogCriteria)}
+            disabled={isMaxed}
+        />
+    ) : null;
+};
+
 const CatalogList: React.FC = () => {
     const { state: teacherTool } = useContext(AppStateContext);
 
@@ -163,31 +194,13 @@ const CatalogList: React.FC = () => {
                     >
                         <Accordion.Header>{tag}</Accordion.Header>
                         <Accordion.Panel>
-                            {criteriaGroupedByTag[tag].map(c => {
-                                const existingInstanceCount = teacherTool.checklist.criteria.filter(
-                                    i => i.catalogCriteriaId === c.id
-                                ).length;
-                                const isMaxed = c.maxCount !== undefined && existingInstanceCount >= c.maxCount;
-                                return (
-                                    c.template && (
-                                        <Button
-                                            id={`criteria_${c.id}`}
-                                            title={getReadableCriteriaTemplate(c)}
-                                            key={c.id}
-                                            className={css["catalog-item"]}
-                                            label={
-                                                <CatalogItemLabel
-                                                    catalogCriteria={c}
-                                                    isMaxed={isMaxed}
-                                                    recentlyAdded={recentlyAddedIds[c.id] !== undefined}
-                                                />
-                                            }
-                                            onClick={() => onItemClicked(c)}
-                                            disabled={isMaxed}
-                                        />
-                                    )
-                                );
-                            })}
+                            {criteriaGroupedByTag[tag].map(c => (
+                                <CatalogItem
+                                    catalogCriteria={c}
+                                    recentlyAddedIds={recentlyAddedIds}
+                                    onItemClicked={onItemClicked}
+                                />
+                            ))}
                         </Accordion.Panel>
                     </Accordion.Item>
                 );

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -122,11 +122,16 @@ const CatalogList: React.FC = () => {
         announceToScreenReader(lf("Added '{0}' to checklist.", getReadableCriteriaTemplate(c)));
     }
 
+    function getItemIdForTag(tag: string) {
+        return `accordion-item-${tag}`;
+    }
+
+    const tags = Object.keys(criteriaGroupedByTag);
     return (
-        <Accordion className={css["catalog-list"]} multiExpand={true}>
-            {Object.keys(criteriaGroupedByTag).map(tag => {
+        <Accordion className={css["catalog-list"]} multiExpand={true} defaultExpandedIds={[getItemIdForTag(tags[0])]}>
+            {tags.map(tag => {
                 return (
-                    <Accordion.Item>
+                    <Accordion.Item itemId={getItemIdForTag(tag)}>
                         <Accordion.Header>{tag}</Accordion.Header>
                         <Accordion.Panel>
                             {criteriaGroupedByTag[tag].map(c => {

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -85,11 +85,12 @@ const CatalogList: React.FC = () => {
     const criteriaGroupedByTag = useMemo<pxt.Map<CatalogCriteria[]>>(() => {
         const grouped: pxt.Map<CatalogCriteria[]> = {};
         getCatalogCriteria(teacherTool)?.forEach(c => {
-            const tag = c.tags?.[0];
-            if (!tag) {
+            if (!c.tags || c.tags.length === 0) {
                 logError(ErrorCode.missingTag, { message: "Catalog criteria missing tag", criteria: c });
                 return;
             }
+
+            const tag = c.tags[0];
             if (!grouped[tag]) {
                 grouped[tag] = [];
             }

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -167,6 +167,7 @@ const CatalogList: React.FC = () => {
 
     const tags = Object.keys(criteriaGroupedByTag);
     if (tags.length === 0) {
+        logError(ErrorCode.noCatalogCriteria);
         return null;
     }
 

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -15,6 +15,8 @@ import { FocusTrap } from "react-common/components/controls/FocusTrap";
 import { logError } from "../services/loggingService";
 import { ErrorCode } from "../types/errorCode";
 import css from "./styling/CatalogOverlay.module.scss";
+import { addExandedCatalogTagAsync, getExpandedCatalogTags, removeExpandedCatalogTagAsync } from "../services/storageService";
+import exp from "constants";
 
 interface CatalogHeaderProps {
     onClose: () => void;
@@ -125,12 +127,33 @@ const CatalogList: React.FC = () => {
         return `accordion-item-${tag}`;
     }
 
+    function onTagExpandToggled(tag: string, expanded: boolean) {
+        if (expanded) {
+            /* await */ addExandedCatalogTagAsync(tag);
+        } else {
+            /* await */ removeExpandedCatalogTagAsync(tag);
+        }
+    }
+
     const tags = Object.keys(criteriaGroupedByTag);
+    if (tags.length === 0) {
+        return null;
+    }
+
+    const expandedTags = getExpandedCatalogTags();
+
+    // If no tags are expanded, expand the first one.
+    if (expandedTags.length === 0) {
+        addExandedCatalogTagAsync(tags[0]);
+        expandedTags.push(tags[0]);
+    }
+
+    const expandedIds = expandedTags.map(t => getItemIdForTag(t));
     return (
-        <Accordion className={css["catalog-list"]} multiExpand={true} defaultExpandedIds={[getItemIdForTag(tags[0])]}>
+        <Accordion className={css["catalog-list"]} multiExpand={true} defaultExpandedIds={expandedIds}>
             {tags.map(tag => {
                 return (
-                    <Accordion.Item itemId={getItemIdForTag(tag)}>
+                    <Accordion.Item itemId={getItemIdForTag(tag)} onExpandToggled={expanded => onTagExpandToggled(tag, expanded)} key={getItemIdForTag(tag)}>
                         <Accordion.Header>{tag}</Accordion.Header>
                         <Accordion.Panel>
                             {criteriaGroupedByTag[tag].map(c => {

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -123,7 +123,7 @@ const CatalogList: React.FC = () => {
     }
 
     return (
-        <Accordion className={css["catalog-list"]}>
+        <Accordion className={css["catalog-list"]} multiExpand={true}>
             {Object.keys(criteriaGroupedByTag).map(tag => {
                 return (
                     <Accordion.Item>

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -140,12 +140,11 @@ const CatalogList: React.FC = () => {
         return null;
     }
 
-    const expandedTags = getExpandedCatalogTags();
-
-    // If no tags are expanded, expand the first one.
-    if (expandedTags.length === 0) {
+    let expandedTags = getExpandedCatalogTags();
+    if (!expandedTags) {
+        // If we haven't saved an expanded set, default expand the first one.
         addExandedCatalogTagAsync(tags[0]);
-        expandedTags.push(tags[0]);
+        expandedTags = [tags[0]];
     }
 
     const expandedIds = expandedTags.map(t => getItemIdForTag(t));

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -12,9 +12,9 @@ import { setCatalogOpen } from "../transforms/setCatalogOpen";
 import { classList } from "react-common/components/util";
 import { announceToScreenReader } from "../transforms/announceToScreenReader";
 import { FocusTrap } from "react-common/components/controls/FocusTrap";
-import css from "./styling/CatalogOverlay.module.scss";
 import { logError } from "../services/loggingService";
 import { ErrorCode } from "../types/errorCode";
+import css from "./styling/CatalogOverlay.module.scss";
 
 interface CatalogHeaderProps {
     onClose: () => void;

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -14,11 +14,7 @@ import { announceToScreenReader } from "../transforms/announceToScreenReader";
 import { FocusTrap } from "react-common/components/controls/FocusTrap";
 import { logError } from "../services/loggingService";
 import { ErrorCode } from "../types/errorCode";
-import {
-    addExpandedCatalogTagAsync,
-    getExpandedCatalogTags,
-    removeExpandedCatalogTagAsync,
-} from "../services/storageService";
+import { addExpandedCatalogTag, getExpandedCatalogTags, removeExpandedCatalogTag } from "../services/storageService";
 import css from "./styling/CatalogOverlay.module.scss";
 
 interface CatalogHeaderProps {
@@ -163,9 +159,9 @@ const CatalogList: React.FC = () => {
 
     function onTagExpandToggled(tag: string, expanded: boolean) {
         if (expanded) {
-            /* await */ addExpandedCatalogTagAsync(tag);
+            addExpandedCatalogTag(tag);
         } else {
-            /* await */ removeExpandedCatalogTagAsync(tag);
+            removeExpandedCatalogTag(tag);
         }
     }
 
@@ -177,7 +173,7 @@ const CatalogList: React.FC = () => {
     let expandedTags = getExpandedCatalogTags();
     if (!expandedTags) {
         // If we haven't saved an expanded set, default expand the first one.
-        addExpandedCatalogTagAsync(tags[0]);
+        addExpandedCatalogTag(tags[0]);
         expandedTags = [tags[0]];
     }
 

--- a/teachertool/src/components/styling/CatalogOverlay.module.scss
+++ b/teachertool/src/components/styling/CatalogOverlay.module.scss
@@ -59,6 +59,10 @@
             width: 100%;
             height: 100%;
 
+            div[class*="common-accordion-chevron"] {
+                width: 3rem; // Match action-indicators
+            }
+
             button[class*="common-accordion-header-outer"] {
                 background-color: var(--pxt-content-foreground);
                 color: var(--pxt-content-background);
@@ -86,7 +90,7 @@
                     .action-indicators {
                         position: relative;
                         padding: 0 1rem 0 0;
-                        width: 3rem;
+                        width: 3rem; // Match common-accordion-chevron
                         display: flex;
                         align-items: center;
                         justify-content: center;

--- a/teachertool/src/components/styling/CatalogOverlay.module.scss
+++ b/teachertool/src/components/styling/CatalogOverlay.module.scss
@@ -57,7 +57,7 @@
             display: flex;
             flex-direction: column;
             width: 100%;
-
+            height: 100%;
 
             button[class*="common-accordion-header-outer"] {
                 background-color: var(--pxt-content-foreground);

--- a/teachertool/src/components/styling/CatalogOverlay.module.scss
+++ b/teachertool/src/components/styling/CatalogOverlay.module.scss
@@ -14,8 +14,8 @@
     align-items: center;
 
     .catalog-content-container {
-        max-width: 95%;
-        max-height: 95%;
+        width: 95%;
+        height: 95%;
         background-color: var(--pxt-page-background);
         border-radius: .285rem; // Match modal
         display: flex;
@@ -57,6 +57,15 @@
             display: flex;
             flex-direction: column;
             width: 100%;
+
+
+            button[class*="common-accordion-header-outer"] {
+                background-color: var(--pxt-content-foreground);
+                color: var(--pxt-content-background);
+                border-bottom: 1px solid var(--pxt-content-accent);
+                font-size: 1.2rem;
+                padding: 0.5rem 0.95rem;
+            }
 
             .catalog-item {
                 width: 100%;

--- a/teachertool/src/components/styling/ReadonlyCriteriaDisplay.module.scss
+++ b/teachertool/src/components/styling/ReadonlyCriteriaDisplay.module.scss
@@ -2,6 +2,8 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    text-wrap: wrap;
+    text-align: start;
 
     .criteria-template {
         margin-bottom: 0.4rem;

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -33,6 +33,7 @@ export namespace Strings {
     export const Checklist = lf("Checklist");
     export const Home = lf("Home");
     export const CreateEmptyChecklist = lf("Create Empty Checklist");
+    export const Other = lf("Other");
 }
 
 export namespace Ticks {

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -214,7 +214,7 @@ export async function setExpandedCatalogTags(tags: string[]) {
     }
 }
 
-export async function addExandedCatalogTagAsync(tag: string) {
+export async function addExpandedCatalogTagAsync(tag: string) {
     let expandedTags = getExpandedCatalogTags();
     if (!expandedTags) {
         expandedTags = [];

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -194,13 +194,15 @@ export async function deleteChecklistAsync(name: string) {
     }
 }
 
-export function getExpandedCatalogTags(): string[] {
+// Returns undefined if it has not been set or if there was an issue.
+// Empty list means it was explicitly set to empty.
+export function getExpandedCatalogTags(): string[] | undefined {
     try {
         const tags = getValue(EXPANDED_CATALOG_TAGS_KEY);
-        return tags ? JSON.parse(tags) : [];
+        return tags ? JSON.parse(tags) : undefined;
     } catch (e) {
         logError(ErrorCode.localStorageReadError, e);
-        return [];
+        return undefined;
     }
 }
 
@@ -213,17 +215,24 @@ export async function setExpandedCatalogTags(tags: string[]) {
 }
 
 export async function addExandedCatalogTagAsync(tag: string) {
-    const expandedTags = getExpandedCatalogTags();
+    let expandedTags = getExpandedCatalogTags();
+    if (!expandedTags) {
+        expandedTags = [];
+    }
     expandedTags.push(tag);
     await setExpandedCatalogTags(expandedTags);
 }
 
 export async function removeExpandedCatalogTagAsync(tag: string) {
-    const expandedTags = getExpandedCatalogTags();
-    const index = expandedTags.indexOf(tag);
-    if (index !== -1) {
-        expandedTags.splice(index, 1);
-        await setExpandedCatalogTags(expandedTags);
+    let expandedTags = getExpandedCatalogTags();
+    if (!expandedTags) {
+        await setExpandedCatalogTags([]);
+    } else {
+        const index = expandedTags.indexOf(tag);
+        if (index !== -1) {
+            expandedTags.splice(index, 1);
+            await setExpandedCatalogTags(expandedTags);
+        }
     }
 }
 

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -235,4 +235,3 @@ export async function removeExpandedCatalogTagAsync(tag: string) {
         }
     }
 }
-

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -206,7 +206,7 @@ export function getExpandedCatalogTags(): string[] | undefined {
     }
 }
 
-export async function setExpandedCatalogTagsAsync(tags: string[]) {
+export function setExpandedCatalogTags(tags: string[]) {
     try {
         setValue(EXPANDED_CATALOG_TAGS_KEY, JSON.stringify(tags));
     } catch (e) {
@@ -214,24 +214,24 @@ export async function setExpandedCatalogTagsAsync(tags: string[]) {
     }
 }
 
-export async function addExpandedCatalogTagAsync(tag: string) {
+export function addExpandedCatalogTag(tag: string) {
     let expandedTags = getExpandedCatalogTags();
     if (!expandedTags) {
         expandedTags = [];
     }
     expandedTags.push(tag);
-    await setExpandedCatalogTagsAsync(expandedTags);
+    setExpandedCatalogTags(expandedTags);
 }
 
-export async function removeExpandedCatalogTagAsync(tag: string) {
+export function removeExpandedCatalogTag(tag: string) {
     let expandedTags = getExpandedCatalogTags();
     if (!expandedTags) {
-        await setExpandedCatalogTagsAsync([]);
+        setExpandedCatalogTags([]);
     } else {
         const index = expandedTags.indexOf(tag);
         if (index !== -1) {
             expandedTags.splice(index, 1);
-            await setExpandedCatalogTagsAsync(expandedTags);
+            setExpandedCatalogTags(expandedTags);
         }
     }
 }

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -206,7 +206,7 @@ export function getExpandedCatalogTags(): string[] | undefined {
     }
 }
 
-export async function setExpandedCatalogTags(tags: string[]) {
+export async function setExpandedCatalogTagsAsync(tags: string[]) {
     try {
         setValue(EXPANDED_CATALOG_TAGS_KEY, JSON.stringify(tags));
     } catch (e) {
@@ -220,18 +220,18 @@ export async function addExpandedCatalogTagAsync(tag: string) {
         expandedTags = [];
     }
     expandedTags.push(tag);
-    await setExpandedCatalogTags(expandedTags);
+    await setExpandedCatalogTagsAsync(expandedTags);
 }
 
 export async function removeExpandedCatalogTagAsync(tag: string) {
     let expandedTags = getExpandedCatalogTags();
     if (!expandedTags) {
-        await setExpandedCatalogTags([]);
+        await setExpandedCatalogTagsAsync([]);
     } else {
         const index = expandedTags.indexOf(tag);
         if (index !== -1) {
             expandedTags.splice(index, 1);
-            await setExpandedCatalogTags(expandedTags);
+            await setExpandedCatalogTagsAsync(expandedTags);
         }
     }
 }

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -11,6 +11,7 @@ const KEY_PREFIX = "teachertool";
 const AUTORUN_KEY = [KEY_PREFIX, "autorun"].join("/");
 const LAST_ACTIVE_CHECKLIST_KEY = [KEY_PREFIX, "lastActiveChecklist"].join("/");
 const SPLIT_POSITION_KEY = [KEY_PREFIX, "splitPosition"].join("/");
+const EXPANDED_CATALOG_TAGS_KEY = [KEY_PREFIX, "expandedCatalogTags"].join("/");
 
 function getValue(key: string, defaultValue?: string): string | undefined {
     return localStorage.getItem(key) || defaultValue;
@@ -192,3 +193,37 @@ export async function deleteChecklistAsync(name: string) {
         setLastActiveChecklistName("");
     }
 }
+
+export function getExpandedCatalogTags(): string[] {
+    try {
+        const tags = getValue(EXPANDED_CATALOG_TAGS_KEY);
+        return tags ? JSON.parse(tags) : [];
+    } catch (e) {
+        logError(ErrorCode.localStorageReadError, e);
+        return [];
+    }
+}
+
+export async function setExpandedCatalogTags(tags: string[]) {
+    try {
+        setValue(EXPANDED_CATALOG_TAGS_KEY, JSON.stringify(tags));
+    } catch (e) {
+        logError(ErrorCode.localStorageWriteError, e);
+    }
+}
+
+export async function addExandedCatalogTagAsync(tag: string) {
+    const expandedTags = getExpandedCatalogTags();
+    expandedTags.push(tag);
+    await setExpandedCatalogTags(expandedTags);
+}
+
+export async function removeExpandedCatalogTagAsync(tag: string) {
+    const expandedTags = getExpandedCatalogTags();
+    const index = expandedTags.indexOf(tag);
+    if (index !== -1) {
+        expandedTags.splice(index, 1);
+        await setExpandedCatalogTags(expandedTags);
+    }
+}
+

--- a/teachertool/src/transforms/loadCatalogAsync.ts
+++ b/teachertool/src/transforms/loadCatalogAsync.ts
@@ -12,11 +12,16 @@ export async function loadCatalogAsync() {
     const { dispatch } = stateAndDispatch();
     const fullCatalog = await loadTestableCollectionFromDocsAsync<CatalogCriteria>(prodFiles, "criteria");
 
-    // Convert parameter names to lower-case for case-insensitive matching
     fullCatalog.forEach(c => {
+        // Convert parameter names to lower-case for case-insensitive matching
         c.params?.forEach(p => {
             p.name = p.name.toLocaleLowerCase();
         });
+
+        // Add default tag if none are present
+        if (!c.tags || c.tags.length === 0) {
+            c.tags = ["Other"];
+        }
     });
 
     dispatch(Actions.setCatalog(fullCatalog));

--- a/teachertool/src/transforms/loadCatalogAsync.ts
+++ b/teachertool/src/transforms/loadCatalogAsync.ts
@@ -1,3 +1,4 @@
+import { Strings } from "../constants";
 import { loadTestableCollectionFromDocsAsync } from "../services/backendRequests";
 import { stateAndDispatch } from "../state";
 import * as Actions from "../state/actions";
@@ -20,7 +21,7 @@ export async function loadCatalogAsync() {
 
         // Add default tag if none are present
         if (!c.tags || c.tags.length === 0) {
-            c.tags = ["Other"];
+            c.tags = [Strings.Other];
         }
     });
 

--- a/teachertool/src/types/criteria.ts
+++ b/teachertool/src/types/criteria.ts
@@ -8,6 +8,7 @@ export interface CatalogCriteria {
     params: CriteriaParameter[] | undefined; // Any parameters that affect the criteria
     hideInCatalog?: boolean; // Whether the criteria should be hidden in the user-facing catalog
     maxCount?: number; // The maximum number of instances allowed for this criteria within a single checklist. Unlimited if undefined.
+    tags?: string[]; // Tags to help categorize the criteria
 }
 
 // An instance of a criteria in a checklist.

--- a/teachertool/src/types/errorCode.ts
+++ b/teachertool/src/types/errorCode.ts
@@ -26,4 +26,5 @@ export enum ErrorCode {
     unrecognizedSystemParameter = "unrecognizedSystemParameter",
     invalidValidatorPlan = "invalidValidatorPlan",
     askCopilotQuestion = "askCopilotQuestion",
+    missingTag = "missingTag",
 }

--- a/teachertool/src/types/errorCode.ts
+++ b/teachertool/src/types/errorCode.ts
@@ -27,4 +27,5 @@ export enum ErrorCode {
     invalidValidatorPlan = "invalidValidatorPlan",
     askCopilotQuestion = "askCopilotQuestion",
     missingTag = "missingTag",
+    noCatalogCriteria = "noCatalogCriteria"
 }


### PR DESCRIPTION
This change adds tags to criteria in the catalog. The schema is setup to support criteria having multiple tags, but for now we only adjust our display based on the first tag. This may change if we add more criteria and start using more granular tags, but it's not necessary given the current catalog.

If a criterion doesn't have any tags, it gets assigned an "Other" tag. Currently, all visible catalog criteria have tags, so the other tag is never shown.

Initially, the first tag in the catalog is expanded, but the tool remembers which tags the user expands/collapses and preserves those for the next time the catalog is opened.

I made a few adjustments to the accordion display to support this change:
1. A flag to allow multiple items to be expanded
2. The ability to specify an initial "open" item set
3. The optional ability to specify ids for each item (to support number 2)

Upload target is here, but since it's looking at production docs, everything is just placed into the "Other" category for now: https://makecode.microbit.org/app/13ea77ed2e1da12176c4c12a9907981375709c43-71c65280c6--eval

Screenshots (from localhost with updated docs)
![image](https://github.com/microsoft/pxt/assets/69657545/4bf42182-6c67-49d3-851b-328f4a3c4d68)
![image](https://github.com/microsoft/pxt/assets/69657545/d36b2653-f167-4b55-b1ce-530991be855c)
![image](https://github.com/microsoft/pxt/assets/69657545/8c0626b2-91c9-407c-913f-8d2e2b50b468)
![image](https://github.com/microsoft/pxt/assets/69657545/5d81e4bf-41f2-4c68-b8e5-bc588a862b79)

Fixes https://github.com/microsoft/pxt-microbit/issues/5597

