### PR TITLE
Bug fix: update user tutorials documentation

### DIFF
--- a/docs/writing-docs/user-tutorials.md
+++ b/docs/writing-docs/user-tutorials.md
@@ -114,7 +114,7 @@ it will automatically be added to the dependencies of the
 program used during the tutorial. This allows you to package custom blocks
 in your tutorials or teach your extensions via tutorials.
 
-However, this includes ``main.ts``, so if you've built a sample program while making the tutorial, make sure to move the code into another project or delete it before sharing the tutorial. If ``main.ts`` has any code in it, the code will run when the tutorial gets opened!
+It's important to know that tutorial project includes any code you might have in ``main.ts``. So, if you've built a sample program while making the tutorial, make sure to move the code into another project or delete it before sharing the tutorial. If ``main.ts`` has any code in it, the code will run when the tutorial gets opened!
 
 ## Report abuse and approvals
 

--- a/docs/writing-docs/user-tutorials.md
+++ b/docs/writing-docs/user-tutorials.md
@@ -12,7 +12,6 @@ https://youtu.be/XsM8hp7eysA
 
 Author the tutorial content in a **Markdown** file in your project. The format is the same as what's documented in [tutorials](/writing-docs/tutorials). 
 
-The dependencies are used when starting the tutorial project, but code content (``main.blocks``, ``main.ts``) is ignored.
 
 ### ~ hint
 
@@ -34,6 +33,10 @@ The easiest way to share a tutorial is to first share the program. Then, use the
 The complete shared url is formatted like:
 
     https://makecode.microbit.org/#tutorial:https://makecode.com/_sIty7Iop
+
+**Important Note**
+
+The dependencies are used when starting the tutorial project, but code content (``main.blocks``, ``main.ts``) is ignored. This includes ``custom.ts``! If you are hoping to include custom blocks in a tutorial, make it as an extension first so it gets added to the project's dependencies. More on how to make an extension is [here](/extensions/getting-started/).
 
 ### ~ alert
 
@@ -104,12 +107,14 @@ region specific language code or language neutral. MakeCode will pick the best m
 
 https://youtu.be/3LKmE0c5UZU
 
-### Repository as extension
+### Repository with custom blocks
 
 If the tutorial repository contains JavaScript files (``.ts``),
 it will automatically be added to the dependencies of the 
 program used during the tutorial. This allows you to package custom blocks
 in your tutorials or teach your extensions via tutorials.
+
+However, this includes ``main.ts``, so if you've built a sample program while making the tutorial, make sure to move the code into another project or delete it before sharing the tutorial. If ``main.ts`` has any code in it, the code will run when the tutorial gets opened!
 
 ## Report abuse and approvals
 

--- a/docs/writing-docs/user-tutorials.md
+++ b/docs/writing-docs/user-tutorials.md
@@ -114,7 +114,7 @@ it will automatically be added to the dependencies of the
 program used during the tutorial. This allows you to package custom blocks
 in your tutorials or teach your extensions via tutorials.
 
-It's important to know that tutorial project includes any code you might have in ``main.ts``. So, if you've built a sample program while making the tutorial, make sure to move the code into another project or delete it before sharing the tutorial. If ``main.ts`` has any code in it, the code will run when the tutorial gets opened!
+It's important to know that the tutorial project includes any code you might have in ``main.ts``. So, if you've built a sample program while making the tutorial, make sure to move the code into another project or delete it before sharing the tutorial. If ``main.ts`` has any code in it, the code will run when the tutorial gets opened!
 
 ## Report abuse and approvals
 

--- a/docs/writing-docs/user-tutorials.md
+++ b/docs/writing-docs/user-tutorials.md
@@ -34,9 +34,9 @@ The complete shared url is formatted like:
 
     https://makecode.microbit.org/#tutorial:https://makecode.com/_sIty7Iop
 
-**Important Note**
+### Project dependencies
 
-The dependencies are used when starting the tutorial project, but code content (``main.blocks``, ``main.ts``) is ignored. This includes ``custom.ts``! If you are hoping to include custom blocks in a tutorial, make it as an extension first so it gets added to the project's dependencies. More on how to make an extension is [here](/extensions/getting-started/).
+The dependencies for a shared tutorial project are used when the tutorial starts. The project code content (``main.blocks``, ``main.ts``) is ignored though. This also includes the code in ``custom.ts``! If you are hoping to include custom blocks in a tutorial, put them in an extension first, then that extension can get added to the project's dependencies. Read more about making [extensions](/extensions/getting-started/).
 
 ### ~ alert
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5385

When a user makes a tutorial, what happens with `main.ts` and `.ts` files in general is dependent on how the tutorial is consumed (via GitHub repo vs. share link). This is expected, so we need to update our documentation to better reflect what happens. Let me know if I explained something incorrectly.

@ganicke, please take a look at these changes and let me know if there is anything I can re-word or clarify. Thanks!