### PR TITLE
Override default zelos behavior for input shapes

### DIFF
--- a/pxtblocks/plugins/renderer/constants.ts
+++ b/pxtblocks/plugins/renderer/constants.ts
@@ -258,4 +258,44 @@ export class ConstantProvider extends Blockly.zelos.ConstantProvider {
 
         return highlightOutlineFilter;
     }
+
+    override shapeFor(connection: Blockly.RenderedConnection) {
+        let checks = connection.getCheck();
+        if (!checks && connection.targetConnection) {
+            checks = connection.targetConnection.getCheck();
+        }
+        switch (connection.type) {
+            case Blockly.ConnectionType.INPUT_VALUE:
+            case Blockly.ConnectionType.OUTPUT_VALUE:
+                // The default zelos renderer just inherits the shape from
+                // the parent if it's set. Instead, respect the type checks.
+                // outputShape = connection.getSourceBlock().getOutputShape();
+                // if (outputShape !== null) {
+                //     switch (outputShape) {
+                //         case this.SHAPES.HEXAGONAL:
+                //             return this.HEXAGONAL!;
+                //         case this.SHAPES.ROUND:
+                //             return this.ROUNDED!;
+                //         case this.SHAPES.SQUARE:
+                //             return this.SQUARED!;
+                //     }
+                // }
+                // Includes doesn't work in IE.
+                if (checks && checks.includes('Boolean')) {
+                    return this.HEXAGONAL!;
+                }
+                if (checks && checks.includes('Number')) {
+                    return this.ROUNDED!;
+                }
+                if (checks && checks.includes('String')) {
+                    return this.ROUNDED!;
+                }
+                return this.ROUNDED!;
+            case Blockly.ConnectionType.PREVIOUS_STATEMENT:
+            case Blockly.ConnectionType.NEXT_STATEMENT:
+                return this.NOTCH!;
+            default:
+                throw Error('Unknown type');
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5690
Fixes https://github.com/microsoft/pxt-microbit/issues/5663

By default, inputs in blocks using the zelos renderer just pull their shape from the parent block; I'm not sure why anyone would want it to work that way, but go figure.

Our old renderer didn't do that, so this PR restores our old behavior of always respecting the types for inputs instead of copying the parent.