### PR TITLE
remove id from blockly search input

### DIFF
--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -441,7 +441,7 @@ div.blocklyTreeIcon span {
         font-size: 3rem;
     }
     /* Hide the blockly toolbox search */
-    #blocklySearchInput.ui.icon.input {
+    .blocklySearchInput.ui.icon.input {
         input {
             padding-right: 0 !important;
             padding-left: 0.2rem;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1076,7 +1076,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 }
                 this.currFile = file;
                 // Clear the search field if a value exists
-                let searchField = document.getElementById('blocklySearchInputField') as HTMLInputElement;
+                let searchField = document.querySelector("input.blocklySearchInput") as HTMLInputElement;
                 if (searchField && searchField.value) {
                     searchField.value = '';
                 }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -1092,7 +1092,6 @@ export class ToolboxSearch extends data.Component<ToolboxSearchProps, ToolboxSea
                         onFocus={this.searchImmediate}
                         onKeyDown={this.handleKeyDown}
                         onChange={this.handleChange}
-                        id="blocklySearchInputField"
                         className="blocklySearchInputField"
                         aria-label={lf("Search")}
                         autoComplete="off"


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5962

our webapp doesn't use the blockly toolbox, but it does use the blockly toolbox div (we just inject our own react component). however, blockly registers an onclick handler on that div that tries to figure out which toolbox category is being clicked based on [the id of the element](https://github.com/google/blockly/blob/bc2b142f62443ce3851c000d990d5a96006b4f5d/core/toolbox/toolbox.ts#L261). our toolbox search input was the only element in that div with an id set, so it was triggering an exception whenever it was clicked. 

fixed in the simplest way possible: i removed the id

also worth noting that this exception was also occurring in chrome; ios safari seems to be the only case where this broke the toolbox for whatever reason. maybe because it uses touch?