### PR TITLE
remove debug button in read only mode

### DIFF
--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -113,7 +113,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
 
         const run = true;
         const restart = run && !simOpts.hideRestart;
-        const debug = targetTheme.debugger && !inTutorial && !pxt.BrowserUtils.isIE();
+        const debug = targetTheme.debugger && !inTutorial && !pxt.BrowserUtils.isIE() && !pxt.shell.isReadOnly();
         const debugging = parentState.debugging;
         // we need to escape full screen from a tutorial!
         const fullscreen = run && !simOpts.hideFullscreen && !sandbox;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5619

originally we talked about keeping it, but as noted in the linked issue there is no toolbox in readonly mode so there's nowhere for the debug controls to go.