### PR TITLE
clean block definitions before attempting to upgrade blocks

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -879,6 +879,7 @@ export function applyUpgradesAsync(): Promise<UpgradeResult> {
 }
 
 function upgradeFromBlocksAsync(): Promise<UpgradeResult> {
+    pxtblockly.cleanBlocks();
     const mainPkg = pkg.mainPkg;
     const project = pkg.getEditorPkg(mainPkg);
     const targetVersion = project.header.targetVersion;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5896

The issue here is that we cache Block definitions when we inject all of the blocks from our API info. This cache gets cleared [when we load a new blocks file](https://github.com/microsoft/pxt/blob/1ba230653cad6aa67f70398b4636996b8b3f075d/webapp/src/blocks.tsx#L1059), but the compiler upgrades happen before that function is called so it's using the cached blocks from the previous injection.

I still haven't figured out when this was introduced, but it appears to be a while ago. My guess would be that this repros on arcade live as well though I haven't tried it.