### PR TITLE
Support for 3rd-party simulator extensions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,11 @@
 			"args": [
 				"serve",
 				"--rebundle",
-				"--noauth"
+				"--noauth",
+				"--hostname",
+				"127.0.0.1",
+				"--backport",
+				"8080"
 			],
 			"cwd": "${workspaceRoot}/../pxt-microbit",
 			"runtimeExecutable": null,

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2855,6 +2855,7 @@ export function serveAsync(parsed: commandParser.ParsedCommand) {
             browser: parsed.flags["browser"] as string,
             serial: !parsed.flags["noSerial"] && !globalConfig.noSerial,
             noauth: parsed.flags["noauth"] as boolean || false,
+            backport: parsed.flags["backport"] as number || 0,
         }))
 }
 
@@ -6966,6 +6967,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
             noauth: {
                 description: "disable localtoken-based authentication",
                 aliases: ["na"],
+            },
+            backport: {
+                description: "port where the locally running backend is listening.",
+                argument: "backport",
+                type: "number",
             }
         }
     }, serveAsync);

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -1278,7 +1278,7 @@ export function serveAsync(options: ServeOptions) {
             }
         }
 
-        // Look for an .html file correspoding to `/---<pathname>`
+        // Look for an .html file corresponding to `/---<pathname>`
         // Handles serving of `trg-<target>.sim.local:<port>/---simulator`
         let match = /^\/?---?(.*)/.exec(pathname)
         if (match && match[1]) {

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -1158,7 +1158,7 @@ export function serveAsync(options: ServeOptions) {
                 method: req.method,
                 headers: req.headers
             };
-            
+
             const passthruReq = http.request(passthruOpts, passthruRes => {
                 res.writeHead(passthruRes.statusCode, passthruRes.headers);
                 passthruRes.pipe(res);

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -291,6 +291,9 @@ declare namespace pxt {
             // don't recycle the iframe between runs
             permanent?: boolean;
         }>;
+        // This is for testing new simulator extensions before adding them to targetconfig.json.
+        // DO NOT SHIP SIMULATOR EXTENSIONS HERE. Add them to targetconfig.json/approvedRepoLib instead.
+        testSimulatorExtensions?: pxt.Map<SimulatorExtensionConfig>;
     }
 
     interface TargetCompileService {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -56,6 +56,19 @@ declare namespace pxt {
         // "acme-corp/pxt-widget": "min:v0.1.2" - auto-upgrade to that version
         // "acme-corp/pxt-widget": "dv:foo,bar" - add "disablesVariant": ["foo", "bar"] to pxt.json
         upgrades?: string[];
+        // This repo's simulator extension configuration
+        simx?: SimulatorExtensionConfig;
+    }
+
+    interface SimulatorExtensionConfig {
+        aspectRatio?: number; // Aspect ratio for the iframe. Default: 1.22.
+        permanent?: boolean; // If true, don't recycle the iframe between runs. Default: true.
+        devUrl?: string; // URL to load for local development. Pass `simxdev` on URL to enable. Default: undefined.
+        index?: string; // The path to the simulator extension's entry point within the repo. Default: "index.html".
+        // backend-only options
+        sha?: string; // The commit to checkout (must exist in the branch/ref). Required.
+        repo?: string; // Actual repo to load simulator extension from. Defaults to key of parent in `approvedRepoLib` map.
+        ref?: string; // The branch of the repo to sync. Default: "gh-pages".
     }
 
     interface ShareConfig {
@@ -267,6 +280,7 @@ declare namespace pxt {
         keymap?: boolean; // when non-empty and autoRun is disabled, this code is run upon simulator first start
 
         // a map of allowed simulator channel to URL to handle specific control messages
+        // DEPRECATED. Use `simx` in targetconfig.json approvedRepoLib instead.
         messageSimulators?: pxt.Map<{
             // the URL to load the simulator, $PARENT_ORIGIN$ will be replaced by the parent
             // origin to validate messages

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -149,7 +149,7 @@ namespace pxt.BrowserUtils {
     export function isLocalHost(ignoreFlags?: boolean): boolean {
         try {
             return typeof window !== "undefined"
-                && /^http:\/\/(localhost|127\.0\.0\.1|192\.168\.\d+\.\d+):\d+\//.test(window.location.href)
+                && /^http:\/\/(?:localhost|127\.0\.0\.1|192\.168\.\d{1,3}\.\d{1,3}|[a-zA-Z0-9.-]+\.local):\d+\/?/.test(window.location.href)
                 && (ignoreFlags || !/nolocalhost=1/.test(window.location.href))
                 && !(pxt?.webConfig?.isStatic);
         } catch (e) { return false; }

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -285,11 +285,13 @@ namespace pxsim {
             return isPxtElectron() || isIpcRenderer();
         }
 
+        export function testLocalhost(url: string): boolean {
+            return /^http:\/\/(?:localhost|127\.0\.0\.1|192\.168\.\d{1,3}\.\d{1,3}|[a-zA-Z0-9.-]+\.local):\d+\/?/.test(url) && !/nolocalhost=1/.test(url);
+        }
+
         export function isLocalHost(): boolean {
             try {
-                return typeof window !== "undefined"
-                    && /^http:\/\/(localhost|127\.0\.0\.1):\d+\//.test(window.location.href)
-                    && !/nolocalhost=1/.test(window.location.href);
+                return typeof window !== "undefined" && testLocalhost(window.location.href);
             } catch (e) { return false; }
         }
 

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -142,7 +142,7 @@ namespace pxsim {
                 });
 
             // Preprocess simulator extensions
-            const hasSimXDevFlag = /[?&]simxdev(?:[=&#]|$)/i.test(window.location.href);
+            const simXDevMode = U.isLocalHost() && /[?&]simxdev(?:[=&#]|$)/i.test(window.location.href);
             Object.entries(options?.simulatorExtensions || {}).forEach(([key, simx]) => {
                 // Verify essential `simx` config was provided
                 if (
@@ -154,7 +154,7 @@ namespace pxsim {
                     return;
                 }
                 // Compute the effective URL
-                if (U.isLocalHost() && simx.devUrl && hasSimXDevFlag) {
+                if (simXDevMode && simx.devUrl) {
                     // Use the dev URL if the dev flag is set (and we're on localhost)
                     simx.url = new URL(simx.index, simx.devUrl).toString();
                 } else {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -30,7 +30,7 @@ namespace pxsim {
         }>;
         // Simulator extensions read from targetconfig.json's `approvedRepoLib` entry.
         simulatorExtensions?: pxt.Map<{
-            // Subset of pxt.SimulatorExtensionConfig
+            // Fields from pxt.SimulatorExtensionConfig
             aspectRatio?: number;
             permanent?: boolean;
             index?: string;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -28,7 +28,7 @@ namespace pxsim {
             aspectRatio?: number;
             permanent?: boolean;
         }>;
-        // Simulator extensions distilled from targetconfig.json's `approvedRepoLib` entry.
+        // Simulator extensions read from targetconfig.json's `approvedRepoLib` entry.
         simulatorExtensions?: pxt.Map<{
             // Subset of pxt.SimulatorExtensionConfig
             aspectRatio?: number;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -159,8 +159,10 @@ namespace pxsim {
                     simx.url = new URL(simx.index, simx.devUrl).toString();
                 } else {
                     const simUrl = this.getSimUrl();
+                    // Ensure we preserve upload target path (/app/<sha>---simulator)
+                    const simPath = simUrl.pathname.replace(/---?.*/, "");
                     // Construct the path. The "-" element delineates the extension key from the resource name.
-                    const simxPath = ["simx", key, "-", simx.index].join("/");
+                    const simxPath = [simPath, "simx", key, "-", simx.index].join("/");
                     simx.url = new URL(simxPath, simUrl.origin).toString();
                 }
 

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -163,7 +163,7 @@ namespace pxsim {
                     const simxPath = ["simx", key, "-", simx.index].join("/");
                     simx.url = new URL(simxPath, simUrl.origin).toString();
                 }
-        
+
                 // Add the origin to the allowed origins
                 this._allowedOrigins.push(new URL(simx.url).origin);
             });
@@ -403,7 +403,7 @@ namespace pxsim {
                             this.startFrame(messageFrame);
                             frames = this.simFrames(); // refresh
                         }
-        
+
                         // should we start a simulator extension for this message?
                         if (simulatorExtension) {
                             // find a frame already running that simulator

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1053,9 +1053,9 @@ export class ProjectView
         this.initDragAndDrop();
     }
 
-    public componentDidMount() {
+    public async componentDidMount() {
         this.allEditors.forEach(e => e.prepare())
-        simulator.initAsync(document.getElementById("boardview"), {
+        await simulator.initAsync(document.getElementById("boardview"), {
             orphanException: brk => {
                 // TODO: start debugging session
                 // TODO: user friendly error message
@@ -1118,12 +1118,12 @@ export class ProjectView
                 pkg.mainEditorPkg().setSimState(k, v)
             },
             editor: this.state.header ? this.state.header.editor : ''
-        }).then(() => {
-            // we now have editors prepared
-            this.forceUpdate();
-            // start blockly load
-            this.loadBlocklyAsync();
         });
+
+        // we now have editors prepared
+        this.forceUpdate();
+        // start blockly load
+        this.loadBlocklyAsync();
 
         // subscribe to user preference changes (for simulator or non-render subscriptions)
         data.subscribe(this.highContrastSubscriber, auth.HIGHCONTRAST);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5382,8 +5382,7 @@ function initPacketIO() {
         const msg = ev.data
         if (msg.type === 'messagepacket'
             && msg.sender !== "packetio"
-            //&& pxt.appTarget.simulator?.messageSimulators?.[msg.channel]
-            //&& pxt.appTarget.simulator?.simulatorExtensions?.[msg.channel]
+            && pxt.appTarget.simulator?.messageSimulators?.[msg.channel]
             && msg.channel === pxt.HF2.CUSTOM_EV_JACDAC)
             pxt.packetio.sendCustomEventAsync(msg.channel, msg.data)
                 .then(() => { }, err => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5366,7 +5366,6 @@ function initPacketIO() {
             }
         },
         (type, payload) => {
-            /*
             const messageSimulators = pxt.appTarget.simulator?.messageSimulators;
             if (messageSimulators?.[type]) {
                 window.postMessage({
@@ -5377,7 +5376,6 @@ function initPacketIO() {
                     sender: "packetio",
                 }, "*")
             }
-            */
         });
 
     window.addEventListener('message', (ev: MessageEvent) => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1055,7 +1055,7 @@ export class ProjectView
 
     public componentDidMount() {
         this.allEditors.forEach(e => e.prepare())
-        simulator.init(document.getElementById("boardview"), {
+        simulator.initAsync(document.getElementById("boardview"), {
             orphanException: brk => {
                 // TODO: start debugging session
                 // TODO: user friendly error message
@@ -1118,11 +1118,12 @@ export class ProjectView
                 pkg.mainEditorPkg().setSimState(k, v)
             },
             editor: this.state.header ? this.state.header.editor : ''
-        })
-        this.forceUpdate(); // we now have editors prepared
-
-        // start blockly load
-        this.loadBlocklyAsync();
+        }).then(() => {
+            // we now have editors prepared
+            this.forceUpdate();
+            // start blockly load
+            this.loadBlocklyAsync();
+        });
 
         // subscribe to user preference changes (for simulator or non-render subscriptions)
         data.subscribe(this.highContrastSubscriber, auth.HIGHCONTRAST);
@@ -5365,6 +5366,7 @@ function initPacketIO() {
             }
         },
         (type, payload) => {
+            /*
             const messageSimulators = pxt.appTarget.simulator?.messageSimulators;
             if (messageSimulators?.[type]) {
                 window.postMessage({
@@ -5375,13 +5377,15 @@ function initPacketIO() {
                     sender: "packetio",
                 }, "*")
             }
+            */
         });
 
     window.addEventListener('message', (ev: MessageEvent) => {
         const msg = ev.data
         if (msg.type === 'messagepacket'
             && msg.sender !== "packetio"
-            && pxt.appTarget.simulator?.messageSimulators?.[msg.channel]
+            //&& pxt.appTarget.simulator?.messageSimulators?.[msg.channel]
+            //&& pxt.appTarget.simulator?.simulatorExtensions?.[msg.channel]
             && msg.channel === pxt.HF2.CUSTOM_EV_JACDAC)
             pxt.packetio.sendCustomEventAsync(msg.channel, msg.data)
                 .then(() => { }, err => {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -73,22 +73,22 @@ export async function initAsync(root: HTMLElement, cfg: SimulatorConfig) {
     const simulatorExtensions: pxt.Map<pxt.SimulatorExtensionConfig> = {};
     Object.entries(trgConfig?.packages?.approvedRepoLib || {})
         .map(([k, v]) => ({ k: k, v: v.simx }))
-        .filter(e => !!e.v)
-        .forEach(e => simulatorExtensions[e.k] = {
+        .filter(x => !!x.v)
+        .forEach(x => simulatorExtensions[x.k] = {
             index: "index.html", // default to index.html
             aspectRatio: pxt.appTarget.simulator.aspectRatio || 1.22, // fallback to 1.22
             permanent: true, // default to true
-            ...e.v
+            ...x.v
         });
     // Add in test simulator extensions
     Object.entries(pxt.appTarget?.simulator?.testSimulatorExtensions || {})
         .map(([k, v]) => ({ k: k, v: v as pxt.SimulatorExtensionConfig }))
-        .filter(e => !!e.v)
-        .forEach(e => simulatorExtensions[e.k] = {
+        .filter(x => !!x.v)
+        .forEach(x => simulatorExtensions[x.k] = {
             index: "index.html", // default to index.html
             aspectRatio: pxt.appTarget.simulator.aspectRatio || 1.22, // fallback to 1.22
             permanent: true, // default to true
-            ...e.v
+            ...x.v
         });
 
     let options: pxsim.SimulatorDriverOptions = {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -3,6 +3,7 @@
 
 import * as core from "./core";
 import * as coretsx from "./coretsx";
+import * as data from "./data";
 import U = pxt.U
 import { postHostMessageAsync, shouldPostHostMessages } from "../../pxteditor";
 
@@ -36,7 +37,7 @@ export function setTranslations(translations: pxt.Map<string>) {
     }
 }
 
-export function init(root: HTMLElement, cfg: SimulatorConfig) {
+export async function initAsync(root: HTMLElement, cfg: SimulatorConfig) {
     if (!root) return;
     pxsim.U.clear(root);
     const simulatorsDiv = document.createElement('div');
@@ -47,6 +48,8 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
     debuggerDiv.id = 'debugger';
     debuggerDiv.className = 'ui item landscape only';
     root.appendChild(debuggerDiv);
+
+    const trgConfig = await data.getAsync<pxt.TargetConfig>("target-config:")
 
     const nestedEditorSim = /nestededitorsim=1/i.test(window.location.href);
     const mpRole = /[\&\?]mp=(server|client)/i.exec(window.location.href)?.[1]?.toLowerCase();
@@ -65,6 +68,18 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
             }
         }
     }
+
+    // Map simulator extensions from approved repos
+    const simulatorExtensions: pxt.Map<pxt.SimulatorExtensionConfig> = {};
+    Object.entries(trgConfig?.packages?.approvedRepoLib || {})
+        .map(([k, v]) => ({ k: k, v: v.simx }))
+        .filter(e => !!e.v)
+        .forEach(e => simulatorExtensions[e.k] = {
+            index: "index.html", // default to index.html
+            aspectRatio: pxt.appTarget.simulator.aspectRatio || 1.22, // fallback to 1.22
+            permanent: true, // default to true
+            ...e.v
+        });
 
     let options: pxsim.SimulatorDriverOptions = {
         restart: () => cfg.restartSimulator(),
@@ -241,6 +256,7 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
         parentOrigin,
         mpRole,
         messageSimulators: pxt.appTarget?.simulator?.messageSimulators,
+        simulatorExtensions,
         userLanguage: pxt.Util.userLanguage()
     };
     driver = new pxsim.SimulatorDriver(document.getElementById('simulators'), options);

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -80,6 +80,16 @@ export async function initAsync(root: HTMLElement, cfg: SimulatorConfig) {
             permanent: true, // default to true
             ...e.v
         });
+    // Add in test simulator extensions
+    Object.entries(pxt.appTarget?.simulator?.testSimulatorExtensions || {})
+        .map(([k, v]) => ({ k: k, v: v as pxt.SimulatorExtensionConfig }))
+        .filter(e => !!e.v)
+        .forEach(e => simulatorExtensions[e.k] = {
+            index: "index.html", // default to index.html
+            aspectRatio: pxt.appTarget.simulator.aspectRatio || 1.22, // fallback to 1.22
+            permanent: true, // default to true
+            ...e.v
+        });
 
     let options: pxsim.SimulatorDriverOptions = {
         restart: () => cfg.restartSimulator(),


### PR DESCRIPTION
This change introduces a more robust system for supporting simulator extensions, making it possible to support third-party extensions (though such extensions must be approved by the team).

### Summary of changes

* **New config section in targetconfig.json**
  - Entries in the existing `approvedRepoLib` map have a new subsection called `simx`. This is used by both the client and the backend to specify and serve simulator extensions. See `SimulatorExtensionConfig` in `localtypings/pxtarget.d.ts` for specifics.

* **New config section in pxtarget.json**
  - To support testing new or updated 3rd party simulator extensions before they go live, I've added a `testSimulatorExtensions` section to `pxtarget.json`. This allows simulator extensions to be configured in an upload target.

* **New URL parameter for local testing**
  - To support local simulator extension development, I've added a new URL parameter called `simxdev`. Including this parameter will cause simulator extensions to be loaded from their configured `devUrl` (only applicable when serving the target locally).

* **`pxt serve` changes**
  - Added a new optional parameter to `pxt serve` called `backport`. It takes a port number where the locally running backend is listening (typically 8080). This is used to proxy simulator extension requests to the locally running backend. Simulator extensions are not loadable through `pxt serve` directly due to the complexities of syncing the extension's repo/branch/commit sha. This approach was simpler, and it enabled simultaneous local testing of frontend and backend changes. It works in concert with a new backend setting called `LOCAL_SIM_PORT`, which I will document in the backend repo. I doubt anyone will ever need to use this :)
