### PR TITLE
fix layout logic for decompiled code

### DIFF
--- a/pxtblocks/layout.ts
+++ b/pxtblocks/layout.ts
@@ -22,9 +22,9 @@ export function patchBlocksFromOldWorkspace(blockInfo: ts.pxtc.BlocksInfo, oldWs
 
     for (const child of oldDom.childNodes) {
         if (
-            child.nodeType !== Node.ELEMENT_NODE ||
-            (child as Element).localName !== "block" ||
-            (child as Element).getAttribute("disabled") !== "true"
+            !pxt.BrowserUtils.isElement(child) ||
+            child.localName !== "block" ||
+            child.getAttribute("disabled") !== "true"
         ) {
             continue;
         }

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1441,4 +1441,8 @@ namespace pxt.BrowserUtils {
             body.classList.add(`theme-${theme}`);
         }
     }
+
+    export function isElement(node: Node): node is Element {
+        return node.nodeType === Node.ELEMENT_NODE;
+    }
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5795

when we load a blocks file we check to see if any of the blocks/comments are in the default position (x=10 and y=10) and format the whole workspace if they are. seems like blockly now [automatically bumps blocks neighbors](https://github.com/google/blockly/blob/ec8f9c8589fd0ea849eba4ae80f59cb878a0f24a/core/render_management.ts#L146) when doing renders, so even if there is no location information the blocks are bumped away from that default position in the first render which thwarts our check.

this PR changes that check so that it looks at the XML we loaded instead which is not subject to any phantom bumping