### PR TITLE
Dev/jwunderl/dont error on empty response

### DIFF
--- a/webapp/src/fileworkspace.ts
+++ b/webapp/src/fileworkspace.ts
@@ -24,6 +24,9 @@ export function setApiAsync(f: (path: string, data?: any) => Promise<any>) {
 function getAsync(h: Header) {
     return apiAsync("pkg/" + h.path)
         .then((resp: pxt.FsPkg) => {
+            if (!resp.files) {
+                return undefined;
+            }
             let r: pxt.workspace.File = {
                 header: h,
                 text: {},

--- a/webapp/src/timeMachine.tsx
+++ b/webapp/src/timeMachine.tsx
@@ -223,8 +223,13 @@ export const TimeMachine = (props: TimeMachineProps) => {
         "controller",
         "skillsMap",
         "noproject",
-        "nocookiebanner"
+        "nocookiebanner",
     ];
+
+    const localToken = pxt.storage.getLocal("local_token");
+    if (localToken) {
+        queryParams.push(`local_token=${localToken}`);
+    }
 
     if (pxt.appTarget?.appTheme.timeMachineQueryParams) {
         queryParams = queryParams.concat(pxt.appTarget.appTheme.timeMachineQueryParams);


### PR DESCRIPTION
first commit: matching https://github.com/microsoft/pxt/blob/master/webapp/src/browserworkspace.ts#L92, don't log an error

second commit: propagate local token so allowed to show time machine iframe fix https://github.com/microsoft/pxt-microbit/issues/5953

also need https://github.com/microsoft/pxt-electron/pull/248, @riknoll question for you on time machine over in that pr