### PR TITLE
Show Error on Failed Criteria Evaluation

### DIFF
--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -48,10 +48,9 @@ interface CriteriaResultErrorProps {
     error: string;
 }
 const CriteriaResultError: React.FC<CriteriaResultErrorProps> = ({ error }) => {
-    // Display an X icon and the error message in a faint red box
     return (
         <div className={css["result-error"]}>
-            <i className="fas fa-times-circle"></i>
+            <i className="fas fa-exclamation-circle"></i>
             <div className={css["error-info-container"]}>
                 <span className={css["error-title"]}>{Strings.UnableToEvaluate}</span>
                 <span className={css["error-details"]}>{error}</span>

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -15,7 +15,6 @@ import { CriteriaInstanceDisplay } from "./CriteriaInstanceDisplay";
 import { runSingleEvaluateAsync } from "../transforms/runSingleEvaluateAsync";
 import { removeCriteriaFromChecklist } from "../transforms/removeCriteriaFromChecklist";
 import { Button } from "react-common/components/controls/Button";
-import { clearEvalResult } from "../state/actions";
 import { setEvalResult } from "../transforms/setEvalResult";
 
 interface CriteriaResultNotesProps {

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -52,7 +52,7 @@ interface CriteriaResultErrorProps {
 
 const CriteriaResultError: React.FC<CriteriaResultErrorProps> = ({ criteriaInstanceId, error }) => {
     return (
-        <div className={css["result-error"]}>
+        <div className={classList(css["result-error"], "no-print")}>
             <i className="fas fa-exclamation-circle"></i>
             <div className={css["error-info-container"]}>
                 <span className={css["error-title"]}>{Strings.UnableToEvaluate}</span>

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -15,6 +15,8 @@ import { CriteriaInstanceDisplay } from "./CriteriaInstanceDisplay";
 import { runSingleEvaluateAsync } from "../transforms/runSingleEvaluateAsync";
 import { removeCriteriaFromChecklist } from "../transforms/removeCriteriaFromChecklist";
 import { Button } from "react-common/components/controls/Button";
+import { clearEvalResult } from "../state/actions";
+import { setEvalResult } from "../transforms/setEvalResult";
 
 interface CriteriaResultNotesProps {
     criteriaId: string;
@@ -45,9 +47,11 @@ const CriteriaResultNotes: React.FC<CriteriaResultNotesProps> = ({ criteriaId })
 };
 
 interface CriteriaResultErrorProps {
+    criteriaInstanceId: string;
     error: string;
 }
-const CriteriaResultError: React.FC<CriteriaResultErrorProps> = ({ error }) => {
+
+const CriteriaResultError: React.FC<CriteriaResultErrorProps> = ({ criteriaInstanceId, error }) => {
     return (
         <div className={css["result-error"]}>
             <i className="fas fa-exclamation-circle"></i>
@@ -55,9 +59,17 @@ const CriteriaResultError: React.FC<CriteriaResultErrorProps> = ({ error }) => {
                 <span className={css["error-title"]}>{Strings.UnableToEvaluate}</span>
                 <span className={css["error-details"]}>{error}</span>
             </div>
+            <Button
+                className={css["dismiss-button"]}
+                leftIcon="fas fa-times-circle"
+                title={Strings.Dismiss}
+                onClick={() =>
+                    setEvalResult(criteriaInstanceId, { result: EvaluationStatus.NotStarted, error: undefined })
+                }
+            />
         </div>
     );
-}
+};
 
 const CriteriaResultToolbarTray: React.FC<{ criteriaId: string }> = ({ criteriaId }) => {
     const { state: teacherTool } = useContext(AppStateContext);
@@ -128,7 +140,7 @@ export const CriteriaResultEntry: React.FC<CriteriaResultEntryProps> = ({ criter
                     {isInProgress ? (
                         <ThreeDotsLoadingDisplay className={css["loading-display"]} />
                     ) : hasError ? (
-                        <CriteriaResultError error={evalResult.error!} />
+                        <CriteriaResultError criteriaInstanceId={criteriaInstance.instanceId} error={evalResult.error!} />
                     ) : (
                         <div className={classList(css["result-notes"], !hasFeedback ? "no-print" : undefined)}>
                             <CriteriaResultNotes criteriaId={criteriaId} />

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -44,6 +44,22 @@ const CriteriaResultNotes: React.FC<CriteriaResultNotesProps> = ({ criteriaId })
     );
 };
 
+interface CriteriaResultErrorProps {
+    error: string;
+}
+const CriteriaResultError: React.FC<CriteriaResultErrorProps> = ({ error }) => {
+    // Display an X icon and the error message in a faint red box
+    return (
+        <div className={css["result-error"]}>
+            <i className="fas fa-times-circle"></i>
+            <div className={css["error-info-container"]}>
+                <span className={css["error-title"]}>{Strings.UnableToEvaluate}</span>
+                <span className={css["error-details"]}>{error}</span>
+            </div>
+        </div>
+    );
+}
+
 const CriteriaResultToolbarTray: React.FC<{ criteriaId: string }> = ({ criteriaId }) => {
     const { state: teacherTool } = useContext(AppStateContext);
 
@@ -86,6 +102,7 @@ export const CriteriaResultEntry: React.FC<CriteriaResultEntryProps> = ({ criter
     const evalResult: CriteriaResult | undefined = teacherTool.evalResults[criteriaId];
     const evalStatus = evalResult ? evalResult.result : EvaluationStatus.NotStarted;
     const hasFeedback = !!evalResult?.notes;
+    const hasError = !!evalResult?.error;
 
     const criteriaInstance = getCriteriaInstanceWithId(teacherTool, criteriaId);
     const catalogCriteria = criteriaInstance ? getCatalogCriteriaWithId(criteriaInstance.catalogCriteriaId) : undefined;
@@ -108,9 +125,11 @@ export const CriteriaResultEntry: React.FC<CriteriaResultEntryProps> = ({ criter
                         )}
                     </div>
 
-                    {/* Notes */}
+                    {/* Notes & Errors */}
                     {isInProgress ? (
                         <ThreeDotsLoadingDisplay className={css["loading-display"]} />
+                    ) : hasError ? (
+                        <CriteriaResultError error={evalResult.error!} />
                     ) : (
                         <div className={classList(css["result-notes"], !hasFeedback ? "no-print" : undefined)}>
                             <CriteriaResultNotes criteriaId={criteriaId} />

--- a/teachertool/src/components/styling/EvalResultDisplay.module.scss
+++ b/teachertool/src/components/styling/EvalResultDisplay.module.scss
@@ -107,6 +107,7 @@
         flex-direction: row;
         align-items: center;
         justify-content: flex-start;
+        position: relative;
         width: 100%;
         padding: 0.5rem;
         border: 1px solid var(--pxt-error);
@@ -126,6 +127,21 @@
 
             .error-details {
                 font-weight: 500;
+            }
+        }
+
+        .dismiss-button {
+            position: absolute;
+            top: 0.5rem;
+            right: 0;
+            background-color: transparent;
+            border-radius: 100%;
+            margin: 0;
+            padding: 0;
+            font-size: 1rem;
+
+            &:hover {
+                font-size: 1.2rem;
             }
         }
     }

--- a/teachertool/src/components/styling/EvalResultDisplay.module.scss
+++ b/teachertool/src/components/styling/EvalResultDisplay.module.scss
@@ -102,6 +102,34 @@
         align-self: flex-end;
     }
 
+    .result-error {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-start;
+        width: 100%;
+        padding: 0.5rem;
+        border: 1px solid var(--pxt-error);
+        border-radius: 1rem;
+        background-color: var(--pxt-error-background);
+        gap: 0.5rem;
+
+        .error-info-container {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            justify-content: space-between;
+
+            .error-title {
+                font-weight: 600;
+            }
+
+            .error-details {
+                font-weight: 500;
+            }
+        }
+    }
+
     &:focus-within,
     &:hover,
     &:focus {

--- a/teachertool/src/components/styling/EvalResultDisplay.module.scss
+++ b/teachertool/src/components/styling/EvalResultDisplay.module.scss
@@ -120,6 +120,7 @@
             flex-direction: column;
             align-items: flex-start;
             justify-content: space-between;
+            overflow: hidden;
 
             .error-title {
                 font-weight: 600;

--- a/teachertool/src/components/styling/EvalResultDisplay.module.scss
+++ b/teachertool/src/components/styling/EvalResultDisplay.module.scss
@@ -132,16 +132,15 @@
 
         .dismiss-button {
             position: absolute;
-            top: 0.5rem;
-            right: 0;
+            top: 0.6rem;
+            right: 0.1rem;
             background-color: transparent;
             border-radius: 100%;
             margin: 0;
             padding: 0;
-            font-size: 1rem;
 
-            &:hover {
-                font-size: 1.2rem;
+            i:hover {
+                scale: 1.1;
             }
         }
     }

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -48,6 +48,7 @@ export namespace Strings {
     export const EvaluateChecklist = lf("Evaluate checklist");
     export const UnableToEvaluate = lf("Unable to evaluate");
     export const UnableToReachAI = lf("Unable to reach the AI");
+    export const Dismiss = lf("Dismiss");
 }
 
 export namespace Ticks {

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -46,6 +46,8 @@ export namespace Strings {
     export const RenameChecklist = lf("Rename checklist");
     export const PrintChecklist = lf("Print checklist");
     export const EvaluateChecklist = lf("Evaluate checklist");
+    export const UnableToEvaluate = lf("Unable to evaluate");
+    export const UnableToReachAI = lf("Unable to reach the AI");
 }
 
 export namespace Ticks {

--- a/teachertool/src/services/backendRequests.ts
+++ b/teachertool/src/services/backendRequests.ts
@@ -1,3 +1,4 @@
+import { Strings } from "../constants";
 import { stateAndDispatch } from "../state";
 import { ErrorCode } from "../types/errorCode";
 import { logError } from "./loggingService";
@@ -106,11 +107,12 @@ export async function askCopilotQuestionAsync(shareId: string, question: string)
         });
 
         if (!request.ok) {
-            throw new Error("Unable to reach Copilot");
+            throw new Error(Strings.UnableToReachAI);
         }
         result = await request.json();
     } catch (e) {
         logError(ErrorCode.askCopilotQuestion, e);
+        throw e; // We will catch this upstream so we can show the error
     }
 
     return result;

--- a/teachertool/src/transforms/mergeEvalResult.ts
+++ b/teachertool/src/transforms/mergeEvalResult.ts
@@ -7,6 +7,10 @@ export function mergeEvalResult(criteriaInstanceId: string, outcome?: Evaluation
     const { state: teacherTool, dispatch } = stateAndDispatch();
 
     const newCriteriaEvalResult = { ...teacherTool.evalResults[criteriaInstanceId] };
+
+    // Clear any errors from the previous result.
+    newCriteriaEvalResult.error = undefined;
+
     if (outcome !== undefined) {
         newCriteriaEvalResult.result = outcome;
     }

--- a/teachertool/src/types/criteria.ts
+++ b/teachertool/src/types/criteria.ts
@@ -47,4 +47,5 @@ export enum EvaluationStatus {
 export interface CriteriaResult {
     result: EvaluationStatus;
     notes?: string;
+    error?: string;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5819

If a criterion fails to evaluate through a non-user error (i.e. we can't reach the AI service), we don't really provide any indication of the issue to the user, it just shows no result.

With this change, we show an error window:
![image](https://github.com/user-attachments/assets/bdbee3e8-646b-4748-bfcb-04a6f15cad84)

Upload target (easy to get an error by using "Ask AI", since ai endpoint doesn't exist yet): https://makecode.microbit.org/app/d51851820874badb8277c7a4bf73ce82ff4bf5f9-eb19b40cfa--eval?tc=1