### PR TITLE
Teacher Tool: Add Optional Feedback on Criteria

### DIFF
--- a/common-docs/teachertool/test/catalog-shared.json
+++ b/common-docs/teachertool/test/catalog-shared.json
@@ -8,6 +8,7 @@
             "docPath": "/teachertool",
             "maxCount": 10,
             "tags": ["General"],
+            "requestFeedback": true,
             "params": [
                 {
                     "name": "question",

--- a/common-docs/teachertool/test/catalog-shared.json
+++ b/common-docs/teachertool/test/catalog-shared.json
@@ -3,7 +3,7 @@
         {
             "id": "499F3572-E655-4DEE-953B-5F26BF0191D7",
             "use": "ai_question",
-            "template": "Ask Copilot: ${question}",
+            "template": "Ask AI: ${question}",
             "description": "Experimental: AI outputs may not be accurate. Use with caution and always review responses.",
             "docPath": "/teachertool",
             "maxCount": 10,

--- a/teachertool/src/components/CriteriaFeedback.tsx
+++ b/teachertool/src/components/CriteriaFeedback.tsx
@@ -1,0 +1,49 @@
+import { Button } from "react-common/components/controls/Button";
+import css from "./styling/CriteriaFeedback.module.scss";
+import { Ticks } from "../constants";
+import { useState } from "react";
+import { showToast } from "../transforms/showToast";
+import { makeToast } from "../utils";
+import { classList } from "react-common/components/util";
+
+interface ICriteriaFeedbackProps {
+    catalogCriteriaId: string;
+    className?: string;
+}
+export const CriteriaFeedback: React.FC<ICriteriaFeedbackProps> = ({className, catalogCriteriaId}) => {
+    const [helpful, setHelpful] = useState<boolean | undefined>(undefined);
+
+    function onResponseClicked(isHelpful: boolean) {
+        const previousHelpful = helpful;
+
+        // If they click the same button again, unset the feedback.
+        const newHelpful = previousHelpful === isHelpful ? undefined : isHelpful;
+
+        setHelpful(newHelpful);
+        pxt.tickEvent(Ticks.CriteriaFeedback, {
+            criteriaId: catalogCriteriaId,
+            helpful: newHelpful + "",
+
+            // Record previous value to help us track if the user is changing feedback that was already sent
+            // (i.e. pressed thumbs up, then changed to thumbs down), or if they reset their feedback.
+            previousValue: previousHelpful + ""
+        });
+
+        if (newHelpful !== undefined) {
+            showToast(makeToast(newHelpful ? "success" : "info", lf("Thanks for your feedback!")));
+        }
+    }
+
+    const thumbsUpIcon = helpful === true ? "fas fa-thumbs-up" : "far fa-thumbs-up";
+    const thumbsDownIcon = helpful === false ? "fas fa-thumbs-down" : "far fa-thumbs-down";
+
+    return (
+        <div className={classList(css["criteria-feedback-container"], className)}>
+            <span className={css["label"]}>{lf("Was this response helpful?")}</span>
+            <span className={css["rate-buttons"]}>
+                <Button className={css["feedback-button"]} title={lf("Helpful")} onClick={() => onResponseClicked(true)} rightIcon={thumbsUpIcon} />
+                <Button className={css["feedback-button"]} title={lf("Unhelpful")} onClick={() => onResponseClicked(false)} rightIcon={thumbsDownIcon} />
+            </span>
+        </div>
+    );
+}

--- a/teachertool/src/components/CriteriaFeedback.tsx
+++ b/teachertool/src/components/CriteriaFeedback.tsx
@@ -1,7 +1,7 @@
-import { Button } from "react-common/components/controls/Button";
 import css from "./styling/CriteriaFeedback.module.scss";
+import { Button } from "react-common/components/controls/Button";
 import { Ticks } from "../constants";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { showToast } from "../transforms/showToast";
 import { makeToast } from "../utils";
 import { classList } from "react-common/components/util";
@@ -13,7 +13,7 @@ interface ICriteriaFeedbackProps {
 export const CriteriaFeedback: React.FC<ICriteriaFeedbackProps> = ({className, catalogCriteriaId}) => {
     const [helpful, setHelpful] = useState<boolean | undefined>(undefined);
 
-    function onResponseClicked(isHelpful: boolean) {
+    const onResponseClicked = useCallback((isHelpful: boolean) => {
         const previousHelpful = helpful;
 
         // If they click the same button again, unset the feedback.
@@ -32,7 +32,7 @@ export const CriteriaFeedback: React.FC<ICriteriaFeedbackProps> = ({className, c
         if (newHelpful !== undefined) {
             showToast(makeToast(newHelpful ? "success" : "info", lf("Thanks for your feedback!")));
         }
-    }
+    }, [helpful, catalogCriteriaId]);
 
     const thumbsUpIcon = helpful === true ? "fas fa-thumbs-up" : "far fa-thumbs-up";
     const thumbsDownIcon = helpful === false ? "fas fa-thumbs-down" : "far fa-thumbs-down";

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -12,6 +12,7 @@ import { getCatalogCriteriaWithId, getCriteriaInstanceWithId } from "../state/he
 import { ReadOnlyCriteriaDisplay } from "./ReadonlyCriteriaDisplay";
 import { EvaluationStatus } from "../types/criteria";
 import { ThreeDotsLoadingDisplay } from "./ThreeDotsLoadingDisplay";
+import { CriteriaFeedback } from "./CriteriaFeedback";
 
 interface AddNotesButtonProps {
     criteriaId: string;
@@ -86,6 +87,7 @@ export const CriteriaResultEntry: React.FC<CriteriaResultEntryProps> = ({ criter
         <>
             {catalogCriteria && (
                 <div className={css["specific-criteria-result"]} key={criteriaId} aria-busy={isInProgress}>
+                    {/* Criteria Text & Overall Result (Looks Good, Needs Work, Etc...) */}
                     <div className={css["result-details"]}>
                         <ReadOnlyCriteriaDisplay
                             catalogCriteria={catalogCriteria}
@@ -99,6 +101,8 @@ export const CriteriaResultEntry: React.FC<CriteriaResultEntryProps> = ({ criter
                             />
                         )}
                     </div>
+
+                    {/* Notes */}
                     {isInProgress ? (
                         <ThreeDotsLoadingDisplay className={css["loading-display"]} />
                     ) : (
@@ -111,6 +115,11 @@ export const CriteriaResultEntry: React.FC<CriteriaResultEntryProps> = ({ criter
                             {!showInput && <AddNotesButton criteriaId={criteriaId} setShowInput={setShowInput} />}
                             {showInput && <CriteriaResultNotes criteriaId={criteriaId} />}
                         </div>
+                    )}
+
+                    {/* Criteria Response Feedback (For us, not student feedback) */}
+                    {!isInProgress && catalogCriteria.requestFeedback && (
+                        <CriteriaFeedback catalogCriteriaId={catalogCriteria.id} className={css["criteria-feedback"]}/>
                     )}
                 </div>
             )}

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -119,7 +119,7 @@ export const CriteriaResultEntry: React.FC<CriteriaResultEntryProps> = ({ criter
 
                     {/* Criteria Response Feedback (For us, not student feedback) */}
                     {!isInProgress && catalogCriteria.requestFeedback && (
-                        <CriteriaFeedback catalogCriteriaId={catalogCriteria.id} className={css["criteria-feedback"]}/>
+                        <CriteriaFeedback catalogCriteriaId={catalogCriteria.id} className={classList(css["no-print"], css["criteria-feedback"])}/>
                     )}
                 </div>
             )}

--- a/teachertool/src/components/styling/CriteriaFeedback.module.scss
+++ b/teachertool/src/components/styling/CriteriaFeedback.module.scss
@@ -1,0 +1,31 @@
+.criteria-feedback-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    .label {
+        margin-right: 0.5rem;
+    }
+
+    .rate-buttons {
+        display: flex;
+        flex-direction: row;
+
+        .feedback-button {
+            padding: 0.1rem;
+            border-radius: 100%;
+            background-color: transparent;
+            color: var(--pxt-page-foreground);
+            border: none;
+            font-size: 1rem;
+
+            :hover {
+                font-size: 1.2rem;
+            }
+
+            i {
+                margin: 0;
+            }
+        }
+    }
+}

--- a/teachertool/src/components/styling/EvalResultDisplay.module.scss
+++ b/teachertool/src/components/styling/EvalResultDisplay.module.scss
@@ -19,6 +19,11 @@
         padding-top: 0;
         flex-grow: 1;
     }
+
+    .criteria-feedback {
+        align-self: flex-end;
+        margin-top: 0.5rem;
+    }
 }
 
 .result-details {

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -55,6 +55,7 @@ export namespace Ticks {
     export const UserMenuSignout = "teachertool.usermenu.signout";
     export const UserMenuSignIn = "teachertool.usermenu.signin";
     export const SignedOutPanelSignIn = "teachertool.signedoutpanel.signin";
+    export const CriteriaFeedback = "teachertool.criteriafeedback"
 }
 
 namespace Misc {

--- a/teachertool/src/index.tsx
+++ b/teachertool/src/index.tsx
@@ -36,8 +36,16 @@ function enableAnalytics() {
 window.addEventListener("DOMContentLoaded", () => {
     const bundle = (window as any).pxtTargetBundle as pxt.TargetBundle;
 
-    pxt.options.debug = /dbg=1/i.test(window.location.href);
+    const optsQuery = pxt.Util.parseQueryString(window.location.href.toLowerCase());
+
+    pxt.options.debug = optsQuery["dbg"] == "1";
     if (pxt.options.debug) pxt.debug = console.debug;
+
+    if (optsQuery["consoleticks"] == "1" || optsQuery["consoleticks"] == "verbose") {
+        pxt.analytics.consoleTicks = pxt.analytics.ConsoleTickOptions.Verbose;
+    } else if (optsQuery["consoleticks"] == "2" || optsQuery["consoleticks"] == "short") {
+        pxt.analytics.consoleTicks = pxt.analytics.ConsoleTickOptions.Short;
+    }
 
     pxt.setupWebConfig((window as any).pxtConfig || pxt.webConfig);
     pxt.setAppTarget(bundle);

--- a/teachertool/src/state/appStateContext.tsx
+++ b/teachertool/src/state/appStateContext.tsx
@@ -41,7 +41,7 @@ export function AppStateProvider(props: React.PropsWithChildren<{}>): React.Reac
     const copilotSlot = url.match(/copilot=([^&]+)/);
     const copilotEndpoint =
         copilotSlot && copilotSlot[1]
-            ? `https://makecode-app-backend-ppe-${copilotSlot[1]}.azurewebsites.net/api`
+            ? `https://makecode-ppe-app-backend-eastus-${copilotSlot[1]}.azurewebsites.net/api`
             : undefined;
 
     // Create the application state and state change mechanism (dispatch)

--- a/teachertool/src/state/appStateContext.tsx
+++ b/teachertool/src/state/appStateContext.tsx
@@ -10,6 +10,8 @@ let dispatch: React.Dispatch<Action>;
 
 let initializationComplete: () => void;
 
+const DEV_BACKEND_LOCALHOST = "http://localhost:8080";
+
 // This promise will resolve when the app state is initialized and available outside the React context.
 export const AppStateReady: Promise<boolean> = new Promise(resolve => {
     initializationComplete = () => resolve(true);
@@ -41,7 +43,9 @@ export function AppStateProvider(props: React.PropsWithChildren<{}>): React.Reac
     const copilotSlot = url.match(/copilot=([^&]+)/);
     const copilotEndpoint =
         copilotSlot && copilotSlot[1]
-            ? `https://makecode-ppe-app-backend-eastus-${copilotSlot[1]}.azurewebsites.net/api`
+            ? copilotSlot[1] === "local"
+                ? `${DEV_BACKEND_LOCALHOST}/api`
+                : `https://makecode-ppe-app-backend-eastus-${copilotSlot[1]}.azurewebsites.net/api`
             : undefined;
 
     // Create the application state and state change mechanism (dispatch)

--- a/teachertool/src/types/criteria.ts
+++ b/teachertool/src/types/criteria.ts
@@ -9,6 +9,7 @@ export interface CatalogCriteria {
     hideInCatalog?: boolean; // Whether the criteria should be hidden in the user-facing catalog
     maxCount?: number; // The maximum number of instances allowed for this criteria within a single checklist. Unlimited if undefined.
     tags?: string[]; // Tags to help categorize the criteria
+    requestFeedback?: boolean; // Whether the criteria should request feedback from the user
 }
 
 // An instance of a criteria in a checklist.


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5742

This change adds an optional flag on catalog criteria which indicates that we should request feedback from the user on the tool's response. It's currently only set to true on the copilot criteria. When feedback is provided, it simply sends a tick event (collecting actual prompt and response data will require a more thorough privacy review). 

There's one slightly odd note about this change: it felt weird to lock a user into their first feedback selection they make, so I've allowed the response to be changed or cleared, but we can't "take back" a tick event. I considered adding a delay before sending the event, but that seemed flaky, like there could always be scenarios where the delay wasn't long enough or the user closed the page before it fired, so instead, each feedback event includes the previous value as well as the new one. We'll have to do a bit of math in our queries to account for that, but it shouldn't be too difficult, something like `actual helpful = count(helpful == true) - count(previousValue == true)`

Because I wanted it for my own debugging here, I also added teacher tool support for the consoleticks flag (uses same infrastructure that the main webapp uses).

Screenshot:
![image](https://github.com/user-attachments/assets/80c23895-bcff-4572-a4bd-0a839c7b4f16)

I also considered adding the feedback option for every response, but I thought it looked a little cluttered...open to making that change though, if folks feel differently. It would be useful data...It looked like this:
<details>
<summary>Screenshot of alternate ui, not ui in change</summary>
<img src="https://github.com/user-attachments/assets/d6a916ce-5945-4d54-a83f-f9665501f4f9" />
</details>