### PR TITLE
Use an id when setting blockly warnings

### DIFF
--- a/pxtblocks/compiler/compiler.ts
+++ b/pxtblocks/compiler/compiler.ts
@@ -25,6 +25,8 @@ interface CommentMap {
     idToComments: pxt.Map<Blockly.comments.RenderedWorkspaceComment[]>;
 }
 
+export const PXT_WARNING_ID = "WARNING_MESSAGE"
+
 
 export function compileBlockAsync(b: Blockly.Block, blockInfo: pxtc.BlocksInfo): Promise<BlockCompilationResult> {
     const w = b.workspace;
@@ -185,7 +187,7 @@ function compileWorkspace(e: Environment, w: Blockly.Workspace, blockInfo: pxtc.
     } catch (err) {
         let be: Blockly.Block = (err as any).block;
         if (be) {
-            be.setWarningText(err + "");
+            be.setWarningText(err + "", PXT_WARNING_ID);
             e.errors.push(be);
         }
         else {

--- a/pxtblocks/compiler/typeChecker.ts
+++ b/pxtblocks/compiler/typeChecker.ts
@@ -4,6 +4,7 @@ import { Point, Environment, VarInfo, Scope, PlaceholderLikeBlock, StdFunc } fro
 import { countOptionals, getFunctionName, getInputTargetBlock, getLoopVariableField, isMutatingBlock, visibleParams } from "./util";
 import { getDefinition } from "../plugins/functions";
 import { CommonFunctionBlock } from "../plugins/functions/commonFunctionMixin";
+import { PXT_WARNING_ID } from "./compiler";
 
 interface DeclaredVariable {
     name: string;
@@ -174,7 +175,7 @@ export function infer(allBlocks: Blockly.Block[], e: Environment, w: Blockly.Wor
             }
         } catch (err) {
             const be = ((<any>err).block as Blockly.Block) || b;
-            be.setWarningText(err + "");
+            be.setWarningText(err + "", PXT_WARNING_ID);
             e.errors.push(be);
         }
     });

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1106,7 +1106,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         // clear previous warnings on non-disabled blocks
         this.editor.getAllBlocks(false).filter(b => b.isEnabled()).forEach((b: Blockly.BlockSvg) => {
-            b.setWarningText(null);
+            b.setWarningText(null, pxtblockly.PXT_WARNING_ID);
             setHighlightWarning(b, false);
         });
         let tsfile = file && file.epkg && file.epkg.files[file.getVirtualFileName(pxt.JAVASCRIPT_PROJECT_NAME)];
@@ -1122,7 +1122,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 let b = this.editor.getBlockById(bid) as Blockly.BlockSvg;
                 if (b) {
                     let txt = ts.pxtc.flattenDiagnosticMessageText(diag.messageText, "\n");
-                    b.setWarningText(txt);
+                    b.setWarningText(txt, pxtblockly.PXT_WARNING_ID);
                     setHighlightWarning(b, true);
                 }
             }
@@ -1133,7 +1133,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 let b = this.editor.getBlockById(d.blockId) as Blockly.BlockSvg;
 
                 if (b) {
-                    b.setWarningText(d.message);
+                    b.setWarningText(d.message, pxtblockly.PXT_WARNING_ID);
                     setHighlightWarning(b, true);
                 }
             }
@@ -1155,7 +1155,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.editor.highlightBlock(bid);
                 if (brk) {
                     const b = this.editor.getBlockById(bid) as Blockly.BlockSvg;
-                    b.setWarningText(brk ? brk.exceptionMessage : undefined);
+                    b.setWarningText(brk ? brk.exceptionMessage : undefined, pxtblockly.PXT_WARNING_ID);
                     // ensure highlight is in the screen when a breakpoint info is available
                     // TODO: make warning mode look good
                     // b.setHighlightWarning(brk && !!brk.exceptionMessage);


### PR DESCRIPTION
Blockly lets you set multiple warnings on a block at once by giving them different ids. This PR sets an id for all of the core pxt warning messages so that field editors can contribute additional warnings without them being clobbered the next time we run a type check.