### PR TITLE
Optionally pass user language to sim extensions

### DIFF
--- a/docs/targets/simulator.md
+++ b/docs/targets/simulator.md
@@ -62,4 +62,6 @@ in ``pxtarget.json`` under the ``simulator.messageSimulators`` field:
 When loading the message simulator url, MakeCode expands ``$PARENT_ORIGIN$`` with the URI-encoded origin of the editor.
 You can use this value to validate the origin of iframe messages.
 
+Similarly, $LANGUAGE$ will be expanded to the URI-encoded language code matching the active MakeCode language.
+
 Optionally, you can specify a ``localHostUrl`` that will be used in local development mode.

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -27,6 +27,8 @@ namespace pxsim {
             aspectRatio?: number;
             permanent?: boolean;
         }>;
+        // needed when messageSimulators are used to provide to their frame
+        userLanguage?: string;
     }
 
     export enum SimulatorState {
@@ -356,6 +358,7 @@ namespace pxsim {
                                 const useLocalHost = U.isLocalHost() && /localhostmessagesims=1/i.test(window.location.href)
                                 const url = ((useLocalHost && messageSimulator.localHostUrl) || messageSimulator.url)
                                     .replace("$PARENT_ORIGIN$", encodeURIComponent(this.options.parentOrigin || ""))
+                                    .replace("$LANGUAGE$", encodeURIComponent(this.options.userLanguage))
                                 let wrapper = this.createFrame(url);
                                 this.container.appendChild(wrapper);
                                 messageFrame = wrapper.firstElementChild as HTMLIFrameElement;

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -240,7 +240,8 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
         nestedEditorSim,
         parentOrigin,
         mpRole,
-        messageSimulators: pxt.appTarget?.simulator?.messageSimulators
+        messageSimulators: pxt.appTarget?.simulator?.messageSimulators,
+        userLanguage: pxt.Util.userLanguage()
     };
     driver = new pxsim.SimulatorDriver(document.getElementById('simulators'), options);
     config = cfg


### PR DESCRIPTION
Closes https://github.com/microsoft/pxt-microbit/issues/5746

Just a possible approach, very happy with any way the achieve the same.

You can see it working by adding &language=$LANGUAGE$ to the jacdac messageSimulator config in pxt-microbit.