### PR TITLE
Add another 'removeAt' reference page

### DIFF
--- a/common-docs/reference/arrays/remove-at-statement.md
+++ b/common-docs/reference/arrays/remove-at-statement.md
@@ -1,0 +1,33 @@
+# remove At (no return value)
+
+Remove an element from an array at some position.
+
+```sig
+[""]._removeAtStatement(0)
+```
+
+The size of the array shrinks by one. The element is removed from the array at the position you want. All the other elements after it are moved (shifted) to down to the next lower position. So, an array that has the numbers
+`4, 5, 9, 3, 2` will be `4, 5, 3, 2` if `9` is removed from the array at index `2`. It looks like this in blocks:
+
+```block
+let myNumbers = [4, 5, 9, 3, 2]
+myNumbers.removeAt(2)
+```
+
+## Parameters
+
+* **index**: the position in the array to get the element from.
+
+## Example
+
+Remove the largest animal from the list of primates.
+
+```block
+let primates = ["chimpanzee", "baboon", "gorilla", "macaque"]
+let largest = primates.indexOf("gorilla")
+primates.removeAt(largest)
+```
+
+## See also
+
+[remove at](/reference/arrays/remove-at), [insert at](/reference/arrays/insert-at)

--- a/common-docs/reference/arrays/remove-at.md
+++ b/common-docs/reference/arrays/remove-at.md
@@ -29,7 +29,7 @@ Remove the most dangerous level of radiation from the list.
 ```block
 let radLevels = ["alpha", "beta", "gamma"]
 let level = radLevels.indexOf("gamma")
-radLevels.removeAt(level)
+let unzapped = radLevels.removeAt(level)
 ```
 
 ## See also

--- a/common-docs/reference/arrays/remove-at.md
+++ b/common-docs/reference/arrays/remove-at.md
@@ -1,6 +1,6 @@
 # remove At
 
-Remove an element from an array at some position.
+Remove and return an element from an array at some position.
 
 ```sig
 [""].removeAt(0)
@@ -10,8 +10,8 @@ The size of the array shrinks by one. The element is removed from the array at t
 `4, 5, 9, 3, 2` will be `4, 5, 3, 2` if `9` is removed from the array at index `2`. It looks like this in blocks:
 
 ```block
-let myNumbers = [4, 5, 9, 3, 2];
-let item = myNumbers.removeAt(2);
+let myNumbers = [4, 5, 9, 3, 2]
+let item = myNumbers.removeAt(2)
 ```
 
 ## Parameters
@@ -27,11 +27,12 @@ let item = myNumbers.removeAt(2);
 Remove the most dangerous level of radiation from the list.
 
 ```block
-let radLevels = ["alpha", "beta", "gamma"];
-let level = radLevels.indexOf("gamma");
-let unzapped = radLevels.removeAt(level);
+let radLevels = ["alpha", "beta", "gamma"]
+let level = radLevels.indexOf("gamma")
+radLevels.removeAt(level)
 ```
 
 ## See also
 
+[remove at (no return value)](/reference/arrays/remove-at-statement),
 [insert at](/reference/arrays/insert-at)

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -155,7 +155,7 @@ interface Array<T> {
     //% shim=Array_::removeElement weight=48
     removeElement(element: T): boolean;
 
-    /** Remove the element at a certain index. */
+    /** Remove and return the element at a certain index. */
     //% help=arrays/remove-at
     //% shim=Array_::removeAt weight=47
     //% blockId="array_removeat" block="%list| get and remove value at %index" blockNamespace="arrays"
@@ -245,7 +245,7 @@ interface Array<T> {
     _shiftStatement(): void;
 
     /** Remove the element at a certain index. */
-    //% help=arrays/remove-at
+    //% help=arrays/remove-at-statement
     //% shim=Array_::removeAt weight=14
     //% blockId="array_removeat_statement" block="%list| remove value at %index" blockNamespace="arrays"
     //% blockAliasFor="Array.removeAt"


### PR DESCRIPTION
Make another `arrays.removeAt()` reference page for the "statement only" version of the function: `arrays._removeAtStatement()`.

Closes https://github.com/microsoft/pxt-microbit/issues/5802