### PR TITLE
Build d.ts for target

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2983,10 +2983,6 @@ class SnippetHost implements pxt.Host {
             }
             p = path.parse(p.dir);
         }
-        // const i = cwd.lastIndexOf(path.sep + "pxt" + path.sep);
-        // if (i !== -1) {
-        //     return cwd.substr(0, i + 5);
-        // }
         return path.join(cwd, "node_modules", "pxt-core");
     }
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1076,6 +1076,7 @@ declare namespace ts.pxtc {
         clearIncrBuildAndRetryOnError?: boolean; // on error when compiling in service, try again with a full recompile.
         errorOnGreyBlocks?: boolean;
         generateSourceMap?: boolean;
+        tsCompileOptions?: pxt.Map<any>; // ts.CompilerOptions;
 
         otherMultiVariants?: ExtensionTarget[];
 

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -25,6 +25,12 @@ namespace ts.pxtc {
         options.noImplicitAny = true;
         options.noImplicitReturns = true;
         options.allowUnreachableCode = true;
+        options.declaration = true;
+
+        for (const [key, value] of Object.entries(opts?.tsCompileOptions ?? {})) {
+            options[key] = value;
+        }
+
         return options
     }
 


### PR DESCRIPTION
Simple version for now since we just want a prototype, but easy to add list of packages to include / from share link support / etc if we want.

Should look at stripping it so hidden / deprecated apis etc are removed as well, but spent too long staring at this before realizing my local arcade build was just very broken so need to look at other stuff that's more useful for now, basically just stashing this here.

it outputs to separate d.ts files but also combines them into a 'combined.d.ts' at the end. This doesn't kick off a build or anything so need to have served first (which does mean it only takes about a second to run

[combined.d.zip](https://github.com/user-attachments/files/17035102/combined.d.zip)
