### PR TITLE
Teacher Tool: User-Friendly Error Messages

### DIFF
--- a/localtypings/evaluation.d.ts
+++ b/localtypings/evaluation.d.ts
@@ -1,5 +1,8 @@
 namespace pxt.blocks {
     export interface EvaluationResult {
-        result: boolean;
+        result?: boolean;
+        notes?: string;
+        executionSuccess: boolean;
+        executionErrorMsg?: string;
     }
 }

--- a/localtypings/validatorPlan.d.ts
+++ b/localtypings/validatorPlan.d.ts
@@ -49,6 +49,8 @@ declare namespace pxt.blocks {
     export interface EvaluationResult {
         result?: boolean;
         notes?: string;
+        executionSuccess: boolean;
+        executionErrorMsg?: string;
     }
 
     export interface BlockFieldValueExistsCheck extends ValidatorCheckBase {

--- a/pxteditor/code-validation/runValidatorPlan.ts
+++ b/pxteditor/code-validation/runValidatorPlan.ts
@@ -41,7 +41,7 @@ export function runValidatorPlan(usedBlocks: Blockly.Block[], plan: pxt.blocks.V
                 pxt.tickEvent("validation.unrecognized_validator", { validator: check.validator });
                 return {
                     executionSuccess: false,
-                    executionErrorMsg: lf(`Unrecognized evaluation rule`)
+                    executionErrorMsg: lf("Unrecognized evaluation rule")
                 };
         }
 

--- a/pxteditor/code-validation/runValidatorPlan.ts
+++ b/pxteditor/code-validation/runValidatorPlan.ts
@@ -10,7 +10,7 @@ import { validateSpecificBlockCommentsExist } from "./validateSpecificBlockComme
 import { getNestedChildBlocks } from "./getNestedChildBlocks";
 import { validateVariableUsage } from "./validateVariableUsage";
 
-export function runValidatorPlan(usedBlocks: Blockly.Block[], plan: pxt.blocks.ValidatorPlan, planLib: pxt.blocks.ValidatorPlan[]): boolean {
+export function runValidatorPlan(usedBlocks: Blockly.Block[], plan: pxt.blocks.ValidatorPlan, planLib: pxt.blocks.ValidatorPlan[]): pxt.blocks.EvaluationResult {
     const startTime = Date.now();
     let checksSucceeded = 0;
     let successfulBlocks: Blockly.Block[] = [];
@@ -38,8 +38,11 @@ export function runValidatorPlan(usedBlocks: Blockly.Block[], plan: pxt.blocks.V
                 break;
             default:
                 pxt.debug(`Unrecognized validator: ${check.validator}`);
-                checkPassed = false;
-                break;
+                pxt.tickEvent("validation.unrecognized_validator", { validator: check.validator });
+                return {
+                    executionSuccess: false,
+                    executionErrorMsg: lf(`Unrecognized evaluation rule`)
+                };
         }
 
         if (checkPassed && check.childValidatorPlans) {
@@ -65,7 +68,10 @@ export function runValidatorPlan(usedBlocks: Blockly.Block[], plan: pxt.blocks.V
         passed: `${passed}`,
     });
 
-    return passed;
+    return {
+        result: passed,
+        executionSuccess: true
+    };
 }
 
 function runBlocksExistValidation(usedBlocks: Blockly.Block[], inputs: pxt.blocks.BlocksExistValidatorCheck): [Blockly.Block[], boolean] {

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -199,7 +199,7 @@ case "renderxml": {
                                         const blocks = projectView.getBlocks();
                                         return runValidatorPlan(blocks, plan, planLib)})
                                     .then (results => {
-                                        resp = { result: results };
+                                        resp = results;
                                     });
                             }
 case "gettoolboxcategories": {

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -72,7 +72,7 @@ export namespace Ticks {
     export const SignedOutPanelSignIn = "teachertool.signedoutpanel.signin";
     export const CriteriaFeedback = "teachertool.criteriafeedback";
     export const Print = "teachertool.print";
-    export const UnhandledEvalError = "teachertool.evaluateerror"
+    export const UnhandledEvalError = "teachertool.evaluateerror";
 }
 
 namespace Misc {

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -48,6 +48,7 @@ export namespace Strings {
     export const EvaluateChecklist = lf("Evaluate checklist");
     export const UnableToEvaluate = lf("Unable to evaluate");
     export const UnableToReachAI = lf("Unable to reach the AI service");
+    export const UnexpectedError = lf("An unexpected error occurred");
     export const Dismiss = lf("Dismiss");
 }
 
@@ -71,6 +72,7 @@ export namespace Ticks {
     export const SignedOutPanelSignIn = "teachertool.signedoutpanel.signin";
     export const CriteriaFeedback = "teachertool.criteriafeedback";
     export const Print = "teachertool.print";
+    export const UnhandledEvalError = "teachertool.evaluateerror"
 }
 
 namespace Misc {

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -47,7 +47,7 @@ export namespace Strings {
     export const PrintChecklist = lf("Print checklist");
     export const EvaluateChecklist = lf("Evaluate checklist");
     export const UnableToEvaluate = lf("Unable to evaluate");
-    export const UnableToReachAI = lf("Unable to reach the AI");
+    export const UnableToReachAI = lf("Unable to reach the AI service");
     export const Dismiss = lf("Dismiss");
 }
 

--- a/teachertool/src/services/backendRequests.ts
+++ b/teachertool/src/services/backendRequests.ts
@@ -102,7 +102,7 @@ export async function askCopilotQuestionAsync(shareId: string, question: string)
         result = await request.resp.json();
     } catch (e) {
         logError(ErrorCode.askAIQuestion, e);
-        throw e; // We will catch this upstream so we can show the error
+        throw new Error(Strings.UnableToReachAI); // We will catch this upstream so we can show the error
     }
 
     return result;

--- a/teachertool/src/services/backendRequests.ts
+++ b/teachertool/src/services/backendRequests.ts
@@ -102,7 +102,6 @@ export async function askCopilotQuestionAsync(shareId: string, question: string)
         result = await request.resp.json();
     } catch (e) {
         logError(ErrorCode.askAIQuestion, e);
-        throw new Error(Strings.UnableToReachAI); // We will catch this upstream so we can show the error
     }
 
     return result;

--- a/teachertool/src/transforms/runSingleEvaluateAsync.ts
+++ b/teachertool/src/transforms/runSingleEvaluateAsync.ts
@@ -14,6 +14,7 @@ import { setEvalResultOutcome } from "./setEvalResultOutcome";
 import { mergeEvalResult } from "./mergeEvalResult";
 import { setEvalResult } from "./setEvalResult";
 import { setUserFeedback } from "./setUserFeedback";
+import { Strings, Ticks } from "../constants";
 
 function generateValidatorPlan(
     criteriaInstance: CriteriaInstance,
@@ -131,7 +132,7 @@ export async function runSingleEvaluateAsync(criteriaInstanceId: string, fromUse
                 planResult = await runValidatorPlanAsync(plan, loadedValidatorPlans);
             }
 
-            if (planResult) {
+            if (planResult && planResult.executionSuccess) {
                 const result =
                     planResult.result === undefined
                         ? EvaluationStatus.CompleteWithNoResult
@@ -142,16 +143,23 @@ export async function runSingleEvaluateAsync(criteriaInstanceId: string, fromUse
                 mergeEvalResult(criteriaInstance.instanceId, result, planResult.notes);
                 return resolve(true); // evaluation completed successfully, so return true (regardless of pass/fail)
             } else {
-                dispatch(Actions.clearEvalResult(criteriaInstance.instanceId));
+                setEvalResult(criteriaInstance.instanceId, {
+                    result: EvaluationStatus.NotStarted,
+                    error: planResult?.executionErrorMsg ?? Strings.UnexpectedError,
+                });
                 setUserFeedback(criteriaInstanceId, undefined);
                 return resolve(false);
             }
         } catch (e) {
+            // Catch-all error scenario. Ideally criteria evaluation will catch errors and report through the result,
+            // but this is a fallback in case something goes extra wrong.
+            pxt.tickEvent(Ticks.UnhandledEvalError, { catalogCriteriaId: criteriaInstance.catalogCriteriaId , error: (e as Error)?.message });
             setUserFeedback(criteriaInstanceId, undefined);
             setEvalResult(criteriaInstance.instanceId, {
                 result: EvaluationStatus.NotStarted,
-                error: (e as Error)?.message,
+                error: Strings.UnexpectedError,
             });
+            return resolve(false);
         }
     });
 

--- a/teachertool/src/transforms/runSingleEvaluateAsync.ts
+++ b/teachertool/src/transforms/runSingleEvaluateAsync.ts
@@ -153,7 +153,10 @@ export async function runSingleEvaluateAsync(criteriaInstanceId: string, fromUse
         } catch (e) {
             // Catch-all error scenario. Ideally criteria evaluation will catch errors and report through the result,
             // but this is a fallback in case something goes extra wrong.
-            pxt.tickEvent(Ticks.UnhandledEvalError, { catalogCriteriaId: criteriaInstance.catalogCriteriaId , error: (e as Error)?.message });
+            pxt.tickEvent(Ticks.UnhandledEvalError, {
+                catalogCriteriaId: criteriaInstance.catalogCriteriaId,
+                error: (e as Error)?.message,
+            });
             setUserFeedback(criteriaInstanceId, undefined);
             setEvalResult(criteriaInstance.instanceId, {
                 result: EvaluationStatus.NotStarted,

--- a/teachertool/src/transforms/runSingleEvaluateAsync.ts
+++ b/teachertool/src/transforms/runSingleEvaluateAsync.ts
@@ -132,7 +132,7 @@ export async function runSingleEvaluateAsync(criteriaInstanceId: string, fromUse
                 planResult = await runValidatorPlanAsync(plan, loadedValidatorPlans);
             }
 
-            if (planResult && planResult.executionSuccess) {
+            if (planResult?.executionSuccess) {
                 const result =
                     planResult.result === undefined
                         ? EvaluationStatus.CompleteWithNoResult

--- a/teachertool/src/validatorPlanOverrides/runAiQuestionValidationPlanAsync.ts
+++ b/teachertool/src/validatorPlanOverrides/runAiQuestionValidationPlanAsync.ts
@@ -21,6 +21,6 @@ export async function runAiQuestionValidationPlanAsync(
         executionSuccess: !!response,
         result: undefined,
         notes: response,
-        executionErrorMsg: response ? undefined : Strings.UnableToReachAI
+        executionErrorMsg: response ? undefined : Strings.UnableToReachAI,
     };
 }

--- a/teachertool/src/validatorPlanOverrides/runAiQuestionValidationPlanAsync.ts
+++ b/teachertool/src/validatorPlanOverrides/runAiQuestionValidationPlanAsync.ts
@@ -1,3 +1,4 @@
+import { Strings } from "../constants";
 import { askCopilotQuestionAsync } from "../services/backendRequests";
 import { logDebug, logError } from "../services/loggingService";
 import { ErrorCode } from "../types/errorCode";
@@ -17,7 +18,9 @@ export async function runAiQuestionValidationPlanAsync(
     logDebug(`Response: ${response}`);
 
     return {
+        executionSuccess: !!response,
         result: undefined,
         notes: response,
+        executionErrorMsg: response ? undefined : Strings.UnableToReachAI
     };
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5873

While fixing this, I decided to avoid relying on Error throwing/catching to communicate these kinds of errors. Instead, I added a field inside our evaluation result.  This will hopefully help make it clear that the error messages are user-visible and should be understandable text.

I considered just using a blanket error message for all criteria evaluation failures which would essentially just say "Evaluation failed" with no details at all, but as a user, I'd find that frustrating, especially when it's not clear if it's a "me" issue or a product issue. This change is trying to strike a middle-ground, where different criteria can surface different errors if they want to, but we will never end up displaying random, unfiltered exception messages (defaults to a generic "unexpected error occurred" message if it isn't properly handled).

![image](https://github.com/user-attachments/assets/604047cd-e4b3-41d4-98bc-ce40cb96bf2d)

I wasn't sure why there are two different definitions of `EvaluationResult`, but I updated them both to be in-sync. @riknoll, is this a  modules thing? Or should I just try to unify them?
