### PR TITLE
Show mini sim in tablet sized monaco projects that originated from tutorials

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4851,6 +4851,7 @@ export class ProjectView
                             pxt.tickEvent("tutorial.share", undefined, { interactiveConsent: false });
                             this.showShareDialog(lf("Well done! Would you like to share your project?"));
                         }
+                        this.showMiniSim(pxt.BrowserUtils.isTabletSize());
                     })
             }
         }
@@ -5160,7 +5161,8 @@ export class ProjectView
         const sandbox = pxt.shell.isSandboxMode();
         const isBlocks = !this.editor.isVisible || this.getPreferredEditor() === pxt.BLOCKS_PROJECT_NAME;
         const sideDocs = !(sandbox || targetTheme.hideSideDocs);
-        const tutorialOptions = this.state.tutorialOptions;
+        const tutorialCompleted = !!this.state.header?.tutorialCompleted;
+        const tutorialOptions = tutorialCompleted ? undefined : this.state.tutorialOptions;
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
         const isSidebarTutorial = pxt.appTarget.appTheme.sidebarTutorial;
         const isTabTutorial = inTutorial && !pxt.BrowserUtils.useOldTutorialLayout();

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -630,6 +630,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         super.setVisible(v);
         // if we are hiding monaco, clear error list
         if (!v) this.onErrorChanges([]);
+        // if we are showing monaco, resize to make sure sim state gets set
+        else this.parent.fireResize();
     }
 
     display(): JSX.Element {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/5568

split into two commits, first fixes the issue, second is some clean up while in the area. The resize at the end of `completeTutorialAsync` is needed to change it during the session a user completes the activity, the force resize is needed on future sessions (e.g. refreshing the page). Blocks would have had the same issue, but got by as it already had the same applied https://github.com/microsoft/pxt/blob/dev/jwunderl/fix-tutorial-check/webapp/src/blocks.tsx#L157