### PR TITLE
Make runtime yield delay configurable

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -29,6 +29,7 @@ namespace pxsim {
         traceDisabled?: boolean;
         activePlayer?: 1 | 2 | 3 | 4 | undefined;
         theme?: string | pxt.Map<string>;
+        yieldDelay?: number;
     }
 
     export interface SimulatorInstructionsMessage extends SimulatorMessage {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1199,6 +1199,7 @@ namespace pxsim {
             let userGlobals: string[];
             let __this = this // ex
             this.traceDisabled = !!msg.traceDisabled;
+            const yieldDelay = msg.yieldDelay !== undefined ? msg.yieldDelay : 5;
 
             // this is passed to generated code
             const evalIface = {
@@ -1277,7 +1278,7 @@ namespace pxsim {
                     lastYield = now
                     s.pc = pc;
                     s.r0 = r0;
-                    setTimeout(loopForSchedule(s), 5)
+                    setTimeout(loopForSchedule(s), yieldDelay)
                     return true
                 }
                 return false


### PR DESCRIPTION
When developing the pxt-bedrock target, I was seeing major performance problems when our code ran within Minecraft's JavaScript runtime. The culprit turned out to be this fixed value of 5ms for the yield delay. Lowering the value to zero completely resolved the issue. Would we see similar improvement in pxt-minecraft? The runtime environments are very different. Experimentation will tell.

Making this value configurable so we can adjust it in the pxt-minecraft target.
