### PR TITLE
Kiosk: make sure exit condition for low score as best score is correctly handled

### DIFF
--- a/kiosk/src/Transforms/exitToEnterHighScore.ts
+++ b/kiosk/src/Transforms/exitToEnterHighScore.ts
@@ -3,7 +3,7 @@ import configData from "../config.json";
 import { KioskState } from "../Types";
 import { exitGame } from "./exitGame";
 
-export function exitToEnterHighScore(): void {
+export function exitToEnterHighScore(highScoreMode: string): void {
     const { state } = stateAndDispatch();
 
     if (!state.mostRecentScores?.length) {
@@ -20,11 +20,12 @@ export function exitToEnterHighScore(): void {
     launchedGameHighs = launchedGameHighs || [];
     const currentHighScore = state.mostRecentScores[0];
     const lastScore = launchedGameHighs[launchedGameHighs.length - 1]?.score;
+    const isScoreInRange = highScoreMode === "lowscore" ? currentHighScore > lastScore : currentHighScore < lastScore;
 
     if (
         launchedGameHighs.length === configData.HighScoresToKeep &&
         lastScore &&
-        currentHighScore < lastScore
+        isScoreInRange
     ) {
         exitGame(KioskState.GameOver);
     } else {

--- a/kiosk/src/Transforms/exitToEnterHighScore.ts
+++ b/kiosk/src/Transforms/exitToEnterHighScore.ts
@@ -20,12 +20,12 @@ export function exitToEnterHighScore(highScoreMode: string): void {
     launchedGameHighs = launchedGameHighs || [];
     const currentHighScore = state.mostRecentScores[0];
     const lastScore = launchedGameHighs[launchedGameHighs.length - 1]?.score;
-    const isScoreInRange = highScoreMode === "lowscore" ? currentHighScore > lastScore : currentHighScore < lastScore;
+    const scoreOutOfRange = highScoreMode === "lowscore" ? currentHighScore > lastScore : currentHighScore < lastScore;
 
     if (
         launchedGameHighs.length === configData.HighScoresToKeep &&
         lastScore &&
-        isScoreInRange
+        scoreOutOfRange
     ) {
         exitGame(KioskState.GameOver);
     } else {

--- a/kiosk/src/Transforms/gameOver.ts
+++ b/kiosk/src/Transforms/gameOver.ts
@@ -24,10 +24,11 @@ export function gameOver(skipHighScore?: boolean): void {
 
         if (
             !skipHighScore &&
-            selectedGame?.highScoreMode !== "None" &&
+            selectedGame &&
+            selectedGame.highScoreMode !== "None" &&
             state.mostRecentScores?.length
         ) {
-            exitToEnterHighScore(selectedGame?.highScoreMode!);
+            exitToEnterHighScore(selectedGame.highScoreMode);
         } else {
             exitGame(KioskState.GameOver);
         }

--- a/kiosk/src/Transforms/gameOver.ts
+++ b/kiosk/src/Transforms/gameOver.ts
@@ -27,7 +27,7 @@ export function gameOver(skipHighScore?: boolean): void {
             selectedGame?.highScoreMode !== "None" &&
             state.mostRecentScores?.length
         ) {
-            exitToEnterHighScore();
+            exitToEnterHighScore(selectedGame?.highScoreMode!);
         } else {
             exitGame(KioskState.GameOver);
         }


### PR DESCRIPTION
A quick fix for a bug that evaded me until today for user high scores. Whether we would exit to entering a high score or just exit to game over had a condition that was reliant on the high score mode being high to low. If all the possible high scores slots were filled for a low to high score game, and you got a lower score than the last value, the game would exit to game over instead of enter a high score. 

I've fixed this now with having exitToHighScore use the high score mode to determine if the score has to be lower or higher than the last recorded score.