### PR TITLE
Always have border for fields in blocks with multiple fields

### DIFF
--- a/pxtblocks/fields/field_dropdown.ts
+++ b/pxtblocks/fields/field_dropdown.ts
@@ -3,6 +3,19 @@ import { showEditorMixin } from "../plugins/newVariableField/fieldDropdownMixin"
 
 export class FieldDropdown extends Blockly.FieldDropdown {
     protected shouldAddBorderRect_() {
+        // Returning false for this function will turn the entire block into
+        // a click target for this field. If there are other editable fields
+        // in this block, make sure we return true so that we don't make them
+        // inaccessible
+        for (const input of this.sourceBlock_.inputList) {
+            for (const field of input.fieldRow) {
+                if (field === this) continue;
+
+                if (field.EDITABLE) {
+                    return true;
+                }
+            }
+        }
         if (!this.sourceBlock_.getInputsInline()) {
             return true;
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5486

See the comment in the PR for a more detailed explanation on why this matters.