### PR TITLE
Lighten or darken border colors for nested same-color blocks

### DIFF
--- a/pxtblocks/plugins/renderer/pathObject.ts
+++ b/pxtblocks/plugins/renderer/pathObject.ts
@@ -188,25 +188,3 @@ Blockly.Css.register(`
     stroke-width: 2;
 }
 `)
-
-function getContrastingBorderColor(color: string) {
-    const darkerColor = pxt.getContrastingColor(color, color, -0.05, 4.5, 100);
-    const lighterColor = pxt.getContrastingColor(color, color, 0.05, 4.5, 100);
-
-    if (!darkerColor) {
-        if (lighterColor) {
-            return lighterColor[0]
-        }
-    }
-    else if (!lighterColor) {
-        return darkerColor[0]
-    }
-    else {
-        if (lighterColor[1] < darkerColor[1]) {
-            return lighterColor[0]
-        }
-        return darkerColor[0];
-    }
-
-    return "#000000";
-}

--- a/pxtlib/color.ts
+++ b/pxtlib/color.ts
@@ -69,7 +69,7 @@ namespace pxt {
         return 0.2126 * r2 + 0.7152 * g2 + 0.0722 * b2;
     }
 
-    function contrastRatio(fg: string, bg: string) {
+    export function contrastRatio(fg: string, bg: string) {
         return (relativeLuminance(fg) + 0.05) / (relativeLuminance(bg) + 0.05)
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4962

Automatically tweaks the block border color when the parent and child are the same color.

![image](https://github.com/user-attachments/assets/20f09fe1-d34e-46e5-bb87-fd7d944ca2e6)

The results do indeed have better contrast, but do look a bit worse imo.

@Jaqster @microbit-carlos please try out this upload target before I merge:

https://makecode.microbit.org/app/cdb16cf340702c5347c39a1b207988ec2a9bad1c-621f187ad4#editor