### PR TITLE
Code eval tool: make exporting available without a project

### DIFF
--- a/teachertool/src/components/EvalResultDisplay.tsx
+++ b/teachertool/src/components/EvalResultDisplay.tsx
@@ -90,7 +90,6 @@ const ResultsHeader: React.FC<ResultsHeaderProps> = ({ printRef }) => {
                         title={Strings.ExportChecklist}
                         rightIcon="fas fa-download"
                         onClick={handleExportChecklistClicked}
-                        disabled={!isProjectLoaded(teacherTool)}
                     />
                     <Button
                         className={classList("secondary", css["control-button"])}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5900

Also curious if we should add a bit more detail in the tooltips for the action buttons.. It seems a bit funky to me that exporting gives me a JSON representation of the checklist and printing gives me exactly what's on the page. As a user, I think I would expect the export and print to give me the same thing or, that exporting would give me the option for file types. 

I'm totally fine with leaving as is, but wanted to have a discussion about it. If we did want to add a bit more explanation, I was thinking of, for export tooltip: "Export checklist JSON for reimport" and then keep print the same. Another option could be rename "Export" to "Save" so that it's a bit clearer that we're giving the export functionality so a user doesn't lose their progress when making a checklist. Let me know what you think.