### PR TITLE
Fix typing for editor message requests

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -44,6 +44,7 @@ declare namespace pxt.editor {
          */
         action: "switchblocks"
         | "switchjavascript"
+        | "switchpython"
         | "startsimulator"
         | "restartsimulator"
         | "stopsimulator" // EditorMessageStopRequest

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -66,7 +66,7 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                     return getEditorAsync().then(projectView => {
                         const req = data as pxt.editor.EditorMessageRequest;
                         pxt.debug(`pxteditor: ${req.action}`);
-                        switch (req.action.toLowerCase()) {
+                        switch (req.action.toLowerCase() as pxt.editor.EditorMessageRequest["action"]) {
                             case "switchjavascript": return Promise.resolve().then(() => projectView.openJavaScript());
                             case "switchpython": return Promise.resolve().then(() => projectView.openPython());
                             case "switchblocks": return Promise.resolve().then(() => projectView.openBlocks());


### PR DESCRIPTION
See my comment in https://github.com/microsoft/pxt/pull/10082#discussion_r1712312836 for an explanation.

Just fixing the typing of this switch statement's argument to enforce that all messages exist within the typing for `EditorMessageRequest`. Also adding the missing `switchpython` message