### PR TITLE
Use github access token when running docker locally

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -387,14 +387,14 @@ function runDockerAsync(args: string[], flags?: string[]) {
         if (process.platform == "darwin")
             mountArg += ":delegated"
 
-        let fullArgs = ["--rm", "-v", mountArg, "-w", "/src"].concat(dargs).concat([cs.dockerImage]).concat(args);
+        let fullArgs = ["--rm", "-v", mountArg, "-w", "/src", ...dargs, cs.dockerImage, ...args];
         if (flags) {
-            fullArgs = flags.concat(fullArgs)
+            fullArgs = [...flags, ...fullArgs];
         }
 
         return nodeutil.spawnAsync({
             cmd: "docker",
-            args: ["run"].concat(fullArgs),
+            args: ["run", ...fullArgs],
             cwd: thisBuild.buildPath
         })
     }

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -58,10 +58,10 @@ export const buildEngines: Map<BuildEngine> = {
 
     dockeryotta: {
         id: "dockeryotta",
-        updateEngineAsync: () => runDockerAsync(["yotta", "update"]),
-        buildAsync: () => runDockerAsync(["yotta", "build"]),
+        updateEngineAsync: () => runDockerYottaAsync(["yotta", "update"]),
+        buildAsync: () => runDockerYottaAsync(["yotta", "build"]),
         setPlatformAsync: () =>
-            runDockerAsync(["yotta", "target", pxt.appTarget.compileService.yottaTarget]),
+            runDockerYottaAsync(["yotta", "target", pxt.appTarget.compileService.yottaTarget]),
         patchHexInfo: patchYottaHexInfo,
         prepBuildDirAsync: noopAsync,
         buildPath: "built/dockeryt",
@@ -368,7 +368,7 @@ function runPlatformioAsync(args: string[]) {
     })
 }
 
-function runDockerAsync(args: string[]) {
+function runDockerAsync(args: string[], flags?: string[]) {
     if (process.env["PXT_NODOCKER"] == "force") {
         const cmd = args.shift()
         return nodeutil.spawnAsync({
@@ -387,12 +387,27 @@ function runDockerAsync(args: string[]) {
         if (process.platform == "darwin")
             mountArg += ":delegated"
 
+        let fullArgs = ["--rm", "-v", mountArg, "-w", "/src"].concat(dargs).concat([cs.dockerImage]).concat(args);
+        if (flags) {
+            fullArgs = flags.concat(fullArgs)
+        }
+
         return nodeutil.spawnAsync({
             cmd: "docker",
-            args: ["run", "--rm", "-v", mountArg, "-w", "/src"].concat(dargs).concat([cs.dockerImage]).concat(args),
+            args: ["run"].concat(fullArgs),
             cwd: thisBuild.buildPath
         })
     }
+}
+
+function runDockerYottaAsync(args: string[]) {
+    let fullpath = process.cwd() + "/" + thisBuild.buildPath + "/"
+
+    fs.copyFileSync(path.join(__dirname, "prepYotta.js"), path.join(fullpath, "prepYotta.js"));
+
+    let argVariable = args.join(" ");
+
+    return runDockerAsync(["/bin/bash", "-c", `node prepYotta.js; ${argVariable}`], ["--env", "GITHUB_ACCESS_TOKEN"])
 }
 
 let parseCppInt = pxt.cpp.parseCppInt;
@@ -844,7 +859,7 @@ async function runDockerCompileAsync(data: string) {
         clone: compileServiceConfig.clone,
         buildcmd: compileServiceConfig.buildcmd,
         image: image,
-        githubToken: process.env["GH_ACCESS_TOKEN"]
+        githubToken: process.env["GITHUB_ACCESS_TOKEN"]
     };
 
     const stdout = await nodeutil.spawnWithPipeAsync({

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1460,7 +1460,7 @@ export async function internalBuildTargetAsync(options: BuildTargetOptions = {})
     copyCommonSim();
     await simshimAsync();
     await buildFolderAsync('compiler', true, 'compiler');
-    await fillInCompilerExtension(pxt.appTarget);
+    fillInCompilerExtension(pxt.appTarget);
 
     if (options.rebundle) {
         await buildTargetCoreAsync({ quick: true });

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -38,7 +38,7 @@ pxt.docs.requireDOMSanitizer = () => require("sanitize-html");
 let forceCloudBuild = process.env["KS_FORCE_CLOUD"] !== "no";
 let forceLocalBuild = !!process.env["PXT_FORCE_LOCAL"];
 let forceBuild = false; // don't use cache
-let useCompileServiceDocker = true;
+let useCompileServiceDocker = false;
 
 Error.stackTraceLimit = 100;
 
@@ -1441,37 +1441,41 @@ export function buildTargetAsync(parsed?: commandParser.ParsedCommand): Promise<
         .then(() => internalBuildTargetAsync(opts));
 }
 
-export function internalBuildTargetAsync(options: BuildTargetOptions = {}): Promise<void> {
+export async function internalBuildTargetAsync(options: BuildTargetOptions = {}): Promise<void> {
     if (pxt.appTarget.id == "core")
         return buildTargetCoreAsync(options)
-
-    let initPromise: Promise<void>;
 
     const commonPackageDir = path.resolve("node_modules/pxt-common-packages")
 
     // Make sure to build common sim in case of a local clean. This will do nothing for
     // targets without pxt-common-packages installed.
     if (!inCommonPkg("built/common-sim.js") || !inCommonPkg("built/common-sim.d.ts")) {
-        initPromise = buildCommonSimAsync();
+        await buildCommonSimAsync();
+    }
+
+    if (nodeutil.existsDirSync(simDir())) {
+        await extractLocStringsAsync("sim-strings", [simDir()]);
+    }
+
+    copyCommonSim();
+    // copyBlocklyMedia();
+    await simshimAsync();
+    await buildFolderAsync('compiler', true, 'compiler');
+    await fillInCompilerExtension(pxt.appTarget);
+
+    if (options.rebundle) {
+        await buildTargetCoreAsync({ quick: true });
     }
     else {
-        initPromise = Promise.resolve();
+        await buildTargetCoreAsync(options);
     }
 
-    if (nodeutil.existsDirSync(simDir()))
-        initPromise = initPromise.then(() => extractLocStringsAsync("sim-strings", [simDir()]));
-
-    return initPromise
-        .then(() => { copyCommonSim(); return simshimAsync() })
-        .then(() => buildFolderAsync('compiler', true, 'compiler'))
-        .then(() => fillInCompilerExtension(pxt.appTarget))
-        .then(() => options.rebundle ? buildTargetCoreAsync({ quick: true }) : buildTargetCoreAsync(options))
-        .then(() => buildSimAsync())
-        .then(() => buildFolderAsync('cmds', true))
-        .then(() => buildSemanticUIAsync())
-        .then(() => buildEditorExtensionAsync("editor", "extendEditor"))
-        .then(() => buildEditorExtensionAsync("fieldeditors", "extendFieldEditors"))
-        .then(() => buildFolderAsync('server', true, 'server'))
+    await buildSimAsync();
+    await buildFolderAsync('cmds', true);
+    await buildSemanticUIAsync();
+    await buildEditorExtensionAsync("editor", "extendEditor");
+    await buildEditorExtensionAsync("fieldeditors", "extendFieldEditors");
+    await buildFolderAsync('server', true, 'server');
 
     function inCommonPkg(p: string) {
         return fs.existsSync(path.join(commonPackageDir, p));
@@ -2717,6 +2721,31 @@ function buildCommonSimAsync() {
         return Promise.resolve();
     }
 }
+
+// async function copyBlocklyMedia() {
+//     let targetMediaDir = path.resolve("sim/public/blockly/media");
+//     const simNodeModule = path.resolve(`node_modules/pxt-${pxt.appTarget.id}-sim`)
+
+//     if (nodeutil.existsDirSync(simNodeModule)) {
+//         targetMediaDir = path.join(simNodeModule, "public", "blockly", "media");
+//     }
+
+//     if (!nodeutil.existsDirSync(targetMediaDir)) {
+//         nodeutil.mkdirP(targetMediaDir);
+//     }
+
+//     let blocklyMediaDir = path.resolve("node_modules/blockly/media");
+
+//     if (!nodeutil.existsDirSync(blocklyMediaDir)) {
+//         blocklyMediaDir = path.resolve("node_modules/pxt-core/node_modules/blockly/media");
+//     }
+
+//     for (const file of fs.readdirSync(blocklyMediaDir)) {
+//         if (file.endsWith(".png") || file.endsWith("svg") || file.endsWith(".cur")) {
+//             nodeutil.cp(path.join(blocklyMediaDir, file), targetMediaDir);
+//         }
+//     }
+// }
 
 function renderDocs(builtPackaged: string, localDir: string) {
     const dst = path.resolve(path.join(builtPackaged, localDir))

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1458,7 +1458,6 @@ export async function internalBuildTargetAsync(options: BuildTargetOptions = {})
     }
 
     copyCommonSim();
-    // copyBlocklyMedia();
     await simshimAsync();
     await buildFolderAsync('compiler', true, 'compiler');
     await fillInCompilerExtension(pxt.appTarget);
@@ -2721,31 +2720,6 @@ function buildCommonSimAsync() {
         return Promise.resolve();
     }
 }
-
-// async function copyBlocklyMedia() {
-//     let targetMediaDir = path.resolve("sim/public/blockly/media");
-//     const simNodeModule = path.resolve(`node_modules/pxt-${pxt.appTarget.id}-sim`)
-
-//     if (nodeutil.existsDirSync(simNodeModule)) {
-//         targetMediaDir = path.join(simNodeModule, "public", "blockly", "media");
-//     }
-
-//     if (!nodeutil.existsDirSync(targetMediaDir)) {
-//         nodeutil.mkdirP(targetMediaDir);
-//     }
-
-//     let blocklyMediaDir = path.resolve("node_modules/blockly/media");
-
-//     if (!nodeutil.existsDirSync(blocklyMediaDir)) {
-//         blocklyMediaDir = path.resolve("node_modules/pxt-core/node_modules/blockly/media");
-//     }
-
-//     for (const file of fs.readdirSync(blocklyMediaDir)) {
-//         if (file.endsWith(".png") || file.endsWith("svg") || file.endsWith(".cur")) {
-//             nodeutil.cp(path.join(blocklyMediaDir, file), targetMediaDir);
-//         }
-//     }
-// }
 
 function renderDocs(builtPackaged: string, localDir: string) {
     const dst = path.resolve(path.join(builtPackaged, localDir))

--- a/cli/prepYotta.ts
+++ b/cli/prepYotta.ts
@@ -1,0 +1,57 @@
+// Do not require this file! It's for docker builds only.
+
+// The built version of this file is used by the CLI to set
+// .netrc and .yotta/config.json when building targets locally
+
+const os = require("os");
+const path = require("path");
+const fs = require("fs");
+
+const token = process.env["GH_ACCESS_TOKEN"];
+if (process.env["GH_ACCESS_TOKEN"]) {
+    console.log("Writing .netrc and .yotta/config.json")
+    const home = os.homedir();
+
+
+    const yottaDir = path.join(home, ".yotta");
+    if (!directoryExists(yottaDir)) {
+        fs.mkdirSync(yottaDir);
+    }
+
+    fs.writeFileSync(path.join(yottaDir, "config.json"), getYottaConfig(token), "utf8");
+    fs.writeFileSync(path.join(home, ".netrc"), getNetrc(token), "utf8");
+}
+
+function getNetrc(token: string) {
+    return (
+`
+machine github.com
+login build
+password ${token}
+
+machine api.github.com
+login build
+password ${token}
+`
+    );
+}
+
+function getYottaConfig(token: string) {
+    const yottaConfig = {
+        "github": {
+            "authtoken": token
+        }
+    };
+
+    return JSON.stringify(yottaConfig);
+}
+
+function directoryExists(dir: string) {
+    try {
+        const stat = fs.lstatSync(dir);
+        return stat.isDirectory;
+    }
+    catch(e) {
+        return false;
+    }
+}


### PR DESCRIPTION
One annoying thing about using our CLI to build locally w/ docker images is that yotta is constantly getting throttled by GitHub. We even have a GITHUB_ACCESS_TOKEN environment variable that we advertise as something you can configure, but it only gets used by PXT and not yotta which is a bummer.

Well, not anymore! This PR passes that GITHUB_ACCESS_TOKEN variable to the docker container and runs a script to setup the local `~/.yotta/config.json` and `~/.netrc` files to prevent throttling. This token doesn't actually need to have any permissions at all, GitHub just wants to use it for authentication.

Also, this PR fixes the `--local` flag which I had accidentally disabled in my last pr.

Completely unrelated to this, I also converted a function in `cli.ts` to use async await because it was bothering me.