### PR TITLE
do not set hash before reset, as reloadEditor already does that.

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3140,7 +3140,6 @@ export class ProjectView
 
     resetWorkspace() {
         this.reload = true;
-        window.location.hash = "#reload";
         return workspace.resetAsync()
             .then(
                 () => this.reloadEditor(),


### PR DESCRIPTION
should fix https://github.com/microsoft/pxt-microbit/issues/5758

The `.then(reloadEditor, reloadEditor)` handles figuring out what the hash should be (https://github.com/microsoft/pxt/blob/dev/jwunderl/fix-reset/webapp/src/app.tsx#L2771), so this line is unnecessary / seems to be cause of the race condition. If anyone happens to recall changes in the hash change / loading path would be interesting to see if anything actually did change to cause this, I didn't dig that deep but nothing stood out immediately. 

mildly interesting note, the only way I was able to reproduce was setting breakpoint here 
![image](https://github.com/user-attachments/assets/958d0339-eb34-4768-b322-89c1366d3ee1)

and stepping into the two lines -- putting the breakpoint any further into function or stepping over has not reproduced on my machine. it's slightly rare for me to see it occur even when doing that though (maybe that's due to doing it with only a few projects / etc loaded though, but it does still occur occasionally then). 