### PR TITLE
Support compiling locally with the new compile service images

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -38,6 +38,7 @@ pxt.docs.requireDOMSanitizer = () => require("sanitize-html");
 let forceCloudBuild = process.env["KS_FORCE_CLOUD"] !== "no";
 let forceLocalBuild = !!process.env["PXT_FORCE_LOCAL"];
 let forceBuild = false; // don't use cache
+let useCompileServiceDocker = true;
 
 Error.stackTraceLimit = 100;
 
@@ -64,6 +65,7 @@ function parseHwVariant(parsed: commandParser.ParsedCommand) {
 function parseBuildInfo(parsed?: commandParser.ParsedCommand) {
     const cloud = parsed && parsed.flags["cloudbuild"];
     const local = parsed && parsed.flags["localbuild"];
+    const useCompService = parsed?.flags["localcompileservice"]
     const hwvariant = parseHwVariant(parsed);
     forceBuild = parsed && !!parsed.flags["force"];
     if (cloud && local)
@@ -76,6 +78,11 @@ function parseBuildInfo(parsed?: commandParser.ParsedCommand) {
     if (local) {
         forceCloudBuild = false;
         forceLocalBuild = true;
+    }
+    if (useCompService) {
+        forceCloudBuild = false;
+        forceLocalBuild = true;
+        useCompileServiceDocker = true;
     }
 
     if (hwvariant) {
@@ -3151,6 +3158,10 @@ class Host
 
         if (!forceLocalBuild && (extInfo.onlyPublic || forceCloudBuild))
             return pxt.hexloader.getHexInfoAsync(this, extInfo)
+
+        if (useCompileServiceDocker) {
+            return build.compileWithLocalCompileService(extInfo);
+        }
 
         setBuildEngine()
         return build.buildHexAsync(build.thisBuild, mainPkg, extInfo, forceBuild)
@@ -6685,6 +6696,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
                 description: "Build native image using local toolchains",
                 aliases: ["local", "l", "local-build", "lb"]
             },
+            localcompileservice: {
+                description: "Build native image using docker",
+                hidden: true,
+                aliases: []
+            },
             force: {
                 description: "skip cache lookup and force build",
                 aliases: ["f"]
@@ -6761,6 +6777,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
                 description: "Build native image using local toolchains",
                 aliases: ["local", "l", "local-build", "lb"]
             },
+            localcompileservice: {
+                description: "Build native image using docker",
+                hidden: true,
+                aliases: []
+            },
             force: {
                 description: "skip cache lookup and force build",
                 aliases: ["f"]
@@ -6835,6 +6856,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
                 description: "Build native image using local toolchains",
                 aliases: ["local", "l", "local-build", "lb"]
             },
+            localcompileservice: {
+                description: "Build native image using docker",
+                hidden: true,
+                aliases: []
+            },
             locs: {
                 description: "Download localization files and bundle them",
                 aliases: ["locales", "crowdin"]
@@ -6892,6 +6918,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
             localbuild: {
                 description: "Build native image using local toolchains",
                 aliases: ["local", "l", "local-build", "lb"]
+            },
+            localcompileservice: {
+                description: "Build native image using docker",
+                hidden: true,
+                aliases: []
             },
             just: { description: "just serve without building" },
             rebundle: { description: "rebundle when change is detected", aliases: ["rb"] },
@@ -6961,6 +6992,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
                 description: "Build native image using local toolchains",
                 aliases: ["local", "l", "local-build", "lb"]
             },
+            localcompileservice: {
+                description: "Build native image using docker",
+                hidden: true,
+                aliases: []
+            },
             force: {
                 description: "skip cache lookup and force build",
                 aliases: ["f"]
@@ -6988,6 +7024,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
             localbuild: {
                 description: "Build native image using local toolchains",
                 aliases: ["local", "l", "local-build", "lb"]
+            },
+            localcompileservice: {
+                description: "Build native image using docker",
+                hidden: true,
+                aliases: []
             },
             force: {
                 description: "skip cache lookup and force build",
@@ -7260,6 +7301,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
             localbuild: {
                 description: "Build native image using local toolchains",
                 aliases: ["local", "l", "local-build", "lb"]
+            },
+            localcompileservice: {
+                description: "Build native image using docker",
+                hidden: true,
+                aliases: []
             },
             clean: { description: "delete all previous repos" },
             fast: { description: "don't check tag" },

--- a/cli/commandparser.ts
+++ b/cli/commandparser.ts
@@ -13,6 +13,7 @@ export interface CommandFlag {
     aliases?: string[];
     possibleValues?: string[];
     deprecated?: boolean;
+    hidden?: boolean;
 
 }
 
@@ -197,6 +198,8 @@ export class CommandParser {
         if (c.flags) {
             for (const flag in c.flags) {
                 const def = c.flags[flag];
+                if (def.hidden) continue;
+
                 if (def.possibleValues && def.possibleValues.length) {
                     usage += ` [${dash(flag)} ${def.possibleValues.join("|")}]`
                 }
@@ -227,7 +230,7 @@ export class CommandParser {
         let maxWidth = 0;
         for (const flag in c.flags) {
             const def = c.flags[flag];
-            if (def.deprecated) continue;
+            if (def.deprecated || def.hidden) continue;
             let usage = dash(flag);
             if (def.aliases && def.aliases.length) {
                 usage += " " + def.aliases.map(dash).join(" ");


### PR DESCRIPTION
This adds a new secret flag for compiling targets locally using the compile service docker images. The flag is currently hidden because right now this requires you to have pxt-deployment-config checked out locally; I might in the future duplicate the relevant parts of that repo in this one so that we don't have that restriction.

To test docker images locally:
* Build the docker file locally
* Open the pxtarget.json of a target that uses the relevant image (e.g. pxt-microbit for yotta:main and yotta:main-gcc5)
* If necessary, fix the tag in pxtarget.json to match your locally compiled docker image (e.g. in pxt-microbit, you want to change [pext/yotta:gcc5](https://github.com/microsoft/pxt-microbit/blob/master/pxtarget.json#L178) to pext/yotta:main-gcc5)
* Set the GH_ACCESS_TOKEN environment variable to a github access token. Note that this token does not need any permissions at all! It's only used to prevent yotta from getting throttled when cloning public repos, so no need to give access to private repos or anything else.
* Inside the target repo, run:
    ```
    rm -rf built/
    pxt buildtarget --localcompileservice
    ```

The `rm -rf` above is just to make sure that the local hexcache is cleared. If the hexcache isn't cleared, the docker build might get skipped.