### PR TITLE
Teacher Tool: More Visual Feedback on Evaluation

### DIFF
--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -195,6 +195,7 @@ const CatalogList: React.FC = () => {
                                     catalogCriteria={c}
                                     recentlyAddedIds={recentlyAddedIds}
                                     onItemClicked={onItemClicked}
+                                    key={`catalog-item-${c.id}`}
                                 />
                             ))}
                         </Accordion.Panel>

--- a/teachertool/src/style.overrides/Button.scss
+++ b/teachertool/src/style.overrides/Button.scss
@@ -47,7 +47,10 @@
     border: solid 1px var(--pxt-page-foreground);
 
     .common-button-flex {
-        padding: 0.75rem;
+        padding: 0.65rem;
+        display: flex;
+        align-items: center;
+        height: 100%;
     }
 
     @media print {
@@ -57,7 +60,7 @@
 
         text-align: center;
         padding-right: 8px;
-        border: none;
+        border: none !important;
 
         .common-button-label {
             border-bottom: 1px solid var(--pxt-page-foreground);
@@ -66,9 +69,9 @@
 }
 
 .fail > .common-button.common-dropdown-button {
-    //background-color: var(--pxt-warning);
+    border: 3px solid var(--pxt-warning);
 }
 
 .pass > .common-button.common-dropdown-button {
-    //background-color: var(--pxt-success);
+    border: 3px solid var(--pxt-success-accent);
 }

--- a/teachertool/src/transforms/runEvaluateAsync.ts
+++ b/teachertool/src/transforms/runEvaluateAsync.ts
@@ -28,6 +28,8 @@ export async function runEvaluateAsync(fromUserInteraction: boolean) {
             showToast(makeToast("error", lf("Unable to run evaluation")));
         } else if (errorCount > 0) {
             showToast(makeToast("error", lf("Unable to evaluate some criteria")));
+        } else {
+            showToast(makeToast("success", lf("Evaluation complete")));
         }
     }
 }


### PR DESCRIPTION
This adds two additional points of feedback when evaluation is done. It colors the borders of the result (since we got rid of the background colors). There's also a success toast that shows if evaluation was done through user interaction (not auto-run).

Also includes small bug fix to add missing key to criteria elements in the catalog.

![image](https://github.com/user-attachments/assets/0ecda274-3570-462b-9c3f-2326f28d434f)

Upload target: https://makecode.microbit.org/app/ee74f3fe2b38baaaad633e6599a962c6642ee0a9-a4d5ebb2c1--eval