### PR TITLE
Teacher Tool: Relative URL for AI Eval (also remove copilot query param)

### DIFF
--- a/teachertool/src/services/backendRequests.ts
+++ b/teachertool/src/services/backendRequests.ts
@@ -2,7 +2,6 @@ import { Strings } from "../constants";
 import { stateAndDispatch } from "../state";
 import { ErrorCode } from "../types/errorCode";
 import { logError } from "./loggingService";
-import * as auth from "./authClient";
 
 export async function fetchJsonDocAsync<T = any>(url: string): Promise<T | undefined> {
     try {
@@ -92,29 +91,15 @@ export async function loadTestableCollectionFromDocsAsync<T>(fileNames: string[]
 }
 
 export async function askCopilotQuestionAsync(shareId: string, question: string): Promise<string | undefined> {
-    const { state: teacherTool } = stateAndDispatch();
-
-    const url = `${
-        teacherTool.copilotEndpointOverride ? teacherTool.copilotEndpointOverride : pxt.Cloud.apiRoot
-    }copilot/question`;
-
+    const url = `/api/copilot/question`;
     const data = { id: shareId, question };
     let result: string = "";
     try {
-        const headers = await auth.getAuthHeadersAsync();
-        headers["Content-Type"] = "application/json";
-
-        const request = await fetch(url, {
-            method: "POST",
-            headers,
-            body: JSON.stringify(data),
-            credentials: "include",
-        });
-
-        if (!request.ok) {
-            throw new Error(Strings.UnableToReachAI);
+        const request = await pxt.auth.AuthClient.staticApiAsync(url, data, "POST");
+        if (request.statusCode != 200) {
+            throw new Error(request.err || lf("Unable to reach AI. Error code: {0}", request.statusCode));
         }
-        result = await request.json();
+        result = await request.resp.json();
     } catch (e) {
         logError(ErrorCode.askAIQuestion, e);
         throw e; // We will catch this upstream so we can show the error

--- a/teachertool/src/state/appStateContext.tsx
+++ b/teachertool/src/state/appStateContext.tsx
@@ -10,13 +10,6 @@ const DEV_BACKEND_LOCALHOST = "http://localhost:8080";
 // Read the URL parameters and set the initial state accordingly
 const url = window.location.href;
 const testCatalog = !!/testcatalog(?:[:=])1/.test(url) || !!/tc(?:[:=])1/.test(url);
-const copilotSlot = url.match(/copilot=([^&]+)/);
-const copilotEndpoint =
-    copilotSlot && copilotSlot[1]
-        ? copilotSlot[1] === "local"
-            ? `${DEV_BACKEND_LOCALHOST}/api/`
-            : `https://${copilotSlot[1]}.staging.pxt.io/api/`
-        : undefined;
 
 let state: AppState;
 let dispatch: React.Dispatch<Action>;
@@ -51,10 +44,9 @@ export function AppStateProvider(props: React.PropsWithChildren<{}>): React.Reac
     const [state_, dispatch_] = useReducer(reducer, {
         ...initialAppState,
         autorun: getAutorun(),
-        copilotEndpointOverride: copilotEndpoint,
         flags: {
             ...initialAppState.flags,
-            testCatalog: testCatalog || !!copilotEndpoint,
+            testCatalog: testCatalog,
         },
     });
 

--- a/teachertool/src/state/state.ts
+++ b/teachertool/src/state/state.ts
@@ -17,7 +17,6 @@ export type AppState = {
     modalOptions: ModalOptions | undefined;
     toolboxCategories?: pxt.Map<pxt.editor.ToolboxCategoryDefinition>;
     blockImageCache: pxt.Map<string>; // block id -> image uri
-    copilotEndpointOverride?: string; // TODO: remove once copilot is available in prod.
     catalogOpen: boolean;
     screenReaderAnnouncement?: string;
     userProfile: pxt.auth.UserProfile | undefined;
@@ -38,7 +37,6 @@ export const initialAppState: AppState = {
     modalOptions: undefined,
     toolboxCategories: undefined,
     blockImageCache: {},
-    copilotEndpointOverride: undefined,
     catalogOpen: false,
     screenReaderAnnouncement: undefined,
     userProfile: undefined,


### PR DESCRIPTION
This is important for ensuring we hit microbit.org instead of makecode.com for authenticated requests (where the auth cookie is associated with microbit.org). It also means we can reuse AuthClient.staticApiAsync(), which is nice.

I did not end up using relative URLs for fetching projects, as they would typically try to access staging instead of prod (depending on how the dev has configured `pxt.cloud.DEV_BACKEND`), but testing with staging projects isn't well supported at the moment. We could change this later, but for now, I think just using `pxt.Cloud.apiRoot` is simplest.

I also removed the copilot query param. It was helpful for debugging and demos, but with auth required, it no longer really works.