### PR TITLE
Update min supported version for Mobile Safari

### DIFF
--- a/common-docs/browsers/technical.md
+++ b/common-docs/browsers/technical.md
@@ -19,13 +19,12 @@ browsers**, but if you can't then you must use at least:
 
 | Browser             | Minimum version | Release date   | Windows     | Mac        | Mobile OS  |
 | ------------------- | --------------- | -------------- | ----------- | ---------- | ---------- |
-| - - - - - - - - - - - - - - - - - - - | - - - - - - - - - - - - - - - | - - - - - - - - - - - - - - | - - - - - - - - - - - | - - - - - - - - - - | - - - - - - - - - - |
 | Microsoft Edge      | 12              | March 2015     | Windows 10+ | N/A        | N/A        |
 | Mozilla Firefox     | 60              | May 2018       | Windows 7+  | OS X 10.6+ | N/A        |
 | Google Chrome       | 60              | October 2018   | Windows 7+  | OS X 10.6+ | Android 5+ |
 | Safari              | 9               | September 2015 | N/A         | OS X 10.9+ | N/A        |
 | Opera               | 21              | May 2014       | Windows 7+  | OS X 10.9+ | N/A        |
-| Mobile Safari       | 9               | September 2015 | N/A         | N/A        | iOS 9+     |
+| Mobile Safari       | 13              | September 2015 | N/A         | N/A        | iOS 9+     |
 | Chrome for Android  | 59              | March 2017     | N/A         | N/A        | Android 5+ |
 | Firefox for Android | 55              | August 2017    | N/A         | N/A        | Android 5+ |
 

--- a/common-docs/browsers/technical.md
+++ b/common-docs/browsers/technical.md
@@ -24,7 +24,7 @@ browsers**, but if you can't then you must use at least:
 | Google Chrome       | 60              | October 2018   | Windows 7+  | OS X 10.6+ | Android 5+ |
 | Safari              | 9               | September 2015 | N/A         | OS X 10.9+ | N/A        |
 | Opera               | 21              | May 2014       | Windows 7+  | OS X 10.9+ | N/A        |
-| Mobile Safari       | 13              | September 2015 | N/A         | N/A        | iOS 9+     |
+| Mobile Safari       | 13              | September 2019 | N/A         | N/A        | iOS 9+     |
 | Chrome for Android  | 59              | March 2017     | N/A         | N/A        | Android 5+ |
 | Firefox for Android | 55              | August 2017    | N/A         | N/A        | Android 5+ |
 

--- a/common-docs/browsers/technical.md
+++ b/common-docs/browsers/technical.md
@@ -24,7 +24,7 @@ browsers**, but if you can't then you must use at least:
 | Google Chrome       | 60              | October 2018   | Windows 7+  | OS X 10.6+ | Android 5+ |
 | Safari              | 9               | September 2015 | N/A         | OS X 10.9+ | N/A        |
 | Opera               | 21              | May 2014       | Windows 7+  | OS X 10.9+ | N/A        |
-| Mobile Safari       | 13              | September 2019 | N/A         | N/A        | iOS 9+     |
+| Mobile Safari       | 13              | September 2019 | N/A         | N/A        | iOS 13+    |
 | Chrome for Android  | 59              | March 2017     | N/A         | N/A        | Android 5+ |
 | Firefox for Android | 55              | August 2017    | N/A         | N/A        | Android 5+ |
 


### PR DESCRIPTION
Update the supported version number for **Mobile Safari** from **9** to **13**.

Closes https://github.com/microsoft/pxt-microbit/issues/5596