### PR TITLE
Add the template code to the first custom file created, no matter the name

### DIFF
--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -362,11 +362,13 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                 return Promise.resolve()
             }
             let fileText = "";
-            if (fileName == customFile) {
+            const tsFiles = pkgCfg.files.filter(f => f.endsWith(".ts"));
+            // if the length is 1, the only ts file is main.ts, thus
+            // we are adding the first custom file to the project
+            if (tsFiles.length === 1) {
                 fileText = customFileHeader(pxt.appTarget.appTheme.homeUrl) + customFileText;
             } else if (comment) {
-                fileText = `${comment} ${commentText}
-`;
+                fileText = `${comment} ${commentText}`;
             }
 
             return this.props.parent.updateFileAsync(fileName, fileText, true);

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -362,13 +362,14 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                 return Promise.resolve()
             }
             let fileText = "";
-            const tsFiles = pkgCfg.files.filter(f => f.endsWith(".ts"));
+            const tsFiles = pkgCfg.files.filter(f => f.endsWith(".ts") && !f.endsWith(".g.ts"));
             // if the length is 1, the only ts file is main.ts, thus
             // we are adding the first custom file to the project
             if (tsFiles.length === 1) {
                 fileText = customFileHeader(pxt.appTarget.appTheme.homeUrl) + customFileText;
             } else if (comment) {
-                fileText = `${comment} ${commentText}`;
+                fileText = `${comment} ${commentText}
+`;
             }
 
             return this.props.parent.updateFileAsync(fileName, fileText, true);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5367

It's frustrating to not have something to work off of if it's your first time creating custom blocks. Including our "creating blocks" template should not depend on that file's name being `custom.ts`. However, for those that are making a lot of custom blocks, having a template in every new file that you make would be frustrating to deal with. Thus, we've changed it so that we are no longer special casing `custom.ts`. For the first custom file that you make, no matter the name, the template will be included in that file. Any subsequent custom files made will have the `Add your code here` comment as is the current behavior.

Upload target: https://makecode.microbit.org/app/6b84da6b59b4491ed7055b51c377ce774d5774e0-f63aae8ed5