### PR TITLE
Dont break decompilation when blocks file is empty

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -483,6 +483,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     pxtblockly.cleanBlocks();
                     pxtblockly.initializeAndInject(blocksInfo);
 
+                    if (!mainPkg.files[blockFile].content) {
+                        return [undefined, true];
+                    }
+
                     // It's possible that the extensions changed and some blocks might not exist anymore
                     if (!pxtblockly.validateAllReferencedBlocksExist(mainPkg.files[blockFile].content)) {
                         return [undefined, true];


### PR DESCRIPTION
This was hit by a forum user here:

https://forum.makecode.com/t/oops-something-went-wrong-trying-to-convert-your-code/1159/6

I'm not sure how they got their project into the state of having an empty blocks file, but whatever the case we shouldn't refuse to decompile if that happens.

The issue was that we were passing the empty string to the xml parser which caused an exception. Fix is to just check if the file is empty before parsing