### PR TITLE
Teacher Tool: Change block display

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -75,7 +75,7 @@ declare namespace pxt.editor {
         | "convertcloudprojectstolocal"
         | "setlanguagerestriction"
         | "gettoolboxcategories"
-        | "getreadableblockname"
+        | "getblocktextparts"
 
         | "toggletrace" // EditorMessageToggleTraceRequest
         | "togglehighcontrast"
@@ -459,12 +459,12 @@ declare namespace pxt.editor {
     }
 
     export interface EditorMessageGetBlockReadableNameRequest extends EditorMessageRequest {
-        action: "getreadableblockname";
+        action: "getblocktextparts";
         blockId: string;
     }
 
     export interface EditorMessageGetBlockReadableNameResponse {
-        readableName: pxt.editor.ReadableBlockName | undefined;
+        readableName: pxt.editor.BlockTextParts | undefined;
     }
 
     export interface EditorMessageServiceWorkerRegisteredRequest extends EditorMessageRequest {
@@ -1007,7 +1007,7 @@ declare namespace pxt.editor {
         // getBlocks(): Blockly.Block[];
         getBlocks(): any[];
         getToolboxCategories(advanced?: boolean): pxt.editor.EditorMessageGetToolboxCategoriesResponse;
-        getReadableBlockName(blockId: string): pxt.editor.ReadableBlockName | undefined;
+        getBlockTextParts(blockId: string): pxt.editor.BlockTextParts | undefined;
 
         toggleHighContrast(): void;
         setHighContrast(on: boolean): void;
@@ -1275,11 +1275,11 @@ declare namespace pxt.editor {
         blockId?: string;
     }
 
-    export interface ReadableBlockName {
-        parts: ReadableBlockNamePart[];
+    export interface BlockTextParts {
+        parts: BlockTextPart[];
     }
 
-    export interface ReadableBlockNamePart {
+    export interface BlockTextPart {
         kind: "label" | "break" | "param",
         content?: string,
     }

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -75,7 +75,7 @@ declare namespace pxt.editor {
         | "convertcloudprojectstolocal"
         | "setlanguagerestriction"
         | "gettoolboxcategories"
-        | "getblocktextparts"
+        | "getblockastext"
 
         | "toggletrace" // EditorMessageToggleTraceRequest
         | "togglehighcontrast"
@@ -458,13 +458,13 @@ declare namespace pxt.editor {
         categories: pxt.editor.ToolboxCategoryDefinition[];
     }
 
-    export interface EditorMessageGetBlockReadableNameRequest extends EditorMessageRequest {
-        action: "getblocktextparts";
+    export interface EditorMessageGetBlockAsTextRequest extends EditorMessageRequest {
+        action: "getblockastext";
         blockId: string;
     }
 
-    export interface EditorMessageGetBlockReadableNameResponse {
-        readableName: pxt.editor.BlockTextParts | undefined;
+    export interface EditorMessageGetBlockAsTextResponse {
+        blockAsText: pxt.editor.BlockAsText | undefined;
     }
 
     export interface EditorMessageServiceWorkerRegisteredRequest extends EditorMessageRequest {
@@ -1007,7 +1007,7 @@ declare namespace pxt.editor {
         // getBlocks(): Blockly.Block[];
         getBlocks(): any[];
         getToolboxCategories(advanced?: boolean): pxt.editor.EditorMessageGetToolboxCategoriesResponse;
-        getBlockTextParts(blockId: string): pxt.editor.BlockTextParts | undefined;
+        getBlockAsText(blockId: string): pxt.editor.BlockAsText | undefined;
 
         toggleHighContrast(): void;
         setHighContrast(on: boolean): void;
@@ -1275,7 +1275,7 @@ declare namespace pxt.editor {
         blockId?: string;
     }
 
-    export interface BlockTextParts {
+    export interface BlockAsText {
         parts: BlockTextPart[];
     }
 

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -75,6 +75,7 @@ declare namespace pxt.editor {
         | "convertcloudprojectstolocal"
         | "setlanguagerestriction"
         | "gettoolboxcategories"
+        | "getreadableblockname"
 
         | "toggletrace" // EditorMessageToggleTraceRequest
         | "togglehighcontrast"
@@ -453,12 +454,21 @@ declare namespace pxt.editor {
         advanced?: boolean;
     }
 
-    export interface EditorMessageServiceWorkerRegisteredRequest extends EditorMessageRequest {
-        action: "serviceworkerregistered";
-    }
-
     export interface EditorMessageGetToolboxCategoriesResponse {
         categories: pxt.editor.ToolboxCategoryDefinition[];
+    }
+
+    export interface EditorMessageGetBlockReadableNameRequest extends EditorMessageRequest {
+        action: "getreadableblockname";
+        blockId: string;
+    }
+
+    export interface EditorMessageGetBlockReadableNameResponse {
+        readableName: pxt.editor.ReadableBlockName | undefined;
+    }
+
+    export interface EditorMessageServiceWorkerRegisteredRequest extends EditorMessageRequest {
+        action: "serviceworkerregistered";
     }
 
     export interface DataStreams<T> {
@@ -997,6 +1007,7 @@ declare namespace pxt.editor {
         // getBlocks(): Blockly.Block[];
         getBlocks(): any[];
         getToolboxCategories(advanced?: boolean): pxt.editor.EditorMessageGetToolboxCategoriesResponse;
+        getReadableBlockName(blockId: string): pxt.editor.ReadableBlockName | undefined;
 
         toggleHighContrast(): void;
         setHighContrast(on: boolean): void;
@@ -1262,6 +1273,15 @@ declare namespace pxt.editor {
          * The Blockly block id used to identify this block.
          */
         blockId?: string;
+    }
+
+    export interface ReadableBlockName {
+        parts: ReadableBlockNamePart[];
+    }
+
+    export interface ReadableBlockNamePart {
+        kind: "label" | "break" | "param",
+        content?: string,
     }
 
     interface BaseAssetEditorRequest {

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -209,12 +209,12 @@ case "renderxml": {
                                         resp = projectView.getToolboxCategories(msg.advanced);
                                     });
                             }
-                            case "getblocktextparts": {
-                                const msg = data as pxt.editor.EditorMessageGetBlockReadableNameRequest;
+                            case "getblockastext": {
+                                const msg = data as pxt.editor.EditorMessageGetBlockAsTextRequest;
                                 return Promise.resolve()
                                     .then(() => {
-                                        const readableName = projectView.getBlockTextParts(msg.blockId);
-                                        resp = { readableName } as pxt.editor.EditorMessageGetBlockReadableNameResponse;
+                                        const readableName = projectView.getBlockAsText(msg.blockId);
+                                        resp = { blockAsText: readableName } as pxt.editor.EditorMessageGetBlockAsTextResponse;
                                     });
                             }
                             case "renderpython": {

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -209,11 +209,11 @@ case "renderxml": {
                                         resp = projectView.getToolboxCategories(msg.advanced);
                                     });
                             }
-                            case "getreadableblockname": {
+                            case "getblocktextparts": {
                                 const msg = data as pxt.editor.EditorMessageGetBlockReadableNameRequest;
                                 return Promise.resolve()
                                     .then(() => {
-                                        const readableName = projectView.getReadableBlockName(msg.blockId);
+                                        const readableName = projectView.getBlockTextParts(msg.blockId);
                                         resp = { readableName } as pxt.editor.EditorMessageGetBlockReadableNameResponse;
                                     });
                             }

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -202,11 +202,19 @@ case "renderxml": {
                                         resp = results;
                                     });
                             }
-case "gettoolboxcategories": {
+                            case "gettoolboxcategories": {
                                 const msg = data as pxt.editor.EditorMessageGetToolboxCategoriesRequest;
                                 return Promise.resolve()
                                     .then(() => {
                                         resp = projectView.getToolboxCategories(msg.advanced);
+                                    });
+                            }
+                            case "getreadableblockname": {
+                                const msg = data as pxt.editor.EditorMessageGetBlockReadableNameRequest;
+                                return Promise.resolve()
+                                    .then(() => {
+                                        const readableName = projectView.getReadableBlockName(msg.blockId);
+                                        resp = { readableName } as pxt.editor.EditorMessageGetBlockReadableNameResponse;
                                     });
                             }
                             case "renderpython": {

--- a/pxtservices/editorDriver.ts
+++ b/pxtservices/editorDriver.ts
@@ -389,6 +389,18 @@ export class EditorDriver extends IframeDriver {
         return (resp.resp as pxt.editor.EditorMessageGetToolboxCategoriesResponse).categories;
     }
 
+    async getBlockReadableName(blockId: string): Promise<pxt.editor.ReadableBlockName | undefined> {
+        const resp = await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "getreadableblockname",
+                blockId
+            } as pxt.editor.EditorMessageGetBlockReadableNameRequest
+        ) as pxt.editor.EditorMessageResponse;
+
+        return (resp.resp as pxt.editor.EditorMessageGetBlockReadableNameResponse)?.readableName;
+    }
+
     async runValidatorPlan(validatorPlan: pxt.blocks.ValidatorPlan, planLib: pxt.blocks.ValidatorPlan[]) {
         const resp = await this.sendRequest(
             {

--- a/pxtservices/editorDriver.ts
+++ b/pxtservices/editorDriver.ts
@@ -389,16 +389,16 @@ export class EditorDriver extends IframeDriver {
         return (resp.resp as pxt.editor.EditorMessageGetToolboxCategoriesResponse).categories;
     }
 
-    async getBlockTextParts(blockId: string): Promise<pxt.editor.BlockTextParts | undefined> {
+    async getBlockAsText(blockId: string): Promise<pxt.editor.BlockAsText | undefined> {
         const resp = await this.sendRequest(
             {
                 type: "pxteditor",
-                action: "getblocktextparts",
+                action: "getblockastext",
                 blockId
-            } as pxt.editor.EditorMessageGetBlockReadableNameRequest
+            } as pxt.editor.EditorMessageGetBlockAsTextRequest
         ) as pxt.editor.EditorMessageResponse;
 
-        return (resp.resp as pxt.editor.EditorMessageGetBlockReadableNameResponse)?.readableName;
+        return (resp.resp as pxt.editor.EditorMessageGetBlockAsTextResponse)?.blockAsText;
     }
 
     async runValidatorPlan(validatorPlan: pxt.blocks.ValidatorPlan, planLib: pxt.blocks.ValidatorPlan[]) {

--- a/pxtservices/editorDriver.ts
+++ b/pxtservices/editorDriver.ts
@@ -389,7 +389,7 @@ export class EditorDriver extends IframeDriver {
         return (resp.resp as pxt.editor.EditorMessageGetToolboxCategoriesResponse).categories;
     }
 
-    async getBlockReadableName(blockId: string): Promise<pxt.editor.ReadableBlockName | undefined> {
+    async getReadableBlockName(blockId: string): Promise<pxt.editor.ReadableBlockName | undefined> {
         const resp = await this.sendRequest(
             {
                 type: "pxteditor",

--- a/pxtservices/editorDriver.ts
+++ b/pxtservices/editorDriver.ts
@@ -389,11 +389,11 @@ export class EditorDriver extends IframeDriver {
         return (resp.resp as pxt.editor.EditorMessageGetToolboxCategoriesResponse).categories;
     }
 
-    async getReadableBlockName(blockId: string): Promise<pxt.editor.ReadableBlockName | undefined> {
+    async getBlockTextParts(blockId: string): Promise<pxt.editor.BlockTextParts | undefined> {
         const resp = await this.sendRequest(
             {
                 type: "pxteditor",
-                action: "getreadableblockname",
+                action: "getblocktextparts",
                 blockId
             } as pxt.editor.EditorMessageGetBlockReadableNameRequest
         ) as pxt.editor.EditorMessageResponse;

--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -146,6 +146,15 @@ interface BlockData {
 const BlockInputSegment: React.FC<BlockInputSegmentProps> = ({ instance, param }) => {
     const { state: teacherTool } = useContext(AppStateContext);
 
+    function handleClick() {
+        pxt.tickEvent(Ticks.BlockPickerOpened, { criteriaCatalogId: instance.catalogCriteriaId });
+        showModal({
+            modal: "block-picker",
+            criteriaInstanceId: instance.instanceId,
+            paramName: param.name,
+        } as BlockPickerOptions);
+    }
+
     const blockData = useMemo<BlockData | undefined>(() => {
         if (!param.value || !teacherTool.toolboxCategories) {
             return undefined;
@@ -160,15 +169,6 @@ const BlockInputSegment: React.FC<BlockInputSegmentProps> = ({ instance, param }
         }
         return undefined;
     }, [param.value, teacherTool.toolboxCategories]);
-
-    function handleClick() {
-        pxt.tickEvent(Ticks.BlockPickerOpened, { criteriaCatalogId: instance.catalogCriteriaId });
-        showModal({
-            modal: "block-picker",
-            criteriaInstanceId: instance.instanceId,
-            paramName: param.name,
-        } as BlockPickerOptions);
-    }
 
     const style = blockData ? { backgroundColor: blockData.category.color, color: "white" } : undefined;
     const blockDisplay = blockData ? <ReadableBlockName blockData={blockData} /> : null;

--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -171,10 +171,10 @@ const BlockInputSegment: React.FC<BlockInputSegmentProps> = ({ instance, param }
     }, [param.value, teacherTool.toolboxCategories]);
 
     const style = blockData ? { backgroundColor: blockData.category.color, color: "white" } : undefined;
-    const blockDisplay = blockData ? <ReadableBlockName blockData={blockData} /> : null;
+    const blockDisplay = blockData ? <ReadableBlockName blockData={blockData} /> : param.value || param.name;
     return (
         <Button
-            label={blockDisplay || param.value || param.name}
+            label={blockDisplay}
             className={classList(css["block-input-btn"], param.value ? undefined : css["error"])}
             onClick={handleClick}
             title={param.value ? Strings.SelectBlock : `${Strings.SelectBlock}: ${Strings.ValueRequired}`}

--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -104,7 +104,7 @@ const ReadableBlockName: React.FC<ReadableBlockNameProps> = ({ blockId }) => {
             } else {
                 // TeacherTool.toolboxCategories has loaded and we still don't have a readable component.
                 // We won't be able to get it, so fallback to the id.
-                setBlockAsText({ parts: [ { kind: "label", content: blockId } ] });
+                setBlockAsText({ parts: [{ kind: "label", content: blockId }] });
             }
         }
 

--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -13,7 +13,7 @@ import { Strings, Ticks } from "../constants";
 import { showModal } from "../transforms/showModal";
 import { BlockPickerOptions } from "../types/modalOptions";
 import { validateParameterValue } from "../utils/validateParameterValue";
-import { getReadableBlockName } from "../services/makecodeEditorService";
+import { loadReadableBlockName } from "../transforms/loadReadableBlockName";
 
 interface InlineInputSegmentProps {
     initialValue: string;
@@ -91,7 +91,7 @@ const ReadableBlockNameDisplay: React.FC<ReadableBlockNameDisplayProps> = ({ blo
         async function updateReadableName(blockId: string | undefined) {
             let blockReadableName: pxt.editor.ReadableBlockName | undefined;
             if (blockId) {
-                blockReadableName = blockId ? await getReadableBlockName(blockId) : undefined;
+                blockReadableName = blockId ? await loadReadableBlockName(blockId) : undefined;
             }
 
             if (blockReadableName) {

--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -13,7 +13,7 @@ import { Strings, Ticks } from "../constants";
 import { showModal } from "../transforms/showModal";
 import { BlockPickerOptions } from "../types/modalOptions";
 import { validateParameterValue } from "../utils/validateParameterValue";
-import { loadReadableBlockName } from "../transforms/loadReadableBlockName";
+import { loadBlockTextParts } from "../transforms/loadReadableBlockName";
 
 interface InlineInputSegmentProps {
     initialValue: string;
@@ -81,33 +81,33 @@ const InlineInputSegment: React.FC<InlineInputSegmentProps> = ({
     );
 };
 
-interface ReadableBlockNameDisplayProps {
+interface ReadableBlockNameProps {
     blockData: BlockData;
 }
-const ReadableBlockNameDisplay: React.FC<ReadableBlockNameDisplayProps> = ({ blockData }) => {
-    const [readableName, setReadableName] = useState<pxt.editor.ReadableBlockName | undefined>(undefined);
+const ReadableBlockName: React.FC<ReadableBlockNameProps> = ({ blockData }) => {
+    const [blockTextParts, setBlockTextParts] = useState<pxt.editor.BlockTextParts | undefined>(undefined);
 
     useEffect(() => {
         async function updateReadableName(blockId: string | undefined) {
-            let blockReadableName: pxt.editor.ReadableBlockName | undefined;
+            let blockReadableName: pxt.editor.BlockTextParts | undefined;
             if (blockId) {
-                blockReadableName = blockId ? await loadReadableBlockName(blockId) : undefined;
+                blockReadableName = blockId ? await loadBlockTextParts(blockId) : undefined;
             }
 
             if (blockReadableName) {
-                setReadableName(blockReadableName);
+                setBlockTextParts(blockReadableName);
             } else {
                 // We were unable to get block name from the editor. Fallback to snippet name and/or name.
-                setReadableName({
+                setBlockTextParts({
                     parts: [{ kind: "label", content: blockData.block.snippetName || blockData.block.name }],
-                } as pxt.editor.ReadableBlockName);
+                } as pxt.editor.BlockTextParts);
             }
         }
 
         updateReadableName(blockData.block.blockId);
     }, [blockData]);
 
-    const readableComponent = readableName?.parts.map((part, i) => {
+    const readableComponent = blockTextParts?.parts.map((part, i) => {
         return (
             <span
                 key={`block-name-part-${i}`}
@@ -162,7 +162,7 @@ const BlockInputSegment: React.FC<BlockInputSegmentProps> = ({ instance, param }
     }
 
     const style = blockData ? { backgroundColor: blockData.category.color, color: "white" } : undefined;
-    const blockDisplay = blockData ? <ReadableBlockNameDisplay blockData={blockData} /> : null;
+    const blockDisplay = blockData ? <ReadableBlockName blockData={blockData} /> : null;
     return (
         <Button
             label={blockDisplay || param.value || param.name}

--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -13,7 +13,7 @@ import { Strings, Ticks } from "../constants";
 import { showModal } from "../transforms/showModal";
 import { BlockPickerOptions } from "../types/modalOptions";
 import { validateParameterValue } from "../utils/validateParameterValue";
-import { loadBlockTextParts } from "../transforms/loadReadableBlockName";
+import { loadBlockAsText } from "../transforms/loadReadableBlockName";
 
 interface InlineInputSegmentProps {
     initialValue: string;
@@ -86,32 +86,32 @@ interface ReadableBlockNameProps {
 }
 const ReadableBlockName: React.FC<ReadableBlockNameProps> = ({ blockId }) => {
     const { state: teacherTool } = useContext(AppStateContext);
-    const [blockTextParts, setBlockTextParts] = useState<pxt.editor.BlockTextParts | undefined>(undefined);
+    const [blockAsText, setBlockAsText] = useState<pxt.editor.BlockAsText | undefined>(undefined);
 
     useEffect(() => {
         async function updateReadableName(blockId: string | undefined) {
-            let blockReadableName: pxt.editor.BlockTextParts | undefined;
+            let blockReadableName: pxt.editor.BlockAsText | undefined;
             if (blockId) {
-                blockReadableName = blockId ? await loadBlockTextParts(blockId) : undefined;
+                blockReadableName = blockId ? await loadBlockAsText(blockId) : undefined;
             }
 
             if (blockReadableName) {
-                setBlockTextParts(blockReadableName);
+                setBlockAsText(blockReadableName);
             } else if (!teacherTool.toolboxCategories) {
                 // If teacherTool.toolboxCategories has not loaded yet, we may get the readable component later once it loads.
                 // Show a spinner (handled below).
-                setBlockTextParts(undefined);
+                setBlockAsText(undefined);
             } else {
                 // TeacherTool.toolboxCategories has loaded and we still don't have a readable component.
                 // We won't be able to get it, so fallback to the id.
-                setBlockTextParts({ parts: [ { kind: "label", content: blockId } ] });
+                setBlockAsText({ parts: [ { kind: "label", content: blockId } ] });
             }
         }
 
         updateReadableName(blockId);
     }, [blockId, teacherTool.toolboxCategories]);
 
-    const readableComponent = blockTextParts?.parts.map((part, i) => {
+    const readableComponent = blockAsText?.parts.map((part, i) => {
         let content = "";
         if (part.kind === "param") {
             // Mask default values like "hello!" with generic "value"

--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -93,9 +93,11 @@ const BlockReadableName: React.FC<BlockReadableNameProps> = ({ blockData }) => {
             if (blockId) {
                 blockReadableName = blockId ? await getBlockReadableName(blockId) : undefined;
             }
+
             if (blockReadableName) {
                 setReadableName(blockReadableName);
             } else {
+                // We were unable to get block name from the editor. Fallback to snippet name and/or name.
                 setReadableName({
                     parts: [{ kind: "label", content: blockData.block.snippetName || blockData.block.name }],
                 } as pxt.editor.ReadableBlockName);
@@ -106,25 +108,17 @@ const BlockReadableName: React.FC<BlockReadableNameProps> = ({ blockData }) => {
     }, [blockData]);
 
     const readableComponent = readableName?.parts.map((part, i) => {
-        if (part.kind === "label" || part.kind === "break") {
-            return (
-                <span
-                    key={`block-name-part-${i}`}
-                    className={classList(css["block-name-segment"], css["block-name-label"])}
-                >
-                    {part.kind == "label" ? part.content : " "}
-                </span>
-            );
-        } else if (part.kind === "param") {
-            return (
-                <span
-                    key={`block-name-part-${i}`}
-                    className={classList(css["block-name-segment"], css["block-name-param"])}
-                >
-                    {part.content}
-                </span>
-            );
-        }
+        return (
+            <span
+                key={`block-name-part-${i}`}
+                className={classList(
+                    css["block-name-segment"],
+                    part.kind === "param" ? css["block-name-param"] : css["block-name-label"]
+                )}
+            >
+                {part.kind == "break" ? "" : part.content}
+            </span>
+        );
     });
 
     return (
@@ -143,7 +137,6 @@ interface BlockData {
 const BlockInputSegment: React.FC<BlockInputSegmentProps> = ({ instance, param }) => {
     const { state: teacherTool } = useContext(AppStateContext);
 
-    // Maybe makes sense to move this to use effect and handle call to setBlockText as a separate part of same use effect?
     const blockData = useMemo<BlockData | undefined>(() => {
         if (!param.value || !teacherTool.toolboxCategories) {
             return undefined;

--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -108,6 +108,15 @@ const ReadableBlockName: React.FC<ReadableBlockNameProps> = ({ blockData }) => {
     }, [blockData]);
 
     const readableComponent = blockTextParts?.parts.map((part, i) => {
+        let content = "";
+        if (part.kind === "param") {
+            // Mask default values like "hello!" with generic "value"
+            // This is done to reduce confusion about what is actually being checked.
+            content = lf("value");
+        } else if (part.kind === "label" && part.content) {
+            content = part.content;
+        }
+
         return (
             <span
                 key={`block-name-part-${i}`}
@@ -116,7 +125,7 @@ const ReadableBlockName: React.FC<ReadableBlockNameProps> = ({ blockData }) => {
                     part.kind === "param" ? css["block-name-param"] : css["block-name-label"]
                 )}
             >
-                {part.kind == "break" ? "" : part.content}
+                {content}
             </span>
         );
     });

--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -13,7 +13,7 @@ import { Strings } from "../constants";
 import { showModal } from "../transforms/showModal";
 import { BlockPickerOptions } from "../types/modalOptions";
 import { validateParameterValue } from "../utils/validateParameterValue";
-import { getBlockReadableName } from "../services/makecodeEditorService";
+import { getReadableBlockName } from "../services/makecodeEditorService";
 
 interface InlineInputSegmentProps {
     initialValue: string;
@@ -81,17 +81,17 @@ const InlineInputSegment: React.FC<InlineInputSegmentProps> = ({
     );
 };
 
-interface BlockReadableNameProps {
+interface ReadableBlockNameDisplayProps {
     blockData: BlockData;
 }
-const BlockReadableName: React.FC<BlockReadableNameProps> = ({ blockData }) => {
+const ReadableBlockNameDisplay: React.FC<ReadableBlockNameDisplayProps> = ({ blockData }) => {
     const [readableName, setReadableName] = useState<pxt.editor.ReadableBlockName | undefined>(undefined);
 
     useEffect(() => {
         async function updateReadableName(blockId: string | undefined) {
             let blockReadableName: pxt.editor.ReadableBlockName | undefined;
             if (blockId) {
-                blockReadableName = blockId ? await getBlockReadableName(blockId) : undefined;
+                blockReadableName = blockId ? await getReadableBlockName(blockId) : undefined;
             }
 
             if (blockReadableName) {
@@ -161,7 +161,7 @@ const BlockInputSegment: React.FC<BlockInputSegmentProps> = ({ instance, param }
     }
 
     const style = blockData ? { backgroundColor: blockData.category.color, color: "white" } : undefined;
-    const blockDisplay = blockData ? <BlockReadableName blockData={blockData} /> : null;
+    const blockDisplay = blockData ? <ReadableBlockNameDisplay blockData={blockData} /> : null;
     return (
         <Button
             label={blockDisplay || param.value || param.name}

--- a/teachertool/src/components/styling/BlockPickerModal.module.scss
+++ b/teachertool/src/components/styling/BlockPickerModal.module.scss
@@ -80,7 +80,7 @@
                             height: 3rem;
                             border-radius: 0.2rem;
                             color: white;
-                            border: 1px solid rgba(0, 0, 0, 0.5);
+                            border: 1px solid var(--pxt-page-dark-shadow);
                             font-size: 1rem;
                             font-weight: bold;
                             background-color: var(--category-color);

--- a/teachertool/src/components/styling/CatalogOverlay.module.scss
+++ b/teachertool/src/components/styling/CatalogOverlay.module.scss
@@ -5,7 +5,7 @@
     width: 100%;
     height: 100%;
     z-index: 49; // Above everything except toasts
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: var(--pxt-page-dark-shadow);
 
     color: var(--pxt-page-foreground);
 

--- a/teachertool/src/components/styling/CriteriaInstanceDisplay.module.scss
+++ b/teachertool/src/components/styling/CriteriaInstanceDisplay.module.scss
@@ -53,9 +53,10 @@
                     .block-name-segment {
                         margin-left: 0;
                         margin-right: 0.2rem;
+                        line-height: normal;
                     }
                     .block-name-param {
-                        border-radius: 0.5rem;
+                        border-radius: 1rem;
                         padding: 0.2rem 0.4rem;
                         background-color: rgba(0, 0, 0, 0.3);
                     }

--- a/teachertool/src/components/styling/CriteriaInstanceDisplay.module.scss
+++ b/teachertool/src/components/styling/CriteriaInstanceDisplay.module.scss
@@ -49,6 +49,18 @@
                 border: solid 1px var(--pxt-page-foreground);
                 padding: 0.4rem;
 
+                .block-readable-name {
+                    .block-name-segment {
+                        margin-left: 0;
+                        margin-right: 0.2rem;
+                    }
+                    .block-name-param {
+                        border-radius: 0.5rem;
+                        padding: 0.2rem 0.4rem;
+                        background-color: rgba(0, 0, 0, 0.3);
+                    }
+                }
+
                 &.error {
                     border: solid 1px var(--pxt-error-accent);
                     background-color: var(--pxt-error-background);

--- a/teachertool/src/components/styling/CriteriaInstanceDisplay.module.scss
+++ b/teachertool/src/components/styling/CriteriaInstanceDisplay.module.scss
@@ -58,7 +58,7 @@
                     .block-name-param {
                         border-radius: 1rem;
                         padding: 0.2rem 0.4rem;
-                        background-color: rgba(0, 0, 0, 0.3);
+                        background-color: var(--pxt-page-dark-shadow);
                     }
                 }
 

--- a/teachertool/src/services/makecodeEditorService.ts
+++ b/teachertool/src/services/makecodeEditorService.ts
@@ -63,8 +63,8 @@ export async function getToolboxCategoriesAsync(
     return response;
 }
 
-export async function getBlockReadableName(blockId: string): Promise<pxt.editor.ReadableBlockName | undefined> {
-    const response = driver ? await driver.getBlockReadableName(blockId) : undefined;
+export async function getReadableBlockName(blockId: string): Promise<pxt.editor.ReadableBlockName | undefined> {
+    const response = driver ? await driver.getReadableBlockName(blockId) : undefined;
     return response;
 }
 

--- a/teachertool/src/services/makecodeEditorService.ts
+++ b/teachertool/src/services/makecodeEditorService.ts
@@ -74,8 +74,8 @@ export async function getToolboxCategoriesAsync(
     return response;
 }
 
-export async function getBlockTextParts(blockId: string): Promise<pxt.editor.BlockTextParts | undefined> {
-    const response = driver ? await driver.getBlockTextParts(blockId) : undefined;
+export async function getBlockAsText(blockId: string): Promise<pxt.editor.BlockAsText | undefined> {
+    const response = driver ? await driver.getBlockAsText(blockId) : undefined;
     return response;
 }
 

--- a/teachertool/src/services/makecodeEditorService.ts
+++ b/teachertool/src/services/makecodeEditorService.ts
@@ -63,6 +63,11 @@ export async function getToolboxCategoriesAsync(
     return response;
 }
 
+export async function getBlockReadableName(blockId: string): Promise<pxt.editor.ReadableBlockName | undefined> {
+    const response = driver ? await driver.getBlockReadableName(blockId) : undefined;
+    return response;
+}
+
 export async function getBlockImageUriFromXmlAsync(xml: string): Promise<string | undefined> {
     const response = driver ? await driver.renderXml(xml) : undefined;
     return response;

--- a/teachertool/src/services/makecodeEditorService.ts
+++ b/teachertool/src/services/makecodeEditorService.ts
@@ -74,8 +74,8 @@ export async function getToolboxCategoriesAsync(
     return response;
 }
 
-export async function getReadableBlockName(blockId: string): Promise<pxt.editor.ReadableBlockName | undefined> {
-    const response = driver ? await driver.getReadableBlockName(blockId) : undefined;
+export async function getBlockTextParts(blockId: string): Promise<pxt.editor.BlockTextParts | undefined> {
+    const response = driver ? await driver.getBlockTextParts(blockId) : undefined;
     return response;
 }
 

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -12,6 +12,7 @@ const RUN_ON_LOAD_KEY = [KEY_PREFIX, "runOnLoad"].join("/");
 const LAST_ACTIVE_CHECKLIST_KEY = [KEY_PREFIX, "lastActiveChecklist"].join("/");
 const SPLIT_POSITION_KEY = [KEY_PREFIX, "splitPosition"].join("/");
 const EXPANDED_CATALOG_TAGS_KEY = [KEY_PREFIX, "expandedCatalogTags"].join("/");
+const READABLE_BLOCK_NAME_PREFIX = [KEY_PREFIX, "readableBlockName"].join("/");
 
 function getValue(key: string, defaultValue?: string): string | undefined {
     return localStorage.getItem(key) || defaultValue;
@@ -110,6 +111,10 @@ async function saveChecklistToIndexedDbAsync(checklist: Checklist) {
 async function deleteChecklistFromIndexedDbAsync(name: string) {
     const db = await getDb;
     await db.deleteChecklist(name);
+}
+
+function getReadableBlockNameKey(blockId: string): string {
+    return [READABLE_BLOCK_NAME_PREFIX, blockId].join("/");
 }
 
 // ----------------------------------
@@ -233,5 +238,25 @@ export function removeExpandedCatalogTag(tag: string) {
             expandedTags.splice(index, 1);
             setExpandedCatalogTags(expandedTags);
         }
+    }
+}
+
+export function getCachedReadableBlockName(blockId: string): pxt.editor.ReadableBlockName | undefined {
+    const key = getReadableBlockNameKey(blockId);
+    try {
+        const cachedReadableBlockName = getValue(key);
+        return cachedReadableBlockName ? JSON.parse(cachedReadableBlockName) : undefined;
+    } catch (e) {
+        logError(ErrorCode.localStorageReadError, e);
+        return undefined;
+    }
+}
+
+export function cacheReadableBlockName(blockId: string, readableBlockName: pxt.editor.ReadableBlockName) {
+    const key = getReadableBlockNameKey(blockId);
+    try {
+        setValue(key, JSON.stringify(readableBlockName));
+    } catch (e) {
+        logError(ErrorCode.localStorageWriteError, e);
     }
 }

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -12,7 +12,7 @@ const RUN_ON_LOAD_KEY = [KEY_PREFIX, "runOnLoad"].join("/");
 const LAST_ACTIVE_CHECKLIST_KEY = [KEY_PREFIX, "lastActiveChecklist"].join("/");
 const SPLIT_POSITION_KEY = [KEY_PREFIX, "splitPosition"].join("/");
 const EXPANDED_CATALOG_TAGS_KEY = [KEY_PREFIX, "expandedCatalogTags"].join("/");
-const READABLE_BLOCK_NAME_PREFIX = [KEY_PREFIX, "readableBlockName"].join("/");
+const BLOCK_TEXT_PARTS_PREFIX = [KEY_PREFIX, "blockTextParts"].join("/");
 
 function getValue(key: string, defaultValue?: string): string | undefined {
     return localStorage.getItem(key) || defaultValue;
@@ -113,8 +113,8 @@ async function deleteChecklistFromIndexedDbAsync(name: string) {
     await db.deleteChecklist(name);
 }
 
-function getReadableBlockNameKey(blockId: string): string {
-    return [READABLE_BLOCK_NAME_PREFIX, blockId].join("/");
+function getBlockTextPartsKey(blockId: string): string {
+    return [BLOCK_TEXT_PARTS_PREFIX, blockId].join("/");
 }
 
 // ----------------------------------
@@ -241,8 +241,8 @@ export function removeExpandedCatalogTag(tag: string) {
     }
 }
 
-export function getCachedReadableBlockName(blockId: string): pxt.editor.ReadableBlockName | undefined {
-    const key = getReadableBlockNameKey(blockId);
+export function getCachedBlockTextParts(blockId: string): pxt.editor.BlockTextParts | undefined {
+    const key = getBlockTextPartsKey(blockId);
     try {
         const cachedReadableBlockName = getValue(key);
         return cachedReadableBlockName ? JSON.parse(cachedReadableBlockName) : undefined;
@@ -252,8 +252,8 @@ export function getCachedReadableBlockName(blockId: string): pxt.editor.Readable
     }
 }
 
-export function cacheReadableBlockName(blockId: string, readableBlockName: pxt.editor.ReadableBlockName) {
-    const key = getReadableBlockNameKey(blockId);
+export function cacheBlockTextParts(blockId: string, readableBlockName: pxt.editor.BlockTextParts) {
+    const key = getBlockTextPartsKey(blockId);
     try {
         setValue(key, JSON.stringify(readableBlockName));
     } catch (e) {

--- a/teachertool/src/services/storageService.ts
+++ b/teachertool/src/services/storageService.ts
@@ -12,7 +12,7 @@ const RUN_ON_LOAD_KEY = [KEY_PREFIX, "runOnLoad"].join("/");
 const LAST_ACTIVE_CHECKLIST_KEY = [KEY_PREFIX, "lastActiveChecklist"].join("/");
 const SPLIT_POSITION_KEY = [KEY_PREFIX, "splitPosition"].join("/");
 const EXPANDED_CATALOG_TAGS_KEY = [KEY_PREFIX, "expandedCatalogTags"].join("/");
-const BLOCK_TEXT_PARTS_PREFIX = [KEY_PREFIX, "blockTextParts"].join("/");
+const BLOCK_AS_TEXT_PREFIX = [KEY_PREFIX, "blockAsText"].join("/");
 
 function getValue(key: string, defaultValue?: string): string | undefined {
     return localStorage.getItem(key) || defaultValue;
@@ -113,8 +113,8 @@ async function deleteChecklistFromIndexedDbAsync(name: string) {
     await db.deleteChecklist(name);
 }
 
-function getBlockTextPartsKey(blockId: string): string {
-    return [BLOCK_TEXT_PARTS_PREFIX, blockId].join("/");
+function getBlockAsTextKey(blockId: string): string {
+    return [BLOCK_AS_TEXT_PREFIX, blockId].join("/");
 }
 
 // ----------------------------------
@@ -241,8 +241,8 @@ export function removeExpandedCatalogTag(tag: string) {
     }
 }
 
-export function getCachedBlockTextParts(blockId: string): pxt.editor.BlockTextParts | undefined {
-    const key = getBlockTextPartsKey(blockId);
+export function getCachedBlockAsText(blockId: string): pxt.editor.BlockAsText | undefined {
+    const key = getBlockAsTextKey(blockId);
     try {
         const cachedReadableBlockName = getValue(key);
         return cachedReadableBlockName ? JSON.parse(cachedReadableBlockName) : undefined;
@@ -252,8 +252,8 @@ export function getCachedBlockTextParts(blockId: string): pxt.editor.BlockTextPa
     }
 }
 
-export function cacheBlockTextParts(blockId: string, readableBlockName: pxt.editor.BlockTextParts) {
-    const key = getBlockTextPartsKey(blockId);
+export function cacheBlockAsText(blockId: string, readableBlockName: pxt.editor.BlockAsText) {
+    const key = getBlockAsTextKey(blockId);
     try {
         setValue(key, JSON.stringify(readableBlockName));
     } catch (e) {

--- a/teachertool/src/transforms/loadReadableBlockName.ts
+++ b/teachertool/src/transforms/loadReadableBlockName.ts
@@ -5,15 +5,13 @@ export async function loadBlockTextParts(blockId: string): Promise<pxt.editor.Bl
     // Check for cached version.
     let readableBlockName = getCachedBlockTextParts(blockId);
     if (readableBlockName) {
-        // TODO thsparks : Uncomment after testing and verify this works.
-        // return Promise.resolve(readableBlockName);
+        return Promise.resolve(readableBlockName);
     }
 
     // Call into editor service & cache result
     readableBlockName = await getBlockTextParts(blockId);
     if (readableBlockName) {
-        // TODO thsparks : Uncomment after testing and verify this works.
-        // cacheBlockTextParts(blockId, readableBlockName);
+        cacheBlockTextParts(blockId, readableBlockName);
     }
 
     return readableBlockName;

--- a/teachertool/src/transforms/loadReadableBlockName.ts
+++ b/teachertool/src/transforms/loadReadableBlockName.ts
@@ -1,0 +1,19 @@
+import { getReadableBlockName } from "../services/makecodeEditorService";
+import { cacheReadableBlockName, getCachedReadableBlockName } from "../services/storageService";
+
+export async function loadReadableBlockName(blockId: string): Promise<pxt.editor.ReadableBlockName | undefined> {
+    // Check for cached version.
+    let readableBlockName = getCachedReadableBlockName(blockId);
+    if (readableBlockName) {
+        return Promise.resolve(readableBlockName);
+    }
+
+    // Call into editor service
+    readableBlockName = await getReadableBlockName(blockId);
+    if (readableBlockName) {
+        // Cache the result
+        cacheReadableBlockName(blockId, readableBlockName);
+    }
+
+    return readableBlockName;
+}

--- a/teachertool/src/transforms/loadReadableBlockName.ts
+++ b/teachertool/src/transforms/loadReadableBlockName.ts
@@ -1,18 +1,18 @@
-import { getReadableBlockName } from "../services/makecodeEditorService";
-import { cacheReadableBlockName, getCachedReadableBlockName } from "../services/storageService";
+import { getBlockTextParts } from "../services/makecodeEditorService";
+import { cacheBlockTextParts, getCachedBlockTextParts } from "../services/storageService";
 
-export async function loadReadableBlockName(blockId: string): Promise<pxt.editor.ReadableBlockName | undefined> {
+export async function loadBlockTextParts(blockId: string): Promise<pxt.editor.BlockTextParts | undefined> {
     // Check for cached version.
-    let readableBlockName = getCachedReadableBlockName(blockId);
+    let readableBlockName = getCachedBlockTextParts(blockId);
     if (readableBlockName) {
         return Promise.resolve(readableBlockName);
     }
 
     // Call into editor service
-    readableBlockName = await getReadableBlockName(blockId);
+    readableBlockName = await getBlockTextParts(blockId);
     if (readableBlockName) {
         // Cache the result
-        cacheReadableBlockName(blockId, readableBlockName);
+        cacheBlockTextParts(blockId, readableBlockName);
     }
 
     return readableBlockName;

--- a/teachertool/src/transforms/loadReadableBlockName.ts
+++ b/teachertool/src/transforms/loadReadableBlockName.ts
@@ -5,7 +5,7 @@ export async function loadBlockAsText(blockId: string): Promise<pxt.editor.Block
     // Check for cached version.
     let readableBlockName = getCachedBlockAsText(blockId);
     if (readableBlockName) {
-        return Promise.resolve(readableBlockName);
+        return readableBlockName;
     }
 
     // Call into editor service & cache result

--- a/teachertool/src/transforms/loadReadableBlockName.ts
+++ b/teachertool/src/transforms/loadReadableBlockName.ts
@@ -5,14 +5,15 @@ export async function loadBlockTextParts(blockId: string): Promise<pxt.editor.Bl
     // Check for cached version.
     let readableBlockName = getCachedBlockTextParts(blockId);
     if (readableBlockName) {
-        return Promise.resolve(readableBlockName);
+        // TODO thsparks : Uncomment after testing and verify this works.
+        // return Promise.resolve(readableBlockName);
     }
 
-    // Call into editor service
+    // Call into editor service & cache result
     readableBlockName = await getBlockTextParts(blockId);
     if (readableBlockName) {
-        // Cache the result
-        cacheBlockTextParts(blockId, readableBlockName);
+        // TODO thsparks : Uncomment after testing and verify this works.
+        // cacheBlockTextParts(blockId, readableBlockName);
     }
 
     return readableBlockName;

--- a/teachertool/src/transforms/loadReadableBlockName.ts
+++ b/teachertool/src/transforms/loadReadableBlockName.ts
@@ -1,17 +1,17 @@
-import { getBlockTextParts } from "../services/makecodeEditorService";
-import { cacheBlockTextParts, getCachedBlockTextParts } from "../services/storageService";
+import { getBlockAsText } from "../services/makecodeEditorService";
+import { cacheBlockAsText, getCachedBlockAsText } from "../services/storageService";
 
-export async function loadBlockTextParts(blockId: string): Promise<pxt.editor.BlockTextParts | undefined> {
+export async function loadBlockAsText(blockId: string): Promise<pxt.editor.BlockAsText | undefined> {
     // Check for cached version.
-    let readableBlockName = getCachedBlockTextParts(blockId);
+    let readableBlockName = getCachedBlockAsText(blockId);
     if (readableBlockName) {
         return Promise.resolve(readableBlockName);
     }
 
     // Call into editor service & cache result
-    readableBlockName = await getBlockTextParts(blockId);
+    readableBlockName = await getBlockAsText(blockId);
     if (readableBlockName) {
-        cacheBlockTextParts(blockId, readableBlockName);
+        cacheBlockAsText(blockId, readableBlockName);
     }
 
     return readableBlockName;

--- a/theme/themepacks.less
+++ b/theme/themepacks.less
@@ -15,6 +15,7 @@
     --pxt-page-foreground: black;
     --pxt-page-foreground-light: #767676;
     --pxt-page-foreground-shadow: rgba(0, 0, 0, 0.08);
+    --pxt-page-dark-shadow: rgba(0, 0, 0, 0.5);
     /// Header bar
     --pxt-headerbar-background: #475569;
     --pxt-headerbar-background-glass: #47556940;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4144,8 +4144,8 @@ export class ProjectView
     }
 
     // TODO thsparks : find a better name for this function
-    getReadableBlockNameFromBlocksBlockDefinition(block: pxt.blocks.BlockDefinition): pxt.editor.ReadableBlockName | undefined {
-        const parts: pxt.editor.ReadableBlockNamePart[] = [];
+    getBlockTextPartsFromBlocksBlockDefinition(block: pxt.blocks.BlockDefinition): pxt.editor.BlockTextParts | undefined {
+        const parts: pxt.editor.BlockTextPart[] = [];
         if (block?.block["message0"]) {
             // These message values use %1, %2, etc. for parameters.
             // Extract these into generic "value" parameters.
@@ -4185,7 +4185,7 @@ export class ProjectView
         return { parts };
     }
 
-    getReadableBlockName(blockId: string): pxt.editor.ReadableBlockName | undefined {
+    getBlockTextParts(blockId: string): pxt.editor.BlockTextParts | undefined {
         // Get toolbox block definition.
         let toolboxBlockMatch: BlockDefinition = undefined;
         for (const advanced of [true, false]) {
@@ -4201,7 +4201,7 @@ export class ProjectView
             return undefined;
         }
 
-        let readableName = toolboxHelpers.getBlockDescription(
+        let readableName = toolboxHelpers.getBlockTextParts(
             toolboxBlockMatch,
             toolboxBlockMatch.parameters ? toolboxBlockMatch.parameters.slice() : null,
             false);
@@ -4209,7 +4209,7 @@ export class ProjectView
         if (!readableName) {
             const blocksBlockMatch = pxt.blocks.getBlockDefinition(blockId);
             if (blocksBlockMatch) {
-                readableName = this.getReadableBlockNameFromBlocksBlockDefinition(blocksBlockMatch);
+                readableName = this.getBlockTextPartsFromBlocksBlockDefinition(blocksBlockMatch);
             }
         }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -49,7 +49,7 @@ import * as sidepanel from "./sidepanel";
 import * as qr from "./qr";
 
 import * as monaco from "./monaco"
-import * as monacoHelpers from "./monacopyhelper"
+import * as toolboxHelpers from "./toolboxHelpers"
 import * as pxtjson from "./pxtjson"
 import * as serial from "./serial"
 import * as blocks from "./blocks"
@@ -4201,7 +4201,7 @@ export class ProjectView
             return undefined;
         }
 
-        let readableName = monacoHelpers.getBlockDescription(
+        let readableName = toolboxHelpers.getBlockDescription(
             toolboxBlockMatch,
             toolboxBlockMatch.parameters ? toolboxBlockMatch.parameters.slice() : null,
             false);
@@ -4216,7 +4216,7 @@ export class ProjectView
         if (!readableName) {
             readableName.parts.push({
                 kind: "label",
-                content: monacoHelpers.getSnippetName(toolboxBlockMatch, false) || toolboxBlockMatch.name,
+                content: toolboxHelpers.getSnippetName(toolboxBlockMatch, false) || toolboxBlockMatch.name,
             });
         }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4143,7 +4143,7 @@ export class ProjectView
         return { categories };
     }
 
-    // TODO thsparks : find a better name
+    // TODO thsparks : find a better name for this function
     getReadableBlockNameFromBlocksBlockDefinition(block: pxt.blocks.BlockDefinition): pxt.editor.ReadableBlockName | undefined {
         const parts: pxt.editor.ReadableBlockNamePart[] = [];
         if (block?.block["message0"]) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4143,48 +4143,6 @@ export class ProjectView
         return { categories };
     }
 
-    // TODO thsparks : find a better name for this function
-    getBlockTextPartsFromBlocksBlockDefinition(block: pxt.blocks.BlockDefinition): pxt.editor.BlockTextParts | undefined {
-        const parts: pxt.editor.BlockTextPart[] = [];
-        if (block?.block["message0"]) {
-            // These message values use %1, %2, etc. for parameters.
-            // Extract these into generic "value" parameters.
-            const message = block.block["message0"];
-            const regex = /%(\d+)/g;
-            let lastIndex = 0;
-            let match;
-
-            while ((match = regex.exec(message)) !== null) {
-                // Add the text before the parameter as a label (if it's not empty)
-                if (match.index > lastIndex) {
-                    const content = message.substring(lastIndex, match.index).trim();
-                    if (content) {
-                        parts.push({ kind: "label", content });
-                    }
-                }
-
-                // Add the parameter
-                parts.push({
-                    kind: "param",
-                    content: "value"
-                });
-                lastIndex = regex.lastIndex;
-            }
-
-            // Add any remaining text after the last parameter as a label
-            if (lastIndex < message.length) {
-                parts.push({
-                    kind: "label",
-                    content: message.substring(lastIndex).trim()
-                });
-            }
-        } else {
-            parts.push({ kind: "label", content: block.name });
-        }
-
-        return { parts };
-    }
-
     getBlockTextParts(blockId: string): pxt.editor.BlockTextParts | undefined {
         // Get toolbox block definition.
         let toolboxBlockMatch: BlockDefinition = undefined;
@@ -4209,7 +4167,7 @@ export class ProjectView
         if (!readableName) {
             const blocksBlockMatch = pxt.blocks.getBlockDefinition(blockId);
             if (blocksBlockMatch) {
-                readableName = this.getBlockTextPartsFromBlocksBlockDefinition(blocksBlockMatch);
+                readableName = toolboxHelpers.getBlockTextPartsFromBlocksBlockDefinition(blocksBlockMatch);
             }
         }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -49,6 +49,7 @@ import * as sidepanel from "./sidepanel";
 import * as qr from "./qr";
 
 import * as monaco from "./monaco"
+import * as monacoHelpers from "./monacopyhelper"
 import * as pxtjson from "./pxtjson"
 import * as serial from "./serial"
 import * as blocks from "./blocks"
@@ -80,7 +81,7 @@ import { mergeProjectCode, appendTemporaryAssets } from "./mergeProjects";
 import { Tour } from "./components/onboarding/Tour";
 import { parseTourStepsAsync } from "./onboarding";
 import { initGitHubDb } from "./idbworkspace";
-import { CategoryNameID } from "./toolbox";
+import { BlockDefinition, CategoryNameID } from "./toolbox";
 
 pxt.blocks.requirePxtBlockly = () => pxtblockly as any;
 pxt.blocks.requireBlockly = () => Blockly;
@@ -4140,6 +4141,26 @@ export class ProjectView
             } as pxt.editor.ToolboxCategoryDefinition;
         });
         return { categories };
+    }
+
+    getReadableBlockName(blockId: string): pxt.editor.ReadableBlockName | undefined {
+        // Get toolbox block definition.
+        let blockMatch: BlockDefinition = undefined;
+        for (const advanced of [true, false]) {
+            for (const category of this.blocksEditor.getToolboxCategories(advanced)) {
+                blockMatch = category.blocks.find(b => b.attributes.blockId === blockId);
+                if (blockMatch) break;
+            }
+            if (blockMatch) break;
+        }
+
+        if (!blockMatch) {
+            console.log("DEBUG: No Block Match for blockId: " + blockId);
+            return undefined;
+        }
+
+        const readableName = monacoHelpers.getBlockDescription(blockMatch, blockMatch.parameters ? blockMatch.parameters.slice() : null, false);
+        return readableName;
     }
 
     launchFullEditor() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4167,7 +4167,7 @@ export class ProjectView
         }
 
         if (!readableName) {
-            // Found nultiple blocks matching the id, or we were unable to generate a readable name from block parameters.
+            // Found multiple blocks matching the id, or we were unable to generate a readable name from block parameters.
             // In this case, use the block snippet names to describe the block.
             const blockSnippets: string[] = [];
             for (const name of blocksWithId.map(b => b.snippetName || b.name)) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4170,11 +4170,12 @@ export class ProjectView
             // Found nultiple blocks matching the id, or we were unable to generate a readable name from block parameters.
             // In this case, use the block snippet names to describe the block.
             const blockSnippets: string[] = [];
-            for (const block of blocksWithId) {
-                    blockSnippets.push(toolboxHelpers.getSnippetName(block, false) || block.name);
+            for (const name of blocksWithId.map(b => b.snippetName || b.name)) {
+                if (blockSnippets.indexOf(name) === -1) {
+                    blockSnippets.push(name);
+                }
             }
-
-            readableName = blockSnippets.length === 0 ? undefined : {
+            readableName = {
                 parts: [
                     {
                         kind: "label",

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4156,14 +4156,14 @@ export class ProjectView
         return matches;
     }
 
-    getBlockTextParts(blockId: string): pxt.editor.BlockTextParts | undefined {
+    getBlockAsText(blockId: string): pxt.editor.BlockAsText | undefined {
         const blocksWithId = this.getBlocksWithId(blockId);
-        let readableName: pxt.editor.BlockTextParts = undefined;
+        let readableName: pxt.editor.BlockAsText = undefined;
         if (blocksWithId.length === 0) {
             return undefined;
         } else if (blocksWithId.length === 1) {
             const block = blocksWithId[0];
-            readableName = toolboxHelpers.getBlockTextParts(block, block.parameters ? block.parameters.slice() : null, false);
+            readableName = toolboxHelpers.getBlockAsText(block, block.parameters ? block.parameters.slice() : null, false);
         }
 
         if (!readableName) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1514,6 +1514,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (ns == onStartNamespace) {
             extraBlocks.push({
                 name: ts.pxtc.ON_START_TYPE,
+                snippetName: "on start",
                 attributes: {
                     blockId: ts.pxtc.ON_START_TYPE,
                     weight: pxt.appTarget.runtime.onStartWeight || 10,

--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -176,7 +176,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 </block>`
                 }, {
                     name: "logic_compare_lt",
-                    snippetName: "less than",
+                    snippetName: "less than | greater than",
                     attributes: {
                         blockId: "logic_compare",
                         group: lf("Comparison"),
@@ -476,7 +476,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_js_round",
-                    snippetName: "round",
+                    snippetName: "round | ceil | floor | trunc",
                     attributes: {
                         blockId: "math_js_round",
                         weight: 80
@@ -632,7 +632,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 },
                 {
                     name: "lists_length",
-                    snippetName: "array length",
+                    snippetName: "length",
                     attributes: {
                         blockId: "lists_length",
                         group: "Read",
@@ -744,7 +744,7 @@ export function getPauseUntil() {
     if (opts) {
         pauseUntil = {
             name: pxtc.PAUSE_UNTIL_TYPE,
-
+            snippetName: "pause until",
             attributes: {
                 blockId: pxtc.PAUSE_UNTIL_TYPE,
                 blockNamespace: opts.category || "loops",
@@ -786,6 +786,7 @@ export function allBuiltinBlocks() {
     // Add on start built in block
     builtinBlockCache[ts.pxtc.ON_START_TYPE] = {
         name: ts.pxtc.ON_START_TYPE,
+        snippetName: "on start",
         attributes: {
             blockId: ts.pxtc.ON_START_TYPE,
             weight: pxt.appTarget.runtime.onStartWeight || 10,

--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -461,7 +461,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_js_op",
-                    snippetName: "square root",
+                    snippetName: "sqrt | sin | cos | tan | ...",
                     attributes: {
                         blockId: "math_js_op",
                         weight: 81

--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -19,6 +19,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
             blocks: [
                 {
                     name: "controls_repeat_ext",
+                    snippetName: "repeat",
                     attributes: {
                         blockId: "controls_repeat_ext",
                         weight: 49
@@ -32,6 +33,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 </block>`
                 }, {
                     name: "device_while",
+                    snippetName: "while",
                     attributes: {
                         blockId: "device_while",
                         weight: 48
@@ -46,6 +48,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 },
                 {
                     name: "pxt_controls_for",
+                    snippetName: "for",
                     attributes: {
                         blockId: "pxt_controls_for",
                         weight: 47
@@ -66,6 +69,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 },
                 {
                     name: "pxt_controls_for_of",
+                    snippetName: "for of",
                     attributes: {
                         blockId: "pxt_controls_for_of",
                         weight: 46
@@ -95,6 +99,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
         if (pxt.appTarget.runtime && pxt.appTarget.runtime.breakBlock) {
             _cachedBuiltinCategories[CategoryNameID.Loops].blocks.push({
                 name: "pxt_break",
+                snippetName: "break",
                 attributes: {
                     blockId: "break_keyword",
                     weight: 30
@@ -105,6 +110,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
         if (pxt.appTarget.runtime && pxt.appTarget.runtime.continueBlock) {
             _cachedBuiltinCategories[CategoryNameID.Loops].blocks.push({
                 name: "pxt_continue",
+                snippetName: "continue",
                 attributes: {
                     blockId: "continue_keyword",
                     weight: 29
@@ -119,6 +125,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
             blocks: [
                 {
                     name: "controls_if",
+                    snippetName: "if",
                     attributes: {
                         blockId: "controls_if",
                         group: lf("Conditionals"),
@@ -133,6 +140,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 </block>`
                 }, {
                     name: "controls_if_else",
+                    snippetName: "if else",
                     attributes: {
                         blockId: "controls_if",
                         group: lf("Conditionals"),
@@ -148,6 +156,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 </block>`
                 }, {
                     name: "logic_compare_eq",
+                    snippetName: "equals",
                     attributes: {
                         blockId: "logic_compare",
                         group: lf("Comparison"),
@@ -167,6 +176,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 </block>`
                 }, {
                     name: "logic_compare_lt",
+                    snippetName: "less than",
                     attributes: {
                         blockId: "logic_compare",
                         group: lf("Comparison"),
@@ -187,6 +197,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 </block>`
                 }, {
                     name: "logic_compare_strings",
+                    snippetName: "equals",
                     attributes: {
                         blockId: "logic_compare",
                         group: lf("Comparison"),
@@ -206,6 +217,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 </block>`
                 }, {
                     name: "logic_operation_and",
+                    snippetName: "and",
                     attributes: {
                         blockId: "logic_operation",
                         group: lf("Boolean"),
@@ -216,6 +228,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 </block>`
                 }, {
                     name: "logic_operation_or",
+                    snippetName: "or",
                     attributes: {
                         blockId: "logic_operation",
                         group: lf("Boolean"),
@@ -226,6 +239,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 </block>`
                 }, {
                     name: "logic_negate",
+                    snippetName: "not",
                     attributes: {
                         blockId: "logic_negate",
                         group: lf("Boolean"),
@@ -234,6 +248,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     blockXml: `<block type="logic_negate"></block>`
                 }, {
                     name: "logic_boolean_true",
+                    snippetName: "true",
                     attributes: {
                         blockId: "logic_boolean",
                         group: lf("Boolean"),
@@ -244,6 +259,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 </block>`
                 }, {
                     name: "logic_boolean_false",
+                    snippetName: "false",
                     attributes: {
                         blockId: "logic_boolean",
                         group: lf("Boolean"),
@@ -282,6 +298,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
             blocks: [
                 {
                     name: "math_arithmetic_ADD",
+                    snippetName: "plus",
                     attributes: {
                         blockId: "math_arithmetic",
                         weight: 90
@@ -301,6 +318,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_arithmetic_MINUS",
+                    snippetName: "minus",
                     attributes: {
                         blockId: "math_arithmetic",
                         weight: 89
@@ -320,6 +338,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_arithmetic_TIMES",
+                    snippetName: "times",
                     attributes: {
                         blockId: "math_arithmetic",
                         weight: 88
@@ -339,6 +358,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_arithmetic_DIVIDE",
+                    snippetName: "divide",
                     attributes: {
                         blockId: "math_arithmetic",
                         weight: 87
@@ -358,6 +378,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_number",
+                    snippetName: "number",
                     attributes: {
                         blockId: "math_number",
                         weight: 86
@@ -367,6 +388,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_modulo",
+                    snippetName: "remainder",
                     attributes: {
                         blockId: "math_modulo",
                         weight: 85
@@ -385,6 +407,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_op2_min",
+                    snippetName: "min",
                     attributes: {
                         blockId: "math_op2",
                         weight: 84
@@ -404,6 +427,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_op2_max",
+                    snippetName: "max",
                     attributes: {
                         blockId: "math_op2",
                         weight: 83
@@ -423,6 +447,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_op3",
+                    snippetName: "absolute value",
                     attributes: {
                         blockId: "math_op3",
                         weight: 82
@@ -436,6 +461,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_js_op",
+                    snippetName: "square root",
                     attributes: {
                         blockId: "math_js_op",
                         weight: 81
@@ -450,6 +476,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "math_js_round",
+                    snippetName: "round",
                     attributes: {
                         blockId: "math_js_round",
                         weight: 80
@@ -494,6 +521,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
             blocks: [
                 {
                     name: "lists_create_with",
+                    snippetName: "create array",
                     attributes: {
                         blockId: "lists_create_with",
                         group: "Create",
@@ -519,6 +547,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "lists_create_with",
+                    snippetName: "create array",
                     attributes: {
                         blockId: "lists_create_with",
                         group: "Create",
@@ -549,6 +578,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "lists_create_with",
+                    snippetName: "create array",
                     attributes: {
                         blockId: "lists_create_with",
                         group: "Create",
@@ -560,6 +590,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 },
                 {
                     name: "lists_index_get",
+                    snippetName: "array get value",
                     attributes: {
                         blockId: "lists_index_get",
                         group: "Read",
@@ -580,6 +611,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 },
                 {
                     name: "lists_index_set",
+                    snippetName: "array set value",
                     attributes: {
                         blockId: "lists_index_set",
                         group: "Modify",
@@ -600,6 +632,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 },
                 {
                     name: "lists_length",
+                    snippetName: "array length",
                     attributes: {
                         blockId: "lists_length",
                         group: "Read",
@@ -629,6 +662,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
             blocks: [
                 {
                     name: "text",
+                    snippetName: "text",
                     attributes: {
                         blockId: "text",
                         weight: 90
@@ -636,6 +670,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     blockXml: `<block type="text"></block>`
                 }, {
                     name: "text_length",
+                    snippetName: "text length",
                     attributes: {
                         blockId: "text_length",
                         weight: 89
@@ -649,6 +684,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </block>`
                 }, {
                     name: "text_join",
+                    snippetName: "text join",
                     attributes: {
                         blockId: "text_join",
                         weight: 88

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -9,6 +9,7 @@ import { HELP_IMAGE_URI } from "../../pxteditor";
 import * as pxtblockly from "../../pxtblocks";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
+import { getSnippetName } from "./monacopyhelper";
 
 const DRAG_THRESHOLD = 5;
 const SELECTED_BORDER_WIDTH = 4;
@@ -135,7 +136,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
                 dragBlock.id = "monacoDraggingBlock";
                 dragBlock.textContent = block.snippetOnly
                     ? block.snippet
-                    : `${this.getQName(block) || this.getSnippetName(block)}${params ? `(${params.map(p => p.name).join(", ")})` : ""}`
+                    : `${this.getQName(block) || getSnippetName(block, this.props.fileType == pxt.editor.FileType.Python)}${params ? `(${params.map(p => p.name).join(", ")})` : ""}`
                 dragBlock.style.backgroundColor = this.dragInfo.color;
                 parent.appendChild(dragBlock);
 
@@ -245,11 +246,6 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
         return this.props.fileType == pxt.editor.FileType.Python && block.pyQName ? block.pyQName : block.qName;
     }
 
-    protected getSnippetName(block: toolbox.BlockDefinition): string {
-        const isPython = this.props.fileType == pxt.editor.FileType.Python;
-        return (isPython ? (block.pySnippetName || block.pyName) : undefined) || block.snippetName || block.name;
-    }
-
     protected getBlockDescription(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[]): JSX.Element[] {
         let description = [];
         let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo);
@@ -295,7 +291,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
             })
         } else {
             // if no blockdef found, use the snippet name
-            description.push(<span key={name}>{this.getSnippetName(block) || block.name}</span>)
+            description.push(<span key={name}>{getSnippetName(block, isPython) || block.name}</span>)
         }
 
         // imitates block behavior in adding "run code" before any handler
@@ -369,7 +365,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
             pxtblockly.external.openHelpUrl(helpUrl);
         };
 
-        const qName = this.getQName(block) || this.getSnippetName(block);
+        const qName = this.getQName(block) || getSnippetName(block, this.props.fileType == pxt.editor.FileType.Python);
         const selected = qName == this.state.selectedBlock;
         const hover = qName == this.state.hoverBlock;
 

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -7,7 +7,7 @@ import * as data from "./data";
 import * as auth from "./auth";
 import * as pxtblockly from "../../pxtblocks";
 import { HELP_IMAGE_URI } from "../../pxteditor";
-import { getBlockTextParts } from "./toolboxHelpers";
+import { getBlockAsText } from "./toolboxHelpers";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -257,9 +257,9 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
         let name = block.qName || block.name;
         const isPython = this.props.fileType == pxt.editor.FileType.Python;
 
-        const blockTextParts = getBlockTextParts(block, params, isPython);
-        if (blockTextParts?.parts?.length) {
-            blockTextParts.parts?.forEach((part, i) => {
+        const blockAsText = getBlockAsText(block, params, isPython);
+        if (blockAsText?.parts?.length) {
+            blockAsText.parts?.forEach((part, i) => {
                 switch (part.kind) {
                     case "label":
                         description.push(<span key={name + i}>{part.content}</span>);

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -5,11 +5,11 @@ import * as toolbox from "./toolbox";
 import * as workspace from "./workspace";
 import * as data from "./data";
 import * as auth from "./auth";
-import { HELP_IMAGE_URI } from "../../pxteditor";
 import * as pxtblockly from "../../pxtblocks";
+import { HELP_IMAGE_URI } from "../../pxteditor";
+import { getSnippetName, getBlockTextParts } from "./toolboxHelpers";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
-import { getSnippetName } from "./monacopyhelper";
 
 const DRAG_THRESHOLD = 5;
 const SELECTED_BORDER_WIDTH = 4;
@@ -249,48 +249,26 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
     protected getBlockDescription(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[]): JSX.Element[] {
         let description = [];
         let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo);
-        let parts = block.attributes._def && block.attributes._def.parts;
-        if (block.attributes.parentBlock) {
-            const parent = block.attributes.parentBlock;
-            const parentBlockParts = [...parent.attributes._def.parts];
-            const overrideLocation = parentBlockParts.findIndex((part: any) => part.kind === "param" && part.name === block.attributes.toolboxParentArgument);
-            if (overrideLocation !== -1) {
-                parentBlockParts.splice(overrideLocation, 1, ...block.attributes._def.parts);
-                parts = parentBlockParts;
-            }
-        }
         let name = block.qName || block.name;
         const isPython = this.props.fileType == pxt.editor.FileType.Python;
 
-        if (parts) {
-            if (params &&
-                parts.filter((p: any) => p.kind == "param").length > params.length) {
-                // add empty param when first argument is "this"
-                params.unshift(null);
-            }
-            parts.forEach((part, i) => {
+        const blockTextParts = getBlockTextParts(block, params, isPython);
+        if (blockTextParts?.parts?.length) {
+            blockTextParts.parts?.forEach((part, i) => {
                 switch (part.kind) {
                     case "label":
-                        description.push(<span key={name + i}>{part.text}</span>);
+                        description.push(<span key={name + i}>{part.content}</span>);
                         break;
                     case "break":
                         description.push(<span key={name + i}>{" "}</span>);
                         break;
                     case "param":
-                        let actualParam = compileInfo?.definitionNameToParam[part.name];
-                        let val = actualParam?.defaultValue
-                            || part.varName
-                            || actualParam?.actualName
-                            || part.name
-                        if (isPython && actualParam?.defaultValue) {
-                            val = pxtc.tsSnippetToPySnippet(val);
-                        }
-                        description.push(<span className="argName" key={name + i}>{val}</span>);
+                        description.push(<span className="argName" key={name + i}>{part.content}</span>);
                         break;
                 }
-            })
+            });
         } else {
-            // if no blockdef found, use the snippet name
+            // if no parts found, use the snippet name
             description.push(<span key={name}>{getSnippetName(block, isPython) || block.name}</span>)
         }
 

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -7,7 +7,7 @@ import * as data from "./data";
 import * as auth from "./auth";
 import * as pxtblockly from "../../pxtblocks";
 import { HELP_IMAGE_URI } from "../../pxteditor";
-import { getSnippetName, getBlockTextParts } from "./toolboxHelpers";
+import { getBlockTextParts } from "./toolboxHelpers";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -136,7 +136,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
                 dragBlock.id = "monacoDraggingBlock";
                 dragBlock.textContent = block.snippetOnly
                     ? block.snippet
-                    : `${this.getQName(block) || getSnippetName(block, this.props.fileType == pxt.editor.FileType.Python)}${params ? `(${params.map(p => p.name).join(", ")})` : ""}`
+                    : `${this.getQName(block) || this.getSnippetName(block)}${params ? `(${params.map(p => p.name).join(", ")})` : ""}`
                 dragBlock.style.backgroundColor = this.dragInfo.color;
                 parent.appendChild(dragBlock);
 
@@ -246,6 +246,11 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
         return this.props.fileType == pxt.editor.FileType.Python && block.pyQName ? block.pyQName : block.qName;
     }
 
+    protected getSnippetName(block: toolbox.BlockDefinition): string {
+        const isPython = this.props.fileType == pxt.editor.FileType.Python;
+        return (isPython ? (block.pySnippetName || block.pyName) : undefined) || block.snippetName || block.name;
+    }
+
     protected getBlockDescription(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[]): JSX.Element[] {
         let description = [];
         let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo);
@@ -269,7 +274,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
             });
         } else {
             // if no parts found, use the snippet name
-            description.push(<span key={name}>{getSnippetName(block, isPython) || block.name}</span>)
+            description.push(<span key={name}>{this.getSnippetName(block) || block.name}</span>)
         }
 
         // imitates block behavior in adding "run code" before any handler
@@ -343,7 +348,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
             pxtblockly.external.openHelpUrl(helpUrl);
         };
 
-        const qName = this.getQName(block) || getSnippetName(block, this.props.fileType == pxt.editor.FileType.Python);
+        const qName = this.getQName(block) || this.getSnippetName(block);
         const selected = qName == this.state.selectedBlock;
         const hover = qName == this.state.hoverBlock;
 

--- a/webapp/src/monacopyhelper.ts
+++ b/webapp/src/monacopyhelper.ts
@@ -100,7 +100,6 @@ export function getBlockDescription(block: toolbox.BlockDefinition, params: pxtc
             parts = parentBlockParts;
         }
     }
-    let name = block.qName || block.name;
 
     if (parts) {
         if (params &&
@@ -129,10 +128,7 @@ export function getBlockDescription(block: toolbox.BlockDefinition, params: pxtc
                     break;
             }
         })
-    } else {
-        // if no blockdef found, use the snippet name
-        description.push({kind: "label", content: getSnippetName(block, isPython) || block.name})
     }
 
-    return { parts: description };
+    return description.length > 0 ? { parts: description } : undefined;
 }

--- a/webapp/src/monacopyhelper.ts
+++ b/webapp/src/monacopyhelper.ts
@@ -1,5 +1,3 @@
-import * as toolbox from "./toolbox";
-
 const INDENT = 4;
 
 interface Line {
@@ -78,57 +76,4 @@ export function fixIndentationInRange(model: monaco.editor.IReadOnlyModel, range
         text: lines.join('\n'),
         range: range.setStartPosition(range.startLineNumber, 0)
     }];
-}
-
-
-export function getSnippetName(block: toolbox.BlockDefinition, isPython: boolean): string {
-    return (isPython ? (block.pySnippetName || block.pyName) : undefined) || block.snippetName || block.name;
-}
-
-// TODO thsparks : move monacoFlyout to use this too.
-// TODO thsparks : this is the monacyPYhelpers class. Will need to find/make a better place for this?
-export function getBlockDescription(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.ReadableBlockName {
-    let description: pxt.editor.ReadableBlockNamePart[] = [];
-    let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo);
-    let parts = block.attributes._def && block.attributes._def.parts;
-    if (block.attributes.parentBlock) {
-        const parent = block.attributes.parentBlock;
-        const parentBlockParts = [...parent.attributes._def.parts];
-        const overrideLocation = parentBlockParts.findIndex((part: any) => part.kind === "param" && part.name === block.attributes.toolboxParentArgument);
-        if (overrideLocation !== -1) {
-            parentBlockParts.splice(overrideLocation, 1, ...block.attributes._def.parts);
-            parts = parentBlockParts;
-        }
-    }
-
-    if (parts) {
-        if (params &&
-            parts.filter((p: any) => p.kind == "param").length > params.length) {
-            // add empty param when first argument is "this"
-            params.unshift(null);
-        }
-        parts.forEach((part, i) => {
-            switch (part.kind) {
-                case "label":
-                    description.push({kind: "label", content: part.text});
-                    break;
-                case "break":
-                    description.push({kind: "break"});
-                    break;
-                case "param":
-                    let actualParam = compileInfo?.definitionNameToParam[part.name];
-                    let val = actualParam?.defaultValue
-                        || part.varName
-                        || actualParam?.actualName
-                        || part.name
-                    if (isPython && actualParam?.defaultValue) {
-                        val = pxtc.tsSnippetToPySnippet(val);
-                    }
-                    description.push({kind: "param", content: val});
-                    break;
-            }
-        })
-    }
-
-    return description.length > 0 ? { parts: description } : undefined;
 }

--- a/webapp/src/monacopyhelper.ts
+++ b/webapp/src/monacopyhelper.ts
@@ -1,3 +1,5 @@
+import * as toolbox from "./toolbox";
+
 const INDENT = 4;
 
 interface Line {
@@ -76,4 +78,61 @@ export function fixIndentationInRange(model: monaco.editor.IReadOnlyModel, range
         text: lines.join('\n'),
         range: range.setStartPosition(range.startLineNumber, 0)
     }];
+}
+
+
+export function getSnippetName(block: toolbox.BlockDefinition, isPython: boolean): string {
+    return (isPython ? (block.pySnippetName || block.pyName) : undefined) || block.snippetName || block.name;
+}
+
+// TODO thsparks : move monacoFlyout to use this too.
+// TODO thsparks : this is the monacyPYhelpers class. Will need to find/make a better place for this?
+export function getBlockDescription(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.ReadableBlockName {
+    let description: pxt.editor.ReadableBlockNamePart[] = [];
+    let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo);
+    let parts = block.attributes._def && block.attributes._def.parts;
+    if (block.attributes.parentBlock) {
+        const parent = block.attributes.parentBlock;
+        const parentBlockParts = [...parent.attributes._def.parts];
+        const overrideLocation = parentBlockParts.findIndex((part: any) => part.kind === "param" && part.name === block.attributes.toolboxParentArgument);
+        if (overrideLocation !== -1) {
+            parentBlockParts.splice(overrideLocation, 1, ...block.attributes._def.parts);
+            parts = parentBlockParts;
+        }
+    }
+    let name = block.qName || block.name;
+
+    if (parts) {
+        if (params &&
+            parts.filter((p: any) => p.kind == "param").length > params.length) {
+            // add empty param when first argument is "this"
+            params.unshift(null);
+        }
+        parts.forEach((part, i) => {
+            switch (part.kind) {
+                case "label":
+                    description.push({kind: "label", content: part.text});
+                    break;
+                case "break":
+                    description.push({kind: "break"});
+                    break;
+                case "param":
+                    let actualParam = compileInfo?.definitionNameToParam[part.name];
+                    let val = actualParam?.defaultValue
+                        || part.varName
+                        || actualParam?.actualName
+                        || part.name
+                    if (isPython && actualParam?.defaultValue) {
+                        val = pxtc.tsSnippetToPySnippet(val);
+                    }
+                    description.push({kind: "param", content: val});
+                    break;
+            }
+        })
+    } else {
+        // if no blockdef found, use the snippet name
+        description.push({kind: "label", content: getSnippetName(block, isPython) || block.name})
+    }
+
+    return { parts: description };
 }

--- a/webapp/src/toolboxHelpers.ts
+++ b/webapp/src/toolboxHelpers.ts
@@ -1,10 +1,6 @@
 
 import * as toolbox from "./toolbox";
 
-export function getSnippetName(block: toolbox.BlockDefinition, isPython: boolean): string {
-    return (isPython ? (block.pySnippetName || block.pyName) : undefined) || block.snippetName || block.name;
-}
-
 // Breaks a block down into segments that can be displayed in a readable format.
 export function getBlockTextParts(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.BlockTextParts | undefined {
     let description: pxt.editor.BlockTextPart[] = [];

--- a/webapp/src/toolboxHelpers.ts
+++ b/webapp/src/toolboxHelpers.ts
@@ -5,6 +5,48 @@ export function getSnippetName(block: toolbox.BlockDefinition, isPython: boolean
     return (isPython ? (block.pySnippetName || block.pyName) : undefined) || block.snippetName || block.name;
 }
 
+// TODO thsparks : find a better name for this function
+export function getBlockTextPartsFromBlocksBlockDefinition(block: pxt.blocks.BlockDefinition): pxt.editor.BlockTextParts | undefined {
+    const parts: pxt.editor.BlockTextPart[] = [];
+    if (block?.block["message0"]) {
+        // These message values use %1, %2, etc. for parameters.
+        // Extract these into generic "value" parameters.
+        const message = block.block["message0"];
+        const regex = /%(\d+)/g;
+        let lastIndex = 0;
+        let match;
+
+        while ((match = regex.exec(message)) !== null) {
+            // Add the text before the parameter as a label (if it's not empty)
+            if (match.index > lastIndex) {
+                const content = message.substring(lastIndex, match.index).trim();
+                if (content) {
+                    parts.push({ kind: "label", content });
+                }
+            }
+
+            // Add the parameter
+            parts.push({
+                kind: "param",
+                content: "value"
+            });
+            lastIndex = regex.lastIndex;
+        }
+
+        // Add any remaining text after the last parameter as a label
+        if (lastIndex < message.length) {
+            parts.push({
+                kind: "label",
+                content: message.substring(lastIndex).trim()
+            });
+        }
+    } else {
+        parts.push({ kind: "label", content: block.name });
+    }
+
+    return { parts };
+}
+
 // TODO thsparks : move monacoFlyout to use this too.
 export function getBlockTextParts(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.BlockTextParts {
     let description: pxt.editor.BlockTextPart[] = [];

--- a/webapp/src/toolboxHelpers.ts
+++ b/webapp/src/toolboxHelpers.ts
@@ -6,8 +6,8 @@ export function getSnippetName(block: toolbox.BlockDefinition, isPython: boolean
 }
 
 // TODO thsparks : move monacoFlyout to use this too.
-export function getBlockDescription(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.ReadableBlockName {
-    let description: pxt.editor.ReadableBlockNamePart[] = [];
+export function getBlockTextParts(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.BlockTextParts {
+    let description: pxt.editor.BlockTextPart[] = [];
     let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo);
     let parts = block.attributes._def && block.attributes._def.parts;
     if (block.attributes.parentBlock) {

--- a/webapp/src/toolboxHelpers.ts
+++ b/webapp/src/toolboxHelpers.ts
@@ -1,4 +1,3 @@
-
 import * as toolbox from "./toolbox";
 
 // Breaks a block down into segments that can be displayed in a readable format.

--- a/webapp/src/toolboxHelpers.ts
+++ b/webapp/src/toolboxHelpers.ts
@@ -1,0 +1,53 @@
+
+import * as toolbox from "./toolbox";
+
+export function getSnippetName(block: toolbox.BlockDefinition, isPython: boolean): string {
+    return (isPython ? (block.pySnippetName || block.pyName) : undefined) || block.snippetName || block.name;
+}
+
+// TODO thsparks : move monacoFlyout to use this too.
+export function getBlockDescription(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.ReadableBlockName {
+    let description: pxt.editor.ReadableBlockNamePart[] = [];
+    let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo);
+    let parts = block.attributes._def && block.attributes._def.parts;
+    if (block.attributes.parentBlock) {
+        const parent = block.attributes.parentBlock;
+        const parentBlockParts = [...parent.attributes._def.parts];
+        const overrideLocation = parentBlockParts.findIndex((part: any) => part.kind === "param" && part.name === block.attributes.toolboxParentArgument);
+        if (overrideLocation !== -1) {
+            parentBlockParts.splice(overrideLocation, 1, ...block.attributes._def.parts);
+            parts = parentBlockParts;
+        }
+    }
+
+    if (parts) {
+        if (params &&
+            parts.filter((p: any) => p.kind == "param").length > params.length) {
+            // add empty param when first argument is "this"
+            params.unshift(null);
+        }
+        parts.forEach((part, i) => {
+            switch (part.kind) {
+                case "label":
+                    description.push({kind: "label", content: part.text});
+                    break;
+                case "break":
+                    description.push({kind: "break"});
+                    break;
+                case "param":
+                    let actualParam = compileInfo?.definitionNameToParam[part.name];
+                    let val = actualParam?.defaultValue
+                        || part.varName
+                        || actualParam?.actualName
+                        || part.name
+                    if (isPython && actualParam?.defaultValue) {
+                        val = pxtc.tsSnippetToPySnippet(val);
+                    }
+                    description.push({kind: "param", content: val});
+                    break;
+            }
+        })
+    }
+
+    return description.length > 0 ? { parts: description } : undefined;
+}

--- a/webapp/src/toolboxHelpers.ts
+++ b/webapp/src/toolboxHelpers.ts
@@ -8,7 +8,7 @@ export function getSnippetName(block: toolbox.BlockDefinition, isPython: boolean
 // TODO thsparks : find a better name for this function
 export function getBlockTextPartsFromBlocksBlockDefinition(block: pxt.blocks.BlockDefinition): pxt.editor.BlockTextParts | undefined {
     const parts: pxt.editor.BlockTextPart[] = [];
-    if (block?.block["message0"]) {
+    if (block?.block && block.block["message0"]) {
         // These message values use %1, %2, etc. for parameters.
         // Extract these into generic "value" parameters.
         const message = block.block["message0"];
@@ -33,7 +33,7 @@ export function getBlockTextPartsFromBlocksBlockDefinition(block: pxt.blocks.Blo
             lastIndex = regex.lastIndex;
         }
 
-        // Add any remaining text after the last parameter as a label
+        // Add any remaining text after the last parameter
         if (lastIndex < message.length) {
             parts.push({
                 kind: "label",
@@ -47,8 +47,8 @@ export function getBlockTextPartsFromBlocksBlockDefinition(block: pxt.blocks.Blo
     return { parts };
 }
 
-// TODO thsparks : move monacoFlyout to use this too.
-export function getBlockTextParts(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.BlockTextParts {
+// Breaks a block down into segments that can be displayed in a readable format.
+export function getBlockTextParts(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.BlockTextParts | undefined {
     let description: pxt.editor.BlockTextPart[] = [];
     let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo);
     let parts = block.attributes._def && block.attributes._def.parts;

--- a/webapp/src/toolboxHelpers.ts
+++ b/webapp/src/toolboxHelpers.ts
@@ -5,48 +5,6 @@ export function getSnippetName(block: toolbox.BlockDefinition, isPython: boolean
     return (isPython ? (block.pySnippetName || block.pyName) : undefined) || block.snippetName || block.name;
 }
 
-// TODO thsparks : find a better name for this function
-export function getBlockTextPartsFromBlocksBlockDefinition(block: pxt.blocks.BlockDefinition): pxt.editor.BlockTextParts | undefined {
-    const parts: pxt.editor.BlockTextPart[] = [];
-    if (block?.block && block.block["message0"]) {
-        // These message values use %1, %2, etc. for parameters.
-        // Extract these into generic "value" parameters.
-        const message = block.block["message0"];
-        const regex = /%(\d+)/g;
-        let lastIndex = 0;
-        let match;
-
-        while ((match = regex.exec(message)) !== null) {
-            // Add the text before the parameter as a label (if it's not empty)
-            if (match.index > lastIndex) {
-                const content = message.substring(lastIndex, match.index).trim();
-                if (content) {
-                    parts.push({ kind: "label", content });
-                }
-            }
-
-            // Add the parameter
-            parts.push({
-                kind: "param",
-                content: "value"
-            });
-            lastIndex = regex.lastIndex;
-        }
-
-        // Add any remaining text after the last parameter
-        if (lastIndex < message.length) {
-            parts.push({
-                kind: "label",
-                content: message.substring(lastIndex).trim()
-            });
-        }
-    } else {
-        parts.push({ kind: "label", content: block.name });
-    }
-
-    return { parts };
-}
-
 // Breaks a block down into segments that can be displayed in a readable format.
 export function getBlockTextParts(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.BlockTextParts | undefined {
     let description: pxt.editor.BlockTextPart[] = [];

--- a/webapp/src/toolboxHelpers.ts
+++ b/webapp/src/toolboxHelpers.ts
@@ -2,7 +2,7 @@
 import * as toolbox from "./toolbox";
 
 // Breaks a block down into segments that can be displayed in a readable format.
-export function getBlockTextParts(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.BlockTextParts | undefined {
+export function getBlockAsText(block: toolbox.BlockDefinition, params: pxtc.ParameterDesc[], isPython: boolean): pxt.editor.BlockAsText | undefined {
     let description: pxt.editor.BlockTextPart[] = [];
     let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo);
     let parts = block.attributes._def && block.attributes._def.parts;


### PR DESCRIPTION
### Overview
This changes the inline block display for the "Block used count times" criteria in the teacher tool. I've reused the approach taken by the monaco editor to generate the javascript toolbox entries (meaning some of that code has been refactored into a shared helper method). This approach looks at the attributes for a block (mostly the block string), then breaks it up into labels, parameters, and breaks. Those sections are returned and can be displayed however the caller sees fit.

I cache the information to minimize any loading time (fewer messages to the iframe) and to reduce the likelihood of ending up with a block where we can't get a display (i.e. a rubric with a block loaded from an extension, opened later from a project without that extension installed).

### The part where I explain some weird decisions
There are a few things I don't love about this change, mostly revolving around built-in blocks which lack the attributes used to generate the different "parts". In these cases, the monaco editor uses snippetNames defined on the blocks in [monacoSnippets.ts](https://github.com/microsoft/pxt/blob/master/webapp/src/monacoSnippets.ts). I've opted for something similar, but since the monaco toolbox lacks some of the blocks that the block-based toolbox has (on start, repeat, etc...), I've gone ahead and updated the [blockSnippets.ts](https://github.com/microsoft/pxt/blob/master/webapp/src/blocksSnippets.ts) file instead of trying to reuse the monaco ones. There's some duplication here, but I think this feels like the right place for it regardless.

### The part where I explain some weirder decisions
Some blocks (specifically, some built-in blocks) have multiple entries in the toolbox which result in blocks of the same id. For example, we have different toolbox entries for plus, minus, times, and divide, but they're all the same math_arithmatic block, so we only show one entry in the block picker and it passes on any of those blocks (since BlockExists validation is based on blockId). In an ideal world, I'd change the BlockExist validator to allow us to check for these separately, but that's out of scope for the current teacher tool work. Instead, I've created a workaround where multiple matches are simply combined into one string, concatenated with " | ":
![image](https://github.com/user-attachments/assets/c5a5feda-16b2-432e-b229-e1ade639e238)

Similarly, there are some blocks that only appear in the toolbox once but still have multiple different dropdown options that make it tricky to find a descriptive overall snippet name. (Notably, the "Square Root" and "Round" blocks.) In these, I've gone with a similar approach of just piping together the different operations in the snippet name. I look forward to the day I can change BlockExist and remove all this code 🙂

![image](https://github.com/user-attachments/assets/b4029f81-b5c7-465f-8f4f-e833fa39c9e2)


### Free Trial
Upload Target: https://makecode.microbit.org/app/c07bd3857b9afa5e604d68f1d16dcbe2bd536dcd-bb5f0ab19d

### Screenshots

**Before**
![image](https://github.com/user-attachments/assets/8665dbd2-ca0e-4f0a-a5e5-a78612126ce2)

**After**
![image](https://github.com/user-attachments/assets/079d01cd-8d90-49b7-b55a-ba2fe9187a7a)

