### PR TITLE
Add option to have an unset gridpicker dropdown width

### DIFF
--- a/pxtblocks/fields/field_gridpicker.ts
+++ b/pxtblocks/fields/field_gridpicker.ts
@@ -60,7 +60,7 @@ export class FieldGridPicker extends Blockly.FieldDropdown implements FieldCusto
 
         this.columns_ = parseInt(options.columns) || 4;
         this.maxRows_ = parseInt(options.maxRows) || 0;
-        this.width_ = parseInt(options.width) || 200;
+        this.width_ = parseInt(options.width) || undefined;
 
         this.backgroundColour_ = parseColour(options.colour);
         this.borderColour_ = pxt.toolbox.fadeColor(this.backgroundColour_, 0.4, false);
@@ -367,14 +367,16 @@ export class FieldGridPicker extends Blockly.FieldDropdown implements FieldCusto
             width: paddingContainer.offsetWidth,
             height: paddingContainer.offsetHeight
         };
+        const windowHeight = window.outerHeight;
 
         // Set width
-        const windowWidth = window.outerWidth;
-        const windowHeight = window.outerHeight;
-        if (this.width_ > windowWidth) {
-            this.width_ = windowWidth;
+        if (this.width_) {
+            const windowWidth = window.outerWidth;
+            if (this.width_ > windowWidth) {
+                this.width_ = windowWidth;
+            }
+            tableContainer.style.width = this.width_ + 'px';
         }
-        tableContainer.style.width = this.width_ + 'px';
 
         let addedHeight = 0;
         if (this.hasSearchBar_) addedHeight += 50; // Account for search bar

--- a/theme/fieldeditors.less
+++ b/theme/fieldeditors.less
@@ -143,6 +143,8 @@
 
 .blocklyWidgetDiv .blocklyGridPickerMenu .goog-menuitem-content {
     color: #fff;
+    font-size: 13px;
+    font-family: @pageFont;
 }
 
 .blocklyWidgetDiv .blocklyGridPickerMenu .floatLeft {


### PR DESCRIPTION
Part of the fix for https://github.com/microsoft/pxt-microbit/issues/5730

In live, that width parameter was just being ignored by the browser. I have no idea how that works (it was being set on the element, just had no effect), but for the pins dropdown we want it to just expand to wrap the whole list anyhow.

Also fixing the font/size of the menu items.