### PR TITLE
Don't delete unrelated arguments when mutating and fix typo

### DIFF
--- a/pxtblocks/builtins/functions.ts
+++ b/pxtblocks/builtins/functions.ts
@@ -396,7 +396,7 @@ export function initFunctions() {
             }
 
             if (this.pathObject) {
-                (this.pathObject as PathObject).setHasDottedOutllineOnHover(this.duplicateOnDrag_);
+                (this.pathObject as PathObject).setHasDottedOutlineOnHover(this.duplicateOnDrag_);
             }
 
             setOutputCheck(this, typeName, cachedBlockInfo);

--- a/pxtblocks/plugins/duplicateOnDrag/variablesGetReporter.ts
+++ b/pxtblocks/plugins/duplicateOnDrag/variablesGetReporter.ts
@@ -23,7 +23,7 @@ const VARIABLES_GET_REPORTER_MIXIN = {
         if (xmlElement.hasAttribute(DUPLICATE_ON_DRAG_MUTATION_KEY)) {
             this.duplicateOnDrag_ = xmlElement.getAttribute(DUPLICATE_ON_DRAG_MUTATION_KEY).toLowerCase() === "true";
             if (this.pathObject) {
-                (this.pathObject as PathObject).setHasDottedOutllineOnHover(this.duplicateOnDrag_);
+                (this.pathObject as PathObject).setHasDottedOutlineOnHover(this.duplicateOnDrag_);
             }
         }
     },

--- a/pxtblocks/plugins/functions/blocks/argumentReporterBlocks.ts
+++ b/pxtblocks/plugins/functions/blocks/argumentReporterBlocks.ts
@@ -36,8 +36,9 @@ const ARGUMENT_REPORTER_MIXIN = {
         if (xmlElement.hasAttribute(DUPLICATE_ON_DRAG_MUTATION_KEY)) {
             this.duplicateOnDrag_ = xmlElement.getAttribute(DUPLICATE_ON_DRAG_MUTATION_KEY).toLowerCase() === "true";
             if (this.pathObject) {
-                (this.pathObject as PathObject).setHasDottedOutllineOnHover(this.duplicateOnDrag_);
-            }        }
+                (this.pathObject as PathObject).setHasDottedOutlineOnHover(this.duplicateOnDrag_);
+            }
+        }
     },
 };
 
@@ -154,7 +155,7 @@ Blockly.Blocks[ARGUMENT_REPORTER_CUSTOM_BLOCK_TYPE] = {
 
         ARGUMENT_REPORTER_MIXIN.domToMutation.call(this, xmlElement);
         if (this.pathObject) {
-            (this.pathObject as PathObject).setHasDottedOutllineOnHover(this.duplicateOnDrag_);
+            (this.pathObject as PathObject).setHasDottedOutlineOnHover(this.duplicateOnDrag_);
         }
     },
 };

--- a/pxtblocks/plugins/functions/utils.ts
+++ b/pxtblocks/plugins/functions/utils.ts
@@ -15,6 +15,7 @@ import { FunctionManager } from "./functionManager";
 import { MsgKey } from "./msg";
 import { newFunctionMutation } from "./blocks/functionDeclarationBlock";
 import { FunctionDefinitionBlock } from "./blocks/functionDefinitionBlock";
+import { ArgumentReporterBlock } from "./blocks/argumentReporterBlocks";
 
 export type StringMap<T> = { [index: string]: T };
 
@@ -213,6 +214,12 @@ export function mutateCallersAndDefinition(name: string, ws: Blockly.Workspace, 
                         // Find the argument ID corresponding to this old argument name.
                         let argName = d.getFieldValue("VALUE");
                         let argId = oldArgNamesToIds[argName];
+
+                        // This argument reporter must belong to a different block. For example,
+                        // a block with handlerStatement=1 and draggableParameters=reporter
+                        if (argId === undefined) {
+                            return;
+                        }
 
                         if (!idsToNewArgNames[argId]) {
                             // That arg ID no longer exists on the new mutation, delete this

--- a/pxtblocks/plugins/functions/utils.ts
+++ b/pxtblocks/plugins/functions/utils.ts
@@ -15,7 +15,6 @@ import { FunctionManager } from "./functionManager";
 import { MsgKey } from "./msg";
 import { newFunctionMutation } from "./blocks/functionDeclarationBlock";
 import { FunctionDefinitionBlock } from "./blocks/functionDefinitionBlock";
-import { ArgumentReporterBlock } from "./blocks/argumentReporterBlocks";
 
 export type StringMap<T> = { [index: string]: T };
 

--- a/pxtblocks/plugins/renderer/pathObject.ts
+++ b/pxtblocks/plugins/renderer/pathObject.ts
@@ -121,7 +121,7 @@ export class PathObject extends Blockly.zelos.PathObject {
         }
     }
 
-    setHasDottedOutllineOnHover(enabled: boolean) {
+    setHasDottedOutlineOnHover(enabled: boolean) {
         this.hasDottedOutlineOnHover = enabled;
 
         if (enabled) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5813

adding a check to the mutateCallersAndDefinition function to ensure that an argument reporter actually belongs to the mutating function before deleting it.

also fixed a random typo I noticed.