### PR TITLE
detect and warn on webusb stall

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -522,6 +522,7 @@ declare namespace pxt {
 
         dragFileImage?: string;
         connectDeviceImage?: string;
+        disconnectDeviceImage?: string;
         selectDeviceImage?: string;
         connectionSuccessImage?: string;
         incompatibleHardwareImage?: string;

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -141,10 +141,8 @@ export function showReconnectDeviceInstructionsAsync(
     const boardName = pxt.appTarget.appTheme.boardName || lf("device");
     const helpUrl = pxt.appTarget.appTheme.usbDocs;
     const jsx = webusb.renderDisconnectDeviceDialog();
-    const body = lf("Your {0} appears to have stalled; please disconnect any battery and usb connection, and try again.", boardName);
     return confirmAsync({
         header: lf("{0} Connection failed...", boardName),
-        body,
         jsx,
         hasCloseIcon: true,
         hideAgree: true,

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -515,6 +515,25 @@ export function renderUnpairDialog() {
     return { header, jsx, helpUrl };
 }
 
+export function renderDisconnectDeviceDialog() {
+    const boardName = getBoardName();
+    const disconnectImage = theme().disconnectDeviceImage;
+
+    return <>
+        {disconnectImage && <img
+            className="ui image centered medium"
+            src={disconnectImage}
+            alt={lf("Image of {0} being disconnected", boardName)}
+        />}
+        <div>
+            {lf("Your {0} appears to have stalled", boardName)}
+            <br />
+            <br />
+            {lf("Please disconnect any battery and usb connection, and try again.")}
+        </div>
+    </>;
+}
+
 export async function showDeviceForgottenDialog(confirmAsync: ConfirmAsync) {
     const boardName = getBoardName();
     const deviceForgottenImage = theme().usbDeviceForgottenImage;


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-microbit/issues/5530#issuecomment-2329825860; with some fiddling you can get your micro:bit into a state where you cannot read from it, and in that scenario the device appears to just be stalled / unrecoverable without power cycling it. This detects the cases where we call into connections from the webapp side -- when refreshing the page, downloading, or just 'pairing'.

The main case this doesn't cover is when you just plug in the micro:bit without downloading; for now it'll still wobble on the status & only show error when they press download, because that path happens entirely over on the micro:bit flash.ts side & it'll take a little more work to get that to pop this dialog properly.