### PR TITLE
Code eval tool: "at least" added to block used criteria

### DIFF
--- a/common-docs/teachertool/catalog-shared.json
+++ b/common-docs/teachertool/catalog-shared.json
@@ -3,8 +3,8 @@
         {
             "id": "59AAC5BA-B0B3-4389-AA90-1E767EFA8563",
             "use": "block_used_n_times",
-            "template": "${Block} used ${count} times",
-            "description": "This block was used the specified number of times in your project.",
+            "template": "${Block} used at least ${count} times",
+            "description": "This block was used at least the specified number of times in your project.",
             "docPath": "/teachertool",
             "tags": ["General"],
             "params": [


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5901. All of our other criteria have the at least wording in the description and "title" area, so the block used criteria now matches that pattern.

![image](https://github.com/user-attachments/assets/d116dfa7-38c3-463d-ab60-47db92cf7714)
