### PR TITLE
use getDate not getDay and simplify date logic

### DIFF
--- a/webapp/src/timeMachine.tsx
+++ b/webapp/src/timeMachine.tsx
@@ -362,21 +362,31 @@ function formatTime(time: number) {
 }
 
 function formatDate(time: number) {
+    const oneDay = 1000 * 60 * 60 * 24;
+
     const now = new Date();
     const nowYear = now.getFullYear();
     const nowMonth = now.getMonth();
     const nowDay = now.getDate();
 
-    const date = new Date(time);
-    const year = date.getFullYear();
-    const month = date.getMonth();
-    const day = date.getDate();
+    const today = new Date(nowYear, nowMonth, nowDay);
+    const yesterday = new Date(today.getTime() - oneDay);
+    const oneWeekAgo = new Date(today.getTime() - oneDay * 7);
 
-    const diff = Date.now() - time;
-    const oneDay = 1000 * 60 * 60 * 24;
+    const editTime = new Date(time);
+    const editDay = new Date(editTime.getFullYear(), editTime.getMonth(), editTime.getDate());
 
-    if (year !== nowYear) {
-        return date.toLocaleDateString(
+    if (time >= today.getTime()) {
+        return lf("Today");
+    }
+    else if (time >= yesterday.getTime()) {
+        return lf("Yesterday")
+    }
+    else if (time >= oneWeekAgo.getTime()) {
+        return lf("{0} days ago", Math.floor((today.getTime() - editDay.getTime()) / oneDay));
+    }
+    else if (editDay.getFullYear() !== today.getFullYear()) {
+        return editTime.toLocaleDateString(
             pxt.U.userLanguage(),
             {
                 year: "numeric",
@@ -385,17 +395,8 @@ function formatDate(time: number) {
             }
         );
     }
-    else if (nowMonth === month && nowDay === day) {
-        return lf("Today");
-    }
-    else if (diff < oneDay * 2) {
-        return lf("Yesterday")
-    }
-    else if (diff < oneDay * 8) {
-        return lf("{0} days ago", Math.floor(diff / oneDay))
-    }
     else {
-        return date.toLocaleDateString(
+        return editTime.toLocaleDateString(
             pxt.U.userLanguage(),
             {
                 month: "short",
@@ -439,7 +440,7 @@ function getTimelineEntries(history: HistoryFile): TimelineEntry[] {
 
     const createTimeEntry = (timestamp: number, kind: "snapshot" | "diff" | "share") => {
         const date = new Date(timestamp);
-        const key = new Date(date.getFullYear(), date.getMonth(), date.getDay()).getTime();
+        const key = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
 
         if (!buckets[key]) {
             buckets[key] = [];


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5935

turns out the `getDay()` method returns the index of the day of the week not the day of the month! I guess those just happened to coincide last week while i was testing this ¯\\\_(ツ)\_/¯

the correct method to use is the confusingly named `getDate()`

i also fixed up the 'x days ago' logic so that it's a little easier to read