### PR TITLE
add cache to github:user data api

### DIFF
--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -516,7 +516,7 @@ function pingApiHandlerAsync(p: string): Promise<any> {
 }
 
 data.mountVirtualApi("sync", { getSync: syncApiHandler })
-data.mountVirtualApi("github", { getSync: githubApiHandler })
+data.mountVirtualApi("github", { getSync: githubApiHandler, expirationTime: p => 24 * 3600 * 1000 })
 data.mountVirtualApi("ping", {
     getAsync: pingApiHandlerAsync,
     expirationTime: p => 24 * 3600 * 1000,

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -122,8 +122,8 @@ export class ProviderBase {
             pxt.storage.setLocal(this.name + CLOUD_USER, JSON.stringify(user))
         else
             pxt.storage.removeLocal(this.name + CLOUD_USER);
-            data.invalidate("sync:user")
-            data.invalidate("github:user")
+        data.invalidate("sync:user")
+        data.invalidate("github:user")
     }
 
     protected token() {


### PR DESCRIPTION
Shouldn't matter basically at all, but noticed it this gets called an annoying amount while trying to nail down a webusb issue with the devtools `pause on caught exceptions` flag on. The api just ends up pointing `github:user` data at https://github.com/microsoft/pxt/blob/dev/jwunderl/add-cache-github-data/webapp/src/cloudsync.ts#L115, and constantly gives an exception parsing undefined when not signed into github (or just reparses the info, if you are signed in). This happens around half a dozen times on any interaction with the workspace (e.g. dragging a block).

As mentioned, can't imagine this specifically impacting performance, but just a tiny thing i saw / maybe worth peeking if there's any 'quick fix' we can make to avoid unnecessary cascading renders. Really the cache here could just be infinite i believe, as we explicitly clear it in `setUser` anyways.