### PR TITLE
fix safari comment rendering glitch

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -59,6 +59,7 @@ svg.blocklySvg {
 body.blocklyMinimalBody {
     min-width: initial;
     overflow: initial;
+    position: unset;
 }
 
 @supports (-ms-accelerator:true) {


### PR DESCRIPTION
this fixes the glitchiness seen in this gif: https://github.com/microsoft/pxt-microbit/issues/5726#issuecomment-2284630270

it does not, however, fix the bug that the linked issue mentions in the top comment. that seems to be a blockly bug and i'll open it against them