### PR TITLE
Poll for compile variant hex files in parallel

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5939,8 +5939,19 @@ document.addEventListener("DOMContentLoaded", async () => {
         return epkg.tilemapProject;
     }
 
-    pxt.hexloader.showLoading = (msg) => core.showLoading("hexcloudcompiler", msg);
-    pxt.hexloader.hideLoading = () => core.hideLoading("hexcloudcompiler");
+    let loadCount = 0;
+    pxt.hexloader.showLoading = (msg) => {
+        loadCount++;
+        if (loadCount === 1) {
+            core.showLoading("hexcloudcompiler", msg);
+        }
+    };
+    pxt.hexloader.hideLoading = () => {
+        loadCount--;
+        if (loadCount === 0) {
+            core.hideLoading("hexcloudcompiler");
+        }
+    };
     pxt.docs.requireMarked = () => require("marked");
 
     // allow static web site to specify custom backend


### PR DESCRIPTION
One benefit of the new compile service is that it can now execute compile jobs in parallel. This PR takes advantage of that feature and makes it so that when hitting the compile service for micro:bit, we request the compiling of both the V1 and V2 hexes at the same time.

In other words, it should cut the CPP compile time in half (but only for micro:bit, since it's the only "fat hex" target).

I'm planning on doing the same thing with our CLI builds in the near future, which should speed up `pxt buildtarget` significantly for targets with multiple compile variants.