### PR TITLE
Fix 'save a copy' time machine bugs

### DIFF
--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -870,6 +870,14 @@ export async function showTurnBackTimeDialogAsync(header: pxt.workspace.Header, 
     if (text?.[pxt.HISTORY_FILE]) {
         history = pxteditor.history.parseHistoryFile(text[pxt.HISTORY_FILE]);
     }
+    else {
+        history = {
+            entries: [],
+            snapshots: [],
+            shares: [],
+            lastSaveTime: Date.now()
+        };
+    }
 
     const loadProject = async (text: pxt.workspace.ScriptText, editorVersion: string) => {
         core.hideDialog();
@@ -895,10 +903,9 @@ export async function showTurnBackTimeDialogAsync(header: pxt.workspace.Header, 
             }
         }
 
-        if (text[pxt.HISTORY_FILE]) {
-            text[pxt.HISTORY_FILE] = JSON.stringify(newHistory);
-        }
-        const date = new Date(timestamp);
+        text[pxt.HISTORY_FILE] = JSON.stringify(newHistory);
+
+        const date = timestamp ? new Date(timestamp) : new Date();
 
         const dateString = date.toLocaleDateString(
             pxt.U.userLanguage(),


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5853

fixes three tiny bugs with the time machine dialog:
* when trying to save a copy from "Now", the project name would contain "invalid date" instead of a timestamp
* projects saved using the "save a copy" button weren't keeping around the project history from before the selected time
* opening the time machine dialog for a project with no history (e.g. you clicked the button too fast) would cause an exception