### PR TITLE
Teacher Tool: Show N/A in Print View

### DIFF
--- a/teachertool/src/components/CriteriaEvalResultDropdown.tsx
+++ b/teachertool/src/components/CriteriaEvalResultDropdown.tsx
@@ -54,7 +54,7 @@ export const CriteriaEvalResultDropdown: React.FC<CriteriaEvalResultProps> = ({ 
         <Dropdown
             id="project-eval-result-dropdown"
             selectedId={selectedResult}
-            className={classList("rounded", selectedResult, selectedResult === "notevaluated" ? "no-print" : undefined)}
+            className={classList("rounded", selectedResult)}
             items={dropdownItems}
             onItemSelected={id => setEvalResultOutcome(criteriaId, itemIdToCriteriaResult[id])}
         />


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5625

We had originally hidden this by design, but it caused some confusion so let's just show it for now. Can adjust again later if we get feedback on it.

Print view with N/A shown:
![image](https://github.com/user-attachments/assets/b0d5ad7f-f25e-41bf-9f8d-29a639bd06bc)
