### PR TITLE
add editor event when a new serviceworker is registered

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -99,6 +99,7 @@ declare namespace pxt.editor {
         | "info" // return info data`
         | "tutorialevent"
         | "editorcontentloaded"
+        | "serviceworkerregistered"
         | "runeval"
 
         // package extension messasges

--- a/webapp/src/appcache.ts
+++ b/webapp/src/appcache.ts
@@ -1,5 +1,6 @@
 import * as core from "./core";
 import * as cmds from "./cmds";
+import { postHostMessageAsync } from "../../pxteditor";
 
 export function init(updated: () => void) {
     if ("serviceWorker" in navigator
@@ -37,6 +38,10 @@ export function init(updated: () => void) {
     }
 
     function scheduleUpdate() {
+        postHostMessageAsync({
+            action: "serviceworkerregistered",
+            type: "pxteditor"
+        });
         if (pxt.appTarget.appTheme && pxt.appTarget.appTheme.noReloadOnUpdate)
             return;
         core.infoNotification(lf("Update download complete. Reloading... "));


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5824

turns out we already have an [appTheme flag](https://github.com/microsoft/pxt/blob/39fe06ad93b7e6b639f7b228db967a74f0ac89ea/localtypings/pxtarget.d.ts#L414) that prevents us from reloading when we get a serviceworker update. this pr adds a new editor event to compliment that flag which is fired when a new serviceworker is registered so that the page hosting the editor in an iframe can handle the refresh themselves instead of getting surprised.

@thsparks for the code eval tool, I recommend that you:
* create a query variant in `pxtarget.json` that sets the `noReloadOnUpdate` flag
* use that query variant in your embedded url
* when you receive the new `serviceworkerregistered` message, either reload the frame in the background or ignore it. you can get information about the current editor version by using the `info` message, which should include the target version, pxt-core version, etc. and use that to decide if the editor is old enough to require a refresh.