### PR TITLE
Code eval tool: use toast upon deletion instead of alert

### DIFF
--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -84,6 +84,7 @@ export const UndoDeleteCriteriaButton: React.FC<{ criteriaId: string }> = ({ cri
 
     return (
         <Button
+            className="undo-button"
             title={Strings.Undo}
             label={Strings.Undo}
             onClick={handleUndoClicked}
@@ -107,7 +108,7 @@ const CriteriaResultToolbarTray: React.FC<{ criteriaId: string }> = ({ criteriaI
 
     async function handleDeleteClickedAsync() {
         removeCriteriaFromChecklist(criteriaId);
-        showToast(makeToast("info", Strings.CriteriaDeleted, 5000, <UndoDeleteCriteriaButton criteriaId={criteriaId} />));
+        showToast(makeToast("info", Strings.CriteriaDeleted, 500000, <UndoDeleteCriteriaButton criteriaId={criteriaId} />));
     }
 
     return (

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -18,6 +18,7 @@ import { Button } from "react-common/components/controls/Button";
 import { setEvalResult } from "../transforms/setEvalResult";
 import { showToast } from "../transforms/showToast";
 import { makeToast } from "../utils";
+import { readdCriteriaToChecklist } from "../transforms/readdCriteriaToChecklist";
 
 interface CriteriaResultNotesProps {
     criteriaId: string;
@@ -76,6 +77,20 @@ const CriteriaResultError: React.FC<CriteriaResultErrorProps> = ({ criteriaInsta
     );
 };
 
+export const UndoDeleteCriteriaButton: React.FC<{ criteriaId: string }> = ({ criteriaId }) => {
+    const handleUndoClicked = () => {
+        readdCriteriaToChecklist(criteriaId);
+    }
+
+    return (
+        <Button
+            title={Strings.Undo}
+            label={Strings.Undo}
+            onClick={handleUndoClicked}
+        />
+    )
+}
+
 const CriteriaResultToolbarTray: React.FC<{ criteriaId: string }> = ({ criteriaId }) => {
     const { state: teacherTool } = useContext(AppStateContext);
 
@@ -91,9 +106,8 @@ const CriteriaResultToolbarTray: React.FC<{ criteriaId: string }> = ({ criteriaI
     }
 
     async function handleDeleteClickedAsync() {
-        if (confirm(Strings.ConfirmDeleteCriteriaInstance)) {
-            removeCriteriaFromChecklist(criteriaId);
-        }
+        removeCriteriaFromChecklist(criteriaId);
+        showToast(makeToast("info", Strings.CriteriaDeleted, 5000, <UndoDeleteCriteriaButton criteriaId={criteriaId} />));
     }
 
     return (

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -19,6 +19,7 @@ import { setEvalResult } from "../transforms/setEvalResult";
 import { showToast } from "../transforms/showToast";
 import { makeToast } from "../utils";
 import { readdCriteriaToChecklist } from "../transforms/readdCriteriaToChecklist";
+import { dismissToast } from "../state/actions";
 
 interface CriteriaResultNotesProps {
     criteriaId: string;
@@ -77,9 +78,13 @@ const CriteriaResultError: React.FC<CriteriaResultErrorProps> = ({ criteriaInsta
     );
 };
 
-export const UndoDeleteCriteriaButton: React.FC<{ criteriaId: string }> = ({ criteriaId }) => {
+const UndoDeleteCriteriaButton: React.FC<{ criteriaId: string, toastId: string }> = ({ criteriaId, toastId }) => {
+    const { dispatch } = useContext(AppStateContext);
     const handleUndoClicked = () => {
         readdCriteriaToChecklist(criteriaId);
+        if (toastId) {
+            dispatch(dismissToast(toastId));
+        }
     }
 
     return (
@@ -108,7 +113,9 @@ const CriteriaResultToolbarTray: React.FC<{ criteriaId: string }> = ({ criteriaI
 
     async function handleDeleteClickedAsync() {
         removeCriteriaFromChecklist(criteriaId);
-        showToast(makeToast("info", Strings.CriteriaDeleted, 500000, <UndoDeleteCriteriaButton criteriaId={criteriaId} />));
+        const toast = makeToast("info", Strings.CriteriaDeleted);
+        toast.jsx = <UndoDeleteCriteriaButton criteriaId={criteriaId} toastId={toast.id} />;
+        showToast(toast);
     }
 
     return (

--- a/teachertool/src/components/EvalResultDisplay.tsx
+++ b/teachertool/src/components/EvalResultDisplay.tsx
@@ -122,6 +122,7 @@ const CriteriaWithResultsTable: React.FC = () => {
         <div className={css["results-list"]}>
             {Object.values(criteria).map(criteriaInstance => {
                 return (
+                    !criteriaInstance.deleted &&
                     <CriteriaResultEntry criteriaId={criteriaInstance.instanceId} key={criteriaInstance.instanceId} />
                 );
             })}

--- a/teachertool/src/components/Toasts.tsx
+++ b/teachertool/src/components/Toasts.tsx
@@ -54,7 +54,7 @@ const ToastNotification: React.FC<IToastNotificationProps> = ({ toast }) => {
                 <div className={css["text-container"]}>
                     {toast.text && <div className={classList(css["text"], "tt-toast-text")}>{toast.text}</div>}
                     {toast.detail && <div className={css["detail"]}>{toast.detail}</div>}
-                    {toast.jsx && <div>{toast.jsx}</div>}
+                    {toast.jsx && <div className={css["custom-jsx"]}>{toast.jsx}</div>}
                 </div>
                 {!toast.hideDismissBtn && !toast.showSpinner && (
                     <div className={css["dismiss-btn"]} onClick={handleDismissClicked}>

--- a/teachertool/src/components/styling/Toasts.module.scss
+++ b/teachertool/src/components/styling/Toasts.module.scss
@@ -88,6 +88,7 @@
 
             .custom-jsx {
                 pointer-events: auto;
+                display: inline;
             }
         }
 

--- a/teachertool/src/components/styling/Toasts.module.scss
+++ b/teachertool/src/components/styling/Toasts.module.scss
@@ -85,6 +85,10 @@
             .detail {
                 font-size: 0.875rem;
             }
+
+            .custom-jsx {
+                pointer-events: auto;
+            }
         }
 
         .dismiss-btn {

--- a/teachertool/src/components/styling/Toasts.module.scss
+++ b/teachertool/src/components/styling/Toasts.module.scss
@@ -43,6 +43,7 @@
         gap: 0.5rem;
         padding: 0.75rem;
         font-size: 1.125rem;
+        align-items: center;
 
         .icon-container {
             display: flex;
@@ -72,7 +73,8 @@
 
         .text-container {
             display: flex;
-            flex-direction: column;
+            flex-direction: row;
+            align-items: center;
             text-align: left;
 
             .text {
@@ -88,7 +90,7 @@
 
             .custom-jsx {
                 pointer-events: auto;
-                display: inline;
+                margin-left: 1rem;
             }
         }
 

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -53,6 +53,8 @@ export namespace Strings {
     export const EvaluationComplete = lf("Evaluation complete");
     export const UnableToEvaluatePartial = lf("Unable to evaluate some criteria");
     export const GiveFeedback = lf("Give Feedback");
+    export const CriteriaDeleted = lf("Criteria Deleted");
+    export const Undo = lf("Undo");
 }
 
 export namespace Ticks {

--- a/teachertool/src/style.overrides/Button.scss
+++ b/teachertool/src/style.overrides/Button.scss
@@ -75,3 +75,14 @@
 .pass > .common-button.common-dropdown-button {
     border: 3px solid var(--pxt-success-accent);
 }
+
+.undo-button {
+    width: 3rem;
+    height: 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--pxt-button-secondary-background);
+    color: var(--pxt-button-secondary-foreground);
+}

--- a/teachertool/src/style.overrides/Button.scss
+++ b/teachertool/src/style.overrides/Button.scss
@@ -83,6 +83,6 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    background-color: var(--pxt-button-secondary-background);
+    background-color: var(--pxt-info-accent-darkened);
     color: var(--pxt-button-secondary-foreground);
 }

--- a/teachertool/src/transforms/readdCriteriaToChecklist.ts
+++ b/teachertool/src/transforms/readdCriteriaToChecklist.ts
@@ -4,7 +4,7 @@ import { setChecklist } from "./setChecklist";
 import { Ticks } from "../constants";
 import { getCriteriaInstanceWithId } from "../state/helpers";
 
-export function removeCriteriaFromChecklist(criteriaInstanceId: string) {
+export function readdCriteriaToChecklist(criteriaInstanceId: string) {
     const { state: teacherTool } = stateAndDispatch();
 
     logDebug(`Removing criteria with id: ${criteriaInstanceId}`);
@@ -12,9 +12,10 @@ export function removeCriteriaFromChecklist(criteriaInstanceId: string) {
     const instance = getCriteriaInstanceWithId(teacherTool, criteriaInstanceId);
     const catalogCriteriaId = instance?.catalogCriteriaId;
     const allCriteria = [...teacherTool.checklist.criteria];
+    console.log("all of the criteria", allCriteria);
     const criteriaIndex = allCriteria.findIndex(c => c.instanceId === criteriaInstanceId);
-    allCriteria[criteriaIndex].deleted = true;
-
+    allCriteria[criteriaIndex].deleted = false;
+    console.log("all of the criteria after deletion", allCriteria);
 
     const newChecklist = {
         ...teacherTool.checklist,

--- a/teachertool/src/transforms/readdCriteriaToChecklist.ts
+++ b/teachertool/src/transforms/readdCriteriaToChecklist.ts
@@ -12,10 +12,8 @@ export function readdCriteriaToChecklist(criteriaInstanceId: string) {
     const instance = getCriteriaInstanceWithId(teacherTool, criteriaInstanceId);
     const catalogCriteriaId = instance?.catalogCriteriaId;
     const allCriteria = [...teacherTool.checklist.criteria];
-    console.log("all of the criteria", allCriteria);
     const criteriaIndex = allCriteria.findIndex(c => c.instanceId === criteriaInstanceId);
     allCriteria[criteriaIndex].deleted = false;
-    console.log("all of the criteria after deletion", allCriteria);
 
     const newChecklist = {
         ...teacherTool.checklist,

--- a/teachertool/src/transforms/runEvaluateAsync.ts
+++ b/teachertool/src/transforms/runEvaluateAsync.ts
@@ -17,7 +17,9 @@ export async function runEvaluateAsync(fromUserInteraction: boolean) {
         setActiveTab("results");
     }
 
-    const evalRequests = teacherTool.checklist.criteria.map(criteriaInstance =>
+    const validCriteria = teacherTool.checklist.criteria.filter(c => !c.deleted);
+
+    const evalRequests = validCriteria.map(criteriaInstance =>
         runSingleEvaluateAsync(criteriaInstance.instanceId, fromUserInteraction)
     );
 

--- a/teachertool/src/types/criteria.ts
+++ b/teachertool/src/types/criteria.ts
@@ -20,6 +20,7 @@ export interface CriteriaInstance {
     instanceId: string;
     params: CriteriaParameterValue[] | undefined;
     userFeedback?: UserFeedback;
+    deleted?: boolean;
 }
 
 // Represents a parameter definition in a catalog criteria.

--- a/teachertool/src/utils/index.ts
+++ b/teachertool/src/utils/index.ts
@@ -5,12 +5,13 @@ import { classList } from "react-common/components/util";
 import { CatalogCriteria } from "../types/criteria";
 import { Strings } from "../constants";
 
-export function makeToast(type: ToastType, text: string, timeoutMs: number = 5000): ToastWithId {
+export function makeToast(type: ToastType, text: string, timeoutMs: number = 5000, jsx?: React.ReactNode): ToastWithId {
     return {
         id: nanoid(),
         type,
         text,
         timeoutMs,
+        jsx,
     };
 }
 


### PR DESCRIPTION
Closes https://github.com/microsoft/pxt-microbit/issues/5911

I found the alert experience to be really clunky, so, as per @eanders-ms's suggestion, I've changed it so when a user deletes a criteria, they can undo it via a toast that pops up. 

As part of this change, I made it so deleting a criteria just performs a soft deletion so undoing a deletion was possible.

![image](https://github.com/user-attachments/assets/ff7f210e-d251-4b3c-97d5-ec1f9004fb02)

Upload target: https://makecode.microbit.org/app/1e6a09bea0071a2dc2a1090b02ea5bce60eb59cf-1d05a9bc99--eval#