### PR TITLE
Teacher Tool: More Telemetry

### DIFF
--- a/teachertool/src/App.tsx
+++ b/teachertool/src/App.tsx
@@ -19,6 +19,7 @@ import { SignedOutPanel } from "./components/SignedOutPanel";
 import * as authClient from "./services/authClient";
 import { ErrorCode } from "./types/errorCode";
 import { loadProjectMetadataAsync } from "./transforms/loadProjectMetadataAsync";
+import { Ticks } from "./constants";
 
 export const App = () => {
     const { state, dispatch } = useContext(AppStateContext);
@@ -47,6 +48,7 @@ export const App = () => {
                     const decoded = decodeURIComponent(projectParam);
                     const shareId = pxt.Cloud.parseScriptId(decoded);
                     if (!!shareId) {
+                        pxt.tickEvent(Ticks.LoadProjectFromUrl);
                         await loadProjectMetadataAsync(decoded, shareId);
                     }
                 }

--- a/teachertool/src/components/BlockPickerModal.tsx
+++ b/teachertool/src/components/BlockPickerModal.tsx
@@ -11,7 +11,7 @@ import { getReadableBlockString } from "../utils";
 import { setParameterValue } from "../transforms/setParameterValue";
 import { ErrorCode } from "../types/errorCode";
 import { logError } from "../services/loggingService";
-import { Strings } from "../constants";
+import { Strings, Ticks } from "../constants";
 import { BlockPickerOptions } from "../types/modalOptions";
 import css from "./styling/BlockPickerModal.module.scss";
 
@@ -51,6 +51,7 @@ const BlockPickerCategory: React.FC<BlockPickerCategoryProps> = ({ category, onB
     const [expanded, setExpanded] = useState(false);
 
     function blockSelected(block: pxt.editor.ToolboxBlockDefinition) {
+        pxt.tickEvent(Ticks.BlockPickerBlockSelected, { blockId: block.blockId ?? "" });
         onBlockSelected?.(block);
     }
 

--- a/teachertool/src/components/CatalogOverlay.tsx
+++ b/teachertool/src/components/CatalogOverlay.tsx
@@ -44,10 +44,7 @@ const CatalogItemLabel: React.FC<CatalogItemLabelProps> = ({ catalogCriteria, is
         <div className={css["catalog-item-label"]}>
             <div className={css["action-indicators"]}>
                 {isMaxed ? (
-                    <i
-                        className="fas fa-check"
-                        title={Strings.MaxReached}
-                    />
+                    <i className="fas fa-check" title={Strings.MaxReached} />
                 ) : (
                     <>
                         <i
@@ -59,10 +56,7 @@ const CatalogItemLabel: React.FC<CatalogItemLabelProps> = ({ catalogCriteria, is
                             title={lf("Added!")}
                         />
                         <i
-                            className={classList(
-                                "fas fa-plus",
-                                recentlyAdded ? css["hide-indicator"] : undefined
-                            )}
+                            className={classList("fas fa-plus", recentlyAdded ? css["hide-indicator"] : undefined)}
                             title={Strings.AddToChecklist}
                         />
                     </>

--- a/teachertool/src/components/CriteriaEvalResultDropdown.tsx
+++ b/teachertool/src/components/CriteriaEvalResultDropdown.tsx
@@ -56,7 +56,7 @@ export const CriteriaEvalResultDropdown: React.FC<CriteriaEvalResultProps> = ({ 
             selectedId={selectedResult}
             className={classList("rounded", selectedResult)}
             items={dropdownItems}
-            onItemSelected={id => setEvalResultOutcome(criteriaId, itemIdToCriteriaResult[id])}
+            onItemSelected={id => setEvalResultOutcome(criteriaId, itemIdToCriteriaResult[id], true)}
         />
     );
 };

--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -9,7 +9,7 @@ import { useContext, useEffect, useMemo, useState } from "react";
 import { Input } from "react-common/components/controls/Input";
 import { Button } from "react-common/components/controls/Button";
 import { AppStateContext } from "../state/appStateContext";
-import { Strings } from "../constants";
+import { Strings, Ticks } from "../constants";
 import { showModal } from "../transforms/showModal";
 import { BlockPickerOptions } from "../types/modalOptions";
 import { validateParameterValue } from "../utils/validateParameterValue";
@@ -91,6 +91,7 @@ interface BlockData {
 const BlockInputSegment: React.FC<BlockInputSegmentProps> = ({ instance, param }) => {
     const { state: teacherTool } = useContext(AppStateContext);
     function handleClick() {
+        pxt.tickEvent(Ticks.BlockPickerOpened, { criteriaCatalogId: instance.catalogCriteriaId });
         showModal({
             modal: "block-picker",
             criteriaInstanceId: instance.instanceId,

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -17,7 +17,7 @@ import { removeCriteriaFromChecklist } from "../transforms/removeCriteriaFromChe
 import { Button } from "react-common/components/controls/Button";
 import { setEvalResult } from "../transforms/setEvalResult";
 import { showToast } from "../transforms/showToast";
-import { makeToast } from "../utils";
+import { getChecklistHash, makeToast } from "../utils";
 
 interface CriteriaResultNotesProps {
     criteriaId: string;
@@ -80,7 +80,12 @@ const CriteriaResultToolbarTray: React.FC<{ criteriaId: string }> = ({ criteriaI
     const { state: teacherTool } = useContext(AppStateContext);
 
     async function handleEvaluateClickedAsync() {
-        pxt.tickEvent(Ticks.Evaluate);
+        const criteriaInstance = getCriteriaInstanceWithId(teacherTool, criteriaId);
+        pxt.tickEvent(Ticks.SingleEvaluate, {
+            catalogCriteriaId: criteriaInstance?.catalogCriteriaId ?? "",
+            checklistHash: getChecklistHash(teacherTool.checklist),
+            projectId: teacherTool.projectMetadata?.id ?? "",
+        });
         const success = await runSingleEvaluateAsync(criteriaId, true);
 
         if (success) {

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -17,7 +17,7 @@ import { removeCriteriaFromChecklist } from "../transforms/removeCriteriaFromChe
 import { Button } from "react-common/components/controls/Button";
 import { setEvalResult } from "../transforms/setEvalResult";
 import { showToast } from "../transforms/showToast";
-import { getChecklistHash, makeToast } from "../utils";
+import { getChecklistHash, getObfuscatedProjectId, makeToast } from "../utils";
 
 interface CriteriaResultNotesProps {
     criteriaId: string;
@@ -84,7 +84,7 @@ const CriteriaResultToolbarTray: React.FC<{ criteriaId: string }> = ({ criteriaI
         pxt.tickEvent(Ticks.SingleEvaluate, {
             catalogCriteriaId: criteriaInstance?.catalogCriteriaId ?? "",
             checklistHash: getChecklistHash(teacherTool.checklist),
-            projectId: teacherTool.projectMetadata?.id ?? "",
+            projectId: getObfuscatedProjectId(teacherTool.projectMetadata?.id),
         });
         const success = await runSingleEvaluateAsync(criteriaId, true);
 

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -69,7 +69,7 @@ const CriteriaResultError: React.FC<CriteriaResultErrorProps> = ({ criteriaInsta
                 leftIcon="fas fa-times-circle"
                 title={Strings.Dismiss}
                 onClick={() =>
-                    setEvalResult(criteriaInstanceId, { result: EvaluationStatus.NotStarted, error: undefined })
+                    setEvalResult(criteriaInstanceId, { result: EvaluationStatus.NotStarted, resultIsManual: false, error: undefined })
                 }
             />
         </div>

--- a/teachertool/src/components/CriteriaResultEntry.tsx
+++ b/teachertool/src/components/CriteriaResultEntry.tsx
@@ -69,7 +69,11 @@ const CriteriaResultError: React.FC<CriteriaResultErrorProps> = ({ criteriaInsta
                 leftIcon="fas fa-times-circle"
                 title={Strings.Dismiss}
                 onClick={() =>
-                    setEvalResult(criteriaInstanceId, { result: EvaluationStatus.NotStarted, resultIsManual: false, error: undefined })
+                    setEvalResult(criteriaInstanceId, {
+                        result: EvaluationStatus.NotStarted,
+                        resultIsManual: false,
+                        error: undefined,
+                    })
                 }
             />
         </div>

--- a/teachertool/src/components/EvalResultDisplay.tsx
+++ b/teachertool/src/components/EvalResultDisplay.tsx
@@ -30,7 +30,6 @@ const ResultsHeader: React.FC<ResultsHeaderProps> = ({ printRef }) => {
     const [checklistNameInputRef, setChecklistNameInputRef] = useState<HTMLInputElement>();
 
     const handleEvaluateClickedAsync = async () => {
-        pxt.tickEvent(Ticks.Evaluate);
         await runEvaluateAsync(true);
     };
 

--- a/teachertool/src/components/EvalResultDisplay.tsx
+++ b/teachertool/src/components/EvalResultDisplay.tsx
@@ -5,7 +5,7 @@ import { useReactToPrint } from "react-to-print";
 import { AppStateContext } from "../state/appStateContext";
 import { CriteriaResultEntry } from "./CriteriaResultEntry";
 import { QRCodeSVG } from "qrcode.react";
-import { getProjectLink } from "../utils";
+import { getChecklistHash, getObfuscatedProjectId, getProjectLink } from "../utils";
 import { classList } from "react-common/components/util";
 import { AddCriteriaButton } from "./AddCriteriaButton";
 import { DebouncedInput } from "./DebouncedInput";
@@ -30,6 +30,15 @@ const ResultsHeader: React.FC<ResultsHeaderProps> = ({ printRef }) => {
     const [checklistNameInputRef, setChecklistNameInputRef] = useState<HTMLInputElement>();
 
     const handleEvaluateClickedAsync = async () => {
+        pxt.tickEvent(Ticks.BulkEvaluate, {
+            fromUserInteraction: true + "",
+            runOnLoad: false + "",
+            criteriaCount: checklist.criteria.length,
+            catalogCriteriaIds: JSON.stringify(checklist.criteria.map(c => c.catalogCriteriaId)),
+            checklistHash: getChecklistHash(checklist),
+            projectId: getObfuscatedProjectId(projectMetadata?.id),
+        });
+
         await runEvaluateAsync(true);
     };
 

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -88,7 +88,6 @@ interface ChecklistResourceCardProps {
 
 const ChecklistResourceCard: React.FC<ChecklistResourceCardProps> = ({ cardTitle, imageUrl, checklistUrl }) => {
     const onCardClickedAsync = async () => {
-        pxt.tickEvent(Ticks.LoadChecklist, { checklistUrl });
         await loadChecklistAsync(checklistUrl);
     };
     return (

--- a/teachertool/src/components/HomeScreen.tsx
+++ b/teachertool/src/components/HomeScreen.tsx
@@ -148,7 +148,7 @@ const GetStarted: React.FC = () => {
     };
 
     const onImportChecklistClicked = () => {
-        pxt.tickEvent(Ticks.ImportChecklist);
+        pxt.tickEvent(Ticks.ImportChecklistOpen);
         showModal({ modal: "import-checklist" } as ImportChecklistOptions);
     };
 

--- a/teachertool/src/components/ImportChecklistModal.tsx
+++ b/teachertool/src/components/ImportChecklistModal.tsx
@@ -4,7 +4,7 @@ import { Modal } from "react-common/components/controls/Modal";
 import { hideModal } from "../transforms/hideModal";
 import { getChecklistFromFileAsync } from "../transforms/getChecklistFromFileAsync";
 import { DragAndDropFileSurface } from "./DragAndDropFileSurface";
-import { Strings } from "../constants";
+import { Strings, Ticks } from "../constants";
 import css from "./styling/ImportChecklistModal.module.scss";
 import { replaceActiveChecklistAsync } from "../transforms/replaceActiveChecklistAsync";
 
@@ -14,7 +14,8 @@ export const ImportChecklistModal: React.FC<IProps> = () => {
     const { state: teacherTool } = useContext(AppStateContext);
     const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
 
-    function closeModal() {
+    function closeModal(hasImported: boolean) {
+        pxt.tickEvent(Ticks.ImportChecklistClose, { hasImported: hasImported + "" });
         setErrorMessage(undefined);
         hideModal();
     }
@@ -22,16 +23,18 @@ export const ImportChecklistModal: React.FC<IProps> = () => {
     async function handleFileDroppedAsync(file: File) {
         const parsedChecklist = await getChecklistFromFileAsync(file, false /* allow partial */);
         if (!parsedChecklist) {
+            pxt.tickEvent(Ticks.ImportChecklistInvalidFile)
             setErrorMessage(Strings.InvalidChecklistFile);
         } else {
+            pxt.tickEvent(Ticks.ImportChecklistSuccess)
             setErrorMessage(undefined);
-            closeModal();
+            closeModal(true);
             replaceActiveChecklistAsync(parsedChecklist);
         }
     }
 
     return teacherTool.modalOptions?.modal === "import-checklist" ? (
-        <Modal title={Strings.ImportChecklist} onClose={closeModal} className={css["import-checklist-modal"]}>
+        <Modal title={Strings.ImportChecklist} onClose={() => closeModal(false)} className={css["import-checklist-modal"]}>
             <div className={css["import-checklist"]}>
                 <DragAndDropFileSurface onFileDroppedAsync={handleFileDroppedAsync} errorMessage={errorMessage} />
             </div>

--- a/teachertool/src/components/ImportChecklistModal.tsx
+++ b/teachertool/src/components/ImportChecklistModal.tsx
@@ -23,10 +23,10 @@ export const ImportChecklistModal: React.FC<IProps> = () => {
     async function handleFileDroppedAsync(file: File) {
         const parsedChecklist = await getChecklistFromFileAsync(file, false /* allow partial */);
         if (!parsedChecklist) {
-            pxt.tickEvent(Ticks.ImportChecklistInvalidFile)
+            pxt.tickEvent(Ticks.ImportChecklistInvalidFile);
             setErrorMessage(Strings.InvalidChecklistFile);
         } else {
-            pxt.tickEvent(Ticks.ImportChecklistSuccess)
+            pxt.tickEvent(Ticks.ImportChecklistSuccess);
             setErrorMessage(undefined);
             closeModal(true);
             replaceActiveChecklistAsync(parsedChecklist);
@@ -34,7 +34,11 @@ export const ImportChecklistModal: React.FC<IProps> = () => {
     }
 
     return teacherTool.modalOptions?.modal === "import-checklist" ? (
-        <Modal title={Strings.ImportChecklist} onClose={() => closeModal(false)} className={css["import-checklist-modal"]}>
+        <Modal
+            title={Strings.ImportChecklist}
+            onClose={() => closeModal(false)}
+            className={css["import-checklist-modal"]}
+        >
             <div className={css["import-checklist"]}>
                 <DragAndDropFileSurface onFileDroppedAsync={handleFileDroppedAsync} errorMessage={errorMessage} />
             </div>

--- a/teachertool/src/components/ShareLinkInput.tsx
+++ b/teachertool/src/components/ShareLinkInput.tsx
@@ -5,6 +5,9 @@ import { AppStateContext } from "../state/appStateContext";
 import { classList } from "react-common/components/util";
 import { Input } from "react-common/components/controls/Input";
 import { loadProjectMetadataAsync } from "../transforms/loadProjectMetadataAsync";
+import { Strings, Ticks } from "../constants";
+import { getChecklistHash, makeToast } from "../utils";
+import { showToast } from "../transforms/showToast";
 
 interface IProps {}
 
@@ -26,7 +29,14 @@ export const ShareLinkInput: React.FC<IProps> = () => {
 
     const onEnterKey = useCallback(() => {
         const shareId = pxt.Cloud.parseScriptId(text);
-        if (!!shareId && !(shareId === projectMetadata?.shortid || shareId === projectMetadata?.persistId)) {
+        if (!shareId) {
+            pxt.tickEvent(Ticks.LoadProjectInvalid);
+            showToast(makeToast("error", lf(Strings.InvalidShareLink)));
+            return;
+        }
+
+        if (shareId !== projectMetadata?.shortid && shareId !== projectMetadata?.persistId) {
+            pxt.tickEvent(Ticks.LoadProjectFromInput, { checklistHash: getChecklistHash(teacherTool.checklist) });
             loadProjectMetadataAsync(text, shareId);
         }
     }, [text, projectMetadata?.shortid, projectMetadata?.persistId]);

--- a/teachertool/src/components/ShareLinkInput.tsx
+++ b/teachertool/src/components/ShareLinkInput.tsx
@@ -31,7 +31,7 @@ export const ShareLinkInput: React.FC<IProps> = () => {
         const shareId = pxt.Cloud.parseScriptId(text);
         if (!shareId) {
             pxt.tickEvent(Ticks.LoadProjectInvalid);
-            showToast(makeToast("error", lf(Strings.InvalidShareLink)));
+            showToast(makeToast("error", Strings.InvalidShareLink));
             return;
         }
 

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -73,7 +73,7 @@ export namespace Ticks {
     export const ImportChecklistSuccess = "teachertool.importchecklist.success";
     export const ImportChecklistClose = "teachertool.importchecklist.close";
     export const ExportChecklist = "teachertool.exportchecklist";
-    export const LoadChecklist = "teachertool.loadchecklist";
+    export const LoadChecklistFromUrl = "teachertool.loadchecklistfromurl";
     export const SingleEvaluate = "teachertool.singleevaluate";
     export const BulkEvaluate = "teachertool.bulkevaluate";
     export const RunOnLoad = "teachertool.runonload";

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -67,7 +67,10 @@ export namespace Ticks {
     export const OrgLink = "teachertool.orglink";
     export const Error = "teachertool.error";
     export const NewChecklist = "teachertool.newchecklist";
-    export const ImportChecklist = "teachertool.importchecklist";
+    export const ImportChecklistOpen = "teachertool.importchecklist.open";
+    export const ImportChecklistInvalidFile = "teachertool.importchecklist.invalidfile";
+    export const ImportChecklistSuccess = "teachertool.importchecklist.success";
+    export const ImportChecklistClose = "teachertool.importchecklist.close";
     export const ExportChecklist = "teachertool.exportchecklist";
     export const LoadChecklist = "teachertool.loadchecklist";
     export const SingleEvaluate = "teachertool.singleevaluate";

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -70,7 +70,8 @@ export namespace Ticks {
     export const ImportChecklist = "teachertool.importchecklist";
     export const ExportChecklist = "teachertool.exportchecklist";
     export const LoadChecklist = "teachertool.loadchecklist";
-    export const Evaluate = "teachertool.evaluate";
+    export const SingleEvaluate = "teachertool.singleevaluate";
+    export const BulkEvaluate = "teachertool.bulkevaluate";
     export const RunOnLoad = "teachertool.runonload";
     export const AddCriteria = "teachertool.addcriteria";
     export const RemoveCriteria = "teachertool.removecriteria";

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -58,6 +58,7 @@ export namespace Strings {
     export const BelowMin = lf("Below minimum value");
     export const ExceedsMax = lf("Exceeds maximum value");
     export const InvalidValue = lf("Invalid value");
+    export const InvalidShareLink = lf("Invalid share link");
 }
 
 export namespace Ticks {
@@ -89,6 +90,9 @@ export namespace Ticks {
     export const ParamErrorMissingMessage = "teachertool.paramerrormissingmessage";
     export const SetEvalResultOutcome = "teachertool.setevalresultoutcome";
     export const SetEvalResultNotes = "teachertool.setevalresultnotes";
+    export const LoadProjectFromInput = "teachertool.loadproject.frominput";
+    export const LoadProjectFromUrl = "teachertool.loadproject.fromurl";
+    export const LoadProjectInvalid = "teachertool.loadproject.invalid";
 }
 
 namespace Misc {

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -83,6 +83,8 @@ export namespace Ticks {
     export const UnhandledEvalError = "teachertool.evaluateerror";
     export const FeedbackForm = "teachertool.feedbackform";
     export const ParamErrorMissingMessage = "teachertool.paramerrormissingmessage";
+    export const SetEvalResultOutcome = "teachertool.setevalresultoutcome";
+    export const SetEvalResultNotes = "teachertool.setevalresultnotes";
 }
 
 namespace Misc {

--- a/teachertool/src/constants.ts
+++ b/teachertool/src/constants.ts
@@ -93,6 +93,8 @@ export namespace Ticks {
     export const LoadProjectFromInput = "teachertool.loadproject.frominput";
     export const LoadProjectFromUrl = "teachertool.loadproject.fromurl";
     export const LoadProjectInvalid = "teachertool.loadproject.invalid";
+    export const BlockPickerBlockSelected = "teachertool.blockpicker.blockselected";
+    export const BlockPickerOpened = "teachertool.blockpicker.opened";
 }
 
 namespace Misc {

--- a/teachertool/src/services/makecodeEditorService.ts
+++ b/teachertool/src/services/makecodeEditorService.ts
@@ -6,6 +6,8 @@ import { EditorDriver } from "pxtservices/editorDriver";
 import { loadToolboxCategoriesAsync } from "../transforms/loadToolboxCategoriesAsync";
 import { stateAndDispatch } from "../state";
 import { runEvaluateAsync } from "../transforms/runEvaluateAsync";
+import { Ticks } from "../constants";
+import { getChecklistHash, getObfuscatedProjectId } from "../utils";
 
 let driver: EditorDriver | undefined;
 let highContrast: boolean = false;
@@ -36,6 +38,15 @@ export function setEditorRef(ref: HTMLIFrameElement | undefined, forceReload: ()
             const { runOnLoad, projectMetadata } = state;
 
             if (runOnLoad && !!projectMetadata) {
+                pxt.tickEvent(Ticks.BulkEvaluate, {
+                    fromUserInteraction: true + "",
+                    runOnLoad: true + "",
+                    criteriaCount: state.checklist.criteria.length,
+                    catalogCriteriaIds: JSON.stringify(state.checklist.criteria.map(c => c.catalogCriteriaId)),
+                    checklistHash: getChecklistHash(state.checklist),
+                    projectId: getObfuscatedProjectId(state.projectMetadata?.id),
+                });
+
                 runEvaluateAsync(true); // cause a switch to checklist tab on run
             }
 

--- a/teachertool/src/state/helpers.ts
+++ b/teachertool/src/state/helpers.ts
@@ -68,7 +68,7 @@ export function isProjectLoaded(state: AppState): boolean {
 }
 
 export function isChecklistLoaded(state: AppState): boolean {
-    return !!(state.checklist.criteria.length || state.checklist.name);
+    return !!state.checklist.criteria.length;
 }
 
 export function getSafeProjectName(state: AppState): string | undefined {

--- a/teachertool/src/transforms/loadBlockImagesAsync.ts
+++ b/teachertool/src/transforms/loadBlockImagesAsync.ts
@@ -17,6 +17,7 @@ async function loadBlockImageAsync(block: pxt.editor.ToolboxBlockDefinition) {
     const imageUri = block.blockXml
         ? await getBlockImageUriFromXmlAsync(block.blockXml)
         : await getBlockImageUriFromBlockIdAsync(block.blockId);
+
     if (imageUri) {
         const { dispatch } = stateAndDispatch();
         dispatch(Actions.setBlockImageUri(block.blockId, imageUri));

--- a/teachertool/src/transforms/loadBlockImagesAsync.ts
+++ b/teachertool/src/transforms/loadBlockImagesAsync.ts
@@ -17,7 +17,6 @@ async function loadBlockImageAsync(block: pxt.editor.ToolboxBlockDefinition) {
     const imageUri = block.blockXml
         ? await getBlockImageUriFromXmlAsync(block.blockXml)
         : await getBlockImageUriFromBlockIdAsync(block.blockId);
-
     if (imageUri) {
         const { dispatch } = stateAndDispatch();
         dispatch(Actions.setBlockImageUri(block.blockId, imageUri));

--- a/teachertool/src/transforms/loadChecklistAsync.ts
+++ b/teachertool/src/transforms/loadChecklistAsync.ts
@@ -1,25 +1,30 @@
-import { Strings } from "../constants";
+import { Strings, Ticks } from "../constants";
 import { fetchJsonDocAsync } from "../services/backendRequests";
+import { logError } from "../services/loggingService";
 import { verifyChecklistIntegrity } from "../state/helpers";
 import { Checklist } from "../types/checklist";
-import { makeToast } from "../utils";
+import { ErrorCode } from "../types/errorCode";
+import { getChecklistHash, makeToast } from "../utils";
 import { replaceActiveChecklistAsync } from "./replaceActiveChecklistAsync";
 import { showToast } from "./showToast";
 
 export async function loadChecklistAsync(checklistUrl: string) {
-    const json = await fetchJsonDocAsync<Checklist | undefined>(checklistUrl);
+    const checklist = await fetchJsonDocAsync<Checklist | undefined>(checklistUrl);
 
-    if (!json) {
+    if (!checklist) {
         showToast(makeToast("error", Strings.ErrorLoadingChecklistMsg));
         return;
     }
 
-    const { valid } = verifyChecklistIntegrity(json);
+    const { valid } = verifyChecklistIntegrity(checklist);
 
     if (!valid) {
+        logError(ErrorCode.invalidPremadeChecklist, { checklistUrl });
         showToast(makeToast("error", Strings.ErrorLoadingChecklistMsg));
         return;
+    } else {
+        pxt.tickEvent(Ticks.LoadChecklistFromUrl, { checklistUrl, checklistHash: getChecklistHash(checklist) });
     }
 
-    await replaceActiveChecklistAsync(json);
+    await replaceActiveChecklistAsync(checklist);
 }

--- a/teachertool/src/transforms/mergeEvalResult.ts
+++ b/teachertool/src/transforms/mergeEvalResult.ts
@@ -4,7 +4,12 @@ import { setEvalResult } from "./setEvalResult";
 import { setUserFeedback } from "./setUserFeedback";
 
 // This will set the outcome and notes for a given criteria instance id, but if the provided value is undefined, it will not change that value.
-export function mergeEvalResult(criteriaInstanceId: string, isManual: boolean, outcome?: EvaluationStatus, notes?: string) {
+export function mergeEvalResult(
+    criteriaInstanceId: string,
+    isManual: boolean,
+    outcome?: EvaluationStatus,
+    notes?: string
+) {
     const { state: teacherTool, dispatch } = stateAndDispatch();
 
     const newCriteriaEvalResult = { ...teacherTool.evalResults[criteriaInstanceId] };

--- a/teachertool/src/transforms/mergeEvalResult.ts
+++ b/teachertool/src/transforms/mergeEvalResult.ts
@@ -4,7 +4,7 @@ import { setEvalResult } from "./setEvalResult";
 import { setUserFeedback } from "./setUserFeedback";
 
 // This will set the outcome and notes for a given criteria instance id, but if the provided value is undefined, it will not change that value.
-export function mergeEvalResult(criteriaInstanceId: string, outcome?: EvaluationStatus, notes?: string) {
+export function mergeEvalResult(criteriaInstanceId: string, isManual: boolean, outcome?: EvaluationStatus, notes?: string) {
     const { state: teacherTool, dispatch } = stateAndDispatch();
 
     const newCriteriaEvalResult = { ...teacherTool.evalResults[criteriaInstanceId] };
@@ -14,6 +14,7 @@ export function mergeEvalResult(criteriaInstanceId: string, outcome?: Evaluation
 
     if (outcome !== undefined) {
         newCriteriaEvalResult.result = outcome;
+        newCriteriaEvalResult.resultIsManual = isManual;
     }
     if (notes !== undefined) {
         if (newCriteriaEvalResult.notes !== notes) {

--- a/teachertool/src/transforms/runEvaluateAsync.ts
+++ b/teachertool/src/transforms/runEvaluateAsync.ts
@@ -1,5 +1,5 @@
 import { stateAndDispatch } from "../state";
-import { getChecklistHash, makeToast } from "../utils";
+import { getChecklistHash, getObfuscatedProjectId, makeToast } from "../utils";
 import { showToast } from "./showToast";
 import { setActiveTab } from "./setActiveTab";
 import { runSingleEvaluateAsync } from "./runSingleEvaluateAsync";
@@ -30,7 +30,7 @@ export async function runEvaluateAsync(fromUserInteraction: boolean) {
         criteriaCount: evalRequests.length,
         catalogCriteriaIds: JSON.stringify(teacherTool.checklist.criteria.map(c => c.catalogCriteriaId)),
         checklistHash: getChecklistHash(teacherTool.checklist),
-        projectId: teacherTool.projectMetadata?.id ?? "",
+        projectId: getObfuscatedProjectId(teacherTool.projectMetadata?.id),
     });
 
     // EvalRequest promises will resolve to true if evaluation completed successfully (regarless of pass/fail).

--- a/teachertool/src/transforms/runEvaluateAsync.ts
+++ b/teachertool/src/transforms/runEvaluateAsync.ts
@@ -1,9 +1,9 @@
 import { stateAndDispatch } from "../state";
-import { getChecklistHash, getObfuscatedProjectId, makeToast } from "../utils";
+import { makeToast } from "../utils";
 import { showToast } from "./showToast";
 import { setActiveTab } from "./setActiveTab";
 import { runSingleEvaluateAsync } from "./runSingleEvaluateAsync";
-import { Strings, Ticks } from "../constants";
+import { Strings } from "../constants";
 
 export async function runEvaluateAsync(fromUserInteraction: boolean) {
     const { state: teacherTool } = stateAndDispatch();
@@ -24,14 +24,6 @@ export async function runEvaluateAsync(fromUserInteraction: boolean) {
     if (evalRequests.length === 0) {
         return;
     }
-
-    pxt.tickEvent(Ticks.BulkEvaluate, {
-        fromUserInteraction: fromUserInteraction + "",
-        criteriaCount: evalRequests.length,
-        catalogCriteriaIds: JSON.stringify(teacherTool.checklist.criteria.map(c => c.catalogCriteriaId)),
-        checklistHash: getChecklistHash(teacherTool.checklist),
-        projectId: getObfuscatedProjectId(teacherTool.projectMetadata?.id),
-    });
 
     // EvalRequest promises will resolve to true if evaluation completed successfully (regarless of pass/fail).
     // They will only resolve to false if evaluation was unable to complete.

--- a/teachertool/src/transforms/runEvaluateAsync.ts
+++ b/teachertool/src/transforms/runEvaluateAsync.ts
@@ -1,9 +1,9 @@
 import { stateAndDispatch } from "../state";
-import { makeToast } from "../utils";
+import { getChecklistHash, makeToast } from "../utils";
 import { showToast } from "./showToast";
 import { setActiveTab } from "./setActiveTab";
 import { runSingleEvaluateAsync } from "./runSingleEvaluateAsync";
-import { Strings } from "../constants";
+import { Strings, Ticks } from "../constants";
 
 export async function runEvaluateAsync(fromUserInteraction: boolean) {
     const { state: teacherTool } = stateAndDispatch();
@@ -24,6 +24,14 @@ export async function runEvaluateAsync(fromUserInteraction: boolean) {
     if (evalRequests.length === 0) {
         return;
     }
+
+    pxt.tickEvent(Ticks.BulkEvaluate, {
+        fromUserInteraction: fromUserInteraction + "",
+        criteriaCount: evalRequests.length,
+        catalogCriteriaIds: JSON.stringify(teacherTool.checklist.criteria.map(c => c.catalogCriteriaId)),
+        checklistHash: getChecklistHash(teacherTool.checklist),
+        projectId: teacherTool.projectMetadata?.id ?? "",
+    });
 
     // EvalRequest promises will resolve to true if evaluation completed successfully (regarless of pass/fail).
     // They will only resolve to false if evaluation was unable to complete.

--- a/teachertool/src/transforms/runSingleEvaluateAsync.ts
+++ b/teachertool/src/transforms/runSingleEvaluateAsync.ts
@@ -121,7 +121,7 @@ export async function runSingleEvaluateAsync(criteriaInstanceId: string, fromUse
             return resolve(true);
         }
 
-        setEvalResultOutcome(criteriaInstance.instanceId, EvaluationStatus.InProgress);
+        setEvalResultOutcome(criteriaInstance.instanceId, EvaluationStatus.InProgress, false);
 
         const loadedValidatorPlans = teacherTool.validatorPlans;
         if (!loadedValidatorPlans) {
@@ -154,11 +154,12 @@ export async function runSingleEvaluateAsync(criteriaInstanceId: string, fromUse
                         ? EvaluationStatus.Pass
                         : EvaluationStatus.Fail;
 
-                mergeEvalResult(criteriaInstance.instanceId, result, planResult.notes);
+                mergeEvalResult(criteriaInstance.instanceId, false, result, planResult.notes);
                 return resolve(true); // evaluation completed successfully, so return true (regardless of pass/fail)
             } else {
                 setEvalResult(criteriaInstance.instanceId, {
                     result: EvaluationStatus.NotStarted,
+                    resultIsManual: false,
                     error: planResult?.executionErrorMsg ?? Strings.UnexpectedError,
                 });
                 setUserFeedback(criteriaInstanceId, undefined);
@@ -174,6 +175,7 @@ export async function runSingleEvaluateAsync(criteriaInstanceId: string, fromUse
             setUserFeedback(criteriaInstanceId, undefined);
             setEvalResult(criteriaInstance.instanceId, {
                 result: EvaluationStatus.NotStarted,
+                resultIsManual: false,
                 error: Strings.UnexpectedError,
             });
             return resolve(false);

--- a/teachertool/src/transforms/setEvalResult.ts
+++ b/teachertool/src/transforms/setEvalResult.ts
@@ -1,8 +1,45 @@
+import { Ticks } from "../constants";
+import { logError } from "../services/loggingService";
 import { stateAndDispatch } from "../state";
 import * as Actions from "../state/actions";
+import { getCriteriaInstanceWithId } from "../state/helpers";
 import { CriteriaResult } from "../types/criteria";
+import { ErrorCode } from "../types/errorCode";
+
+// Send tick events related to changes happening in the criteria result.
+function reportChanges(criteriaId: string, result: CriteriaResult) {
+    const { state: teacherTool } = stateAndDispatch();
+
+    const previousResult = teacherTool.evalResults[criteriaId];
+    if (previousResult.result != result.result) {
+        const criteriaInstance = getCriteriaInstanceWithId(teacherTool, criteriaId);
+        if (!criteriaInstance) {
+            // This checs should have happened already, but including these in case we ever have some bug in that code.
+            logError(ErrorCode.missingCriteriaInstance, "Unable to find criteria with unrecognized instance with id", { id: criteriaId });
+            return;
+        }
+
+        pxt.tickEvent(Ticks.SetEvalResultOutcome, {
+            catalogCriteriaId: criteriaInstance.catalogCriteriaId,
+            newValue: result.result,
+            oldValue: previousResult?.result,
+            newValueIsManual: result.resultIsManual + "",
+            oldValueIsManual: previousResult?.resultIsManual + "",
+        });
+    }
+
+    if (previousResult.notes != result.notes) {
+        // Setting notes is debounced so this isn't too noisy.
+        pxt.tickEvent(Ticks.SetEvalResultNotes, {
+            criteriaId,
+            newLength: result.notes?.length ?? 0,
+            oldLength: previousResult?.notes?.length ?? 0,
+        });
+    }
+}
 
 export function setEvalResult(criteriaId: string, result: CriteriaResult) {
     const { dispatch } = stateAndDispatch();
+    reportChanges(criteriaId, result);
     dispatch(Actions.setEvalResult(criteriaId, result));
 }

--- a/teachertool/src/transforms/setEvalResult.ts
+++ b/teachertool/src/transforms/setEvalResult.ts
@@ -3,7 +3,7 @@ import { logError } from "../services/loggingService";
 import { stateAndDispatch } from "../state";
 import * as Actions from "../state/actions";
 import { getCriteriaInstanceWithId } from "../state/helpers";
-import { CriteriaResult } from "../types/criteria";
+import { CriteriaResult, EvaluationStatus } from "../types/criteria";
 import { ErrorCode } from "../types/errorCode";
 
 // Send tick events related to changes happening in the criteria result.
@@ -21,8 +21,8 @@ function reportChanges(criteriaId: string, result: CriteriaResult) {
 
         pxt.tickEvent(Ticks.SetEvalResultOutcome, {
             catalogCriteriaId: criteriaInstance.catalogCriteriaId,
-            newValue: result.result,
-            oldValue: previousResult?.result,
+            newValue: EvaluationStatus[result.result],
+            oldValue: previousResult?.result ? EvaluationStatus[previousResult.result] : "",
             newValueIsManual: result.resultIsManual + "",
             oldValueIsManual: previousResult?.resultIsManual + "",
         });

--- a/teachertool/src/transforms/setEvalResult.ts
+++ b/teachertool/src/transforms/setEvalResult.ts
@@ -11,16 +11,11 @@ function reportChanges(criteriaId: string, result: CriteriaResult) {
     const { state: teacherTool } = stateAndDispatch();
 
     const previousResult = teacherTool.evalResults[criteriaId];
-    if (previousResult.result != result.result) {
-        const criteriaInstance = getCriteriaInstanceWithId(teacherTool, criteriaId);
-        if (!criteriaInstance) {
-            // This checs should have happened already, but including these in case we ever have some bug in that code.
-            logError(ErrorCode.missingCriteriaInstance, "Unable to find criteria with unrecognized instance with id", { id: criteriaId });
-            return;
-        }
+    const criteriaInstance = getCriteriaInstanceWithId(teacherTool, criteriaId);
 
+    if (previousResult.result != result.result) {
         pxt.tickEvent(Ticks.SetEvalResultOutcome, {
-            catalogCriteriaId: criteriaInstance.catalogCriteriaId,
+            catalogCriteriaId: criteriaInstance?.catalogCriteriaId ?? "",
             newValue: EvaluationStatus[result.result],
             oldValue: previousResult?.result ? EvaluationStatus[previousResult.result] : "",
             newValueIsManual: result.resultIsManual + "",
@@ -31,7 +26,7 @@ function reportChanges(criteriaId: string, result: CriteriaResult) {
     if (previousResult.notes != result.notes) {
         // Setting notes is debounced so this isn't too noisy.
         pxt.tickEvent(Ticks.SetEvalResultNotes, {
-            criteriaId,
+            catalogCriteriaId: criteriaInstance?.catalogCriteriaId ?? "",
             newLength: result.notes?.length ?? 0,
             oldLength: previousResult?.notes?.length ?? 0,
         });

--- a/teachertool/src/transforms/setEvalResultOutcome.ts
+++ b/teachertool/src/transforms/setEvalResultOutcome.ts
@@ -3,12 +3,13 @@ import { EvaluationStatus } from "../types/criteria";
 import { setEvalResult } from "./setEvalResult";
 
 // This will set the outcome for a given criteria instance id. If result is undefined, it will clear it.
-export function setEvalResultOutcome(criteriaId: string, result: EvaluationStatus) {
-    const { state: teacherTool, dispatch } = stateAndDispatch();
+export function setEvalResultOutcome(criteriaId: string, result: EvaluationStatus, isManual: boolean) {
+    const { state: teacherTool } = stateAndDispatch();
 
     const newCriteriaEvalResult = {
         ...teacherTool.evalResults[criteriaId],
         result,
+        resultIsManual: isManual,
     };
 
     setEvalResult(criteriaId, newCriteriaEvalResult);

--- a/teachertool/src/transforms/setParameterValue.ts
+++ b/teachertool/src/transforms/setParameterValue.ts
@@ -36,5 +36,5 @@ export function setParameterValue(instanceId: string, paramName: string, newValu
     const newChecklist = { ...teacherTool.checklist, criteria: newInstanceSet };
 
     setChecklist(newChecklist);
-    setEvalResultOutcome(instanceId, EvaluationStatus.NotStarted);
+    setEvalResultOutcome(instanceId, EvaluationStatus.NotStarted, false);
 }

--- a/teachertool/src/transforms/setRunOnLoad.ts
+++ b/teachertool/src/transforms/setRunOnLoad.ts
@@ -1,7 +1,6 @@
 import { stateAndDispatch } from "../state";
 import * as Actions from "../state/actions";
 import * as Storage from "../services/storageService";
-import { runEvaluateAsync } from "./runEvaluateAsync";
 
 export function setRunOnLoad(runOnLoad: boolean) {
     const { dispatch } = stateAndDispatch();

--- a/teachertool/src/types/criteria.ts
+++ b/teachertool/src/types/criteria.ts
@@ -40,6 +40,7 @@ export enum EvaluationStatus {
 
 export interface CriteriaResult {
     result: EvaluationStatus;
+    resultIsManual?: boolean;
     notes?: string;
     error?: string;
 }

--- a/teachertool/src/types/criteriaParameters.ts
+++ b/teachertool/src/types/criteriaParameters.ts
@@ -6,29 +6,29 @@ export type CriteriaParameterBase = {
     type: CriteriaParameterType;
     default: string | undefined;
     paths: string[]; // The json path(s) to update with the parameter value in the catalog criteria.
-}
+};
 
 export type StringParameterBase = CriteriaParameterBase & {
     maxCharacters?: number;
-}
+};
 
 export type StringParameter = StringParameterBase & {
     type: "string";
-}
+};
 
 export type LongStringParameter = StringParameterBase & {
     type: "longString";
-}
+};
 
 export type NumberParameter = CriteriaParameterBase & {
     type: "number";
     min?: number;
     max?: number;
-}
+};
 
 export type BlockParameter = CriteriaParameterBase & {
     type: "block";
-}
+};
 
 /**
  * System parameters are fields that can change for a criteria but which are not set directly by the user.
@@ -37,9 +37,14 @@ export type BlockParameter = CriteriaParameterBase & {
 export type SystemParameter = CriteriaParameterBase & {
     type: "system";
     key?: string;
-}
+};
 
-export type CriteriaParameter = StringParameter | LongStringParameter | NumberParameter | BlockParameter | SystemParameter;
+export type CriteriaParameter =
+    | StringParameter
+    | LongStringParameter
+    | NumberParameter
+    | BlockParameter
+    | SystemParameter;
 
 export interface CriteriaParameterValidationResult {
     valid: boolean;

--- a/teachertool/src/types/errorCode.ts
+++ b/teachertool/src/types/errorCode.ts
@@ -34,4 +34,5 @@ export enum ErrorCode {
     authCheckFailed = "authCheckFailed",
     unrecognizedParameterType = "unrecognizedParameterType",
     invalidParameterValue = "invalidParameterValue",
+    invalidPremadeChecklist = "invalidPremadeChecklist",
 }

--- a/teachertool/src/utils/index.ts
+++ b/teachertool/src/utils/index.ts
@@ -86,3 +86,8 @@ export function getChecklistHash(checklist: Checklist): string {
     // and it could be translated, etc for built-in checklists.
     return pxt.Util.sha256(JSON.stringify(checklist.criteria));
 }
+
+export function getObfuscatedProjectId(projectId: string | undefined): string {
+    // Just to err on the safe side for privacy, don't log the whole share id.
+    return !projectId || projectId?.length <= 5 ? "" : "..." + projectId.slice(-5);
+}

--- a/teachertool/src/utils/index.ts
+++ b/teachertool/src/utils/index.ts
@@ -80,3 +80,9 @@ export function getReadableBlockString(name: string) {
         return pxt.Util.camelCaseToLowercaseWithSpaces(name);
     }
 }
+
+export function getChecklistHash(checklist: Checklist): string {
+    // We only hash the criteria (not the name), since the name doesn't really matter in our scenarios,
+    // and it could be translated, etc for built-in checklists.
+    return pxt.Util.sha256(JSON.stringify(checklist.criteria));
+}

--- a/teachertool/src/utils/index.ts
+++ b/teachertool/src/utils/index.ts
@@ -84,7 +84,7 @@ export function getReadableBlockString(name: string) {
 export function getChecklistHash(checklist: Checklist): string {
     // We only hash the criteria (not the name), since the name doesn't really matter in our scenarios,
     // and it could be translated, etc for built-in checklists.
-    return pxt.Util.sha256(JSON.stringify(checklist.criteria));
+    return checklist.criteria.length == 0 ? "empty" : pxt.Util.sha256(JSON.stringify(checklist.criteria));
 }
 
 export function getObfuscatedProjectId(projectId: string | undefined): string {


### PR DESCRIPTION
This change adds a few telemetry events and some code changes to support them:

1. Changing the eval result (including a field indicating whether or not it's manual and whether the previous result was manual, which necessitated adding resultIsManual to the result type. I think this could be helpful in the future too, if we decide not to overwrite manual results when doing bulk evaluate)
2. Changing eval notes (debounced)
3. Run single eval (including hash of the checklist which should help with understanding evals / checklist and usage of pre-made checklists)
4. Run bulk eval
5. Importing a checklist (whether there's an invalid file, a successful import, or closed without doing anything)
6. Loading in new projects
7. Block picker opened & block selected
8. Adjusted logging of opening pre-built checklists so we can include checklist hash (and error reporting if a pre-built checklist is invalid)


There's also a one-line bug fix so we don't show the "Replace existing checklist" warning when the user clicks new checklist for the first time (only consider having an "existing checklist" if there is criteria, regardless of name).

Try it here (check console for tick events): https://makecode.microbit.org/app/8599694db2dc091609db8744031e60b1b68348cd-27cb4c68cb--eval?consoleticks=1