### PR TITLE
add optional timeout to recvPacketAsync

### DIFF
--- a/pxtlib/packetio.ts
+++ b/pxtlib/packetio.ts
@@ -29,7 +29,7 @@ namespace pxt.packetio {
 
     export interface PacketIO {
         sendPacketAsync(pkt: Uint8Array): Promise<void>;
-        recvPacketAsync?: () => Promise<Uint8Array>;
+        recvPacketAsync?: (timeout?: number) => Promise<Uint8Array>;
         onDeviceConnectionChanged: (connect: boolean) => void;
         onConnectionChanged: () => void;
         onData: (v: Uint8Array) => void;


### PR DESCRIPTION
Noticed something interesting in the video of the hang in https://github.com/microsoft/pxt-microbit/issues/5530#issuecomment-2318234233, which was that when the download started to halt it came after these two logs: 
![image](https://github.com/user-attachments/assets/14cc935a-b8c9-4269-bb6e-cb9a2542bb7c)

which would indicate it was stalling as it never gave out the following logs https://github.com/microsoft/pxt-microbit/blob/master/editor/flash.ts#L460 after '; retrying' --would expect either the ';retry success' or the log to error. Looking at this code path, it looks like that would be from falling into final & recursing indefinitely. Adding a timeout to pass in from flash side to make this not go until device gets unplugged, at minimum.

(still not able to reproduce the error, but something we'll want either way)