### PR TITLE
Code eval tool: put s's in parentheses for criteria

### DIFF
--- a/common-docs/teachertool/catalog-shared.json
+++ b/common-docs/teachertool/catalog-shared.json
@@ -3,7 +3,7 @@
         {
             "id": "59AAC5BA-B0B3-4389-AA90-1E767EFA8563",
             "use": "block_used_n_times",
-            "template": "${Block} used at least ${count} times",
+            "template": "${Block} used at least ${count} time(s)",
             "description": "This block was used at least the specified number of times in your project.",
             "docPath": "/teachertool",
             "tags": ["General"],
@@ -24,7 +24,7 @@
         {
             "id": "7AE7EA2A-3AC8-42DC-89DB-65E3AE157156",
             "use": "block_comment_used",
-            "template": "At least ${count} comments",
+            "template": "At least ${count} comment(s)",
             "description": "The project contains at least the specified number of comments.",
             "docPath": "/teachertool",
             "maxCount": 1,
@@ -41,7 +41,7 @@
         {
             "id": "B8987394-1531-4C71-8661-BE4086CE0C6E",
             "use": "n_loops",
-            "template": "At least ${count} loops used",
+            "template": "At least ${count} loop(s) used",
             "docPath": "/teachertool",
             "description": "The program uses at least this many loops of any kind (for, repeat, while, or for-of).",
             "maxCount": 1,
@@ -58,7 +58,7 @@
         {
             "id": "79D5DAF7-FED3-473F-81E2-E004922E5F55",
             "use": "custom_function_called",
-            "template": "At least ${count} custom functions exist and get called",
+            "template": "At least ${count} custom function(s) exist and get called",
             "docPath": "/teachertool",
             "description": "At least this many user-defined functions are created and called.",
             "maxCount": 1,
@@ -75,7 +75,7 @@
         {
             "id": "0DFA44C8-3CA5-4C77-946E-AF09F6C03879",
             "use": "variable_usage",
-            "template": "Uses at least ${count} variables",
+            "template": "Uses at least ${count} variable(s)",
             "docPath": "/teachertool",
             "description": "The program creates and uses at least this many user-defined variables.",
             "maxCount": 1,


### PR DESCRIPTION
Added parentheses around the s's in criteria because it would read incorrectly if there was only one block being checked. 

![image](https://github.com/user-attachments/assets/1a43de03-0fa1-4717-b6ae-cd70270f3bec)
