### PR TITLE
Fix AI Response Parsing

### DIFF
--- a/teachertool/src/services/backendRequests.ts
+++ b/teachertool/src/services/backendRequests.ts
@@ -99,7 +99,7 @@ export async function askCopilotQuestionAsync(shareId: string, question: string)
         if (!request.success) {
             throw new Error(request.err || lf("Unable to reach AI. Error code: {0}", request.statusCode));
         }
-        result = await request.resp.json();
+        result = await request.resp;
     } catch (e) {
         logError(ErrorCode.askAIQuestion, e);
     }


### PR DESCRIPTION
Now that I can actually see real successful responses from the staging server, it seems this response parsing was incorrect (likely from when we switched to using `staticApiAsync` instead of sending the request directly via `fetch`). The response passed back from `staticApiAsync` has already handled the `json()` call.