### PR TITLE
store variants attempted before compiling

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3277,6 +3277,7 @@ export class ProjectView
             if (simRestart) this.stopSimulator();
             let state = this.editor.snapshotState()
             this.syncPreferredEditor()
+            const attemptedVariants = pxt.appTarget.multiVariants;
 
             try {
                 const resp = await compiler.compileAsync({ native: true, forceEmit: true });
@@ -3304,7 +3305,7 @@ export class ProjectView
 
                     if (noHexFileDiagnostic?.code === 9283 /*program too large*/ && pxt.commands.showProgramTooLargeErrorAsync) {
                         pxt.tickEvent("compile.programTooLargeDialog");
-                        const res = await pxt.commands.showProgramTooLargeErrorAsync(pxt.appTarget.multiVariants, core.confirmAsync, saveOnly);
+                        const res = await pxt.commands.showProgramTooLargeErrorAsync(attemptedVariants, core.confirmAsync, saveOnly);
                         if (res?.recompile) {
                             pxt.tickEvent("compile.programTooLargeDialog.recompile");
                             const oldVariants = pxt.appTarget.multiVariants;


### PR DESCRIPTION
When I was stepping through here in a program that was too big for v2 microbit, it started getting stuck in a retry loop; the putting a breakpoint after `compiler.compileAsync` would reset `pxt.appTarget.multiVariants` to the original value with 2 variants while the `if (res?.recompile) {` block was going / before it got to the finally. Just storing prior to attempting compile so `pxt.commands.showProgramTooLargeErrorAsync` gets the correct value for now, worth looking into a bit more later.

(big program https://makecode.microbit.org/_6oaTMe08Yc7b)