### PR TITLE
fix the size of decompiled comments

### DIFF
--- a/pxtblocks/importer.ts
+++ b/pxtblocks/importer.ts
@@ -368,6 +368,12 @@ export function patchCommentIds(xml: Element) {
             comment.setAttribute("id", Blockly.utils.idGenerator.genUid());
         }
     }
+
+    // Also patch comments that don't have a width/height set
+    for (const comment of xml.querySelectorAll("comment:not([h])")) {
+        comment.setAttribute("h", "80");
+        comment.setAttribute("w", "160");
+    }
 }
 
 function promoteShadow(shadow: Element) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5876

the decompiler doesn't set the initial comment width/height so we have to patch it when loading the xml into the workspace