### PR TITLE
Bug fix: expanded else if now has shadow block with false as default

### DIFF
--- a/pxtblocks/plugins/logic/ifElse.ts
+++ b/pxtblocks/plugins/logic/ifElse.ts
@@ -64,6 +64,7 @@ const IF_ELSE_MIXIN = {
      */
     restoreConnections_: function (this: IfElseBlock) {
         for (let i = 1; i <= this.elseifCount_; i++) {
+            this.getInput('IF' + i).connection.setShadowState({ 'type': 'logic_boolean', 'fields': { 'BOOL': 'FALSE' } });
             this.valueConnections_[i]?.reconnect(this, 'IF' + i);
             this.statementConnections_[i]?.reconnect(this, 'DO' + i);
         }


### PR DESCRIPTION
We shouldn't have a completely empty spot in a block, as does else if in the conditional in live. I added a shadow to the else if now that defaults to false since the `if` shadow defaults to true.

**Live**
![image](https://github.com/microsoft/pxt/assets/49178322/c2360186-667f-4a16-b2e2-c3d011e0669c)

**The Fix**
![image](https://github.com/microsoft/pxt/assets/49178322/b19e186c-1760-430d-adea-471fdd26a223)


Fixes https://github.com/microsoft/pxt-microbit/issues/5387