### PR TITLE
store block comment position in block data

### DIFF
--- a/pxtblocks/fields/field_utils.ts
+++ b/pxtblocks/fields/field_utils.ts
@@ -479,3 +479,9 @@ export function setBlockDataForField(block: Blockly.Block, field: string, data: 
 export function getBlockDataForField(block: Blockly.Block, field: string) {
     return getBlockData(block).fieldData[field];
 }
+
+export function deleteBlockDataForField(block: Blockly.Block, field: string) {
+    const blockData = getBlockData(block);
+    delete blockData.fieldData[field];
+    setBlockData(block, blockData);
+}

--- a/pxtblocks/plugins/comments/bubble.ts
+++ b/pxtblocks/plugins/comments/bubble.ts
@@ -206,6 +206,10 @@ export abstract class Bubble implements Blockly.IDeletable {
         this.renderTail();
     }
 
+    getPositionRelativeToAnchor() {
+        return new Blockly.utils.Coordinate(this.relativeLeft, this.relativeTop);
+    }
+
     /** @returns the size of this bubble. */
     protected getSize() {
         return this.size;

--- a/pxtblocks/plugins/comments/textinput_bubble.ts
+++ b/pxtblocks/plugins/comments/textinput_bubble.ts
@@ -37,6 +37,9 @@ export class TextInputBubble extends Bubble {
     /** Functions listening for changes to the size of this bubble. */
     private sizeChangeListeners: (() => void)[] = [];
 
+     /** Functions listening for changes to the position of this bubble. */
+    private positionChangeListeners: (() => void)[] = []
+
     /** The text of this bubble. */
     private text = '';
 
@@ -83,6 +86,11 @@ export class TextInputBubble extends Bubble {
         return this.text;
     }
 
+    override moveTo(x: number, y: number) {
+        super.moveTo(x, y);
+        this.onPositionChange();
+    }
+
     /** Sets the text of this bubble. Calls change listeners. */
     setText(text: string) {
         this.text = text;
@@ -98,6 +106,10 @@ export class TextInputBubble extends Bubble {
     /** Adds a change listener to be notified when this bubble's size changes. */
     addSizeChangeListener(listener: () => void) {
         this.sizeChangeListeners.push(listener);
+    }
+
+    addPositionChangeListener(listener: () => void) {
+        this.positionChangeListeners.push(listener);
     }
 
     /** Creates the editor UI for this bubble. */
@@ -313,6 +325,13 @@ export class TextInputBubble extends Bubble {
     /** Handles a size change event for the text area. Calls event listeners. */
     private onSizeChange() {
         for (const listener of this.sizeChangeListeners) {
+            listener();
+        }
+    }
+
+    /** Handles a position change event for the text area. Calls event listeners. */
+    private onPositionChange() {
+        for (const listener of this.positionChangeListeners) {
             listener();
         }
     }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5889

one of the additions we made in pxt-blockly was the ability for block comments to serialize their position to the XML when saving workspaces. unfortunately, we can't do the same thing with unforked blockly because there are no extension points in the XML serialization of comments. however, blockly _does_ have a data element on blocks that you can stick arbitrary data into and will get saved in the XML (we already use this for persisting data for some of our field editors)

this pr brings back the saving of the comment position by shoving it into the block's data element. note that this will not fix existing projects from before the blockly upgrade, but i really don't think anyone will notice.