### PR TITLE
Kiosk: user-added games can now have high scores

### DIFF
--- a/kiosk/src/Components/EnterHighScore.tsx
+++ b/kiosk/src/Components/EnterHighScore.tsx
@@ -2,20 +2,35 @@ import NewScoreEntry from "./NewScoreEntry";
 import ExistingScoreEntry from "./ExistingScoreEntry";
 import { useContext } from "react";
 import { AppStateContext } from "../State/AppStateContext";
-import { getHighScores } from "../State";
+import { getHighScores, getScoringType } from "../State";
+import { HighScore } from "../Types";
 
 interface IProps {}
+
 
 const EnterHighScore: React.FC<IProps> = ({}) => {
     const { state: kiosk } = useContext(AppStateContext);
     const existingHighScores = getHighScores(kiosk.selectedGameId);
+    const launchedGameScoringMethod = getScoringType(kiosk.selectedGameId);
+
+    const sortingFunction = (a: HighScore, b: HighScore) => {
+        return (
+            launchedGameScoringMethod === "highscore" || launchedGameScoringMethod === "SingleAscending"
+            ? b.score - a.score
+            : a.score - b.score
+        )
+    }
 
     const aboveScores = existingHighScores
-        .filter(item => item.score > kiosk.mostRecentScores[0])
-        .sort((a, b) => b.score - a.score);
+        .filter(item =>
+            launchedGameScoringMethod === "highscore" || launchedGameScoringMethod === "SingleAscending"
+            ? item.score > kiosk.mostRecentScores[0]
+            : item.score < kiosk.mostRecentScores[0]
+        )
+        .sort(sortingFunction);
     const belowScores = existingHighScores
         .slice(aboveScores.length, existingHighScores.length)
-        .sort((a, b) => b.score - a.score);
+        .sort(sortingFunction);
 
     return (
         <div className="enterHighScore">

--- a/kiosk/src/Components/PlayingGame.tsx
+++ b/kiosk/src/Components/PlayingGame.tsx
@@ -45,9 +45,10 @@ export default function PlayingGame() {
         }
     }, [launchedGame]);
 
+    const playUrlRoot = pxt.BrowserUtils.isLocalHost() ? configData.LocalPlayUrlRoot : configData.PlayUrlRoot;
     const playUrl = useMemo(() => {
         if (launchedGame && !fetchingBuiltJsInfo) {
-            return stringifyQueryString(configData.PlayUrlRoot, {
+            return stringifyQueryString(playUrlRoot, {
                 id: getEffectiveGameId(launchedGame),
                 // TODO: Show sim buttons on mobile & touch devices.
                 hideSimButtons: pxt.BrowserUtils.isMobile() ? undefined : 1,

--- a/kiosk/src/Services/SimHostService.ts
+++ b/kiosk/src/Services/SimHostService.ts
@@ -88,16 +88,25 @@ export function initialize() {
                 switch (event.data.command) {
                     case "setstate":
                         switch (event.data.stateKey) {
-                            case Constants.allScoresStateKey:
+                            case Constants.allScoresStateKey: {
                                 const rawData = atob(event.data.stateValue);
                                 const json = decodeURIComponent(rawData);
+                                const scoresEntry = JSON.parse(json);
+                                let scoresList: number[] = scoresEntry;
+                                if (scoresEntry["allScores"] !== undefined) {
+                                    scoresList = scoresEntry["allScores"];
+                                }
+                                if (state.launchedGameId && scoresEntry["scoringType"]) {
+                                    dispatch(Actions.updateGame(state.launchedGameId, { ...launchedGame, highScoreMode: scoresEntry["scoringType"]}));
+                                }
                                 dispatch(
                                     Actions.setMostRecentScores(
-                                        JSON.parse(json)
+                                        scoresList
                                     )
                                 );
                                 gameOver();
                                 break;
+                            }
                         }
                         break;
                 }

--- a/kiosk/src/State/Reducer.ts
+++ b/kiosk/src/State/Reducer.ts
@@ -3,7 +3,7 @@ import { Action } from "./Actions";
 import * as Storage from "../Services/LocalStorage";
 import { setSoundEffectVolume } from "../Services/SoundEffectService";
 import configData from "../config.json";
-import { GameData } from "../Types";
+import { GameData, HighScoreWithId } from "../Types";
 
 // The reducer's job is to apply state changes by creating a copy of the existing state with the change applied.
 // The reducer must not create side effects. E.g. do not dispatch a state change from within the reducer.
@@ -140,11 +140,17 @@ export default function reducer(state: AppState, action: Action): AppState {
             const { gameId, highScore } = action;
             const allHighScores = { ...state.allHighScores };
             const highScores = allHighScores[gameId] || [];
+            const scoringType = state.allGames.find(g => g.id === gameId)?.highScoreMode;
+            const sortingFunction = (first: HighScoreWithId, second: HighScoreWithId) => {
+                return scoringType === "highscore" || scoringType === "SingleAscending"
+                    ? second.score - first.score
+                    : first.score - second.score;
+            }
             // Before saving this high score, ensure we don't already have it recorded.
             // Protect against duplicate action dispatches.
             if (!highScores.find(hs => hs.id === highScore.id)) {
                 highScores.push(highScore);
-                highScores.sort((first, second) => second.score - first.score);
+                highScores.sort(sortingFunction);
                 highScores.splice(configData.HighScoresToKeep);
                 allHighScores[gameId] = highScores;
                 Storage.setHighScores(allHighScores);

--- a/kiosk/src/State/index.ts
+++ b/kiosk/src/State/index.ts
@@ -9,6 +9,15 @@ function getHighScores(gameId: string | undefined): HighScore[] {
     return state.allHighScores[gameId];
 }
 
+function getScoringType(gameId: string | undefined): string {
+    const { state } = stateAndDispatch();
+    if (!gameId || !state.allGames.find(game => game.id === gameId)) {
+        return "None";
+    }
+    return state.allGames.find(game => game.id === gameId)!.highScoreMode;
+
+}
+
 function getSelectedGameIndex(): number | undefined {
     const { state } = stateAndDispatch();
     if (!state.selectedGameId) {
@@ -39,4 +48,5 @@ export {
     getSelectedGameId,
     getSelectedGame,
     getLaunchedGame,
+    getScoringType,
 };

--- a/kiosk/src/config.json
+++ b/kiosk/src/config.json
@@ -1,6 +1,7 @@
 {
     "GameDataUrl": "/kiosk-data/GameList.json",
     "PlayUrlRoot": "https://arcade.makecode.com/---run",
+    "LocalPlayUrlRoot": "http://localhost:3232/--run",
     "EnterHighScoreDelayMilli": 3000,
     "EnterHighScorePoll": 100,
     "HighScoresToKeep": 10,


### PR DESCRIPTION
Because it was tricky to know what type of scoring a user-added game had, we didn't give user-added games the option for high score entries on the creation of the kiosk. When a new game was added, we would set the "highScoreMode" to "None" and never change it. There are two important pieces that needed to happen in order to accept user's games' high scores:

1. Modify the game over block's event that gets recognized by the kiosk to include the scoring type. This change is made in common packages. We utilize this "scoring type" data in kiosk to sort the high score lists properly.
2. Update the game's scores and scoring type on the kiosk if the game supplies it upon playing said game. This is to allow for user-added games to be sorted from lowest scores at the top or highest scores at the top.