### PR TITLE
Accessibility compliance: inline blocks styling updates

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -734,11 +734,7 @@ async function renderNamespaces(options: ClientRenderOptions): Promise<void> {
         const color = namespaceToColor[ns];
         nsStyleBuffer += `
                 span.docs.${ns.toLowerCase()} {
-                    border-radius: 0;
-                    border-bottom: 2px solid ${color};
-                    color: black;
-                    font-weight: 600;
-                    background-color: transparent;
+                    --inline-namespace-color: ${color};
                 }
             `;
     }
@@ -747,11 +743,7 @@ async function renderNamespaces(options: ClientRenderOptions): Promise<void> {
         const color = pxt.toolbox.getNamespaceColor(ns);
         nsStyleBuffer += `
                 span.docs.${ns.toLowerCase()} {
-                    border-radius: 0;
-                    border-bottom: 2px solid ${color};
-                    color: black;
-                    font-weight: 600;
-                    background-color: transparent;
+                    --inline-namespace-color: ${color};
                 }
             `;
     }

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -731,11 +731,14 @@ async function renderNamespaces(options: ClientRenderOptions): Promise<void> {
 
     let nsStyleBuffer = '';
     for (const ns of Object.keys(namespaceToColor)) {
-        const color = pxt.getWhiteContrastingBackground(namespaceToColor[ns] || '#dddddd');
+        const color = namespaceToColor[ns];
         nsStyleBuffer += `
                 span.docs.${ns.toLowerCase()} {
-                    background-color: ${color} !important;
-                    border-color: ${pxt.toolbox.fadeColor(color, 0.1, false)} !important;
+                    border-radius: 0;
+                    border-bottom: 2px solid ${color};
+                    color: black;
+                    font-weight: 600;
+                    background-color: transparent;
                 }
             `;
     }
@@ -744,8 +747,11 @@ async function renderNamespaces(options: ClientRenderOptions): Promise<void> {
         const color = pxt.toolbox.getNamespaceColor(ns);
         nsStyleBuffer += `
                 span.docs.${ns.toLowerCase()} {
-                    background-color: ${color} !important;
-                    border-color: ${pxt.toolbox.fadeColor(color, 0.1, false)} !important;
+                    border-radius: 0;
+                    border-bottom: 2px solid ${color};
+                    color: black;
+                    font-weight: 600;
+                    background-color: transparent;
                 }
             `;
     }
@@ -774,7 +780,8 @@ function renderInlineBlocksAsync(options: BlocksRenderOptions): Promise<void> {
         if (mbtn) {
             const mtxt = /^(([^\:\.]*?)[\:\.])?(.*)$/.exec(mbtn[2]);
             const ns = mtxt[2] ? mtxt[2].trim().toLowerCase() : '';
-            const lev = mbtn[1].length == 1 ? `docs inlinebutton ${ns}` : `docs inlineblock ${ns}`;
+            const fixedNs = ns.replace(/\(.*?\)/g, '');
+            const lev = mbtn[1].length == 1 ? `docs inlinebutton ${fixedNs}` : `docs inlineblock ${fixedNs}`;
             const txt = mtxt[3].trim();
             $el.replaceWith($(`<span class="${lev}"/>`).text(pxt.U.rlf(txt)));
             return renderNextAsync();

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -378,11 +378,16 @@
     }
 
     span.docs.inlineblock {
-        border-bottom: 2px solid var(--inline-namespace-color);
+        border-bottom: 3px solid var(--inline-namespace-color);
         border-radius: 0;
         color: black;
         font-weight: 600;
         background-color: transparent;
+        padding-bottom: 0.1rem;
+        
+        i {
+            margin-right: 6px;
+        }
     }
 }
 

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -376,6 +376,14 @@
             padding: 0;
         }
     }
+
+    span.docs.inlineblock {
+        border-bottom: 2px solid var(--inline-namespace-color);
+        border-radius: 0;
+        color: black;
+        font-weight: 600;
+        background-color: transparent;
+    }
 }
 
 .ui.sidebar.menu.docs {

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -384,10 +384,6 @@
         font-weight: 600;
         background-color: transparent;
         padding-bottom: 0.1rem;
-        
-        i {
-            margin-right: 6px;
-        }
     }
 }
 

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -312,28 +312,6 @@ div.blocklyTreeIcon span {
 }
 
 /*******************************
-    Inline Block Previews
-*******************************/
-span.docs.inlineblock {
-    border-radius: 0;
-    border-bottom: 2px solid var(--inline-namespace-color);
-    color: black;
-    font-weight: 600;
-    background-color: transparent;
-}
-
-.hc span.docs.inlineblock {
-    color: white;
-}
-
-span.docs.inlineblock i {
-    font-family: 'Icons';
-    color: var(--inline-namespace-color);
-    font-style: normal;
-    margin-right: 4px;
-}
-
-/*******************************
         Media Adjustments
 *******************************/
 

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -312,6 +312,28 @@ div.blocklyTreeIcon span {
 }
 
 /*******************************
+    Inline Block Previews
+*******************************/
+span.docs.inlineblock {
+    border-radius: 0;
+    border-bottom: 2px solid var(--inline-namespace-color);
+    color: black;
+    font-weight: 600;
+    background-color: transparent;
+}
+
+.hc span.docs.inlineblock {
+    color: white;
+}
+
+span.docs.inlineblock i {
+    font-family: 'Icons';
+    color: var(--inline-namespace-color);
+    font-style: normal;
+    margin-right: 4px;
+}
+
+/*******************************
         Media Adjustments
 *******************************/
 

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -258,12 +258,23 @@ span.docs.inlinebutton {
 
 span.docs.inlineblock {
     padding: 0.05rem .2rem;
-    border-radius: .2rem;
+    padding-bottom: 0.1rem;
     white-space: nowrap;
-    background-color: @inlineBlockColor;
-    color: @white;
+    border-radius: 0;
+    border-bottom: 3px solid var(--inline-namespace-color);
+    color: black;
+    font-weight: 600;
+    background-color: transparent;
     font-family: @blocklyFont !important;
     font-size: 1em !important;
+
+    i {
+        font-family: 'Icons';
+        color: var(--inline-namespace-color);
+        font-style: normal;
+        margin-right: 6px;
+    }
+
     &.clickable {
         cursor: pointer;
 
@@ -271,6 +282,10 @@ span.docs.inlineblock {
             opacity: .8;
         }
     }
+}
+
+.hc span.docs.inlineblock {
+    color: @white;
 }
 
 code.lang-filterblocks {

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -400,10 +400,12 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                         : `docs inlineblock ${displayNs}`;
 
                     const inlineBlockDiv = document.createElement('span');
+                    const inlineBlockIcon = document.createElement('i');
                     pxsim.U.clear(inlineBlock);
                     inlineBlock.appendChild(inlineBlockDiv);
                     inlineBlockDiv.className = lev;
-                    inlineBlockDiv.textContent = pxt.U.rlf(txt);
+                    inlineBlockDiv.append(inlineBlockIcon);
+                    inlineBlockDiv.append(pxt.U.rlf(txt));
                     inlineBlockDiv.setAttribute("data-ns", behaviorNs);
                     if (displayNs !== behaviorNs) {
                         inlineBlockDiv.setAttribute("data-norecolor", "true")
@@ -446,10 +448,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     inlineBlock.tabIndex = 0;
                     inlineBlock.ariaLabel = lf("Toggle the {0} category", ns);
                     inlineBlock.title = inlineBlock.ariaLabel;
-                    if (color && !inlineBlock.getAttribute("data-norecolor")) {
-                        inlineBlock.style.backgroundColor = color;
-                        inlineBlock.style.borderColor = pxt.toolbox.fadeColor(color, 0.1, false);
-                    }
+                    inlineBlock.children[0].append(bi?.attributes?.icon || pxt.toolbox.getNamespaceIcon(ns) || "");
                     inlineBlock.addEventListener("click", e => {
                         // need to filter out editors that are currently hidden as we leave toolboxes in dom
                         const editorSelector = `#maineditor > div:not([style*="display:none"]):not([style*="display: none"])`;

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -977,9 +977,27 @@ export class ToolboxStyle extends data.Component<ToolboxStyleProps, {}> {
         return <style>
             {categories.filter(c => !!c.color).map(category =>
                 `span.docs.inlineblock.${category.nameid.toLowerCase()} {
-                    background-color: ${category.color};
-                    border-color: ${pxt.toolbox.fadeColor(category.color, 0.1, false)};
-                }`
+                    border-radius: 0;
+                    border-bottom: 2px solid ${category.color};
+                    color: black;
+                    font-weight: 600;
+                    background-color: transparent;
+                }
+                span.docs.inlineblock {
+                    border-radius: 0;
+                    border-bottom: 2px solid black;
+                    color: black;
+                    font-weight: 600;
+                    background-color: transparent;
+                }
+                span.docs.inlineblock.${category.nameid.toLowerCase()} i {
+                    font-family: 'Icons';
+                    content: "${category.icon || pxt.toolbox.getNamespaceIcon(category.nameid.toLowerCase())}";
+                    color: ${category.color || pxt.toolbox.getNamespaceColor(category.nameid.toLowerCase())};
+                    font-style: normal;
+                    margin-right: 4px;
+                }
+                `
             )}
         </style>
     }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -992,7 +992,6 @@ export class ToolboxStyle extends data.Component<ToolboxStyleProps, {}> {
                 }
                 span.docs.inlineblock.${category.nameid.toLowerCase()} i {
                     font-family: 'Icons';
-                    content: "${category.icon || pxt.toolbox.getNamespaceIcon(category.nameid.toLowerCase())}";
                     color: ${category.color || pxt.toolbox.getNamespaceColor(category.nameid.toLowerCase())};
                     font-style: normal;
                     margin-right: 4px;

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -976,19 +976,19 @@ export class ToolboxStyle extends data.Component<ToolboxStyleProps, {}> {
         // and assosiate them with a specific category
         return <style>
             {categories.filter(c => !!c.color).map(category =>
-                `span.docs.inlineblock.${category.nameid.toLowerCase()} {
-                    border-radius: 0;
-                    border-bottom: 2px solid ${category.color};
-                    color: black;
-                    font-weight: 600;
-                    background-color: transparent;
-                }
+                `
                 span.docs.inlineblock {
                     border-radius: 0;
                     border-bottom: 2px solid black;
                     color: black;
                     font-weight: 600;
                     background-color: transparent;
+                }
+                .hc span.docs.inlineblock {
+                    color: white;
+                }
+                span.docs.inlineblock.${category.nameid.toLowerCase()} {
+                    border-bottom: 2px solid ${category.color};
                 }
                 span.docs.inlineblock.${category.nameid.toLowerCase()} i {
                     font-family: 'Icons';

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -977,24 +977,8 @@ export class ToolboxStyle extends data.Component<ToolboxStyleProps, {}> {
         return <style>
             {categories.filter(c => !!c.color).map(category =>
                 `
-                span.docs.inlineblock {
-                    border-radius: 0;
-                    border-bottom: 2px solid black;
-                    color: black;
-                    font-weight: 600;
-                    background-color: transparent;
-                }
-                .hc span.docs.inlineblock {
-                    color: white;
-                }
                 span.docs.inlineblock.${category.nameid.toLowerCase()} {
-                    border-bottom: 2px solid ${category.color};
-                }
-                span.docs.inlineblock.${category.nameid.toLowerCase()} i {
-                    font-family: 'Icons';
-                    color: ${category.color || pxt.toolbox.getNamespaceColor(category.nameid.toLowerCase())};
-                    font-style: normal;
-                    margin-right: 4px;
+                    --inline-namespace-color: ${category.color || pxt.toolbox.getNamespaceColor(category.nameid.toLowerCase()) || "black"};
                 }
                 `
             )}


### PR DESCRIPTION
Because not all of our block colors are accessible, we've come up with an alternative solution for displaying inline blocks. With this update, we are using underlines and namespace icons to depict the blocks. For block highlights in tutorials and docs that are not clickable, we just use an underline. 

Fixes https://github.com/microsoft/pxt-arcade/issues/4870

**IMPORTANT** 
This will also affect micro:bit, so if, after testing, users respond positively to this, we might need to go through more steps to get approval from the micro:bit team.

Upload targets:
micro:bit ~~https://makecode.microbit.org/app/5ad32a6d20c70ec72517ad979b75b21a90250a27-45f381e4aa#~~
https://makecode.microbit.org/app/b01d093aa836e1a318f38be16d589f5d608836f9-3fe55a0f54#
arcade ~~https://arcade.makecode.com/app/d601caf565ccfe8cfae4809ba8436fe9749c2316-82ab3f31e0#~~
https://arcade.makecode.com/app/1403937f656f6e50637c8a8cb7cca026690a6ca4-14c598d835#editor

Make sure to look at both tutorials and docs.
