### PR TITLE
Fix a couple blockly flyout issues

### DIFF
--- a/localtypings/navigationController.d.ts
+++ b/localtypings/navigationController.d.ts
@@ -13,6 +13,7 @@ declare module '@blockly/keyboard-navigation' {
     class Navigation {
         resetFlyout(workspace: WorkspaceSvg, shouldHide: boolean): void;
         setState(workspace: WorkspaceSvg, state: BlocklyNavigationState): void;
+        focusFlyout(workspace: WorkspaceSvg): void;
     }
 
     type BlocklyNavigationState = "workspace" | "toolbox" | "flyout";

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -899,7 +899,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     public moveFocusToFlyout() {
-        // TODO: Add accessible blocks plugin from Blockly
+        if (this.navigationController) {
+            this.navigationController.navigation.focusFlyout(this.editor);
+        }
+
+        (this.editor.getInjectionDiv() as HTMLDivElement).focus();
     }
 
     renderToolbox(immediate?: boolean) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -646,7 +646,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 pxtblockly.FIELD_EDITOR_OPEN_EVENT_TYPE
             ];
 
-            if (ev.type !== "var_create" && ev.type !== "marker_move") {
+            if (shouldEventHideFlyout(ev)) {
                 this.hideFlyout();
             }
 
@@ -1967,4 +1967,21 @@ function fixHighlight(block: Blockly.BlockSvg) {
     if (connectedTo) {
         fixHighlight(connectedTo);
     }
+}
+
+function shouldEventHideFlyout(ev: Blockly.Events.Abstract) {
+    if (ev.type === "var_create" || ev.type === "marker_move") {
+        return false;
+    }
+
+    // If a block is selected when the user clicks on a flyout button (e.g. "Make a Variable"),
+    // a selected event will fire unselecting the block before the var_create event is fired.
+    // Make sure we don't close the flyout in the case where a block is simply being unselected.
+    if (ev.type === "selected") {
+        if (!(ev as Blockly.Events.Selected).newElementId) {
+            return false;
+        }
+    }
+
+    return true;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5540

This fixes two issues:
* the blockly flyout would sometimes close itself when you clicked on the Make a Variable or Make a Function buttons
* the 'out' shortcut in the blockly keyboard navigation wasn't working when the flyout was open


The first issue was being caused by an event firing when the current block is unselected.

The second issue was because the Blockly injection div wasn't being focused.