### PR TITLE
Some app.tsx cleanup

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1696,6 +1696,8 @@ export class ProjectView
             }
             simulator.setDirty();
 
+            await compiler.applyUpgradesAsync();
+
             await this.loadTutorialJresCodeAsync();
             await this.loadTutorialCustomTsAsync();
             await this.loadTutorialTemplateCodeAsync();

--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -406,7 +406,7 @@ export function initGitHubDb() {
             if (tag == "master")
                 return this.mem.loadConfigAsync(repopath, tag);
 
-            const id = `config-${repopath}-${tag}`;
+            const id = `config-${repopath.toLowerCase()}-${tag}`;
 
             const cache = await getGitHubCacheAsync();
 
@@ -440,7 +440,7 @@ export function initGitHubDb() {
             if (tag == "master")
                 return this.mem.loadPackageAsync(repopath, tag);
 
-            const id = `pkg-${repopath}-${tag}`;
+            const id = `pkg-${repopath.toLowerCase()}-${tag}`;
             const cache = await getGitHubCacheAsync();
 
             try {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -748,7 +748,7 @@ export function importAsync(h: Header, text: ScriptText, isCloud = false) {
     return forceSaveAsync(h, text, isCloud)
 }
 
-export function installAsync(h0: InstallHeader, text: ScriptText, dontOverwriteID = false) {
+export async function installAsync(h0: InstallHeader, text: ScriptText, dontOverwriteID = false) {
     U.assert(h0.target == pxt.appTarget.id);
 
     const h = <Header>h0
@@ -762,9 +762,9 @@ export function installAsync(h0: InstallHeader, text: ScriptText, dontOverwriteI
         pxt.shell.setEditorLanguagePref(cfg.preferredEditor);
     }
 
-    return pxt.github.cacheProjectDependenciesAsync(cfg)
-        .then(() => importAsync(h, text))
-        .then(() => h);
+    await pxt.github.cacheProjectDependenciesAsync(cfg)
+    await importAsync(h, text);
+    return h;
 }
 
 export async function renameAsync(h: Header, newName: string): Promise<Header> {


### PR DESCRIPTION
as i was tracing our tutorial loading code, i went ahead and fixed a few tiny bugs and converted some functions to async/await. i know the async/await changes make it a little difficult to tell what changed, so here's a summary of the few actual behavior changes:

1. removed a redundant call to `compiler.newProjectAsync()` in `internalLoadHeaderAsync`
2. removed a redundant call to `pxt.github.cacheProjectDependenciesAsync()` in `createProjectAsync()`
3. made the github repo db keys in `idbworkspace.ts` case insensitive so that we don't miss the cache when a markdown author is inconsistent with their capitalization (this was happening in the HOC minecraft tutorials)