### PR TITLE
[Stable 9.3] Cherry pick adding tutorial option for a python template (#10097)

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1153,6 +1153,7 @@ declare namespace pxt.tutorial {
         code: string[]; // all code
         language?: string; // language of code snippet (ts or python)
         templateCode?: string;
+        templateLanguage?: string; // language of template code
         metadata?: TutorialMetadata;
         assetFiles?: pxt.Map<string>;
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
@@ -1258,6 +1259,7 @@ declare namespace pxt.tutorial {
         tutorialCode?: string[]; // all tutorial code bundled
         tutorialRecipe?: boolean; // micro tutorial running within the context of a script
         templateCode?: string;
+        templateLanguage?: string;
         mergeHeaderId?: string;
         mergeCarryoverCode?: boolean;
         autoexpandStep?: boolean; // autoexpand tutorial card if instruction text overflows

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -13,6 +13,7 @@ namespace pxt.tutorial {
         const {
             code,
             templateCode,
+            templateLanguage,
             editor,
             language,
             jres,
@@ -51,6 +52,7 @@ namespace pxt.tutorial {
             activities,
             code,
             templateCode,
+            templateLanguage,
             metadata,
             language,
             jres,
@@ -63,7 +65,7 @@ namespace pxt.tutorial {
     }
 
     export function getMetadataRegex(): RegExp {
-        return /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres|assetjson|customts|simtheme)\s*\n([\s\S]*?)\n```/gmi;
+        return /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres|assetjson|customts|simtheme|python-template|ts-template|typescript-template|js-template|javascript-template)\s*\n([\s\S]*?)\n```/gmi;
     }
 
     function computeBodyMetadata(body: string) {
@@ -74,6 +76,7 @@ namespace pxt.tutorial {
         let jres: string;
         let code: string[] = [];
         let templateCode: string;
+        let templateLanguage: string;
         let language: string;
         let idx = 0;
         let assetJson: string;
@@ -109,6 +112,22 @@ namespace pxt.tutorial {
                     case "template":
                         templateCode = m2;
                         break;
+                    case "python-template":
+                        if (!checkTutorialEditor(pxt.PYTHON_PROJECT_NAME))
+                            return undefined;
+                        templateCode = m2;
+                        templateLanguage = "python";
+                        language = "python";
+                        break;
+                    case "ts-template":
+                    case "typescript-template":
+                    case "js-template":
+                    case "javascript-template":
+                        if (!checkTutorialEditor(pxt.JAVASCRIPT_PROJECT_NAME))
+                            return undefined;
+                        templateCode = m2;
+                        templateLanguage = "typescript";
+                        break;
                     case "jres":
                         jres = m2;
                         break;
@@ -132,6 +151,7 @@ namespace pxt.tutorial {
         return {
             code,
             templateCode,
+            templateLanguage,
             editor,
             language,
             jres,
@@ -443,6 +463,7 @@ ${code}
             tutorialCode: tutorialInfo.code,
             tutorialRecipe: !!recipe,
             templateCode: tutorialInfo.templateCode,
+            templateLanguage: tutorialInfo.templateLanguage,
             autoexpandStep: tutorialInfo.metadata?.autoexpandOff ? false : true,
             metadata: tutorialInfo.metadata,
             language: tutorialInfo.language,

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1974,8 +1974,10 @@ export class ProjectView
 
         const projectname = projectNameForEditor(preferredEditor || header.editor);
 
-
-        if (projectname === pxt.JAVASCRIPT_PROJECT_NAME) {
+        if (projectname === pxt.PYTHON_PROJECT_NAME && header.tutorial.templateLanguage === "python") {
+            currentText[pxt.MAIN_PY] = template;
+        }
+        else if (projectname === pxt.JAVASCRIPT_PROJECT_NAME) {
             currentText[pxt.MAIN_TS] = template;
         }
         else if (projectname === pxt.PYTHON_PROJECT_NAME) {


### PR DESCRIPTION
I guess I cherry picked to the wrong stable branch before, cause it certainly isn't in this one!