### PR TITLE
cli: default to "shell: true" when spawning child process on win32

### DIFF
--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -63,6 +63,8 @@ export function readResAsync(g: events.EventEmitter) {
 
 export function spawnAsync(opts: SpawnOptions) {
     opts.pipe = false
+    // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+    if (os.platform() === "win32" && typeof opts.shell === "undefined") opts.shell = true
     return spawnWithPipeAsync(opts)
         .then(() => { })
 }


### PR DESCRIPTION
Fixed issue with spawning `npm.cmd` during `pxt bump` on Windows due to NodeJS security update.

Starting from NodeJS v18.20.2, a security update changed the default behavior of `spawn`, causing it to fail on Windows when spawning executables ending in ".bat" or ".cmd" unless the `shell: true` option is specified.

NodeJS security release notes:
https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
and
https://github.com/nodejs/node/issues/52681

Note: This fix is scoped to the pxt cli. There may be other instances in the codebase that to be updated.