### PR TITLE
teacher tool: persist user feedback

### DIFF
--- a/teachertool/src/components/CriteriaFeedback.tsx
+++ b/teachertool/src/components/CriteriaFeedback.tsx
@@ -1,60 +1,65 @@
 import css from "./styling/CriteriaFeedback.module.scss";
 import { Button } from "react-common/components/controls/Button";
 import { Ticks } from "../constants";
-import { useState, useCallback } from "react";
-import { showToast } from "../transforms/showToast";
-import { makeToast } from "../utils";
+import { useCallback, useContext, useMemo } from "react";
 import { classList } from "react-common/components/util";
+import { AppStateContext } from "../state/appStateContext";
+import { getCriteriaInstanceWithId } from "../state/helpers";
+import { setUserFeedback } from "../transforms/setUserFeedback";
 
 interface ICriteriaFeedbackProps {
-    catalogCriteriaId: string;
+    criteriaInstanceId: string;
     className?: string;
 }
-export const CriteriaFeedback: React.FC<ICriteriaFeedbackProps> = ({ className, catalogCriteriaId }) => {
-    const [helpful, setHelpful] = useState<boolean | undefined>(undefined);
+
+export const CriteriaFeedback: React.FC<ICriteriaFeedbackProps> = ({ className, criteriaInstanceId }) => {
+    const { state: teacherTool } = useContext(AppStateContext);
+
+    const catalogInstance = useMemo(
+        () => getCriteriaInstanceWithId(teacherTool, criteriaInstanceId),
+        [teacherTool, criteriaInstanceId]
+    );
+    const userFeedback = catalogInstance?.userFeedback;
+    const catalogCriteriaId = catalogInstance?.catalogCriteriaId;
 
     const onResponseClicked = useCallback(
         (isHelpful: boolean) => {
-            const previousHelpful = helpful;
+            if (!catalogCriteriaId) {
+                return;
+            }
 
-            // If they click the same button again, unset the feedback.
-            const newHelpful = previousHelpful === isHelpful ? undefined : isHelpful;
+            setUserFeedback(criteriaInstanceId, isHelpful ? "helpful" : "not-helpful");
 
-            setHelpful(newHelpful);
             pxt.tickEvent(Ticks.CriteriaFeedback, {
                 criteriaId: catalogCriteriaId,
-                helpful: newHelpful + "",
-
-                // Record previous value to help us track if the user is changing feedback that was already sent
-                // (i.e. pressed thumbs up, then changed to thumbs down), or if they reset their feedback.
-                previousValue: previousHelpful + "",
+                helpful: isHelpful + "",
             });
-
-            if (newHelpful !== undefined) {
-                showToast(makeToast(newHelpful ? "success" : "info", lf("Thanks for your feedback!")));
-            }
         },
-        [helpful, catalogCriteriaId]
+        [catalogCriteriaId]
     );
 
-    const thumbsUpIcon = helpful === true ? "fas fa-thumbs-up" : "far fa-thumbs-up";
-    const thumbsDownIcon = helpful === false ? "fas fa-thumbs-down" : "far fa-thumbs-down";
+    const thumbsUpIcon = userFeedback === "helpful" ? "fas fa-thumbs-up" : "far fa-thumbs-up";
+    const thumbsDownIcon = userFeedback === "not-helpful" ? "fas fa-thumbs-down" : "far fa-thumbs-down";
 
     return (
         <div className={classList(css["criteria-feedback-container"], className)}>
-            <span className={css["label"]}>{lf("Was this response helpful?")}</span>
+            <span className={css["label"]}>
+                {!userFeedback ? lf("Was this response helpful?") : lf("Thanks for your feedback!")}
+            </span>
             <span className={css["rate-buttons"]}>
                 <Button
                     className={css["feedback-button"]}
                     title={lf("Helpful")}
                     onClick={() => onResponseClicked(true)}
                     rightIcon={thumbsUpIcon}
+                    disabled={!!userFeedback}
                 />
                 <Button
                     className={css["feedback-button"]}
                     title={lf("Unhelpful")}
                     onClick={() => onResponseClicked(false)}
                     rightIcon={thumbsDownIcon}
+                    disabled={!!userFeedback}
                 />
             </span>
         </div>

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -44,11 +44,7 @@ const CriteriaResultNotes: React.FC<CriteriaResultNotesProps> = ({ criteriaId })
                     intervalMs={500}
                 />
             </div>
-            {notes && (
-                <div className={classList(css["notes-container"], css["for-print"], "only-print")}>
-                    {notes}
-                </div>
-            )}
+            {notes && <div className={classList(css["notes-container"], css["for-print"], "only-print")}>{notes}</div>}
         </>
     );
 };
@@ -158,9 +154,9 @@ export const CriteriaResultEntry: React.FC<CriteriaResultEntryProps> = ({ criter
                     )}
 
                     {/* Criteria Response Feedback (For us, not student feedback) */}
-                    {!isInProgress && !isNotStarted && catalogCriteria.requestFeedback && (
+                    {!isInProgress && !isNotStarted && !hasError && catalogCriteria.requestFeedback && (
                         <CriteriaFeedback
-                            catalogCriteriaId={catalogCriteria.id}
+                            criteriaInstanceId={criteriaInstance.instanceId}
                             className={classList("no-print", css["criteria-feedback"])}
                         />
                     )}

--- a/teachertool/src/components/styling/CriteriaFeedback.module.scss
+++ b/teachertool/src/components/styling/CriteriaFeedback.module.scss
@@ -19,7 +19,7 @@
             border: none;
             font-size: 1rem;
 
-            :hover {
+            &:not([class~="disabled"]):hover {
                 font-size: 1.2rem;
             }
 

--- a/teachertool/src/state/actions.ts
+++ b/teachertool/src/state/actions.ts
@@ -1,4 +1,4 @@
-import { ToastWithId, TabName, ProjectData } from "../types";
+import { ToastWithId, TabName, ProjectData, UserFeedback } from "../types";
 import { CatalogCriteria, CriteriaResult } from "../types/criteria";
 import { ModalOptions } from "../types/modalOptions";
 import { Checklist } from "../types/checklist";
@@ -115,6 +115,12 @@ type SetUserProfile = ActionBase & {
     profile: pxt.auth.UserProfile | undefined;
 };
 
+type SetUserFeedback = ActionBase & {
+    type: "SET_USER_FEEDBACK";
+    criteriaInstanceId: string;
+    userFeedback: UserFeedback;
+};
+
 /**
  * Union of all actions
  */
@@ -140,7 +146,8 @@ export type Action =
     | SetToolboxCategories
     | SetBlockImageUri
     | SetScreenReaderAnnouncement
-    | SetUserProfile;
+    | SetUserProfile
+    | SetUserFeedback;
 
 /**
  * Action creators
@@ -249,6 +256,12 @@ const setUserProfile = (profile: pxt.auth.UserProfile | undefined): SetUserProfi
     profile,
 });
 
+const setUserFeedback = (criteriaInstanceId: string, userFeedback: UserFeedback): SetUserFeedback => ({
+    type: "SET_USER_FEEDBACK",
+    criteriaInstanceId,
+    userFeedback,
+});
+
 export {
     showToast,
     dismissToast,
@@ -271,4 +284,5 @@ export {
     setBlockImageUri,
     setScreenReaderAnnouncement,
     setUserProfile,
+    setUserFeedback,
 };

--- a/teachertool/src/state/reducer.ts
+++ b/teachertool/src/state/reducer.ts
@@ -151,5 +151,16 @@ export default function reducer(state: AppState, action: Action): AppState {
                 userProfile: action.profile,
             };
         }
+        case "SET_USER_FEEDBACK": {
+            const checklist = { ...state.checklist };
+            const criteriaInstance = checklist.criteria.find(c => c.instanceId === action.criteriaInstanceId);
+            if (criteriaInstance) {
+                criteriaInstance.userFeedback = action.userFeedback;
+            }
+            return {
+                ...state,
+                checklist,
+            };
+        }
     }
 }

--- a/teachertool/src/transforms/mergeEvalResult.ts
+++ b/teachertool/src/transforms/mergeEvalResult.ts
@@ -1,6 +1,7 @@
 import { stateAndDispatch } from "../state";
 import { EvaluationStatus } from "../types/criteria";
 import { setEvalResult } from "./setEvalResult";
+import { setUserFeedback } from "./setUserFeedback";
 
 // This will set the outcome and notes for a given criteria instance id, but if the provided value is undefined, it will not change that value.
 export function mergeEvalResult(criteriaInstanceId: string, outcome?: EvaluationStatus, notes?: string) {
@@ -15,6 +16,10 @@ export function mergeEvalResult(criteriaInstanceId: string, outcome?: Evaluation
         newCriteriaEvalResult.result = outcome;
     }
     if (notes !== undefined) {
+        if (newCriteriaEvalResult.notes !== notes) {
+            // If the notes are changing, we should clear any user feedback.
+            setUserFeedback(criteriaInstanceId, undefined);
+        }
         newCriteriaEvalResult.notes = notes;
     }
 

--- a/teachertool/src/transforms/runSingleEvaluateAsync.ts
+++ b/teachertool/src/transforms/runSingleEvaluateAsync.ts
@@ -13,6 +13,7 @@ import { runValidatorPlanOverrideAsync } from "../validatorPlanOverrides/runVali
 import { setEvalResultOutcome } from "./setEvalResultOutcome";
 import { mergeEvalResult } from "./mergeEvalResult";
 import { setEvalResult } from "./setEvalResult";
+import { setUserFeedback } from "./setUserFeedback";
 
 function generateValidatorPlan(
     criteriaInstance: CriteriaInstance,
@@ -142,9 +143,11 @@ export async function runSingleEvaluateAsync(criteriaInstanceId: string, fromUse
                 return resolve(true); // evaluation completed successfully, so return true (regardless of pass/fail)
             } else {
                 dispatch(Actions.clearEvalResult(criteriaInstance.instanceId));
+                setUserFeedback(criteriaInstanceId, undefined);
                 return resolve(false);
             }
         } catch (e) {
+            setUserFeedback(criteriaInstanceId, undefined);
             setEvalResult(criteriaInstance.instanceId, {
                 result: EvaluationStatus.NotStarted,
                 error: (e as Error)?.message,

--- a/teachertool/src/transforms/setUserFeedback.ts
+++ b/teachertool/src/transforms/setUserFeedback.ts
@@ -1,0 +1,8 @@
+import { stateAndDispatch } from "../state";
+import * as Actions from "../state/actions";
+import { UserFeedback } from "../types";
+
+export function setUserFeedback(criteriaInstanceId: string, userFeedback: UserFeedback) {
+    const { dispatch } = stateAndDispatch();
+    dispatch(Actions.setUserFeedback(criteriaInstanceId, userFeedback));
+}

--- a/teachertool/src/types/criteria.ts
+++ b/teachertool/src/types/criteria.ts
@@ -1,3 +1,5 @@
+import { UserFeedback } from ".";
+
 // A criteria defined in the catalog of all possible criteria for the user to choose from when creating a checklist.
 export interface CatalogCriteria {
     id: string; // A unique id (GUID) for the catalog criteria
@@ -17,6 +19,7 @@ export interface CriteriaInstance {
     catalogCriteriaId: string;
     instanceId: string;
     params: CriteriaParameterValue[] | undefined;
+    userFeedback?: UserFeedback;
 }
 
 // Represents a parameter definition in a catalog criteria.

--- a/teachertool/src/types/index.ts
+++ b/teachertool/src/types/index.ts
@@ -51,3 +51,5 @@ export type CriteriaTemplateSegment = {
     type: "plain-text" | "param";
     content: string; // plain text or parameter name
 };
+
+export type UserFeedback = "helpful" | "not-helpful" | undefined;


### PR DESCRIPTION
Store user feedback in state so that it isn't cleared when the feedback control unmounts for any reason.
Feedback state will be programmatically cleared when:
* The criteria evaluation returns a different value for `notes`
* The criteria fails to evaluate.

When feedback is given, the text label now changes to "Thanks for your feedback!". Because of this, I removed the toast that appears with the same message.

![image](https://github.com/user-attachments/assets/32681c07-f591-456f-8863-968051d3ddde)


Fixes https://github.com/microsoft/pxt-microbit/issues/5815
Fixes https://github.com/microsoft/pxt-microbit/issues/5831
