### PR TITLE
Make dropdown checkbox white

### DIFF
--- a/pxtblocks/plugins/renderer/css.ts
+++ b/pxtblocks/plugins/renderer/css.ts
@@ -1,0 +1,7 @@
+import * as Blockly from "blockly";
+
+Blockly.Css.register(`
+.blocklyDropdownMenu .blocklyMenuItemCheckbox.goog-menuitem-checkbox {
+    filter: contrast(0) brightness(100);
+}
+`)

--- a/pxtblocks/plugins/renderer/index.ts
+++ b/pxtblocks/plugins/renderer/index.ts
@@ -1,2 +1,3 @@
 export * from "./renderer";
 export * from "./connectionPreviewer";
+export * from "./css";


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5789

This is something we did by changing Blockly's PNG spritesheet in our fork a while back: https://github.com/microsoft/pxt-blockly/pull/118

I don't want to override that PNG, so instead I'm using some css filters to make it white:

![image](https://github.com/user-attachments/assets/addd1080-7d6e-4608-b8a5-3cb013701d9d)
