### PR TITLE
Fix time machine restore

### DIFF
--- a/tests/pxt-editor-test/editorrunner.ts
+++ b/tests/pxt-editor-test/editorrunner.ts
@@ -255,23 +255,12 @@ describe("updateHistory", () => {
 
         const history = pxteditor.history.parseHistoryFile(prevText[pxt.HISTORY_FILE]);
 
-        for (const entry of history.entries) {
-            console.log(new Date(entry.timestamp).toString())
-        }
-
         chai.expect(history.entries.length).to.equal(Math.floor((testVersions.length / 5)) + 1);
 
         for (let i = 0; i < history.entries.length; i++) {
             const index = history.entries.length - 1 - i;
             const timestamp = history.entries[index].timestamp;
             const currentText = getTextAtTime(prevText, history, timestamp, patchText).files;
-
-            for (let j = 0; j < testVersions.length; j++) {
-                if (testVersions[j][pxt.MAIN_BLOCKS] === currentText[pxt.MAIN_BLOCKS]) {
-                    console.log(`timestamp: ${timestamp} index: ${index} versionIndex: ${j}`);
-                    break;
-                }
-            }
 
             const compIndex = index ? Math.floor(history.entries[index].timestamp / ONE_MINUTE) : 0;
             const comp = testVersions[compIndex];

--- a/tests/pxt-editor-test/editorrunner.ts
+++ b/tests/pxt-editor-test/editorrunner.ts
@@ -5,6 +5,7 @@ import "mocha";
 import * as chai from "chai";
 import * as dmp from "diff-match-patch";
 import * as pxteditor from "../../pxteditor";
+import { getTextAtTime, HistoryFile, updateHistory } from "../../pxteditor/history";
 
 pxt.appTarget = {
     versions: {
@@ -221,7 +222,7 @@ describe("updateHistory", () => {
         for (let i = 1; i < testVersions.length; i++) {
             let nextText = { ...testVersions[i] };
 
-            pxteditor.history.updateHistory(prevText, nextText, i * ONE_HOUR, [], diffText, patchText);
+            pxteditor.history.updateHistory(prevText, nextText, i * ONE_HOUR, i * ONE_HOUR, [], diffText, patchText);
 
             prevText = nextText;
         }
@@ -247,7 +248,7 @@ describe("updateHistory", () => {
         for (let i = 1; i < testVersions.length; i++) {
             let nextText = { ...testVersions[i] };
 
-            pxteditor.history.updateHistory(prevText, nextText, i * ONE_MINUTE, [], diffText, patchText);
+            pxteditor.history.updateHistory(prevText, nextText, i * ONE_MINUTE, i * ONE_MINUTE, [], diffText, patchText);
 
             prevText = nextText;
         }
@@ -276,7 +277,7 @@ describe("updateHistory", () => {
         for (let i = 1; i < testVersions.length; i++) {
             let nextText = { ...testVersions[i] };
 
-            pxteditor.history.updateHistory(prevText, nextText, i * ONE_HOUR, [], diffText, patchText);
+            pxteditor.history.updateHistory(prevText, nextText, i * ONE_HOUR, i * ONE_HOUR, [], diffText, patchText);
 
             prevText = nextText;
         }
@@ -305,7 +306,7 @@ describe("updateHistory", () => {
         for (let i = 1; i < testVersions.length; i++) {
             let nextText = { ...testVersions[i] };
 
-            pxteditor.history.updateHistory(prevText, nextText, i * period, [], diffText, patchText);
+            pxteditor.history.updateHistory(prevText, nextText, i * period, i * period, [], diffText, patchText);
 
             prevText = nextText;
         }
@@ -326,4 +327,117 @@ describe("updateHistory", () => {
             chai.expect(currentText[pxt.CONFIG_NAME]).to.equal(comp[pxt.CONFIG_NAME])
         }
     });
-})
+
+    it("should restore to the version on the timestamp", () => {
+        const project = createProjectText();
+        const history = JSON.parse(project[pxt.HISTORY_FILE]) as HistoryFile;
+
+        for (const entry of history.entries) {
+            const { files } = getTextAtTime(project, history, entry.timestamp, patchText);
+
+            chai.expect(files[pxt.MAIN_TS]).equals(entry.timestamp.toString());
+        }
+    });
+});
+
+function createProjectText(): pxt.workspace.ScriptText {
+    // A realistic timeline of project edits
+    const dates = [
+        new Date(2024, 8, 13, 8, 0, 0, 0),
+        new Date(2024, 8, 13, 8, 15, 0, 0),
+        new Date(2024, 8, 13, 8, 17, 0, 0),
+        new Date(2024, 8, 13, 8, 23, 0, 0),
+        new Date(2024, 8, 13, 8, 24, 0, 0),
+        new Date(2024, 8, 13, 8, 25, 0, 0),
+        new Date(2024, 8, 13, 8, 45, 0, 0),
+        new Date(2024, 8, 13, 8, 47, 0, 0),
+        new Date(2024, 8, 13, 9, 13, 0, 0),
+        new Date(2024, 8, 13, 9, 27, 0, 0),
+        new Date(2024, 8, 13, 9, 34, 0, 0),
+        new Date(2024, 8, 13, 9, 52, 0, 0),
+        new Date(2024, 8, 13, 9, 54, 0, 0),
+        new Date(2024, 8, 13, 9, 56, 0, 0),
+        new Date(2024, 8, 13, 10, 5, 0, 0),
+        new Date(2024, 8, 13, 10, 7, 0, 0),
+        new Date(2024, 8, 15, 8, 0, 0, 0),
+        new Date(2024, 8, 15, 8, 15, 0, 0),
+        new Date(2024, 8, 15, 8, 15, 20, 0),
+        new Date(2024, 8, 15, 8, 15, 45, 0),
+        new Date(2024, 8, 15, 8, 16, 0, 0),
+        new Date(2024, 8, 15, 8, 16, 20, 0),
+        new Date(2024, 8, 15, 8, 16, 45, 0),
+        new Date(2024, 8, 15, 8, 17, 0, 0),
+        new Date(2024, 8, 15, 8, 17, 20, 0),
+        new Date(2024, 8, 15, 8, 17, 45, 0),
+        new Date(2024, 8, 15, 8, 18, 0, 0),
+        new Date(2024, 8, 15, 8, 18, 20, 0),
+        new Date(2024, 8, 15, 8, 18, 45, 0),
+        new Date(2024, 8, 15, 8, 19, 0, 0),
+        new Date(2024, 8, 15, 8, 19, 20, 0),
+        new Date(2024, 8, 15, 8, 19, 45, 0),
+        new Date(2024, 8, 15, 8, 20, 0, 0),
+        new Date(2024, 8, 15, 8, 20, 20, 0),
+        new Date(2024, 8, 15, 8, 20, 45, 0),
+        new Date(2024, 8, 15, 8, 21, 0, 0),
+        new Date(2024, 8, 15, 8, 21, 20, 0),
+        new Date(2024, 8, 15, 8, 21, 45, 0),
+        new Date(2024, 8, 15, 8, 22, 0, 0),
+        new Date(2024, 8, 15, 8, 22, 20, 0),
+        new Date(2024, 8, 15, 8, 22, 45, 0),
+        new Date(2024, 8, 15, 8, 23, 0, 0),
+        new Date(2024, 8, 15, 8, 23, 20, 0),
+        new Date(2024, 8, 15, 8, 23, 45, 0),
+        new Date(2024, 8, 15, 8, 24, 0, 0),
+        new Date(2024, 8, 15, 8, 24, 20, 0),
+        new Date(2024, 8, 15, 8, 24, 45, 0),
+        new Date(2024, 8, 15, 8, 25, 0, 0),
+        new Date(2024, 8, 15, 8, 25, 20, 0),
+        new Date(2024, 8, 15, 8, 25, 45, 0),
+        new Date(2024, 8, 15, 8, 26, 0, 0),
+        new Date(2024, 8, 15, 8, 26, 20, 0),
+        new Date(2024, 8, 15, 8, 26, 45, 0),
+        new Date(2024, 8, 15, 8, 27, 0, 0),
+        new Date(2024, 8, 15, 8, 27, 20, 0),
+        new Date(2024, 8, 15, 8, 27, 45, 0),
+        new Date(2024, 8, 15, 8, 28, 0, 0),
+        new Date(2024, 8, 15, 8, 28, 20, 0),
+        new Date(2024, 8, 15, 8, 28, 45, 0),
+        new Date(2024, 8, 15, 8, 29, 0, 0),
+        new Date(2024, 8, 15, 8, 29, 20, 0),
+        new Date(2024, 8, 15, 8, 29, 45, 0),
+        new Date(2024, 8, 15, 8, 30, 0, 0),
+        new Date(2024, 8, 15, 8, 30, 20, 0),
+        new Date(2024, 8, 15, 8, 30, 45, 0),
+        new Date(2024, 8, 18, 8, 45, 0, 0),
+    ];
+
+    let currentText = {
+        [pxt.MAIN_TS]: "start"
+    };
+
+    // At each time, push an edit that contains the
+    // timestamp
+    let prevEditTime: number;
+    for (const date of dates) {
+        const newText = {
+            ...currentText,
+            [pxt.MAIN_TS]: "" + date.getTime()
+        };
+
+        updateHistory(
+            currentText,
+            newText,
+            prevEditTime || date.getTime(),
+            date.getTime(),
+            [],
+            diffText,
+            patchText
+        )
+
+        currentText = {
+            ...newText
+        };
+    }
+
+    return currentText;
+}

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -890,7 +890,8 @@ export async function showTurnBackTimeDialogAsync(header: pxt.workspace.Header, 
             newHistory = {
                 entries:  history.entries.slice(0, history.entries.findIndex(e => e.timestamp === timestamp)),
                 snapshots: history.snapshots.filter(s => s.timestamp <= timestamp),
-                shares: history.shares.filter(s => s.timestamp <= timestamp)
+                shares: history.shares.filter(s => s.timestamp <= timestamp),
+                lastSaveTime: timestamp
             }
         }
 

--- a/webapp/src/timeMachine.tsx
+++ b/webapp/src/timeMachine.tsx
@@ -6,7 +6,7 @@ import { Button } from "../../react-common/components/controls/Button";
 import { hideDialog, warningNotification } from "./core";
 import { FocusTrap } from "../../react-common/components/controls/FocusTrap";
 import { classList } from "../../react-common/components/util";
-import { HistoryFile, applySnapshot, getTextAtTime, patchConfigEditorVersion } from "../../pxteditor/history";
+import { HistoryFile, applySnapshot, patchConfigEditorVersion } from "../../pxteditor/history";
 
 import ScriptText = pxt.workspace.ScriptText;
 

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -20,6 +20,7 @@ import U = pxt.Util;
 import Cloud = pxt.Cloud;
 
 import * as pxtblockly from "../../pxtblocks";
+import { getTextAtTime, HistoryFile } from "../../pxteditor/history";
 
 
 // Avoid importing entire crypto-js
@@ -662,8 +663,10 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
                         toWrite = { ...previous.text };
                     }
 
+                    const lastEditTime = h.recentUse * 1000;
+
                     if (toWrite) {
-                        pxteditor.history.updateHistory(previous.text, toWrite, Date.now(), h.pubVersions || [], diffText, patchText);
+                        pxteditor.history.updateHistory(previous.text, toWrite, lastEditTime || Date.now(), Date.now(), h.pubVersions || [], diffText, patchText);
                     }
                 }
             }
@@ -735,8 +738,8 @@ function patchText(patch: unknown, a: string) {
     return differ.patch_apply(patch as any, a)[0]
 }
 
-export function applyDiff(text: ScriptText, history: pxteditor.history.HistoryEntry) {
-    return pxteditor.history.applyDiff(text, history, patchText);
+export function restoreTextToTime(text: ScriptText, history: HistoryFile, timestamp: number) {
+    return getTextAtTime(text, history, timestamp, patchText);
 }
 
 export function importAsync(h: Header, text: ScriptText, isCloud = false) {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -663,10 +663,8 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
                         toWrite = { ...previous.text };
                     }
 
-                    const lastEditTime = h.recentUse * 1000;
-
                     if (toWrite) {
-                        pxteditor.history.updateHistory(previous.text, toWrite, lastEditTime || Date.now(), Date.now(), h.pubVersions || [], diffText, patchText);
+                        pxteditor.history.updateHistory(previous.text, toWrite, Date.now(), h.pubVersions || [], diffText, patchText);
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5674
Fixes https://github.com/microsoft/pxt-microbit/issues/5788

Fixes the time machine restore function so that the timestamp that the user chooses in the timeline matches the code at that point in time. There was both an off-by-one error in the getTextAtTimeAsync function and we weren't saving the correct time when creating new diffs in the history file.

Also added a test to keep it from regressing.