### PR TITLE
print layout improvements

### DIFF
--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -1,11 +1,10 @@
+import css from "./styling/CriteriaInstanceDisplay.module.scss";
 import { getCatalogCriteriaWithId } from "../state/helpers";
 import { CriteriaInstance, CriteriaParameterValue } from "../types/criteria";
 import { logDebug } from "../services/loggingService";
 import { setParameterValue } from "../transforms/setParameterValue";
 import { classList } from "react-common/components/util";
 import { getReadableBlockString, splitCriteriaTemplate } from "../utils";
-// eslint-disable-next-line import/no-internal-modules
-import css from "./styling/CriteriaInstanceDisplay.module.scss";
 import { useContext, useMemo, useState } from "react";
 import { Input } from "react-common/components/controls/Input";
 import { Button } from "react-common/components/controls/Button";
@@ -158,7 +157,10 @@ export const CriteriaInstanceDisplay: React.FC<CriteriaInstanceDisplayProps> = (
                     </span>
                 ))}
             </div>
-            <div className={css["criteria-description"]}>{catalogCriteria.description}</div>
+            <div className={classList(css["criteria-description"], "no-print")}>{catalogCriteria.description}</div>
+            <div className={classList(css["criteria-description"], css["for-print"], "only-print")}>
+                {catalogCriteria.description}
+            </div>
         </div>
     ) : null;
 };

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -23,7 +23,7 @@ interface CriteriaResultNotesProps {
 
 const CriteriaResultNotes: React.FC<CriteriaResultNotesProps> = ({ criteriaId }) => {
     const { state: teacherTool } = useContext(AppStateContext);
-    const notesInitialValue = teacherTool.evalResults[criteriaId]?.notes;
+    const notes = teacherTool.evalResults[criteriaId]?.notes;
 
     const onTextChange = (str: string) => {
         setEvalResultNotes(criteriaId, str);
@@ -37,16 +37,16 @@ const CriteriaResultNotes: React.FC<CriteriaResultNotesProps> = ({ criteriaId })
                     ariaLabel={lf("Feedback regarding the criteria result")}
                     label={lf("Feedback")}
                     title={lf("Write your notes here")}
-                    initialValue={notesInitialValue}
+                    initialValue={notes}
                     autoResize={true}
                     onChange={onTextChange}
                     autoComplete={false}
                     intervalMs={500}
                 />
             </div>
-            {notesInitialValue && (
+            {notes && (
                 <div className={classList(css["notes-container"], css["for-print"], "only-print")}>
-                    {notesInitialValue}
+                    {notes}
                 </div>
             )}
         </>

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -23,25 +23,33 @@ interface CriteriaResultNotesProps {
 
 const CriteriaResultNotes: React.FC<CriteriaResultNotesProps> = ({ criteriaId }) => {
     const { state: teacherTool } = useContext(AppStateContext);
+    const notesInitialValue = teacherTool.evalResults[criteriaId]?.notes;
 
     const onTextChange = (str: string) => {
         setEvalResultNotes(criteriaId, str);
     };
 
     return (
-        <div className={css["notes-container"]}>
-            <DebouncedTextarea
-                placeholder={lf("Write your notes here")}
-                ariaLabel={lf("Feedback regarding the criteria result")}
-                label={lf("Feedback")}
-                title={lf("Write your notes here")}
-                initialValue={teacherTool.evalResults[criteriaId]?.notes}
-                autoResize={true}
-                onChange={onTextChange}
-                autoComplete={false}
-                intervalMs={500}
-            />
-        </div>
+        <>
+            <div className={classList(css["notes-container"], "no-print")}>
+                <DebouncedTextarea
+                    placeholder={lf("Write your notes here")}
+                    ariaLabel={lf("Feedback regarding the criteria result")}
+                    label={lf("Feedback")}
+                    title={lf("Write your notes here")}
+                    initialValue={notesInitialValue}
+                    autoResize={true}
+                    onChange={onTextChange}
+                    autoComplete={false}
+                    intervalMs={500}
+                />
+            </div>
+            {notesInitialValue && (
+                <div className={classList(css["notes-container"], css["for-print"], "only-print")}>
+                    {notesInitialValue}
+                </div>
+            )}
+        </>
     );
 };
 

--- a/teachertool/src/components/styling/CriteriaInstanceDisplay.module.scss
+++ b/teachertool/src/components/styling/CriteriaInstanceDisplay.module.scss
@@ -159,5 +159,9 @@
         color: var(--pxt-page-foreground-light);
         margin-top: 0.2rem;
         width: -webkit-fill-available;
+
+        &.for-print {
+            font-style: italic;
+        }
     }
 }

--- a/teachertool/src/components/styling/EvalResultDisplay.module.scss
+++ b/teachertool/src/components/styling/EvalResultDisplay.module.scss
@@ -19,28 +19,29 @@
     font-size: 1rem;
     line-height: 2rem;
 
-    span[class*="common-button-flex"] {
+    span[class~="common-button-flex"] {
         display: flex;
         gap: 0.5rem;
         align-items: center;
     }
 
-    i[class*="fas"] {
+    i[class~="fas"] {
         margin: 0;
         width: auto;
         height: auto;
         font-size: unset;
     }
 
-    &[class*="disabled"] {
+    &[class~="disabled"] {
         border: 1px solid var(--pxt-button-secondary-accent) !important;
     }
 
-    @container (inline-size < 665px) {
-        span[class*="common-button-label"] {
-            display: none;
+    @container (inline-size < 645px) {
+        &:not([class~="common-button"][class~="primary"]) {
+            span[class~="common-button-label"] {
+                display: none !important;
+            }
         }
-       
     }
 }
 
@@ -50,12 +51,12 @@
     align-items: center;
     gap: 0.5rem;
 
-    div[class*="common-input-group"] {
+    div[class~="common-input-group"] {
         flex-grow: 1;
         height: unset;
     }
 
-    input[class*="common-input"] {
+    input[class~="common-input"] {
         // Need !important to override react-common/common-input-group's font-size specificity
         font-size: 1.5rem !important;
         font-weight: 500;
@@ -65,8 +66,8 @@
 }
 
 .edit-checklist-name-button {
-    margin: 0;   
-    padding: 0; 
+    margin: 0;
+    padding: 0;
     width: 1.75rem;
     height: 1.75rem;
     border-radius: 0.25rem;
@@ -90,7 +91,6 @@
     justify-content: flex-start;
     width: -webkit-fill-available;
     min-height: 9rem;
-    break-inside: avoid;
     gap: 0.5rem;
 
     .loading-display {
@@ -151,6 +151,7 @@
     &:focus {
         .result-toolbar-button {
             opacity: 1 !important;
+
             .disabled {
                 border: 1px solid var(--pxt-button-secondary-accent) !important;
                 opacity: 0.8 !important;
@@ -194,7 +195,7 @@
     // Need !important to override common-button's opacity in disabled state
     opacity: 0 !important;
 
-    span[class*="common-button-label"] {
+    span[class~="common-button-label"] {
         display: none;
     }
 }
@@ -203,6 +204,8 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    align-self: flex-start;
+    margin-top: 0.5rem;
 }
 
 .result-notes {
@@ -216,14 +219,20 @@
 
     .notes-container {
         width: 100%;
+        max-width: 100%;
         font-weight: 600;
+
+        &.for-print {
+            font-weight: normal;
+            white-space: pre-wrap;
+        }
     }
 
-    div[class*="common-input-wrapper"] {
+    div[class~="common-input-wrapper"] {
         width: 100%;
         font-weight: 500;
 
-        div[class*="common-input-group"] {
+        div[class~="common-input-group"] {
             min-height: 3rem;
             max-height: 5rem;
             border-radius: 0.5rem;

--- a/teachertool/src/global.scss
+++ b/teachertool/src/global.scss
@@ -110,6 +110,7 @@ code {
     border-radius: 99px;
     background-clip: padding-box;
     background-color: rgb(206, 205, 206);
+
     &:hover {
         // Style matching the standalone editor
         //background-color: rgb(187, 187, 187);
@@ -124,6 +125,10 @@ code {
 /*******************************/
 
 @media print {
+    * {
+        break-before: avoid;
+    }
+
     .no-print {
         display: none !important;
     }
@@ -151,6 +156,7 @@ code {
 .min-2xs {
     display: initial;
 }
+
 // Become invisible at the given breakpoint
 .max-xl,
 .max-lg,
@@ -175,66 +181,79 @@ $widescreenMonitorBreakpoint: 1920px;
         display: none !important;
     }
 }
+
 @media (min-width: $largeMonitorBreakpoint) {
     .max-lg {
         display: none !important;
     }
 }
+
 @media (min-width: $computerBreakpoint) {
     .max-md {
         display: none !important;
     }
 }
+
 @media (min-width: $tabletBreakpoint) {
     .max-sm {
         display: none !important;
     }
 }
+
 @media (min-width: $smallTabletBreakpoint) {
     .max-2sm {
         display: none !important;
     }
 }
+
 @media (min-width: $mobileBreakpoint) {
     .max-xs {
         display: none !important;
     }
 }
+
 @media (min-width: $smallMobileBreakpoint) {
     .max-2xs {
         display: none !important;
     }
 }
+
 @media (max-width: ($widescreenMonitorBreakpoint - 0.02px)) {
     .min-xl {
         display: none !important;
     }
 }
+
 @media (max-width: ($largeMonitorBreakpoint - 0.02px)) {
     .min-lg {
         display: none !important;
     }
 }
+
 @media (max-width: ($computerBreakpoint - 0.02px)) {
     .min-md {
         display: none !important;
     }
 }
+
 @media (max-width: ($tabletBreakpoint - 0.02px)) {
     .min-sm {
         display: none !important;
     }
 }
+
 @media (max-width: ($smallTabletBreakpoint - 0.02px)) {
     .min-2sm {
         display: none !important;
     }
 }
+
 @media (max-width: ($mobileBreakpoint - 0.02px)) {
     .min-xs {
         display: none !important;
     }
 }
+
 @media (max-width: ($smallMobileBreakpoint - 0.02px)) {
     .min-2xs {
         display: none !important;


### PR DESCRIPTION
**Improvements to print layout**
- Animation-based resize of notes textarea wasn't reflowing properly in print preview. Fixed by showing a div in this view instead of the textarea.
- Prevent insertion of page breaks before notes if feedback runs over a page, as this was causing insertion of blank pages.

**Other tweaks**
- Format criteria description in italics in print preview. Without this distinction it looked like it was part of the feedback notes.
- Don't hide label of the Evaluate button on narrow panels. The removal of autorun allowed for this button to remain prominent.
- prettier

![image](https://github.com/user-attachments/assets/98a60486-991c-4688-9a8b-40808d4fe2fb)

![image](https://github.com/user-attachments/assets/8756f7ed-5c42-438a-afaa-9d2b13c66b30)


Fixes https://github.com/microsoft/pxt-microbit/issues/5611