### PR TITLE
Kiosk: now using the config run url if it exists

### DIFF
--- a/kiosk/src/Components/PlayingGame.tsx
+++ b/kiosk/src/Components/PlayingGame.tsx
@@ -17,9 +17,7 @@ export default function PlayingGame() {
     }, [kiosk.launchedGameId]);
 
     const makeRunUrl = () => {
-        return pxt.webConfig?.runUrl
-        ? "https://arcade.makecode.com" + pxt.webConfig.runUrl
-        : configData.PlayUrlRoot;
+        return pxt.webConfig?.runUrl ?? configData.PlayUrlRoot;
     }
 
     // Handle Back and Start button presses

--- a/kiosk/src/Components/PlayingGame.tsx
+++ b/kiosk/src/Components/PlayingGame.tsx
@@ -16,6 +16,12 @@ export default function PlayingGame() {
         return getLaunchedGame();
     }, [kiosk.launchedGameId]);
 
+    const makeRunUrl = () => {
+        return pxt.webConfig?.runUrl
+        ? "https://arcade.makecode.com" + pxt.webConfig.runUrl
+        : configData.PlayUrlRoot;
+    }
+
     // Handle Back and Start button presses
     useOnControlPress(
         [],
@@ -45,7 +51,7 @@ export default function PlayingGame() {
         }
     }, [launchedGame]);
 
-    const playUrlRoot = pxt.BrowserUtils.isLocalHost() ? configData.LocalPlayUrlRoot : configData.PlayUrlRoot;
+    const playUrlRoot = pxt.BrowserUtils.isLocalHost() ? configData.LocalPlayUrlRoot : makeRunUrl();
     const playUrl = useMemo(() => {
         if (launchedGame && !fetchingBuiltJsInfo) {
             return stringifyQueryString(playUrlRoot, {


### PR DESCRIPTION
This change to kiosk is to make sure that we are using the correct run url in our different environments. For example, in stable, we should be using stable in order to test the changes that we're trying to ship or change. We can make sure that's the case by using the webConfig's run url. However, when testing locally, webConfig was null. While I am already specializing local host, I also wanted to keep that case in mind for the live/built scenarios, so I'm keeping the hard-coded "PlayUrlRoot" as a fall back just in case webConfig is null.

Edit: Here's an upload target (this upload target includes some console logs for testing but those console logs are now removed): https://arcade.makecode.com/app/b864d38cd277079aa0d82d37340a2a5c08132a96-51ba117ade--kiosk. You can see in those logs and the network request for when you play a game that the run url being used is according to the environment, which, in this case is the upload target url.