### PR TITLE
Add generated name mirrored from vscode-edu

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -1138,6 +1138,7 @@ declare namespace pxt.editor {
         notifyProjectCompiled?: (headerId: string, compileResult: pxtc.CompileResult) => void;
         notifyProjectSaved?: (header: pxt.workspace.Header) => void;
         onDownloadButtonClick?: () => Promise<void>;
+        getDefaultProjectName?: () => string; // If defined, replaces 'Untitled' as the default project name
     
         // Used with the @tutorialCompleted macro. See docs/writing-docs/tutorials.md for more info
         onTutorialCompleted?: () => void;

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -44,4 +44,5 @@ namespace pxt.commands {
     export let notifyProjectCompiled: (headerId: string, compileResult: pxtc.CompileResult) => void = undefined;
     export let notifyProjectSaved: (header: pxt.workspace.Header) => void = undefined;
     export let onDownloadButtonClick: () => Promise<void> = undefined;
+    export let getDefaultProjectName: () => string = undefined;
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2476,7 +2476,7 @@ export class ProjectView
             this.hintManager.clearViewedHints();
 
             return this.createProjectAsync({
-                name: "untitled",
+                name: lf("untitled"),
                 tutorial: options,
                 preferredEditor: editor,
                 dependencies
@@ -2894,7 +2894,7 @@ export class ProjectView
         this.setSideDoc(undefined);
         if (!options.prj) options.prj = pxt.appTarget.blocksprj;
         let cfg = pxt.U.clone(options.prj.config);
-        cfg.name = options.name || lf("Untitled");
+        cfg.name = options.name || pxt.commands.getDefaultProjectName?.() || lf("Untitled");
         cfg.documentation = options.documentation;
         let files: pxt.workspace.ScriptText = Util.clone(options.prj.files)
         if (options.filesOverride) {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -393,6 +393,10 @@ function applyExtensionResult() {
         log(`extension showProgramTooLargeErrorAsync`);
         pxt.commands.showProgramTooLargeErrorAsync = res.showProgramTooLargeErrorAsync;
     }
+    if (res.getDefaultProjectName) {
+        log(`extension getDefaultProjectName`);
+        pxt.commands.getDefaultProjectName = res.getDefaultProjectName;
+    }
     if (res.getDownloadMenuItems) {
         log(`extension getDownloadMenuItems`);
         pxt.commands.getDownloadMenuItems = res.getDownloadMenuItems;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1483,7 +1483,7 @@ export class NewProjectDialog extends data.Component<ISettingsProps, NewProjectD
     show = () => {
         pxt.tickEvent('newprojectdialog.show', undefined, { interactiveConsent: false });
         this.setState({
-            name: "",
+            name: pxt.commands.getDefaultProjectName?.() || "",
             emoji: "",
             visible: true,
             languageRestriction: pxt.editor.LanguageRestriction.Standard


### PR DESCRIPTION
pxt side glue

Guess one question, we don't fill in on this screen

![image](https://github.com/user-attachments/assets/249ec8d0-4137-43aa-a91f-0774bfbc13ca)

but I could if we wanted? Don't really mind behavior as is, if they click through it generates a name, but don't get in their way if they actually plan to fill it out

![image](https://github.com/user-attachments/assets/d7951384-57f4-4033-b687-a025b2837bce)
