### PR TITLE
fix selection behavior of the ledmatrix field

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -203,7 +203,7 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
 
             // select and hide chaff
             Blockly.hideChaff();
-            (this.sourceBlock_ as Blockly.BlockSvg).select();
+            Blockly.common.setSelected(this.sourceBlock_ as Blockly.BlockSvg);
 
             this.toggleRect(x, y);
             pxsim.pointerEvents.down.forEach(evid => svgRoot.addEventListener(evid, this.dontHandleMouseEvent_));


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5860

i think the behavior of the .select() function must have changed with the blockly upgrade. now it just adds the selection highlight but does not set the global selection