### PR TITLE
fix icons in snapshot in safari

### DIFF
--- a/pxtblocks/contextMenu/workspaceItems.ts
+++ b/pxtblocks/contextMenu/workspaceItems.ts
@@ -83,6 +83,13 @@ function registerSnapshotCode() {
             pxt.tickEvent("blocks.context.screenshot", undefined, { interactiveConsent: true });
             (async () => {
                 let uri = await screenshotAsync(scope.workspace, null, pxt.appTarget.appTheme?.embedBlocksInSnapshot);
+
+                if (pxt.BrowserUtils.isSafari()) {
+                    // For some reason, Safari doesn't always load embedded images the first time. This is a silly fix,
+                    // but snapshotting a second time fixes the issue.
+                    uri = await screenshotAsync(scope.workspace, null, pxt.appTarget.appTheme?.embedBlocksInSnapshot);
+                }
+
                 if (pxt.BrowserUtils.isSafari()) {
                     uri = uri.replace(/^data:image\/[^;]/, 'data:application/octet-stream');
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5885

Well, I hate this fix. Hate it. Hate it Hate Hate it Hate it Hate it. But it works.

The only substantive thing in here is the change in workspaceItems.ts, which takes a second snapshot in Safari after the first. For some reason, this fixes the mysterious issue where icons sometimes don't load.

The changes in the other file are just a small optimization; we were loading the images in the cache in parallel which is actually a bad idea when 99% of the icons being loaded are just the same dropdown chevron