### PR TITLE
Bug fix: GitHub import with different languages in private repos

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -289,10 +289,11 @@ namespace pxt.github {
             const f = resp.json as FileContent
             isPrivateRepoCache[parsed.slug] = true
             // if they give us content, just return it
-            if (f && f.encoding == "base64" && f.content != null)
-                return atob(f.content)
+            if (f && f.encoding == "base64" && f.content != null) {
+                return Util.fromUTF8(atob(f.content));
+            }
             // otherwise, go to download URL
-            return U.httpGetTextAsync(f.download_url)
+            return U.httpGetTextAsync(f.download_url);
         })
     }
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-microbit/issues/5389

**The Root Cause**
TL;DR: We needed to follow the same steps for decoding content that we do for encoding content.

As the issue notes, the problem was with how we compare the SHAs generated from parsing the text from the files in GitHub repositories. When a user creates a new repo from one of our targets, we convert the text to UTF-8 and then use `btoa` to base64 encode the content: https://github.com/microsoft/pxt/blob/master/pxtlib/github.ts#L412. If a user then deletes that repo and imports it back into the target, we were only using `atob` to decode the contents, meaning that there would be inconsistencies in the text that upon importing if there were any non-ASCII characters in any files: https://developer.mozilla.org/en-US/docs/Web/API/Window/atob. Since the file that we parsed is not the same that Github returned to us, we throw an error saying that the SHA was corrupted, even though the text content was the same other than the non-ASCII characters. (You can find this logic here: https://github.com/microsoft/pxt/blob/2805be15c19b420cb8413b29adc3712dd425d424/webapp/src/workspace.ts#L1215-L1241)

I was stuck on what to do for a bit because I thought that Github was doing something weird with the encoding that we wouldn't be able to counter-act. But once I realized that we were encoding the content ourselves before creating the repos, I realized it was something that we could control. Since we convert to UTF-8 and then encode when creating the files, we need to make sure that when we're importing the files back, we do the reverse by decoding the base64 and then converting it to UTF-8. So, we do not need to make the extra http request every time like I thought we would in stand-up, just need to add an extra decoding step when fetching the content.

This was only a problem with private repos because private repos go through the `fallbackDownloadTextAsync` function where we need to more manually get the content. We can successfully grab the content from public repos on the first download try: https://github.com/microsoft/pxt/blob/master/pxtlib/github.ts#L307-L312. Private repos use a url that is a bit different: https://github.com/microsoft/pxt/blob/master/pxtlib/github.ts#L284-L297. 

Upload target: https://makecode.microbit.org/app/0f4d7c2e58d76a70d0b90c60721cac39b7736249-4132a16546#
If you want to test it, I recommend following the steps listed on the issue.