### PR TITLE
don't include duplicate on drag shadows in connection checker

### DIFF
--- a/pxtblocks/plugins/duplicateOnDrag/duplicateOnDrag.ts
+++ b/pxtblocks/plugins/duplicateOnDrag/duplicateOnDrag.ts
@@ -13,7 +13,7 @@ export function setDraggableShadowBlocks(ids: string[]) {
 }
 
 export function isAllowlistedShadow(block: Blockly.Block) {
-    if (draggableShadowAllowlist && block.isShadow()) {
+    if (draggableShadowAllowlist) {
         if (draggableShadowAllowlist.indexOf(block.type) !== -1) {
             return true;
         }

--- a/pxtblocks/plugins/duplicateOnDrag/duplicateOnDrag.ts
+++ b/pxtblocks/plugins/duplicateOnDrag/duplicateOnDrag.ts
@@ -5,8 +5,6 @@ export const DUPLICATE_ON_DRAG_MUTATION_KEY = "duplicateondrag";
 let draggableShadowAllowlist: string[];
 
 export function isDuplicateOnDragBlock(block: Blockly.Block) {
-    if (isAllowlistedShadow(block)) return true;
-
     return block.mutationToDom?.()?.getAttribute(DUPLICATE_ON_DRAG_MUTATION_KEY)?.toLowerCase() === "true";
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5785

Fixing the allowlisted duplicate on drag blocks not allowing anything else to connect to their inputs!