### PR TITLE
Limit Max AI question count to 5 instead of 10

### DIFF
--- a/common-docs/teachertool/test/catalog-shared.json
+++ b/common-docs/teachertool/test/catalog-shared.json
@@ -6,7 +6,7 @@
             "template": "Ask AI: ${question}",
             "description": "Experimental: AI outputs may not be accurate. Use with caution and always review responses.",
             "docPath": "/teachertool",
-            "maxCount": 10,
+            "maxCount": 5,
             "tags": ["General"],
             "requestFeedback": true,
             "params": [


### PR DESCRIPTION
Bringing this down to a more reasonable number. 10 feels excessive, and since these calls can be expensive, best to keep it more limited.