### PR TITLE
Add advanced blocks debugger experiment and fix debugger issues

### DIFF
--- a/localtypings/pxtparts.d.ts
+++ b/localtypings/pxtparts.d.ts
@@ -223,6 +223,7 @@ declare namespace pxsim {
     export interface VariablesRequestMessage extends DebuggerMessage {
         variablesReference: string;
         fields?: string[]
+        includeAll?: boolean;
     }
 
     export interface VariablesMessage extends DebuggerMessage {

--- a/pxtblocks/importer.ts
+++ b/pxtblocks/importer.ts
@@ -109,6 +109,11 @@ export function workspaceToDom(workspace: Blockly.Workspace, keepIds?: boolean):
         v.remove();
     }
 
+    // Make sure we never accidentally save projects in readonly mode
+    clearReadOnlyInfo(xml.getElementsByTagName("block"));
+    clearReadOnlyInfo(xml.getElementsByTagName("shadow"));
+    clearReadOnlyInfo(xml.getElementsByTagName("comment"));
+
     if (xml.firstChild) {
         xml.insertBefore(variables, xml.firstChild);
     }
@@ -117,6 +122,18 @@ export function workspaceToDom(workspace: Blockly.Workspace, keepIds?: boolean):
     }
 
     return xml;
+}
+
+function clearReadOnlyInfo(elements: HTMLCollectionOf<Element>) {
+    for (let i = 0; i < elements.length; i++) {
+        const current = elements.item(i);
+        if (current.hasAttribute("editable")) {
+            current.removeAttribute("editable");
+        }
+        if (current.hasAttribute("movable")) {
+            current.removeAttribute("movable");
+        }
+    }
 }
 
 // Saves only the blocks xml by iterating over the top blocks

--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -109,6 +109,11 @@ export function all(): Experiment[] {
             description: lf("Use the JavaScript debugger to debug extension code")
         },
         {
+            id: "advancedBlockDebugger",
+            name: lf("Advanced Blocks Debugger"),
+            description: lf("Enables extra options and variables in the Blocks debugger")
+        },
+        {
             id: "snippetBuilder",
             name: lf("Snippet Builder"),
             description: lf("Try out the new snippet dialogs.")

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -95,7 +95,12 @@ namespace pxsim {
         static toDebugString(o: any): string {
             if (o === null) return "null";
             if (o === undefined) return "undefined;"
-            if (o.vtable && o.vtable.name) return o.vtable.name;
+            if (o.vtable && o.vtable.name) {
+                if (o.vtable.name === "_Map" && o instanceof RefMap) {
+                    return "(object)";
+                }
+                return o.vtable.name;
+            }
             if (o.toDebugString) return o.toDebugString();
             if (typeof o == "string") return JSON.stringify(o);
             return o.toString();

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1352,7 +1352,7 @@ namespace pxsim {
                         if (dbgHeap) {
                             const v = dbgHeap[vmsg.variablesReference];
                             if (v !== undefined)
-                                vars = dumpHeap(v, dbgHeap, vmsg.fields);
+                                vars = dumpHeap(v, dbgHeap, vmsg.fields, undefined, vmsg.includeAll);
                         }
                         Runtime.postMessage(<pxsim.VariablesMessage>{
                             type: "debugger",

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -909,8 +909,8 @@ namespace pxsim {
             this.postDebuggerMessage("traceConfig", { interval: intervalMs });
         }
 
-        public variablesAsync(id: number, fields?: string[]): Promise<VariablesMessage> {
-            return this.postDebuggerMessageAsync("variables", { variablesReference: id, fields: fields } as DebugProtocol.VariablesArguments, this.debuggingFrame)
+        public variablesAsync(id: number, fields?: string[], includeAll = false): Promise<VariablesMessage> {
+            return this.postDebuggerMessageAsync("variables", { variablesReference: id, fields: fields, includeAll } as DebugProtocol.VariablesArguments, this.debuggingFrame)
                 .then(msg => msg as VariablesMessage, e => undefined)
         }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -410,11 +410,13 @@ export class ProjectView
         }
 
         if (!active && this.state.autoRun) {
-            if (simulator.driver.state == pxsim.SimulatorState.Running) {
-                this.suspendSimulator();
-                this.setState({ resumeOnVisibility: true });
+            if (!this.state.debugging) {
+                if (simulator.driver.state == pxsim.SimulatorState.Running) {
+                    this.suspendSimulator();
+                    this.setState({ resumeOnVisibility: true });
+                }
+                this.saveFileAsync();
             }
-            this.saveFileAsync();
         } else if (active) {
             data.invalidate("header:*")
             let hdrId = this.state.header ? this.state.header.id : '';

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -244,7 +244,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     onPageVisibilityChanged(isVisible: boolean) {
         if (!isVisible) return;
-        this.highlightStatement(this.highlightedStatement);
+        if (!this.parent.state.debugging) {
+            this.highlightStatement(this.highlightedStatement);
+        }
     }
 
     isDropdownDivVisible(): boolean {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -25,7 +25,7 @@ import Util = pxt.Util;
 import { DebuggerToolbox } from "./debuggerToolbox";
 import { ErrorList } from "./errorList";
 import { resolveExtensionUrl } from "./extensionManager";
-import { initEditorExtensionsAsync } from "../../pxteditor";
+import { experiments, initEditorExtensionsAsync } from "../../pxteditor";
 
 
 import IProjectView = pxt.editor.IProjectView;
@@ -915,7 +915,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         pxt.perf.measureStart("updateToolbox")
         const debugging = !!this.parent.state.debugging;
-        let debuggerToolbox = debugging ? <DebuggerToolbox ref={this.handleDebuggerToolboxRef} parent={this.parent} apis={this.blockInfo.apis.byQName} /> : <div />;
+        let debuggerToolbox = debugging ? <DebuggerToolbox
+                ref={this.handleDebuggerToolboxRef}
+                parent={this.parent}
+                apis={this.blockInfo.apis.byQName}
+                showCallStack={experiments.isEnabled("advancedBlockDebugger")}
+            /> : <div />;
 
         if (debugging) {
             this.toolbox.hide();

--- a/webapp/src/debuggerToolbar.tsx
+++ b/webapp/src/debuggerToolbar.tsx
@@ -8,6 +8,7 @@ import ISettingsProps = pxt.editor.ISettingsProps;
 import SimState = pxt.editor.SimState;
 
 export interface DebuggerToolbarProps extends ISettingsProps {
+    showAdvancedControls: boolean;
 }
 
 export interface DebuggerToolbarState {
@@ -81,7 +82,7 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
         if (!isDebugging) return <div />;
 
         const isDebuggerRunning = simulator.driver && simulator.driver.state == pxsim.SimulatorState.Running;
-        const advancedDebugging = !this.props.parent.isBlocksActive();
+        const advancedDebugging = this.props.showAdvancedControls;
 
         const isValidDebugFile = advancedDebugging || this.props.parent.isBlocksActive() || pxt.appTarget.appTheme.debugExtensionCode;
         if (!isValidDebugFile) return <div />;

--- a/webapp/src/debuggerToolbox.tsx
+++ b/webapp/src/debuggerToolbox.tsx
@@ -39,12 +39,13 @@ export class DebuggerToolbox extends React.Component<DebuggerToolboxProps, Debug
 
     render() {
         return <div>
-            <DebuggerToolbar parent={this.props.parent} />
+            <DebuggerToolbar parent={this.props.parent} showAdvancedControls={this.props.showCallStack} />
             <DebuggerVariables
                 apis={this.props.apis}
                 breakpoint={this.state.lastBreakpoint}
                 filters={this.state.varFilters}
                 activeFrame={this.state.currentFrame}
+                includeAllVariables={this.props.showCallStack}
                 sequence={this.state.sequence} />
             { this.props.showCallStack &&
                 <DebuggerCallStack openLocation={this.props.openLocation} activeFrame={this.state.currentFrame} stackframes={this.state.lastBreakpoint ? this.state.lastBreakpoint.stackframes : []}  /> }


### PR DESCRIPTION
This PR does four things:

1. Fixes a bug where the debugger's variables get cleared when you swap tabs while stopped on a breakpoint
2. Improves the dumpHeap function to properly handle RefMap and RefImage properties
3. Makes it so that the JavaScript debugger now includes the "hidden" fields of objects (anything that starts with a _)
4. Adds an experiment that you can use to enable the "advanced" JavaScript debugger in the blocks editor. This lets you use step in/out/over, see the call stack, and see the hidden fields mentioned above