### PR TITLE
Remove the decompiler block limit

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -65,7 +65,7 @@ namespace ts.pxtc.decompiler {
     /**
      * Max number of blocks before we bail out of decompilation
      */
-    const MAX_BLOCKS = 1500;
+    const MAX_BLOCKS = 6000;
 
     const lowerCaseAlphabetStartCode = 97;
     const lowerCaseAlphabetEndCode = 122;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -459,10 +459,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 tsFile = pxt.MAIN_TS;
             }
 
-            const failedAsync = (file: string, programTooLarge = false) => {
+            const failedAsync = (file: string) => {
                 core.cancelAsyncLoading("switchtoblocks");
                 this.forceDiagnosticsUpdate();
-                return this.showBlockConversionFailedDialog(file, programTooLarge);
+                return this.showBlockConversionFailedDialog(file);
             }
 
             // might be undefined
@@ -519,9 +519,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                                         if (!resp.success) {
                                             const failed = resp.failedResponse;
                                             this.currFile.diagnostics = failed.diagnostics;
-                                            let tooLarge = false;
-                                            failed.diagnostics.forEach(d => tooLarge = (tooLarge || d.code === 9266 /* error code when script is too large */));
-                                            return failedAsync(blockFile, tooLarge);
+                                            return failedAsync(blockFile);
                                         }
                                         xml = resp.outText;
                                         Util.assert(!!xml);
@@ -530,7 +528,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                                     })
                             }
                             else {
-                                return failedAsync(blockFile, false)
+                                return failedAsync(blockFile)
                             }
 
                         })
@@ -544,29 +542,22 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         return initPromise;
     }
 
-    public showBlockConversionFailedDialog(blockFile: string, programTooLarge: boolean): Promise<void> {
+    public showBlockConversionFailedDialog(blockFile: string): Promise<void> {
         const isPython = this.fileType == pxt.editor.FileType.Python;
         const tickLang = isPython ? "python" : "typescript";
 
         let bf = pkg.mainEditorPkg().files[blockFile];
-        if (programTooLarge) {
-            pxt.tickEvent(`${tickLang}.programTooLarge`);
-        }
         let body: string;
         let disagreeLbl: string;
         if (isPython) {
-            body = programTooLarge ?
-                lf("Your program is too large to convert into blocks. You can keep working in Python or discard your changes and go back to the previous Blocks version.") :
-                lf("We are unable to convert your Python code back to blocks. You can keep working in Python or discard your changes and go back to the previous Blocks version.");
+            body = lf("We are unable to convert your Python code back to blocks. You can keep working in Python or discard your changes and go back to the previous Blocks version.");
             disagreeLbl = lf("Stay in Python");
         } else {
-            body = programTooLarge ?
-                lf("Your program is too large to convert into blocks. You can keep working in JavaScript or discard your changes and go back to the previous Blocks version.") :
-                lf("We are unable to convert your JavaScript code back to blocks. You can keep working in JavaScript or discard your changes and go back to the previous Blocks version.");
+            body = lf("We are unable to convert your JavaScript code back to blocks. You can keep working in JavaScript or discard your changes and go back to the previous Blocks version.");
             disagreeLbl = lf("Stay in JavaScript");
         }
         return core.confirmAsync({
-            header: programTooLarge ? lf("Program too large") : lf("Oops, there is a problem converting your code."),
+            header: lf("Oops, there is a problem converting your code."),
             body,
             agreeLbl: lf("Discard and go to Blocks"),
             agreeClass: "cancel",


### PR DESCRIPTION
People run into this all the time on the forum, most recently here:

https://forum.makecode.com/t/my-code-seems-to-big-to-be-decompile-in-block/28637/4

If you have a very large blocks project, you can get stuck if you switch to text because we have a limit in place for the maximum size of a project we decompile. This limit was added many years ago in response to an issue where someone tried to decompile a gigantic script (they had copy+pasted code over and over again) and it basically hung the browser when Blockly tried to load the gigantic workspace file we generated.

I think this made sense at the time, but nowadays Blockly perf has improved and I don't think we need the restriction anymore. I was able to decompile a 9000 block program locally just now (on my admittedly nice laptop) and it was fine, it just took a while for Blockly to render the workspace.