### PR TITLE
support blocks generated from static class methods

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1033,6 +1033,7 @@ declare namespace ts.pxtc {
         pyName?: string;
         pyQName?: string;
         snippetAddsDefinitions?: boolean;
+        isStatic?: boolean;
     }
 
     interface ApisInfo {

--- a/pxtcompiler/emitter/annotate.ts
+++ b/pxtcompiler/emitter/annotate.ts
@@ -116,7 +116,9 @@ namespace ts.pxtc {
                     case SK.SetAccessor:
                     case SK.MethodDeclaration:
                     case SK.MethodSignature:
-                        isMethod = true
+                        if (!isStatic(decl)) {
+                            isMethod = true
+                        }
                         break;
                     default:
                         break;

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -204,6 +204,7 @@ namespace ts.pxtc {
                 pkg,
                 pkgs,
                 extendsTypes,
+                isStatic: decl.modifiers?.some(m => m.kind === SyntaxKind.StaticKeyword),
                 retType:
                     stmt.kind == SyntaxKind.Constructor ? "void" :
                         kind == SymbolKind.Module ? "" :

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -126,7 +126,7 @@ namespace pxt.blocks {
             handlerArgs: []
         };
 
-        const instance = (fn.kind == ts.pxtc.SymbolKind.Method || fn.kind == ts.pxtc.SymbolKind.Property) && !fn.attributes.defaultInstance;
+        const instance = (fn.kind == ts.pxtc.SymbolKind.Method || fn.kind == ts.pxtc.SymbolKind.Property) && !fn.attributes.defaultInstance && !fn.isStatic;
         const hasBlockDef = !!fn.attributes._def;
         const defParameters = hasBlockDef ? fn.attributes._def.parameters.slice(0) : undefined;
         const optionalStart = hasBlockDef ? defParameters.length : (fn.parameters ? fn.parameters.length : 0);


### PR DESCRIPTION
Support blocks defined as static methods on classes.

This works fine in the editor, but for some reason when I attempted to add a test case to the decompiler tests I was getting errors. I'll need to do some more investigation to figure out what's different between those two scenarios; this isn't the first time that the decompiler tests have given me grief on things that worked fine. I'm guessing it's an issue with the annotate function.