### PR TITLE
add importexternalproject editor command

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -53,6 +53,7 @@ declare namespace pxt.editor {
         | "closeflyout"
         | "newproject"
         | "importproject"
+        | "importexternalproject"
         | "importtutorial"
         | "openheader"
         | "proxytosim" // EditorMessageSimulatorMessageProxyRequest
@@ -256,6 +257,19 @@ declare namespace pxt.editor {
         // (optional) filtering argument
         filters?: ProjectFilters;
         searchBar?: boolean;
+    }
+
+    export interface EditorMessageImportExternalProjectRequest extends EditorMessageRequest {
+        action: "importexternalproject";
+        // project to load
+        project: pxt.workspace.Project;
+    }
+
+    export interface EditorMessageImportExternalProjectResponse extends EditorMessageResponse {
+        action: "importexternalproject";
+        resp: {
+            importUrl: string;
+        };
     }
 
     export interface EditorMessageSaveLocalProjectsToCloud extends EditorMessageRequest {

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -4,6 +4,7 @@ import { runValidatorPlan } from "./code-validation/runValidatorPlan";
 import IProjectView = pxt.editor.IProjectView;
 
 import { IFrameEmbeddedClient } from "../pxtservices/iframeEmbeddedClient";
+import { saveProjectAsync } from "./projectImport";
 
 const pendingRequests: pxt.Map<{
     resolve: (res?: pxt.editor.EditorMessageResponse | PromiseLike<pxt.editor.EditorMessageResponse>) => void;
@@ -111,6 +112,16 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                         filters: load.filters,
                                         searchBar: load.searchBar
                                     }));
+                            }
+                            case "importexternalproject": {
+                                const importExternal = data as pxt.editor.EditorMessageImportExternalProjectRequest
+                                return saveProjectAsync(importExternal.project)
+                                    .then(importId => {
+                                        const importUrl = location.origin + location.pathname + `#embedimport:${importId}`;
+                                        resp = {
+                                            importUrl
+                                        } as Partial<pxt.editor.EditorMessageImportExternalProjectResponse>
+                                    });
                             }
                             case "openheader": {
                                 const open = data as pxt.editor.EditorMessageOpenHeaderRequest;

--- a/pxteditor/index.ts
+++ b/pxteditor/index.ts
@@ -3,6 +3,7 @@ import * as monaco from "./monaco";
 import * as workspace from "./workspace";
 import * as experiments from "./experiments";
 import * as validation from "./code-validation";
+import * as importDb from "./projectImport";
 
 export * from "./editor";
 export * from "./editorcontroller";
@@ -18,5 +19,6 @@ export {
     monaco,
     workspace,
     experiments,
-    validation
+    validation,
+    importDb
 };

--- a/pxteditor/projectImport.ts
+++ b/pxteditor/projectImport.ts
@@ -28,7 +28,7 @@ export async function removeProjectAsync(importId: string): Promise<pxt.workspac
     const stored = await db.getAsync<StoredProject>(PROJECT_TABLE, importId);
     await db.deleteAllAsync(PROJECT_TABLE);
 
-    return stored.project;
+    return stored?.project;
 }
 
 async function initAsync() {

--- a/pxteditor/projectImport.ts
+++ b/pxteditor/projectImport.ts
@@ -16,6 +16,7 @@ export async function saveProjectAsync(project: pxt.workspace.Project): Promise<
     };
 
     const db = await initAsync();
+    await db.deleteAllAsync(PROJECT_TABLE);
     await db.setAsync(PROJECT_TABLE, toStore);
 
     return toStore.importId;
@@ -25,7 +26,7 @@ export async function removeProjectAsync(importId: string): Promise<pxt.workspac
     const db = await initAsync();
 
     const stored = await db.getAsync<StoredProject>(PROJECT_TABLE, importId);
-    await db.deleteAsync(PROJECT_TABLE, importId);
+    await db.deleteAllAsync(PROJECT_TABLE);
 
     return stored.project;
 }

--- a/pxteditor/projectImport.ts
+++ b/pxteditor/projectImport.ts
@@ -1,0 +1,48 @@
+let _db: pxt.BrowserUtils.IDBWrapper;
+
+
+interface StoredProject {
+    importId: string;
+    project: pxt.workspace.Project;
+}
+
+const PROJECT_TABLE = "projects";
+const KEYPATH = "importId";
+
+export async function saveProjectAsync(project: pxt.workspace.Project): Promise<string> {
+    const toStore: StoredProject = {
+        importId: pxt.U.guidGen(),
+        project
+    };
+
+    const db = await initAsync();
+    await db.setAsync(PROJECT_TABLE, toStore);
+
+    return toStore.importId;
+}
+
+export async function removeProjectAsync(importId: string): Promise<pxt.workspace.Project> {
+    const db = await initAsync();
+
+    const stored = await db.getAsync<StoredProject>(PROJECT_TABLE, importId);
+    await db.deleteAsync(PROJECT_TABLE, importId);
+
+    return stored.project;
+}
+
+async function initAsync() {
+    if (_db) {
+        return _db;
+    }
+
+    const dbName = pxt.appTarget.id + "-import";
+    const version = 1;
+    _db = new pxt.BrowserUtils.IDBWrapper(dbName, version, (_, request) => {
+        const db = request.result as IDBDatabase;
+        db.createObjectStore(PROJECT_TABLE, { keyPath: KEYPATH });
+    });
+
+    await _db.openAsync();
+
+    return _db;
+}

--- a/pxtservices/editorDriver.ts
+++ b/pxtservices/editorDriver.ts
@@ -259,6 +259,18 @@ export class EditorDriver extends IframeDriver {
         );
     }
 
+    async importExternalProject(project: pxt.workspace.Project) {
+        const resp = await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "importexternalproject",
+                project,
+            } as pxt.editor.EditorMessageImportExternalProjectRequest
+        ) as pxt.editor.EditorMessageImportExternalProjectResponse;
+
+        return resp.resp.importUrl;
+    }
+
     async openHeader(headerId: string) {
         await this.sendRequest(
             {

--- a/webapp/public/controller.html
+++ b/webapp/public/controller.html
@@ -8,10 +8,12 @@
     <style>
         @import "/blb/semantic.css";
 
+        body {
+            display: flex;
+            flex-direction: column;
+        }
+
         #logs {
-            position: absolute;
-            left: 0;
-            top: 2rem;
             width: 100%;
             height: 10rem;
             border: 0;
@@ -23,12 +25,12 @@
         }
 
         #iframe {
-            position: absolute;
-            left: 0;
-            top: 12.5rem;
-            width: 100%;
-            height: calc(100% - 12.5rem);
             border: 0;
+            flex-grow: 1;
+        }
+
+        .ui.buttons {
+            flex-wrap: wrap;
         }
     </style>
     <script>
@@ -41,6 +43,24 @@
             "pxt.json": "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"core\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ]\n}"
           }
         }];
+        var header = {
+            target: "microbit",
+            targetVersion: "7.0.15",
+            name: "controller-test-project",
+            meta: {},
+            editor: "blocksprj",
+            pubId: "",
+            pubCurrent: false,
+            _rev: null,
+            id: "762e2fa2-2129-4122-a651-bff7fd72cc95",
+            recentUse: Date.now(),
+            modificationTime: Date.now(),
+            cloudUserId: null,
+            cloudCurrent: false,
+            cloudVersion: null,
+            cloudLastSyncTime: 0,
+            isDeleted: false,
+        };
         var filters = {
             "namespaces": {
                 "events": 0,
@@ -107,6 +127,17 @@
                 msg.restriction = languageRestrictions[languageRestrictionIndex];
                 languageRestrictionIndex = (languageRestrictionIndex + 1) % languageRestrictions.length;
             }
+            else if (action == 'importexternalproject') {
+                const text =  { ...projects[0].text }
+                const config = JSON.parse(text["pxt.json"]);
+                config.name = header.name;
+                text["pxt.json"] = JSON.stringify(config);
+                msg.project = {
+                    header,
+                    text
+                };
+                msg.response = true;
+            }
             if (msg.response)
                 pendingMsgs[msg.id] = msg;
             editor.postMessage(msg, "*")
@@ -140,6 +171,9 @@
                 } else if (msg.action == "workspacesave") {
                     console.log(JSON.stringify(msg.project, null, 2))
                     lastSaved = msg.project;
+                }
+                else if (msg.action == "importexternalproject") {
+                    console.log(msg.resp);
                 }
             }
             if (msg.type == "pxteditor") {
@@ -212,6 +246,7 @@
         <button class="ui button" onclick="sendMessage('print')">print</button>
         <button class="ui button" onclick="sendMessage('pair')">pair</button>
         <button class="ui button" onclick="sendMessage('info')">info</button>
+        <button class="ui button" onclick="sendMessage('importexternalproject')">importexternalproject</button>
         <br/>
         <input id="hexfile" class="ui input" type="file" />
         <button class="ui button" onclick="importHexFile()">import hex</button>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2516,6 +2516,17 @@ export class ProjectView
         await this.loadHeaderAsync(newHeader)
     }
 
+    async importEmbedProjectAsync(importId: string) {
+        const project = await pxteditor.importDb.removeProjectAsync(importId);
+
+        if (project) {
+            return this.installAndLoadProjectAsync(project);
+        }
+        else {
+            Util.userError(lf("Unable to import project"));
+        }
+    }
+
     openProjectByHeaderIdAsync(headerId: string) {
         const header = workspace.getHeader(headerId);
         return this.loadHeaderAsync(header);
@@ -5607,6 +5618,15 @@ function handleHash(newHash: { cmd: string; arg: string }, loading: boolean): bo
                 .finally(() => {
                     pxt.BrowserUtils.changeHash("");
                     core.hideLoading("skillmapimport")
+                });
+            return true;
+        case "embedimport":
+            const importId = newHash.arg;
+            core.showLoading("embedimport", lf("loading project..."));
+            editor.importEmbedProjectAsync(importId)
+                .finally(() => {
+                    pxt.BrowserUtils.changeHash("");
+                    core.hideLoading("embedimport")
                 });
             return true;
         case "github": {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5748

Adds a command for importing projects for the embedded editor scenario. It works pretty similarly to the skillmap codepath, but it doesn't require the projects to be stored on the same domain.

The flow goes like this:

1. Outside frame sends the `importexternalproject` command to the iframe with a project
2. The inner frame saves the project to a temporary DB (not the workspace DB)
3. The inner frame responds with a URL that the outer frame can open in a new tab to import the project
4. When the URL gets opened, the project is removed from the temporary DB and stored in whatever workspace is active (e.g. the indexedDB, the cloud, etc.)

The temporary db gets cleared whenever a new project is written or removed, so this can't be used to import multiple projects at once. If that's a scenario, I can loosen this restriction. Right now, it's really meant to be an "Open in MakeCode" button for a single project.

@microbit-matt-hillsdon @microbit-carlos @jaustin let me know if you have any feedback on this