### PR TITLE
fix interleaving of save/sync operations

### DIFF
--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -285,6 +285,7 @@ async function listAsync(): Promise<pxt.workspace.Header[]> {
 async function getAsync(h: Header): Promise<pxt.workspace.File> {
     const db = await getCurrentDbAsync();
     const res = await db.getAsync<StoredText>(TEXTS_TABLE, h.id);
+    if (!res) return undefined;
     return {
         header: h,
         text: res.files,

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -574,7 +574,6 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
             text,
             version: null
         }
-        allScripts.push(e)
     }
 
     const hasUserFileChanges = () => {
@@ -691,6 +690,10 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
 
         if (text) {
             e.version = ver;
+        }
+
+        if (newSave) {
+            allScripts.push(e);
         }
 
         if (isUserChange) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5926

this fixes a bug caused by interleaving save/sync operations when duplicating a project from within the code editor.

we maintain a global array of all the available headers in the current workspace that we pull projects from. currently, that array gets updated in two places:
1.  when we do a sync operation
2. when we start to save a new project (but before the project is actually saved)

if a sync operation gets triggered after we start saving a new project but before that save has actually completed, it can accidentally overwrite the change that was made when we saved a new project.

luckily, it's an easy fix. we just need to wait to add the project to the header array until after it's actually saved.