### PR TITLE
Don't dispose already disposed block when creating function declaration

### DIFF
--- a/pxtblocks/plugins/functions/commonFunctionMixin.ts
+++ b/pxtblocks/plugins/functions/commonFunctionMixin.ts
@@ -175,7 +175,9 @@ export const COMMON_FUNCTION_MIXIN = {
                 if (saveInfo) {
                     const block = saveInfo["block"];
                     if (block?.isShadow()) {
-                        block.dispose(false);
+                        if (!block.isDeadOrDying()) {
+                            block.dispose(false);
+                        }
                         delete connectionMap[id];
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5784

Basically the same problem as https://github.com/microsoft/pxt/pull/10071

I think this must be a new restriction that came in from the most recent Blockly update.