### PR TITLE
[cherry pick stable8.5] Kiosk: make sure exit condition for low score as best score is correc…

### DIFF
--- a/kiosk/src/Transforms/exitToEnterHighScore.ts
+++ b/kiosk/src/Transforms/exitToEnterHighScore.ts
@@ -3,7 +3,7 @@ import configData from "../config.json";
 import { KioskState } from "../Types";
 import { exitGame } from "./exitGame";
 
-export function exitToEnterHighScore(): void {
+export function exitToEnterHighScore(highScoreMode: string): void {
     const { state } = stateAndDispatch();
 
     if (!state.mostRecentScores?.length) {
@@ -20,11 +20,12 @@ export function exitToEnterHighScore(): void {
     launchedGameHighs = launchedGameHighs || [];
     const currentHighScore = state.mostRecentScores[0];
     const lastScore = launchedGameHighs[launchedGameHighs.length - 1]?.score;
+    const scoreOutOfRange = highScoreMode === "lowscore" ? currentHighScore > lastScore : currentHighScore < lastScore;
 
     if (
         launchedGameHighs.length === configData.HighScoresToKeep &&
         lastScore &&
-        currentHighScore < lastScore
+        scoreOutOfRange
     ) {
         exitGame(KioskState.GameOver);
     } else {

--- a/kiosk/src/Transforms/gameOver.ts
+++ b/kiosk/src/Transforms/gameOver.ts
@@ -24,10 +24,11 @@ export function gameOver(skipHighScore?: boolean): void {
 
         if (
             !skipHighScore &&
-            selectedGame?.highScoreMode !== "None" &&
+            selectedGame &&
+            selectedGame.highScoreMode !== "None" &&
             state.mostRecentScores?.length
         ) {
-            exitToEnterHighScore();
+            exitToEnterHighScore(selectedGame.highScoreMode);
         } else {
             exitGame(KioskState.GameOver);
         }


### PR DESCRIPTION
…tly handled (#10059)

* make sure exit condition for low score as best score is correctly handled

* rename variable

* explicitly check that a selected game exists to forego optional chaining