### PR TITLE
webusb attempt to disconnect on .forget

### DIFF
--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -270,6 +270,7 @@ namespace pxt.usb {
             if (!this.dev?.forget)
                 return false;
             try {
+                await this.disconnectAsync();
                 await this.dev.forget();
                 return true;
                 // connection changed listener will handle disconnecting when access is revoked.


### PR DESCRIPTION
At least make an attempt to call disconnect code before forgetting usb device, to give firmware a notice it's being disconnected. Does not currently consistently make it so you can forget then repair, but mild improvement / makes best effort.

Close https://github.com/microsoft/pxt-microbit/issues/5672, the issue does show them skipping over the modal that gives instructions on reconnecting / indication of the requirement to fully disconnect and reconnect (depending on firmware version). Perhaps this will get improved with other micro:bit webusb fixes, but doesn't seem like a thing to prioritize when it's already an edge case button / it gives proper instructions to fix it.