### PR TITLE
eval tool: better print preview handling of long title

### DIFF
--- a/teachertool/src/components/styling/EvalResultDisplay.module.scss
+++ b/teachertool/src/components/styling/EvalResultDisplay.module.scss
@@ -208,8 +208,8 @@
         align-items: flex-start;
         justify-content: space-between;
         gap: 0.5rem;
-        min-width: 14rem;
-    
+        flex-grow: 1;
+
         h2 {
             font-size: 1.5rem;
             font-weight: 500;
@@ -221,8 +221,8 @@
     .project-details {
         display: flex;
         flex-direction: row;
-        align-items: center;
-        justify-content: center;
+        align-items: flex-end;
+        justify-content: flex-start;
 
         h3 {
             margin: 0;
@@ -249,11 +249,4 @@
     display: flex;
     flex-direction: column;
     margin-top: 0.5rem;
-}
-
-@media print {
-    .specific-criteria-result {
-        min-height: 5.5rem;
-    }
-
 }


### PR DESCRIPTION
It still has problems with long titles without any spaces, but that isn't a common scenario, so I think this is an acceptable fix for now.

Fixes https://github.com/microsoft/pxt-microbit/issues/5638

![image](https://github.com/user-attachments/assets/2a4159e3-2af4-4649-85b7-388151d56f44)

