### PR TITLE
Don't run local CLI builds in parallel

### DIFF
--- a/cli/prepYotta.ts
+++ b/cli/prepYotta.ts
@@ -7,8 +7,8 @@ const os = require("os");
 const path = require("path");
 const fs = require("fs");
 
-const token = process.env["GH_ACCESS_TOKEN"];
-if (process.env["GH_ACCESS_TOKEN"]) {
+const token = process.env["GITHUB_ACCESS_TOKEN"];
+if (process.env["GITHUB_ACCESS_TOKEN"]) {
     console.log("Writing .netrc and .yotta/config.json")
     const home = os.homedir();
 

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -1187,6 +1187,8 @@ namespace pxt {
                     }
                 }
 
+                einfo.appVariant = variant;
+
                 const inf = target.isNative ? await this.host().getHexInfoAsync(einfo) : null
 
                 einfo = U.flatClone(einfo)


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5915

the global state in our CLI is definitely going to be the death of me

this PR fixes the issue with local builds by de-parallelizing them using a promise queue. i also took this opportunity to remove the last reference to the old GH_ACCESS_TOKEN environment variable (missed this one i guess)