### PR TITLE
support compileServiceVariants in daldts command

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -442,7 +442,7 @@ export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage
     const constName = "dal.d.ts";
     let constPath = constName;
     const config = mainPkg && mainPkg.config;
-    const corePackage = config && config.dalDTS && config.dalDTS.corePackage;
+    const corePackage = config?.dalDTS?.corePackage;
     if (corePackage)
         constPath = path.join(corePackage, constName);
     let vals: Map<string> = {}

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4778,18 +4778,21 @@ async function buildDalDTSAsync(c: commandParser.ParsedCommand) {
 
     if (fs.existsSync("pxtarget.json")) {
         pxt.log(`generating dal.d.ts for packages`)
-        return rebundleAsync()
-            .then(() => forEachBundledPkgAsync((f, dir) => {
-                return f.loadAsync()
-                    .then(() => {
-                        if (f.config.dalDTS && f.config.dalDTS.corePackage) {
-                            console.log(`  ${dir}`)
-                            return prepAsync()
-                                .then(() => build.buildDalConst(build.thisBuild, f, true, true));
-                        }
-                        return Promise.resolve();
-                    })
-            }));
+        await rebundleAsync();
+        await forEachBundledPkgAsync(async (f, dir) => {
+            await f.loadAsync();
+            if (f.config.dalDTS && f.config.dalDTS.corePackage) {
+                console.log(`  ${dir}`)
+
+                if (f.config.dalDTS.compileServiceVariant) {
+                    pxt.setAppTargetVariant(f.config.dalDTS.compileServiceVariant);
+                    setBuildEngine();
+                }
+
+                await prepAsync();
+                build.buildDalConst(build.thisBuild, f, true, true);
+            }
+        })
     } else {
         ensurePkgDir()
         await mainPkg.loadAsync()

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -76,6 +76,7 @@ declare namespace pxt {
             corePackage?: string;
             includeDirs?: string[];
             excludePrefix?: string[];
+            compileServiceVariant?: string;
         };
         features?: string[];
         hidden?: boolean; // hide package from package selection dialog


### PR DESCRIPTION
We have [this property](https://github.com/microsoft/pxt-microbit/blob/eb1498eb70c937b8c132fb32893bf49374e6188c/libs/core/pxt.json#L78) set in the pxt-microbit/libs/core pxt.json but AFAIK we never actually consumed it in the pxt cli. Well, I was rebuilding the dal.d.ts for pxt-microbit and it was broken so I added support to fix it.

This just lets us specify which build engine to use when parsing C++ files to regenerate dal.d.ts