### PR TITLE
Teacher Tool: Ensure Run-All Re-Runs Everything

### DIFF
--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -16,6 +16,8 @@ import { runSingleEvaluateAsync } from "../transforms/runSingleEvaluateAsync";
 import { removeCriteriaFromChecklist } from "../transforms/removeCriteriaFromChecklist";
 import { Button } from "react-common/components/controls/Button";
 import { setEvalResult } from "../transforms/setEvalResult";
+import { showToast } from "../transforms/showToast";
+import { makeToast } from "../utils";
 
 interface CriteriaResultNotesProps {
     criteriaId: string;
@@ -79,7 +81,13 @@ const CriteriaResultToolbarTray: React.FC<{ criteriaId: string }> = ({ criteriaI
 
     async function handleEvaluateClickedAsync() {
         pxt.tickEvent(Ticks.Evaluate);
-        await runSingleEvaluateAsync(criteriaId, true);
+        const success = await runSingleEvaluateAsync(criteriaId, true);
+
+        if (success) {
+            showToast(makeToast("success", Strings.EvaluationComplete));
+        } else {
+            showToast(makeToast("error", Strings.UnableToEvaluate));
+        }
     }
 
     async function handleDeleteClickedAsync() {

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -50,6 +50,8 @@ export namespace Strings {
     export const UnableToReachAI = lf("Unable to reach the AI service");
     export const UnexpectedError = lf("An unexpected error occurred");
     export const Dismiss = lf("Dismiss");
+    export const EvaluationComplete = lf("Evaluation complete");
+    export const UnableToEvaluatePartial = lf("Unable to evaluate some criteria")
 }
 
 export namespace Ticks {

--- a/teachertool/src/transforms/runEvaluateAsync.ts
+++ b/teachertool/src/transforms/runEvaluateAsync.ts
@@ -19,7 +19,7 @@ export async function runEvaluateAsync(fromUserInteraction: boolean) {
     // EvalRequest promises will resolve to true if evaluation completed successfully (regarless of pass/fail).
     // They will only resolve to false if evaluation was unable to complete.
     const evalRequests = teacherTool.checklist.criteria.map(criteriaInstance =>
-        runSingleEvaluateAsync(criteriaInstance.instanceId, false)
+        runSingleEvaluateAsync(criteriaInstance.instanceId, fromUserInteraction)
     );
 
     if (evalRequests.length === 0) {

--- a/teachertool/src/transforms/runEvaluateAsync.ts
+++ b/teachertool/src/transforms/runEvaluateAsync.ts
@@ -3,6 +3,7 @@ import { makeToast } from "../utils";
 import { showToast } from "./showToast";
 import { setActiveTab } from "./setActiveTab";
 import { runSingleEvaluateAsync } from "./runSingleEvaluateAsync";
+import { Strings } from "../constants";
 
 export async function runEvaluateAsync(fromUserInteraction: boolean) {
     const { state: teacherTool } = stateAndDispatch();
@@ -16,8 +17,6 @@ export async function runEvaluateAsync(fromUserInteraction: boolean) {
         setActiveTab("results");
     }
 
-    // EvalRequest promises will resolve to true if evaluation completed successfully (regarless of pass/fail).
-    // They will only resolve to false if evaluation was unable to complete.
     const evalRequests = teacherTool.checklist.criteria.map(criteriaInstance =>
         runSingleEvaluateAsync(criteriaInstance.instanceId, fromUserInteraction)
     );
@@ -26,15 +25,17 @@ export async function runEvaluateAsync(fromUserInteraction: boolean) {
         return;
     }
 
+    // EvalRequest promises will resolve to true if evaluation completed successfully (regarless of pass/fail).
+    // They will only resolve to false if evaluation was unable to complete.
     const results = await Promise.all(evalRequests);
     if (fromUserInteraction) {
         const errorCount = results.filter(r => !r).length;
         if (errorCount === teacherTool.checklist.criteria.length) {
-            showToast(makeToast("error", lf("Unable to run evaluation")));
+            showToast(makeToast("error", Strings.UnableToEvaluate));
         } else if (errorCount > 0) {
-            showToast(makeToast("error", lf("Unable to evaluate some criteria")));
+            showToast(makeToast("error", Strings.UnableToEvaluatePartial));
         } else {
-            showToast(makeToast("success", lf("Evaluation complete")));
+            showToast(makeToast("success", Strings.EvaluationComplete));
         }
     }
 }

--- a/teachertool/src/transforms/runSingleEvaluateAsync.ts
+++ b/teachertool/src/transforms/runSingleEvaluateAsync.ts
@@ -5,8 +5,6 @@ import * as Actions from "../state/actions";
 import { getCatalogCriteriaWithId, getCriteriaInstanceWithId } from "../state/helpers";
 import { EvaluationStatus, CriteriaInstance } from "../types/criteria";
 import { ErrorCode } from "../types/errorCode";
-import { makeToast } from "../utils";
-import { showToast } from "./showToast";
 import jp from "jsonpath";
 import { getSystemParameter } from "../utils/getSystemParameter";
 import { runValidatorPlanOverrideAsync } from "../validatorPlanOverrides/runValidatorPlanOverrideAsync";
@@ -166,13 +164,5 @@ export async function runSingleEvaluateAsync(criteriaInstanceId: string, fromUse
         }
     });
 
-    const success = await evalRequest;
-
-    if (fromUserInteraction) {
-        if (!success) {
-            showToast(makeToast("error", lf("Unable to run evaluation")));
-        }
-    }
-
-    return success;
+    return await evalRequest;
 }


### PR DESCRIPTION
The user interaction flag is what determines if we should bypass the "run if unchanged / modified" check. We just need to pass it through.

I've pushed the toast display code back up to the callers of runSingleEvaluateAsync since we want different behavior in a run-all scenario vs a single run scenario that can't be totally decided via user interaction. 

Fixes https://github.com/microsoft/pxt-microbit/issues/5829