### PR TITLE
Teacher Tool: Handle Reload on ServiceWorkerRegistered Events

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -453,6 +453,10 @@ declare namespace pxt.editor {
         advanced?: boolean;
     }
 
+    export interface EditorMessageServiceWorkerRegisteredRequest extends EditorMessageRequest {
+        action: "serviceworkerregistered";
+    }
+
     export interface EditorMessageGetToolboxCategoriesResponse {
         categories: pxt.editor.ToolboxCategoryDefinition[];
     }

--- a/pxtservices/editorDriver.ts
+++ b/pxtservices/editorDriver.ts
@@ -447,6 +447,7 @@ export class EditorDriver extends IframeDriver {
     addEventListener(event: "workspacediagnostics", handler: (ev: pxt.editor.EditorWorkspaceDiagnostics) => void): void;
     addEventListener(event: "editorcontentloaded", handler: (ev: pxt.editor.EditorContentLoadedRequest) => void): void;
     addEventListener(event: "projectcloudstatus", handler: (ev: pxt.editor.EditorMessageProjectCloudStatus) => void): void;
+    addEventListener(event: "serviceworkerregistered", handler: (ev: pxt.editor.EditorMessageServiceWorkerRegisteredRequest) => void): void;
     addEventListener(event: string, handler: (ev: any) => void): void {
         super.addEventListener(event, handler);
     }

--- a/teachertool/src/components/MakecodeFrame.tsx
+++ b/teachertool/src/components/MakecodeFrame.tsx
@@ -45,7 +45,7 @@ export const MakeCodeFrame: React.FC<IProps> = () => {
         return url;
     }
 
-    function handleIFrameRef (el: HTMLIFrameElement | null) {
+    function handleIFrameRef(el: HTMLIFrameElement | null) {
         iframeRef.current = el;
         if (el) {
             setEditorRef(el, forceIFrameReload);

--- a/teachertool/src/components/MakecodeFrame.tsx
+++ b/teachertool/src/components/MakecodeFrame.tsx
@@ -1,17 +1,25 @@
 /// <reference path="../../../localtypings/pxteditor.d.ts" />
 
 import css from "./styling/MakeCodeFrame.module.scss";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { setEditorRef } from "../services/makecodeEditorService";
 import { AppStateContext } from "../state/appStateContext";
 import { getEditorUrl } from "../utils";
 import { classList } from "react-common/components/util";
+import { logDebug } from "../services/loggingService";
 
 interface IProps {}
 
 export const MakeCodeFrame: React.FC<IProps> = () => {
     const { state: teacherTool } = useContext(AppStateContext);
-    const [frameId] = useState(pxt.Util.guidGen());
+    const [frameId, setFrameId] = useState(pxt.Util.guidGen());
+    const [frameUrl, setFrameUrl] = useState("");
+    const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+    useEffect(() => {
+        const newUrl = createIFrameUrl(teacherTool.projectMetadata?.id || "");
+        setFrameUrl(newUrl);
+    }, [frameId, teacherTool.projectMetadata?.id]);
 
     function createIFrameUrl(shareId: string): string {
         const editorUrl: string = pxt.BrowserUtils.isLocalHost()
@@ -37,17 +45,23 @@ export const MakeCodeFrame: React.FC<IProps> = () => {
         return url;
     }
 
-    const handleIFrameRef = (el: HTMLIFrameElement | null) => {
+    function handleIFrameRef (el: HTMLIFrameElement | null) {
+        iframeRef.current = el;
         if (el) {
-            setEditorRef(el);
+            setEditorRef(el, forceIFrameReload);
         }
-    };
+    }
+
+    function forceIFrameReload() {
+        setFrameId(pxt.Util.guidGen());
+    }
 
     /* eslint-disable @microsoft/sdl/react-iframe-missing-sandbox */
     return (
         <iframe
+            id="code-eval-project-view-frame"
             className={classList(css["makecode-frame"], teacherTool.projectMetadata?.id ? undefined : css["invisible"])}
-            src={createIFrameUrl(teacherTool.projectMetadata?.id || "")}
+            src={frameUrl}
             title={"title"}
             ref={handleIFrameRef}
         />

--- a/teachertool/src/services/makecodeEditorService.ts
+++ b/teachertool/src/services/makecodeEditorService.ts
@@ -10,7 +10,7 @@ import { runEvaluateAsync } from "../transforms/runEvaluateAsync";
 let driver: EditorDriver | undefined;
 let highContrast: boolean = false;
 
-export function setEditorRef(ref: HTMLIFrameElement | undefined) {
+export function setEditorRef(ref: HTMLIFrameElement | undefined, forceReload: () => void) {
     if (driver) {
         if (driver.iframe === ref) return;
 
@@ -27,6 +27,10 @@ export function setEditorRef(ref: HTMLIFrameElement | undefined) {
         driver.addEventListener("sent", ev => {
             logDebug(`Sent message to iframe. ID: ${ev?.id}`, ev);
         });
+        driver.addEventListener("serviceworkerregistered", ev => {
+            logDebug(`Service worker registered. Reloading iframe.`);
+            forceReload();
+        })
         driver.addEventListener("editorcontentloaded", ev => {
             const { state } = stateAndDispatch();
             const { runOnLoad, projectMetadata } = state;

--- a/teachertool/src/services/makecodeEditorService.ts
+++ b/teachertool/src/services/makecodeEditorService.ts
@@ -30,7 +30,7 @@ export function setEditorRef(ref: HTMLIFrameElement | undefined, forceReload: ()
         driver.addEventListener("serviceworkerregistered", ev => {
             logDebug(`Service worker registered. Reloading iframe.`);
             forceReload();
-        })
+        });
         driver.addEventListener("editorcontentloaded", ev => {
             const { state } = stateAndDispatch();
             const { runOnLoad, projectMetadata } = state;

--- a/webapp/src/appcache.ts
+++ b/webapp/src/appcache.ts
@@ -40,7 +40,7 @@ export function init(updated: () => void) {
     function scheduleUpdate() {
         postHostMessageAsync({
             action: "serviceworkerregistered",
-            type: "pxteditor"
+            type: "pxthost"
         });
         if (pxt.appTarget.appTheme && pxt.appTarget.appTheme.noReloadOnUpdate)
             return;


### PR DESCRIPTION
With https://github.com/microsoft/pxt-microbit/pull/5875, we disabled the automatic webapp reload that occurs when a new service worker is registered. We did that because the unexpected reload was causing https://github.com/microsoft/pxt-microbit/issues/5824 and https://github.com/microsoft/pxt-microbit/issues/5822.

Now, however, we have to handle that refresh ourselves. In this change, we listen for the event added in https://github.com/microsoft/pxt/pull/10120 and refresh the iframe (via changing the src) when we get it.

A few details:
1. I had to change the event type for the serviceworkerregistered event. Since this comes from the iframe unprompted, we want "pxthost" rather than "pxteditor" (which is more for responding to requests)

2. I moved the iframe url into the component's state. I'm not sure why I didn't do this in the first place, but I couldn't find or think of a reason not to and it simplified the code a bit.

3. I'm forcing the reload by changing the iframe id. This is a little bit arbitrary as a way to modify the url and trigger a refresh, but it does have the benefit that the iframe driver handling communication will filter out any weird lingering messages from the old id and only focus on the new one, should that ever occur. It creates something of a "clean slate" for the messaging infrastructure.

Fixes https://github.com/microsoft/pxt-microbit/issues/5824
Fixes https://github.com/microsoft/pxt-microbit/issues/5822