### PR TITLE
Add recursion to block codecard xml

### DIFF
--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -108,7 +108,7 @@ export function injectBlocks(blockInfo: pxtc.BlocksInfo): pxtc.SymbolInfo[] {
     return blockInfo.blocks
         .map(fn => {
             const comp = pxt.blocks.compileInfo(fn);
-            const block = createToolboxBlock(blockInfo, fn, comp);
+            const block = createToolboxBlock(blockInfo, fn, comp, false, 2);
 
             if (fn.attributes.blockBuiltin) {
                 pxt.Util.assert(!!builtinBlocks()[fn.attributes.blockId]);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5665

This adds recursion to the `createToolboxBlock` function so that we can recursively fill in shadow blocks when generating a block's codecard XML. The codecard XML gets used in a few places including the `cards` and `signature` snippets in docs pages. 

The webapp toolbox already has [its own recursion logic](https://github.com/microsoft/pxt/blob/66e6476112e0cc3bd388361b6b0312ff76ed106c/webapp/src/blocks.tsx#L1853) for filling in shadows which this PR doesn't alter in any way. The default value for the `maxRecursion` parameter is 0 which means no recursion.