### PR TITLE
Don't convert indexOf to python's .index

### DIFF
--- a/cli/pyconv.ts
+++ b/cli/pyconv.ts
@@ -412,7 +412,7 @@ namespace py {
     }
     export interface Constant extends Expr {
         kind: "Constant";
-        value: any; // ??? 
+        value: any; // ???
     }
 
     // the following expression can appear in assignment context
@@ -470,7 +470,7 @@ def to_json(val):
         for attr_name in dir(val):
             if not attr_name.startswith("_"):
                 js[attr_name] = to_json(getattr(val, attr_name))
-        return js    
+        return js
     if isinstance(val, (bytearray, bytes)):
         return [x for x in val]
     raise Exception("unhandled: %s (type %s)" % (val, type(val)))
@@ -1443,7 +1443,6 @@ let funMap: Map<FunOverride> = {
     "ustruct.calcsize": { n: "pins.packedSize", t: tpNumber },
     "pins.I2CDevice.read_into": { n: ".readInto", t: tpVoid },
     "bool": { n: "!!", t: tpBoolean },
-    "Array.index": { n: ".indexOf", t: tpNumber },
     "time.sleep": { n: "pause", t: tpVoid, scale: 1000 }
 }
 

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -29,7 +29,6 @@ namespace ts.pxtc {
         "control.createBuffer": { n: "bytearray", t: ts.SyntaxKind.Unknown },
         "control.createBufferFromArray": { n: "bytes", t: ts.SyntaxKind.Unknown },
         "!!": { n: "bool", t: ts.SyntaxKind.BooleanKeyword },
-        "Array.indexOf": { n: "Array.index", t: ts.SyntaxKind.Unknown },
         "Array.push": { n: "Array.append", t: ts.SyntaxKind.Unknown },
         "parseInt": { n: "int", t: ts.SyntaxKind.NumberKeyword, snippet: 'int("0")' },
         "_py.range": { n: "range", t: ts.SyntaxKind.Unknown, snippet: 'range(4)' }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5703

This removes the mapping between JavaScript's `Array.indexOf` and Python's `List.index` function. Python's index function throws an exception if the value is missing instead of returning -1, so this isn't a safe conversion to make.

This means that if you are using `Array.indexOf` in Blocks or TypeScript, when you switch to Python you will now get the non-standard `.index_of`, which will maintain the same behavior at the cost of being a function that doesn't exist.