### PR TITLE
Accessibility compliance: fixed focus for closed modals

### DIFF
--- a/react-common/components/controls/FocusTrap.tsx
+++ b/react-common/components/controls/FocusTrap.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { classList, nodeListToArray, findNextFocusableElement } from "../util";
+import { classList, nodeListToArray, findNextFocusableElement, isFocusable } from "../util";
 
 export interface FocusTrapProps extends React.PropsWithChildren<{}> {
     onEscape: () => void;
@@ -8,6 +8,7 @@ export interface FocusTrapProps extends React.PropsWithChildren<{}> {
     arrowKeyNavigation?: boolean;
     dontStealFocus?: boolean;
     includeOutsideTabOrder?: boolean;
+    dontRestoreFocus?: boolean;
 }
 
 export const FocusTrap = (props: FocusTrapProps) => {
@@ -18,12 +19,25 @@ export const FocusTrap = (props: FocusTrapProps) => {
         onEscape,
         arrowKeyNavigation,
         dontStealFocus,
-        includeOutsideTabOrder
+        includeOutsideTabOrder,
+        dontRestoreFocus
     } = props;
 
     let container: HTMLDivElement;
-
+    const previouslyFocused = React.useRef<Element>(document.activeElement);
     const [stoleFocus, setStoleFocus] = React.useState(false);
+
+    React.useEffect(() => {
+        return () => {
+            if (!dontRestoreFocus) {
+                let toFocus = previouslyFocused.current as HTMLElement
+                while (!isFocusable(toFocus)) {
+                    toFocus = toFocus.parentElement;
+                }
+                toFocus.focus()
+            }
+        }
+    }, [previouslyFocused])
 
     const getElements = () => {
         const all = nodeListToArray(

--- a/react-common/components/controls/FocusTrap.tsx
+++ b/react-common/components/controls/FocusTrap.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { classList, nodeListToArray, findNextFocusableElement, isFocusable } from "../util";
+import { classList, nodeListToArray, findNextFocusableElement, focusLastActive } from "../util";
 
 export interface FocusTrapProps extends React.PropsWithChildren<{}> {
     onEscape: () => void;
@@ -29,15 +29,11 @@ export const FocusTrap = (props: FocusTrapProps) => {
 
     React.useEffect(() => {
         return () => {
-            if (!dontRestoreFocus) {
-                let toFocus = previouslyFocused.current as HTMLElement
-                while (!isFocusable(toFocus)) {
-                    toFocus = toFocus.parentElement;
-                }
-                toFocus.focus()
+            if (!dontRestoreFocus && previouslyFocused.current) {
+                focusLastActive(previouslyFocused.current as HTMLElement)
             }
         }
-    }, [previouslyFocused])
+    }, [])
 
     const getElements = () => {
         const all = nodeListToArray(

--- a/react-common/components/util.tsx
+++ b/react-common/components/util.tsx
@@ -113,3 +113,9 @@ export function findNextFocusableElement(elements: HTMLElement[], focusedIndex: 
     }
     return findNextFocusableElement(elements, focusedIndex, index, forward);
 }
+
+export function isFocusable(e: HTMLElement) {
+    return (e.getAttribute("data-isfocusable") === "true"
+        || e.tabIndex !== -1)
+        && getComputedStyle(e).display !== "none";
+}

--- a/react-common/components/util.tsx
+++ b/react-common/components/util.tsx
@@ -115,7 +115,23 @@ export function findNextFocusableElement(elements: HTMLElement[], focusedIndex: 
 }
 
 export function isFocusable(e: HTMLElement) {
-    return (e.getAttribute("data-isfocusable") === "true"
+    if (e) {
+        return (e.getAttribute("data-isfocusable") === "true"
         || e.tabIndex !== -1)
         && getComputedStyle(e).display !== "none";
+    } else {
+        return false;
+    }
+}
+
+export function focusLastActive(el: HTMLElement) {
+    while (el && !isFocusable(el)) {
+        const toFocusParent = el.parentElement;
+        if (toFocusParent) {
+            el = toFocusParent;
+        } else {
+            break;
+        }
+    }
+    el.focus();
 }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1218,7 +1218,9 @@ export class Modal extends data.Component<ModalProps, ModalState> {
         cancelAnimationFrame(this.animationRequestId);
         if (!this.props.dontRestoreFocus) {
             let toFocus = this.state.previouslyFocused as HTMLElement;
-            focusLastActive(toFocus);
+            if (toFocus) {
+                focusLastActive(toFocus);
+            }
         }
     }
 

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -7,6 +7,7 @@ import * as data from "./data";
 import * as core from "./core";
 import * as auth from "./auth";
 import { fireClickOnEnter } from "./util";
+import { focusLastActive } from "../../react-common/components/util";
 
 export const appElement = document.getElementById('content');
 
@@ -1195,16 +1196,6 @@ export class Modal extends data.Component<ModalProps, ModalState> {
         this.afterOpen = this.afterOpen.bind(this);
     }
 
-    private isFocusable(e: HTMLElement) {
-        if (e) {
-            return (e.getAttribute("data-isfocusable") === "true"
-            || e.tabIndex !== -1)
-            && getComputedStyle(e).display !== "none";
-        } else {
-            return false;
-        }
-    }
-
     private afterOpen() {
         const { modalDidOpen } = this.props;
         this.setState({ scrolling: false });
@@ -1227,15 +1218,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
         cancelAnimationFrame(this.animationRequestId);
         if (!this.props.dontRestoreFocus) {
             let toFocus = this.state.previouslyFocused as HTMLElement;
-            while (toFocus && !this.isFocusable(toFocus)) {
-                const toFocusParent = toFocus.parentElement;
-                if (toFocusParent) {
-                    toFocus = toFocusParent;
-                } else {
-                    break;
-                }
-            }
-            toFocus.focus();
+            focusLastActive(toFocus);
         }
     }
 

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1196,9 +1196,13 @@ export class Modal extends data.Component<ModalProps, ModalState> {
     }
 
     private isFocusable(e: HTMLElement) {
-        return (e.getAttribute("data-isfocusable") === "true"
+        if (e) {
+            return (e.getAttribute("data-isfocusable") === "true"
             || e.tabIndex !== -1)
             && getComputedStyle(e).display !== "none";
+        } else {
+            return false;
+        }
     }
 
     private afterOpen() {
@@ -1222,9 +1226,14 @@ export class Modal extends data.Component<ModalProps, ModalState> {
     componentWillUnmount() {
         cancelAnimationFrame(this.animationRequestId);
         if (!this.props.dontRestoreFocus) {
-            let toFocus = this.state.previouslyFocused as HTMLElement
-            while (!this.isFocusable(toFocus)) {
-                toFocus = toFocus.parentElement;
+            let toFocus = this.state.previouslyFocused as HTMLElement;
+            while (toFocus && !this.isFocusable(toFocus)) {
+                const toFocusParent = toFocus.parentElement;
+                if (toFocusParent) {
+                    toFocus = toFocusParent;
+                } else {
+                    break;
+                }
             }
             toFocus.focus();
         }


### PR DESCRIPTION
If a user were to close a modal with keyboard navigation, their focus would be put on the root rather than the most recent element they were focused on, which is a poor user experience. This PR fixes that and, upon closing a modal, will put focus on the DOM element that had focus before the modal was opened.

I want to give a quick thanks to @thsparks for this idea! Going with this approach greatly limited the amount of work that was needed for this fix.

EDIT: I wanted to add a quick note that the "Experiments" full-screen modal isn't performing correctly.. I want to look into this in a follow-up since the other full-screen modals are working as expected.

Follow-up: The "experiments" modal does not restore focus to the "settings" menuitem as expected because the last item that was focused upon opening the "experiments" modal is the experiments button in the "about" modal. The "about" modal is closed and thus does not have anything to focus on and thus just restores focus to the base. This is something that should be fixed, either by moving experiments or making the experiments area not a modal, but I don't think needs to be addressed in this change.

fixes https://github.com/microsoft/pxt-microbit/issues/5476

Upload target: https://makecode.microbit.org/app/02245e3b8695a39a2cf0053d656c5064581af07e-f2b0cbf1a5