### PR TITLE
fix workspace search plugin CSS in Firefox

### DIFF
--- a/pxtblocks/workspaceSearch.ts
+++ b/pxtblocks/workspaceSearch.ts
@@ -34,3 +34,9 @@ export class PxtWorkspaceSearch extends WorkspaceSearch {
         Blockly.utils.dom.removeClass(this.injectionDiv, 'blockly-ws-searching');
     }
 }
+
+Blockly.Css.register(`
+.blockly-ws-search button {
+    padding-left: 6px;
+    padding-right: 6px;
+}`);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5902

The workspace search plugin's buttons just use the padding from the user agent's button style. Whoever implemented this the first time around was probably testing with Chrome, which has 6px padding on its buttons by default. Firefox has 4px padding, which results in the error in the issue.

This was an issue in the plugin itself. I have also [filed it on the Blockly team](https://github.com/google/blockly-samples/issues/2458) and [opened a PR](https://github.com/google/blockly-samples/pull/2459) to fix it.