### PR TITLE
Add survey reminder to teacher verification page

### DIFF
--- a/docs/github-teacher-verification.md
+++ b/docs/github-teacher-verification.md
@@ -4,6 +4,14 @@ To access certain curriculum resources, you must have a verified [GitHub Teacher
 
 The process of obtaining a GitHub Teacher account is free and includes other benefits. Learn more at https://education.github.com/teachers.
 
+### ~ reminder
+
+#### Verification Survey
+
+For teachers who have gone through this process, we would love to hear from you! The Microsoft and GitHub Education teams are working to improve this process. Please consider filling out this short survey to share your experiences, thoughts, and suggestions with us! -- **[Take the survey here](https://forms.office.com/r/cb5sXHpVVz)**.
+
+### ~
+
 ## Create a GitHub Teacher Account
 
 https://youtu.be/XYErnMTILEQ


### PR DESCRIPTION
Add a survey reminder note and link to the Github Teacher Verification page.

How's this?:

![image](https://github.com/user-attachments/assets/2459d94f-1184-4ff6-95ce-179f28f6dcad)

Closes #10201