### PR TITLE
re-enable scroll to zoom in blocks

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1268,7 +1268,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 minScale: .2,
                 scaleSpeed: 1.5,
                 startScale: pxt.BrowserUtils.isMobile() ? 0.7 : 0.9,
-                pinch: true
+                pinch: true,
+                wheel: true
             },
             rtl: Util.isUserLanguageRtl()
         };


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5942

not sure how this got disabled in the first place, but it's probably my fault