### PR TITLE
code eval: add beta tag

### DIFF
--- a/teachertool/src/components/HeaderBar.tsx
+++ b/teachertool/src/components/HeaderBar.tsx
@@ -4,13 +4,21 @@ import css from "./styling/HeaderBar.module.scss";
 import { Button } from "react-common/components/controls/Button";
 import { MenuBar } from "react-common/components/controls/MenuBar";
 import { AppStateContext } from "../state/appStateContext";
-import { Ticks } from "../constants";
+import { Strings, Ticks } from "../constants";
 import { MenuDropdown, MenuItem } from "react-common/components/controls/MenuDropdown";
 import { showModal } from "../transforms/showModal";
 import * as authClient from "../services/authClient";
 import { classList } from "react-common/components/util";
 
-interface HeaderBarProps {}
+const betaTag = () => {
+    return (
+        <div className={css["beta-tag"]}>
+            {lf("Beta")}
+        </div>
+    );
+};
+
+interface HeaderBarProps { }
 
 export const HeaderBar: React.FC<HeaderBarProps> = () => {
     const { state: teacherTool } = useContext(AppStateContext);
@@ -35,11 +43,18 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
         return (
             <div className={css["org"]} onClick={onOrgClick}>
                 {appTheme.organizationWideLogo || appTheme.organizationLogo ? (
-                    <img
-                        className={css["logo"]}
-                        src={appTheme.organizationWideLogo || appTheme.organizationLogo}
-                        alt={lf("{0} Logo", appTheme.organization)}
-                    />
+                    <>
+                        {appTheme.organizationWideLogo && <img
+                            className={classList(css["logo"], "min-lg")}
+                            src={appTheme.organizationWideLogo}
+                            alt={lf("{0} Logo", appTheme.organization)}
+                        />}
+                        {appTheme.organizationLogo && <img
+                            className={classList(css["logo"], "max-lg")}
+                            src={appTheme.organizationLogo}
+                            alt={lf("{0} Logo", appTheme.organization)}
+                        />}
+                    </>
                 ) : (
                     <span className="name">{appTheme.organization}</span>
                 )}
@@ -65,11 +80,18 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
                         </span>,
                     ]
                 ) : appTheme.logo || appTheme.portraitLogo ? (
-                    <img
-                        className={css["logo"]}
-                        src={appTheme.logo || appTheme.portraitLogo}
-                        alt={lf("{0} Logo", appTheme.boardName)}
-                    />
+                    <>
+                        {appTheme.logo && <img
+                            className={classList(css["logo"], "min-md")}
+                            src={appTheme.logo}
+                            alt={lf("{0} Logo", appTheme.boardName)}
+                        />}
+                        {appTheme.portraitLogo && <img
+                            className={classList(css["logo"], "max-md")}
+                            src={appTheme.portraitLogo}
+                            alt={lf("{0} Logo", appTheme.boardName)}
+                        />}
+                    </>
                 ) : (
                     <span className={css["name"]}>{appTheme.boardName}</span>
                 )}
@@ -154,6 +176,15 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
             <div className={css["left-menu"]}>
                 {getOrganizationLogo()}
                 {getTargetLogo()}
+            </div>
+
+            <div className={css["centered-panel"]}>
+                <div className={classList(css["app-title"], "min-md")}>{Strings.AppTitle}
+                    {betaTag()}
+                </div>
+                <div className={classList(css["app-title"], "max-md min-sm")}>{Strings.AppTitleShort}
+                    {betaTag()}
+                </div>
             </div>
 
             <div className={css["right-menu"]}>{getUserMenu()}</div>

--- a/teachertool/src/components/HeaderBar.tsx
+++ b/teachertool/src/components/HeaderBar.tsx
@@ -45,12 +45,12 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
                 {appTheme.organizationWideLogo || appTheme.organizationLogo ? (
                     <>
                         {appTheme.organizationWideLogo && <img
-                            className={classList(css["logo"], "min-lg")}
+                            className={classList(css["logo"], "min-sm")}
                             src={appTheme.organizationWideLogo}
                             alt={lf("{0} Logo", appTheme.organization)}
                         />}
                         {appTheme.organizationLogo && <img
-                            className={classList(css["logo"], "max-lg")}
+                            className={classList(css["logo"], "max-sm")}
                             src={appTheme.organizationLogo}
                             alt={lf("{0} Logo", appTheme.organization)}
                         />}
@@ -82,12 +82,12 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
                 ) : appTheme.logo || appTheme.portraitLogo ? (
                     <>
                         {appTheme.logo && <img
-                            className={classList(css["logo"], "min-md")}
+                            className={classList(css["logo"], "min-2sm")}
                             src={appTheme.logo}
                             alt={lf("{0} Logo", appTheme.boardName)}
                         />}
                         {appTheme.portraitLogo && <img
-                            className={classList(css["logo"], "max-md")}
+                            className={classList(css["logo"], "max-2sm")}
                             src={appTheme.portraitLogo}
                             alt={lf("{0} Logo", appTheme.boardName)}
                         />}
@@ -179,10 +179,10 @@ export const HeaderBar: React.FC<HeaderBarProps> = () => {
             </div>
 
             <div className={css["centered-panel"]}>
-                <div className={classList(css["app-title"], "min-md")}>{Strings.AppTitle}
+                <div className={classList(css["app-title"], "min-sm")}>{Strings.AppTitle}
                     {betaTag()}
                 </div>
-                <div className={classList(css["app-title"], "max-md min-sm")}>{Strings.AppTitleShort}
+                <div className={classList(css["app-title"], "min-2xs max-sm")}>{Strings.AppTitleShort}
                     {betaTag()}
                 </div>
             </div>

--- a/teachertool/src/components/styling/HeaderBar.module.scss
+++ b/teachertool/src/components/styling/HeaderBar.module.scss
@@ -42,6 +42,22 @@
         }
     }
 
+    .centered-panel {
+        position: absolute;
+        justify-content: center;
+        align-items: center;
+        display: flex;
+        width: 100%;
+
+        div.app-title {
+            position: relative;
+            justify-content: center;
+            align-items: center;
+            font-size: 1.25rem;
+            text-align: center;
+        }
+    }
+
     .user-menu {
         height: 100%;
         display: flex;
@@ -76,4 +92,17 @@
             }
         }
     }
+}
+
+.beta-tag {
+    text-transform: uppercase;
+    position: absolute;
+    top: 3px;
+    right: -50px;
+    background-color: var(--pxt-success);
+    color: black;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: bold;
 }

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -1,4 +1,6 @@
 export namespace Strings {
+    export const AppTitle = lf("Code Evaluation");
+    export const AppTitleShort = lf("Code Eval");
     export const ErrorLoadingChecklistMsg = lf("That wasn't a valid checklist.");
     export const ConfirmReplaceChecklistMsg = lf("This will replace your current checklist. Continue?");
     export const UntitledProject = lf("Untitled Project");

--- a/teachertool/src/global.scss
+++ b/teachertool/src/global.scss
@@ -139,78 +139,104 @@ code {
 /****  BREAKPOINT QUERIES  *****/
 /*******************************/
 
-// Composable breakpoints
+// Composable breakpoints, aligned to react-common breakpoint sizes (see https://github.com/microsoft/pxt/blob/master/react-common/styles/react-common-breakpoints.less)
 
+// Become visible at the given breakpoint
 .min-xl,
-.max-xl,
 .min-lg,
-.max-lg,
 .min-md,
-.max-md,
 .min-sm,
-.max-sm,
+.min-2sm,
 .min-xs,
-.max-xs {
+.min-2xs {
+    display: initial;
+}
+// Become invisible at the given breakpoint
+.max-xl,
+.max-lg,
+.max-md,
+.max-sm,
+.max-2sm,
+.max-xs,
+.max-2xs {
     display: initial;
 }
 
-// becomes visible at width >= 1024px
-@media (min-width: 1024px) {
+$smallMobileBreakpoint: 240px;
+$mobileBreakpoint: 320px;
+$smallTabletBreakpoint: 480px;
+$tabletBreakpoint: 768px;
+$computerBreakpoint: 992px;
+$largeMonitorBreakpoint: 1200px;
+$widescreenMonitorBreakpoint: 1920px;
+
+@media (min-width: $widescreenMonitorBreakpoint) {
     .max-xl {
         display: none !important;
     }
 }
-// becomes visible at width < 1024px
-@media (max-width: 1023.98px) {
-    .min-xl {
-        display: none !important;
-    }
-}
-// becomes visible at width >= 720px
-@media (min-width: 720px) {
+@media (min-width: $largeMonitorBreakpoint) {
     .max-lg {
         display: none !important;
     }
 }
-// becomes visible at width < 720px
-@media (max-width: 719.98px) {
-    .min-lg {
-        display: none !important;
-    }
-}
-// becomes visible at width >= 480px
-@media (min-width: 480px) {
+@media (min-width: $computerBreakpoint) {
     .max-md {
         display: none !important;
     }
 }
-// becomes visible at width < 480px
-@media (max-width: 479.98px) {
-    .min-md {
-        display: none !important;
-    }
-}
-// becomes visible at width >= 240px
-@media (min-width: 240px) {
+@media (min-width: $tabletBreakpoint) {
     .max-sm {
         display: none !important;
     }
 }
-// becomes visible at width < 240px
-@media (max-width: 239.98px) {
-    .min-sm {
+@media (min-width: $smallTabletBreakpoint) {
+    .max-2sm {
         display: none !important;
     }
 }
-// becomes visible at width >= 240px
-@media (min-width: 240px) {
+@media (min-width: $mobileBreakpoint) {
     .max-xs {
         display: none !important;
     }
 }
-// becomes visible at width < 240px
-@media (max-width: 239.98px) {
+@media (min-width: $smallMobileBreakpoint) {
+    .max-2xs {
+        display: none !important;
+    }
+}
+@media (max-width: ($widescreenMonitorBreakpoint - 0.02px)) {
+    .min-xl {
+        display: none !important;
+    }
+}
+@media (max-width: ($largeMonitorBreakpoint - 0.02px)) {
+    .min-lg {
+        display: none !important;
+    }
+}
+@media (max-width: ($computerBreakpoint - 0.02px)) {
+    .min-md {
+        display: none !important;
+    }
+}
+@media (max-width: ($tabletBreakpoint - 0.02px)) {
+    .min-sm {
+        display: none !important;
+    }
+}
+@media (max-width: ($smallTabletBreakpoint - 0.02px)) {
+    .min-2sm {
+        display: none !important;
+    }
+}
+@media (max-width: ($mobileBreakpoint - 0.02px)) {
     .min-xs {
+        display: none !important;
+    }
+}
+@media (max-width: ($smallMobileBreakpoint - 0.02px)) {
+    .min-2xs {
         display: none !important;
     }
 }

--- a/teachertool/src/global.scss
+++ b/teachertool/src/global.scss
@@ -136,6 +136,86 @@ code {
 }
 
 /*******************************/
+/****  BREAKPOINT QUERIES  *****/
+/*******************************/
+
+// Composable breakpoints
+
+.min-xl,
+.max-xl,
+.min-lg,
+.max-lg,
+.min-md,
+.max-md,
+.min-sm,
+.max-sm,
+.min-xs,
+.max-xs {
+    display: initial;
+}
+
+// becomes visible at width >= 1024px
+@media (min-width: 1024px) {
+    .max-xl {
+        display: none !important;
+    }
+}
+// becomes visible at width < 1024px
+@media (max-width: 1023.98px) {
+    .min-xl {
+        display: none !important;
+    }
+}
+// becomes visible at width >= 720px
+@media (min-width: 720px) {
+    .max-lg {
+        display: none !important;
+    }
+}
+// becomes visible at width < 720px
+@media (max-width: 719.98px) {
+    .min-lg {
+        display: none !important;
+    }
+}
+// becomes visible at width >= 480px
+@media (min-width: 480px) {
+    .max-md {
+        display: none !important;
+    }
+}
+// becomes visible at width < 480px
+@media (max-width: 479.98px) {
+    .min-md {
+        display: none !important;
+    }
+}
+// becomes visible at width >= 240px
+@media (min-width: 240px) {
+    .max-sm {
+        display: none !important;
+    }
+}
+// becomes visible at width < 240px
+@media (max-width: 239.98px) {
+    .min-sm {
+        display: none !important;
+    }
+}
+// becomes visible at width >= 240px
+@media (min-width: 240px) {
+    .max-xs {
+        display: none !important;
+    }
+}
+// becomes visible at width < 240px
+@media (max-width: 239.98px) {
+    .min-xs {
+        display: none !important;
+    }
+}
+
+/*******************************/
 /****  NOTIFICATION STYLING  ***/
 /*******************************/
 


### PR DESCRIPTION
This change adds a beta tag to the code evaluation tool. To give the tag a place to anchor, I included the app title in the header bar, which also aligns with previous feedback. However, since the title is wide and doesn't fit well on small screens, I defined standard media breakpoints to allow the header layout to be responsive. If the teacher tool already has a set of generic breakpoints, I'll use those; otherwise, these breakpoints can be adopted across the app when we address responsiveness.

The design of these breakpoints is somewhat unique in that they're composable.

Test target: https://makecode.microbit.org/app/cf32d5a03e863c227a7d4bee10b3b9193dc75b08-0e9e16aba4--eval

Header layouts at different widths:
![image](https://github.com/user-attachments/assets/5243b770-3a59-40a9-a5e5-a4066d34dc08)
![image](https://github.com/user-attachments/assets/ffbaa45c-a987-4610-83ae-da8f38cdd814)
![image](https://github.com/user-attachments/assets/2c88e517-77fc-4721-8cae-69e3b4ec1d31)

Fixes https://github.com/microsoft/pxt-microbit/issues/5743
