### PR TITLE
Fix the "Delete all" blocks context menu option

### DIFF
--- a/pxtblocks/contextMenu/workspaceItems.ts
+++ b/pxtblocks/contextMenu/workspaceItems.ts
@@ -219,19 +219,20 @@ function registerDeleteAllBlocks() {
 
             // Add a little animation to deleting.
             const DELAY = 10;
+            let eventGroup = Blockly.utils.idGenerator.genUid();
             const deleteNext = () => {
-                let eventGroup = Blockly.utils.idGenerator.genUid();
-                Blockly.Events.setGroup(eventGroup);
                 let block = deleteList.shift();
                 if (block) {
-                    if (block.workspace) {
+                    if (!block.isDeadOrDying()) {
+                        Blockly.Events.setGroup(eventGroup);
                         block.dispose(false, true);
+                        Blockly.Events.setGroup(false);
+
                         setTimeout(deleteNext, DELAY);
                     } else {
                         deleteNext();
                     }
                 }
-                Blockly.Events.setGroup(false);
             }
 
             pxt.tickEvent("blocks.context.delete", undefined, { interactiveConsent: true });


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5774

This was throwing an exception when it attempted to delete a block that had already been deleted. For example, if the block was within an event and the event had already been disposed.

Also fixed the event grouping while I was at it.