### PR TITLE
Blocks with toolbox parents will have correct snippets and toolbox previews in JS/PY

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1020,6 +1020,10 @@ namespace ts.pxtc.service {
             const { apis } = lastApiInfo;
             const blocksInfo = blocksInfoOp(apis, bannedCategories);
             const checker = service && service.getProgram().getTypeChecker();
+            // needed for blocks that have parent wraps like music.play(...)
+            // with this snippet call, we are dragging a block from the toolbox,
+            // so we want to include the parent snippet
+            const includeParentSnippet = true;
             const snippetContext = {
                 apis,
                 blocksInfo,
@@ -1027,6 +1031,7 @@ namespace ts.pxtc.service {
                 bannedCategories,
                 screenSize,
                 checker,
+                includeParentSnippet
             }
             const snippetNode = getSnippet(snippetContext, fn, n as FunctionLikeDeclaration, isPython)
             const snippet = snippetStringify(snippetNode)

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -125,7 +125,9 @@ namespace ts.pxtc.service {
         let overrideSnippet: SnippetNode;
         if (parameterOverride) {
             overrideParamLabel = Object.keys(parameterOverride)?.[0];
-            overrideSnippet = parameterOverride[overrideParamLabel];
+            if (overrideParamLabel) {
+                overrideSnippet = parameterOverride[overrideParamLabel];
+            }
         }
 
 

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -104,12 +104,14 @@ namespace ts.pxtc.service {
         takenNames: pxt.Map<SymbolInfo>;
         checker: ts.TypeChecker;
         screenSize?: pxt.Size;
+        parameterOverride?: { [key: string]: SnippetNode };
+        includeParentSnippet?: boolean;
     }
 
     export function getSnippet(context: SnippetContext, fn: SymbolInfo, decl: ts.FunctionLikeDeclaration, python?: boolean, recursionDepth = 0): SnippetNode {
         // TODO: a lot of this is duplicate logic with blocklyloader.ts:buildBlockFromDef; we should
         //  unify these approaches
-        let { apis, takenNames, blocksInfo, screenSize, checker } = context;
+        let { apis, takenNames, blocksInfo, screenSize, checker, parameterOverride, includeParentSnippet } = context;
 
         const PY_INDENT: string = (pxt as any).py.INDENT;
         const fileType = python ? "python" : "typescript";
@@ -118,6 +120,14 @@ namespace ts.pxtc.service {
         let addNamespace = false;
         let namespaceToUse = "";
         let functionCount = 0;
+        let parentSnippet: SnippetNode;
+        let overrideParamLabel: string;
+        let overrideSnippet: SnippetNode;
+        if (parameterOverride) {
+            overrideParamLabel = Object.keys(parameterOverride)?.[0];
+            overrideSnippet = parameterOverride[overrideParamLabel];
+        }
+
 
         let preStmt: SnippetNode[] = [];
 
@@ -280,6 +290,21 @@ namespace ts.pxtc.service {
             }
         }
 
+        if (includeParentSnippet && element.attributes.toolboxParent && recursionDepth === 0) {
+            overrideSnippet = [preStmt, insertText];
+            overrideParamLabel = element.attributes.toolboxParentArgument;
+            parameterOverride = {[overrideParamLabel]: overrideSnippet}
+            const parentFn = blocksById[fn.attributes.toolboxParent];
+            parentSnippet = getSnippet(
+                {...context, parameterOverride},
+                parentFn,
+                lastApiInfo.decls[parentFn.qName] as ts.FunctionLikeDeclaration,
+                python,
+                recursionDepth + 1,
+            );
+            return parentSnippet;
+        }
+
         return [preStmt, insertText]
 
         function getUniqueName(inName: string): string {
@@ -292,6 +317,10 @@ namespace ts.pxtc.service {
             const typeNode = param.type;
             if (!typeNode)
                 return python ? "None" : "null"
+
+            if (overrideSnippet && param.symbol.escapedName === overrideParamLabel) {
+                return snippetStringify(overrideSnippet);
+            }
 
             const name = param.name.kind === SK.Identifier ? (param.name as ts.Identifier).text : undefined;
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1724,6 +1724,13 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 res[ns] = [];
             }
             res[ns].push(fn);
+            if (fn.attributes.toolboxParent) {
+                const parent = this.blockInfo.blocks.find(b => b.attributes.blockId === fn.attributes.toolboxParent);
+                const currentBlock = res[ns].find(resB => resB.name === fn.name);
+                if (parent && currentBlock) {
+                    currentBlock.attributes.parentBlock = parent;
+                }
+            }
 
             const subcat = fn.attributes.subcategory;
             const advanced = fn.attributes.advanced;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -128,7 +128,7 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
                         // remove what precedes the "." in the full snippet.
                         // E.g. if the user is typing "mobs.", we want to complete with "spawn" (name) not "mobs.spawn" (qName)
                         if (completions.isMemberCompletion && snippet) {
-                            const nameStart = snippet.lastIndexOf(name);
+                            const nameStart = snippet.split("(")[0].lastIndexOf(name);
                             if (nameStart !== -1) {
                                 snippet = snippet.substr(nameStart)
                             }

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -252,8 +252,17 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
 
     protected getBlockDescription(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[]): JSX.Element[] {
         let description = [];
-        let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo)
+        let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo);
         let parts = block.attributes._def && block.attributes._def.parts;
+        if (block.attributes.parentBlock) {
+            const parent = block.attributes.parentBlock;
+            const parentBlockParts = [...parent.attributes._def.parts];
+            const overrideLocation = parentBlockParts.findIndex((part: any) => part.kind === "param" && part.name === block.attributes.toolboxParentArgument);
+            if (overrideLocation !== -1) {
+                parentBlockParts.splice(overrideLocation, 1, ...block.attributes._def.parts);
+                parts = parentBlockParts;
+            }
+        }
         let name = block.qName || block.name;
         const isPython = this.props.fileType == pxt.editor.FileType.Python;
 

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -54,6 +54,8 @@ export interface BlockDefinition {
         topblockWeight?: number;
         help?: string;
         _def?: pxtc.ParsedBlockDef;
+        parentBlock?: BlockDefinition;
+        toolboxParentArgument?: string;
     };
     retType?: string;
     blockXml?: string;


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-microbit/issues/5349

As described in the bug, the problem we were having is that the music play blocks, with the new Playable infrastructure that we have in place, have a `toolboxParent`. This parent is the `play(toPlay, playbackMode)` block. We handle this `toolboxParent` in blocks, but it was not getting handled in JS/Python snippets, so when the play blocks would get dragged into the Monaco editor from the toolbox, the inner block would be generated, but not the outer parent block.

Big thank you to @riknoll for all your help getting situated in the right files and implementation guidance.

This PR does the following:
1. Fixes the snippet drag out problems that are the root of the linked issue. These changes can be found in `snippet.ts` and has to do with the `parameterOverride` object added to the SnippetContext.
2. Adds an `includeParentSnippet` flag to `getSnippet` to dictate whether or not we actually want the snippet to include that `toolboxParent`. We create snippets both when we drag the JS/Py snippets from the toolbox _and_ when a user makes completions (as in, presses tab to fill in code). In the "drag-out-of-the-toolbox" scenario, we want the parent block to exist in order to get the correct block that will convert smoothly when switching back to blocks. However, in the "completions" scenario, we shouldn't be getting the parent because it could introduce nesting that we don't want. Thus, the flag is passed in order to say "only bring the parent with the toolbox drag, not on completions". Changes in `snippet.ts` and `pxtcompiler/emitter/service.ts` reflect this fix. 
**Before**
![image](https://github.com/user-attachments/assets/0a7c77bf-354d-41ab-9f9c-44bef6e292c7)
**After**
![image](https://github.com/user-attachments/assets/e4c76c18-d5c9-4700-b731-24b61394c882)

3. Fixes a bug with completions that came apparent to me when trying to complete `music.play`. When tabbing on `music.play`, it would complete to `music.playable` and include the rest of the inner part of `music.play`. @riknoll, (thank you!!) noticed that this was because we weren't indexing correctly and would essentially cut out the first left parenthesis that we would find, so we just needed to account for finding that parenthesis when completing. This is the one line change in `monaco.tsx`.
4. Fixes the snippet preview in the toolbox. The snippet previews are handled separately from actually generating the snippet code in the editor. The "block" that you see for JS/Python snippets is generated in `monacoFlyout.tsx`, so I've added `toolboxParent` handling logic there. This fix also needed some changes in `monaco.tsx`, where we actually get/generate the block definitions for the toolbox, specifically in `partitionBlocks()`.

Upload target: https://makecode.microbit.org/app/674c0781c279b633915e3c16177d0232799eacb2-262379068a#editor you can play with the `music.play` completions in JS and Python and also take a look at the toolbox improvements.