### PR TITLE
Restore workspace search extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@blockly/field-colour": "5.0.5",
     "@blockly/keyboard-navigation": "0.6.5",
-    "@blockly/plugin-workspace-search": "9.0.5",
+    "@blockly/plugin-workspace-search": "9.1.0",
     "@crowdin/crowdin-api-client": "^1.33.0",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@microsoft/applicationinsights-web": "^2.8.11",

--- a/pxtblocks/index.ts
+++ b/pxtblocks/index.ts
@@ -19,6 +19,7 @@ export * from "./importer";
 export * from "./diff";
 export * from "./legacyMutations";
 export * from "./blockDragger";
+export * from "./workspaceSearch";
 
 import * as contextMenu from "./contextMenu";
 import * as external from "./external";

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -1,6 +1,5 @@
 /// <reference path="../built/pxtlib.d.ts" />
 import * as Blockly from "blockly";
-import { WorkspaceSearch } from "@blockly/plugin-workspace-search";
 import { optionalDummyInputPrefix, optionalInputWithFieldPrefix, provider } from "./constants";
 import { initExpandableBlock, initVariableArgsBlock, appendMutation } from "./composableMutations";
 import { addMutation, MutatingBlock, MutatorTypes } from "./legacyMutations";
@@ -840,81 +839,5 @@ export function setVarFieldValue(block: Blockly.Block, fieldName: string, newNam
         const model = varField.getVariable();
         model.name = newName;
         varField.setValue(model.getId());
-    }
-}
-
-export class PxtWorkspaceSearch extends WorkspaceSearch {
-    protected injectionDiv: Element;
-    protected inputElement_: HTMLInputElement;
-
-    constructor(workspace: Blockly.WorkspaceSvg) {
-        super(workspace);
-        this.injectionDiv = workspace.getInjectionDiv();
-    }
-
-    protected override createTextInput(): HTMLInputElement {
-        const textInput = super.createTextInput();
-        this.inputElement_ = textInput;
-
-        // Register this event listener before the Blockly implementation
-        // registers theres. Inside the listener we call stopImmediatePropagation
-        // to prevent the Blockly listener from firing.
-        textInput.addEventListener("keydown", e => {
-            this.onKeyDown_(e);
-        });
-
-        return textInput;
-    }
-
-    // This is the same as the Blockly implementation but allows you to
-    // search backwards by holding shift and pressing enter
-    protected onKeyDown_(e: KeyboardEvent) {
-        if (e.key === 'Escape') {
-            this.close();
-            e.stopImmediatePropagation();
-        }
-        else if (e.key === 'Enter') {
-            if (this.searchOnInput) {
-                if (e.shiftKey) {
-                    this.previous();
-                }
-                else {
-                    this.next();
-                }
-                e.stopImmediatePropagation();
-            } else {
-                if (!this.inputElement_) return;
-                const inputValue = this.inputElement_.value.trim();
-                if (inputValue !== this.searchText) {
-                    this.searchAndHighlight(inputValue, this.preserveSelected);
-                    e.stopImmediatePropagation();
-                }
-            }
-        }
-    }
-
-    protected override highlightSearchGroup(blocks: Blockly.BlockSvg[]) {
-        blocks.forEach((block) => {
-            const blockPath = block.pathObject.svgPath;
-            Blockly.utils.dom.addClass(blockPath, 'blockly-ws-search-highlight-pxt');
-        });
-    }
-
-    protected override unhighlightSearchGroup(blocks: Blockly.BlockSvg[]) {
-        blocks.forEach((block) => {
-            const blockPath = block.pathObject.svgPath;
-            Blockly.utils.dom.removeClass(blockPath, 'blockly-ws-search-highlight-pxt');
-        });
-    }
-
-    override open() {
-        super.open();
-        this.inputElement_.select();
-        Blockly.utils.dom.addClass(this.injectionDiv, 'blockly-ws-searching');
-    }
-
-    override close() {
-        super.close();
-        Blockly.utils.dom.removeClass(this.injectionDiv, 'blockly-ws-searching');
     }
 }

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -844,127 +844,77 @@ export function setVarFieldValue(block: Blockly.Block, fieldName: string, newNam
 }
 
 export class PxtWorkspaceSearch extends WorkspaceSearch {
+    protected injectionDiv: Element;
+    protected inputElement_: HTMLInputElement;
 
+    constructor(workspace: Blockly.WorkspaceSvg) {
+        super(workspace);
+        this.injectionDiv = workspace.getInjectionDiv();
+    }
+
+    protected override createTextInput(): HTMLInputElement {
+        const textInput = super.createTextInput();
+        this.inputElement_ = textInput;
+
+        // Register this event listener before the Blockly implementation
+        // registers theres. Inside the listener we call stopImmediatePropagation
+        // to prevent the Blockly listener from firing.
+        textInput.addEventListener("keydown", e => {
+            this.onKeyDown_(e);
+        });
+
+        return textInput;
+    }
+
+    // This is the same as the Blockly implementation but allows you to
+    // search backwards by holding shift and pressing enter
+    protected onKeyDown_(e: KeyboardEvent) {
+        if (e.key === 'Escape') {
+            this.close();
+            e.stopImmediatePropagation();
+        }
+        else if (e.key === 'Enter') {
+            if (this.searchOnInput) {
+                if (e.shiftKey) {
+                    this.previous();
+                }
+                else {
+                    this.next();
+                }
+                e.stopImmediatePropagation();
+            } else {
+                if (!this.inputElement_) return;
+                const inputValue = this.inputElement_.value.trim();
+                if (inputValue !== this.searchText) {
+                    this.searchAndHighlight(inputValue, this.preserveSelected);
+                    e.stopImmediatePropagation();
+                }
+            }
+        }
+    }
+
+    protected override highlightSearchGroup(blocks: Blockly.BlockSvg[]) {
+        blocks.forEach((block) => {
+            const blockPath = block.pathObject.svgPath;
+            Blockly.utils.dom.addClass(blockPath, 'blockly-ws-search-highlight-pxt');
+        });
+    }
+
+    protected override unhighlightSearchGroup(blocks: Blockly.BlockSvg[]) {
+        blocks.forEach((block) => {
+            const blockPath = block.pathObject.svgPath;
+            Blockly.utils.dom.removeClass(blockPath, 'blockly-ws-search-highlight-pxt');
+        });
+    }
+
+    override open() {
+        super.open();
+        this.inputElement_.select();
+        Blockly.utils.dom.addClass(this.injectionDiv, 'blockly-ws-searching');
+    }
+
+    override close() {
+        super.close();
+        Blockly.utils.dom.removeClass(this.injectionDiv, 'blockly-ws-searching');
+    }
 }
-
-// FIXME (riknoll): This probably needs to be re-implemented
-
-// export class PxtWorkspaceSearch extends WorkspaceSearch {
-//     protected createDom_() {
-//         super.createDom_();
-//         this.addEvent_(this.workspace_.getInjectionDiv(), "click", this, (e: any) => {
-//             if (this.htmlDiv_.style.display == "flex" && !this.htmlDiv_.contains(e.target)) {
-//                 this.close()
-//             }
-//         });
-//     }
-
-//     /**
-//      * onKeyDown_ is a private method in WorkspaceSearch, overwrite it to allow searching backwards.
-//      * https://github.com/microsoft/pxt-arcade/issues/5716
-//      */
-//     onKeyDown_(e: KeyboardEvent) {
-//         if (e.key === 'Escape') {
-//             this.close();
-//         } else if (e.key === 'Enter') {
-//             if (e.shiftKey) {
-//                 this.previous();
-//             } else {
-//                 this.next();
-//             }
-//         }
-//     }
-
-//     protected highlightSearchGroup_(blocks: Blockly.BlockSvg[]) {
-//         blocks.forEach((block) => {
-//             const blockPath = block.pathObject.svgPath;
-//             Blockly.utils.dom.addClass(blockPath, 'blockly-ws-search-highlight-pxt');
-//         });
-//     }
-
-//     protected unhighlightSearchGroup_(blocks: Blockly.BlockSvg[]) {
-//         blocks.forEach((block) => {
-//             const blockPath = block.pathObject.svgPath;
-//             Blockly.utils.dom.removeClass(blockPath, 'blockly-ws-search-highlight-pxt');
-//         });
-//     }
-
-//     /**
-//      * https://github.com/google/blockly-samples/blob/master/plugins/workspace-search/src/WorkspaceSearch.js#L633
-//      *
-//      * Modified to center offscreen blocks.
-//      */
-//     protected scrollToVisible_(block: Blockly.BlockSvg) {
-//         if (!this.workspace_.isMovable()) {
-//             // Cannot scroll to block in a non-movable workspace.
-//             return;
-//         }
-//         // XY is in workspace coordinates.
-//         const xy = block.getRelativeToSurfaceXY();
-//         const scale = this.workspace_.scale;
-
-//         // Block bounds in pixels relative to the workspace origin (0,0 is centre).
-//         const width = block.width * scale;
-//         const height = block.height * scale;
-//         const top = xy.y * scale;
-//         const bottom = (xy.y + block.height) * scale;
-//         // In RTL the block's position is the top right of the block, not top left.
-//         const left = this.workspace_.RTL ? xy.x * scale - width : xy.x * scale;
-//         const right = this.workspace_.RTL ? xy.x * scale : xy.x * scale + width;
-
-//         const metrics = this.workspace_.getMetrics();
-
-//         let targetLeft = metrics.viewLeft;
-//         const overflowLeft = left < metrics.viewLeft;
-//         const overflowRight = right > metrics.viewLeft + metrics.viewWidth;
-//         const wideBlock = width > metrics.viewWidth;
-
-//         if ((!wideBlock && overflowLeft) || (wideBlock && !this.workspace_.RTL)) {
-//             // Scroll to show left side of block
-//             targetLeft = left;
-//         } else if ((!wideBlock && overflowRight) ||
-//             (wideBlock && this.workspace_.RTL)) {
-//             // Scroll to show right side of block
-//             targetLeft = right - metrics.viewWidth;
-//         }
-
-//         let targetTop = metrics.viewTop;
-//         const overflowTop = top < metrics.viewTop;
-//         const overflowBottom = bottom > metrics.viewTop + metrics.viewHeight;
-//         const tallBlock = height > metrics.viewHeight;
-
-//         if (overflowTop || (tallBlock && overflowBottom)) {
-//             // Scroll to show top of block
-//             targetTop = top;
-//         } else if (overflowBottom) {
-//             // Scroll to show bottom of block
-//             targetTop = bottom - metrics.viewHeight;
-//         }
-//         if (targetLeft !== metrics.viewLeft || targetTop !== metrics.viewTop) {
-//             const activeEl = document.activeElement as HTMLElement;
-//             if (wideBlock || tallBlock) {
-//                 this.workspace_.scroll(-targetLeft, -targetTop);
-//             } else {
-//                 this.workspace_.centerOnBlock(block.id);
-//             }
-
-//             if (activeEl) {
-//                 // Blockly.WidgetDiv.hide called in scroll is taking away focus.
-//                 // TODO: Review setFocused call in Blockly.WidgetDiv.hide.
-//                 activeEl.focus();
-//             }
-//         }
-//     }
-
-//     open() {
-//         super.open();
-//         this.inputElement_.select();
-//         Blockly.utils.dom.addClass(this.workspace_.getInjectionDiv(), 'blockly-ws-searching');
-//     }
-
-//     close() {
-//         super.close();
-//         Blockly.utils.dom.removeClass(this.workspace_.getInjectionDiv(), 'blockly-ws-searching');
-//     }
-
-// }

--- a/pxtblocks/workspaceSearch.ts
+++ b/pxtblocks/workspaceSearch.ts
@@ -1,0 +1,36 @@
+import * as Blockly from "blockly";
+import { WorkspaceSearch } from "@blockly/plugin-workspace-search";
+
+export class PxtWorkspaceSearch extends WorkspaceSearch {
+    protected injectionDiv: Element;
+    protected inputElement_: HTMLInputElement;
+
+    constructor(workspace: Blockly.WorkspaceSvg) {
+        super(workspace);
+        this.injectionDiv = workspace.getInjectionDiv();
+    }
+
+    protected override highlightSearchGroup(blocks: Blockly.BlockSvg[]) {
+        blocks.forEach((block) => {
+            const blockPath = block.pathObject.svgPath;
+            Blockly.utils.dom.addClass(blockPath, 'blockly-ws-search-highlight-pxt');
+        });
+    }
+
+    protected override unhighlightSearchGroup(blocks: Blockly.BlockSvg[]) {
+        blocks.forEach((block) => {
+            const blockPath = block.pathObject.svgPath;
+            Blockly.utils.dom.removeClass(blockPath, 'blockly-ws-search-highlight-pxt');
+        });
+    }
+
+    override open() {
+        super.open();
+        Blockly.utils.dom.addClass(this.injectionDiv, 'blockly-ws-searching');
+    }
+
+    override close() {
+        super.close();
+        Blockly.utils.dom.removeClass(this.injectionDiv, 'blockly-ws-searching');
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5629

This restores all of our extensions to Blockly's workspace search plugin; I had disabled them temporarily when we upgraded Blockly. The changes include:

* Pressing Shift+Enter navigates backwards through the list of search matches (default plugin can only move forwards)
* The content of the searchbox is selected when the search box is opened, which matches the behavior of most ctrl+f search boxes
* Custom rendering (selected blocks are outlined, all non-matching blocks in the workspace are faded out)

I had to do some hacks to customize the keydown behavior and get a reference to the text input element. I'll probably try to contribute the first two things back to Blockly since that's how all search boxes work.