### PR TITLE
async/awaitify remaining logic in webusb.ts, tweak error message on locked device

### DIFF
--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -234,8 +234,8 @@ namespace pxt.usb {
 
             this.enabled = false;
             this.log(`unregistering webusb events`);
-            navigator?.usb.removeEventListener('disconnect', this.handleUSBDisconnected);
-            navigator?.usb.removeEventListener('connect', this.handleUSBConnected);
+            navigator.usb?.removeEventListener('disconnect', this.handleUSBDisconnected);
+            navigator.usb?.removeEventListener('connect', this.handleUSBConnected);
         }
 
         async disposeAsync(): Promise<void> {
@@ -507,7 +507,7 @@ namespace pxt.usb {
             this.ready = true;
             if (isHF2) {
                 // just starting, not waiting on it.
-                this.readLoop();
+                /* await */ this.readLoop();
             }
             this.onConnectionChanged?.();
         }
@@ -515,7 +515,7 @@ namespace pxt.usb {
 
     export async function pairAsync(): Promise<boolean> {
         try {
-            const dev = await navigator.usb.requestDevice({
+            const dev = await navigator.usb?.requestDevice({
                 filters: filters
             });
             return !!dev;
@@ -530,7 +530,7 @@ namespace pxt.usb {
     export async function tryGetDevicesAsync(): Promise<USBDevice[]> {
         log(`webusb: get devices`)
         try {
-            const devs = await navigator.usb.getDevices();
+            const devs = await navigator.usb?.getDevices();
             return devs || [];
         }
         catch (e) {

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -38,7 +38,7 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
     }
 
     const notPairedResult = () => userPrefersDownloadFlag ? pxt.commands.WebUSBPairResult.UserRejected : pxt.commands.WebUSBPairResult.Failed;
-
+    let lastPairingError: any;
 
     if (!await showConnectDeviceDialogAsync(confirmAsync))
         return notPairedResult();
@@ -82,6 +82,7 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
                 paired = await pairAsync();
             } catch (e) {
                 errMessage = e.message;
+                lastPairingError = e;
             }
             core.hideDialog();
 
@@ -111,6 +112,7 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
         } catch (e) {
             // Error while attempting connection
             paired = false;
+            lastPairingError = e;
         }
         core.hideLoading("attempting-connection");
     }
@@ -119,7 +121,7 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
         await showConnectionSuccessAsync(confirmAsync, implicitlyCalled);
     }
     else {
-        const tryAgain = await showConnectionFailureAsync(confirmAsync, implicitlyCalled);
+        const tryAgain = await showConnectionFailureAsync(confirmAsync, implicitlyCalled, lastPairingError);
 
         if (tryAgain) return webUsbPairThemedDialogAsync(pairAsync, confirmAsync, implicitlyCalled);
     }
@@ -254,16 +256,19 @@ function showConnectionSuccessAsync(confirmAsync: ConfirmAsync, willTriggerDownl
 }
 
 
-function showConnectionFailureAsync(confirmAsync: ConfirmAsync, showDownloadAsFileButton?: boolean) {
+function showConnectionFailureAsync(confirmAsync: ConfirmAsync, showDownloadAsFileButton: boolean, error: any) {
     const boardName = getBoardName();
     const tryAgainText = lf("Try Again");
     const helpText = lf("Help");
     const downloadAsFileText = lf("Download as File");
 
+    const errorDisplay = error?.type === "devicelocked"
+        ? lf("We couldn't connect to your {0}. It may be in use by another application.", boardName)
+        : lf("We couldn't find your {0}.", boardName);
     const jsxd = () => (
         <div>
             <div className="ui content download-troubleshoot-header">
-                {lf("We couldn't find your {0}.", boardName)}
+                {errorDisplay}
                 <br />
                 <br />
                 {lf("Click \"{0}\" for more info, \"{1}\" to retry pairing, or \"{2}\" for drag-and-drop flashing.", helpText, tryAgainText, downloadAsFileText)}


### PR DESCRIPTION
Was walking through this code line by line on friday to try and figure out what was up with chromebook webusb, so async/await-ified the remaining bits along the way. Also added some type info to navigator to remove some unnecessary casting, & made the 'connection failure' dialog a bit more explicit in cases where user gave a device but it didn't work (as that most often comes down to them having it already open in another browser / application, e.g. incognito + normal browser at once).