### PR TITLE
Fix recursion issue in pxt-arcade and gridLiteral comment attribute

### DIFF
--- a/pxtblocks/toolbox.ts
+++ b/pxtblocks/toolbox.ts
@@ -210,10 +210,8 @@ export function createShadowValue(info: pxtc.BlocksInfo, p: pxt.blocks.BlockPara
     }
 
     if (maxRecursion) {
-        const allShadows = value.getElementsByTagName("shadow");
-        for (let i = 0; i < allShadows.length; i++) {
-            const shadow = allShadows.item(i);
-
+        const allShadows = pxt.Util.toArray(value.getElementsByTagName("shadow"));
+        for (const shadow of allShadows) {
             if (!shadow.innerHTML) {
                 const shadowSymbol = info.blocks.find(s => s.attributes.blockId === shadow.getAttribute("type"));
                 if (shadowSymbol) {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -834,7 +834,7 @@ namespace ts.pxtc {
         return r;
     }
 
-    const numberAttributes = ["weight", "imageLiteral", "topblockWeight", "inlineInputModeLimit"]
+    const numberAttributes = ["weight", "imageLiteral", "gridLiteral", "topblockWeight", "inlineInputModeLimit"]
     const booleanAttributes = [
         "advanced",
         "handlerStatement",


### PR DESCRIPTION
This PR contains two small unrelated fixes that I was too lazy to open separately:

1. Fixes an infinite loop in pxt-arcade caused by my toolbox XML recursion change that I checked in recently
2. Fixes the `gridLiteral` comment attribute so that it is correctly marked as a numeric attribute (just like `imageLiteral`)

Turns out that `getElementsByTagName` returns a "live" list, so if more shadow blocks were added by the recursive call it would end up making the length of the array longer so that it looped infinitely. I fixed it by using our `toArray` util to convert it into a static list.

`gridLiteral` is used for creating blocks that have the matrix field editor (like the show leds block in pxt-microbit). I need it for the CSP robot extension that I'm working on.