### PR TITLE
add decompile shadow alias attribute

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -830,6 +830,7 @@ declare namespace ts.pxtc {
         fixedInstance?: boolean;
         expose?: boolean; // expose to VM despite being in pxt:: namespace
         decompileIndirectFixedInstances?: boolean; // Attribute on TYPEs with fixedInstances set to indicate that expressions with that type may be decompiled even if not a fixed instance
+        decompilerShadowAlias?: string; // hints to the decompiler that this block can be replaced with the block with this id if doing so would create a shadow block
         constantShim?: boolean;
         indexedInstanceNS?: string;
         indexedInstanceShim?: string;

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1216,6 +1216,9 @@ ${output}</xml>`;
             }
 
             let idfn = attributes.blockIdentity ? blocksInfo.apis.byQName[attributes.blockIdentity] : blocksInfo.blocksById[blockId];
+            if (blockId && idfn.attributes.blockId !== blockId && idfn.attributes.decompilerShadowAlias === blockId) {
+                idfn = blocksInfo.blocksById[blockId];
+            }
             return getEnumFieldBlock(idfn, value);
         }
 

--- a/tests/decompile-test/baselines/decompiler_shadow_alias.blocks
+++ b/tests/decompile-test/baselines/decompiler_shadow_alias.blocks
@@ -1,0 +1,19 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="device_set_digital_pin">
+<value name="name">
+<shadow type="digital_pin_shadow">
+<field name="pin">P0</field>
+</shadow>
+</value>
+<value name="value">
+<shadow type="math_number_minmax">
+<mutation min="0" max="1" />
+<field name="SLIDER">2</field>
+</shadow>
+</value>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/decompiler_shadow_alias.ts
+++ b/tests/decompile-test/cases/decompiler_shadow_alias.ts
@@ -1,0 +1,1 @@
+pins.digitalWritePin(DigitalPin.P0, 2)

--- a/tests/decompile-test/cases/testBlocks/decompilerShadowAlias.ts
+++ b/tests/decompile-test/cases/testBlocks/decompilerShadowAlias.ts
@@ -1,0 +1,92 @@
+
+enum DigitalPin {
+    //% blockIdentity="pins._digitalPin"
+    P0 = 100,  // MICROBIT_ID_IO_P0
+    //% blockIdentity="pins._digitalPin"
+    P1 = 101,  // MICROBIT_ID_IO_P1
+    //% blockIdentity="pins._digitalPin"
+    P2 = 102,  // MICROBIT_ID_IO_P2
+    //% blockIdentity="pins._digitalPin"
+    P3 = 103,  // MICROBIT_ID_IO_P3
+    //% blockIdentity="pins._digitalPin"
+    P4 = 104,  // MICROBIT_ID_IO_P4
+    //% blockIdentity="pins._digitalPin"
+    P5 = 105,  // MICROBIT_ID_IO_P5
+    //% blockIdentity="pins._digitalPin"
+    P6 = 106,  // MICROBIT_ID_IO_P6
+    //% blockIdentity="pins._digitalPin"
+    P7 = 107,  // MICROBIT_ID_IO_P7
+    //% blockIdentity="pins._digitalPin"
+    P8 = 108,  // MICROBIT_ID_IO_P8
+    //% blockIdentity="pins._digitalPin"
+    P9 = 109,  // MICROBIT_ID_IO_P9
+    //% blockIdentity="pins._digitalPin"
+    P10 = 110,  // MICROBIT_ID_IO_P10
+    //% blockIdentity="pins._digitalPin"
+    P11 = 111,  // MICROBIT_ID_IO_P11
+    //% blockIdentity="pins._digitalPin"
+    P12 = 112,  // MICROBIT_ID_IO_P12
+    //% blockIdentity="pins._digitalPin"
+    P13 = 113,  // MICROBIT_ID_IO_P13
+    //% blockIdentity="pins._digitalPin"
+    P14 = 114,  // MICROBIT_ID_IO_P14
+    //% blockIdentity="pins._digitalPin"
+    P15 = 115,  // MICROBIT_ID_IO_P15
+    //% blockIdentity="pins._digitalPin"
+    P16 = 116,  // MICROBIT_ID_IO_P16
+    //% blockIdentity="pins._digitalPin"
+    //% blockHidden=1
+    P19 = 119,  // MICROBIT_ID_IO_P19
+    //% blockIdentity="pins._digitalPin"
+    //% blockHidden=1
+    P20 = 120,  // MICROBIT_ID_IO_P20
+}
+
+
+namespace pins {
+    /**
+     * Returns the value of a C++ runtime constant
+     */
+    //% help=pins/digital-pin
+    //% shim=TD_ID
+    //% blockId=digital_pin
+    //% block="digital pin $pin"
+    //% pin.fieldEditor=pinpicker
+    //% pin.fieldOptions.columns=4
+    //% pin.fieldOptions.tooltips="false"
+    //% group="Pins"
+    //% weight=17
+    //% blockGap=8
+    //% advanced=true
+    //% decompilerShadowAlias=digital_pin_shadow
+    export function _digitalPin(pin: DigitalPin): number {
+        return pin;
+    }
+
+    /**
+     * Returns the value of a C++ runtime constant
+     */
+    //% help=pins/digital-pin
+    //% shim=TD_ID
+    //% blockId=digital_pin_shadow
+    //% block="$pin"
+    //% pin.fieldEditor=pinpicker
+    //% pin.fieldOptions.columns=4
+    //% pin.fieldOptions.tooltips="false"
+    //% blockHidden=1
+    export function _digitalPinShadow(pin: DigitalPin): number {
+        return pin;
+    }
+
+    /**
+     * Set a pin or connector value to either 0 or 1.
+     * @param name pin to write to, eg: DigitalPin.P0
+     * @param value value to set on the pin, 1 eg,0
+     */
+    //% help=pins/digital-write-pin weight=29
+    //% blockId=device_set_digital_pin block="digital write|pin %name|to %value"
+    //% value.min=0 value.max=1
+    //% name.shadow=digital_pin_shadow shim=pins::digitalWritePin
+    export function digitalWritePin(name: number, value: number): void {
+    }
+}

--- a/tests/decompile-test/cases/testBlocks/pxt.json
+++ b/tests/decompile-test/cases/testBlocks/pxt.json
@@ -14,7 +14,8 @@
         "templateStrings.ts",
         "classHandlerParameter.ts",
         "globals.ts",
-        "spritekind.ts"
+        "spritekind.ts",
+        "decompilerShadowAlias.ts"
     ],
     "public": true,
     "dependencies": {},


### PR DESCRIPTION
required for https://github.com/microsoft/pxt-microbit/issues/5834

this attribute hints to the decompiler that this block can be replaced with the block with the given id if doing so would create a shadow block