### PR TITLE
Add warning when trying to carry over code without a template code block

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1961,8 +1961,15 @@ export class ProjectView
 
     private async loadTutorialTemplateCodeAsync(): Promise<void> {
         const header = pkg.mainEditorPkg().header;
-        if (!header || !header.tutorial || !header.tutorial.templateCode || header.tutorial.templateLoaded)
+        if (!header || !header.tutorial) {
             return;
+        }
+        else if (!header.tutorial.templateCode || header.tutorial.templateLoaded) {
+            if (header.tutorial.mergeCarryoverCode && header.tutorial.mergeHeaderId) {
+                console.warn(lf(`Refusing to carry code between tutorials because the loaded tutorial "{0}" does not contain a template code block.`, header.tutorial.tutorial));
+            }
+            return;
+        }
 
         const template = header.tutorial.templateCode;
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1966,7 +1966,7 @@ export class ProjectView
         }
         else if (!header.tutorial.templateCode || header.tutorial.templateLoaded) {
             if (header.tutorial.mergeCarryoverCode && header.tutorial.mergeHeaderId) {
-                console.warn(lf(`Refusing to carry code between tutorials because the loaded tutorial "{0}" does not contain a template code block.`, header.tutorial.tutorial));
+                console.warn(lf("Refusing to carry code between tutorials because the loaded tutorial \"{0}\" does not contain a template code block.", header.tutorial.tutorial));
             }
             return;
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6386

When you try to carry code between skillmap steps, we refuse to import the old code if the destination tutorial doesn't have a template code block. This behavior was confusing to content authors, so adding an explicit warning to the console to hopefully make everything a little more discoverable. Check out the forum thread in the linked issue for more info.