### PR TITLE
Consume new ghtutorial route when loading tutorials from github

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -256,6 +256,10 @@ class FileGithubDb implements pxt.github.IGithubDb {
     loadTutorialMarkdown(repopath: string, tag?: string): Promise<pxt.github.CachedPackage> {
         return this.loadAsync(repopath, tag, "tutorial", (r, t) => this.db.loadTutorialMarkdown(r, t));
     }
+
+    cacheReposAsync(resp: pxt.github.GHTutorialResponse) {
+        return this.db.cacheReposAsync(resp);
+    }
 }
 
 function searchAsync(...query: string[]) {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -252,6 +252,10 @@ class FileGithubDb implements pxt.github.IGithubDb {
     loadPackageAsync(repopath: string, tag: string): Promise<pxt.github.CachedPackage> {
         return this.loadAsync(repopath, tag, "pkg", (r, t) => this.db.loadPackageAsync(r, t));
     }
+
+    loadTutorialMarkdown(repopath: string, tag?: string): Promise<pxt.github.CachedPackage> {
+        return this.loadAsync(repopath, tag, "tutorial", (r, t) => this.db.loadTutorialMarkdown(r, t));
+    }
 }
 
 function searchAsync(...query: string[]) {

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -1147,6 +1147,7 @@ declare namespace pxt.editor {
 
         // Used with the @tutorialCompleted macro. See docs/writing-docs/tutorials.md for more info
         onTutorialCompleted?: () => void;
+        onMarkdownActivityLoad?: (path: string, title?: string, editorProjectName?: string) => Promise<void>;
 
         // Used with @codeStart, @codeStop metadata (MINECRAFT HOC ONLY)
         onCodeStart?: () => void;

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -102,6 +102,7 @@ declare namespace pxt.editor {
         | "editorcontentloaded"
         | "serviceworkerregistered"
         | "runeval"
+        | "precachetutorial"
 
         // package extension messasges
         | ExtInitializeType
@@ -406,6 +407,12 @@ declare namespace pxt.editor {
         title?: string;
         previousProjectHeaderId?: string;
         carryoverPreviousCode?: boolean;
+    }
+
+    export interface PrecacheTutorialRequest extends EditorMessageRequest {
+        action: "precachetutorial";
+        data: pxt.github.GHTutorialResponse;
+        lang?: string;
     }
 
     export interface InfoMessage {

--- a/pxtcompiler/simpledriver.ts
+++ b/pxtcompiler/simpledriver.ts
@@ -55,6 +55,10 @@ namespace pxt {
         loadPackageAsync(repopath: string, tag: string): Promise<pxt.github.CachedPackage> {
             return this.loadAsync(repopath, tag, "pkg", (r, t) => this.db.loadPackageAsync(r, t));
         }
+
+        loadTutorialMarkdown(repopath: string, tag?: string): Promise<pxt.github.CachedPackage> {
+            return this.loadAsync(repopath, tag, "tutorial", (r, t) => this.db.loadTutorialMarkdown(r, t));
+        }
     }
 
     function pkgOverrideAsync(pkg: pxt.Package) {

--- a/pxtcompiler/simpledriver.ts
+++ b/pxtcompiler/simpledriver.ts
@@ -59,6 +59,10 @@ namespace pxt {
         loadTutorialMarkdown(repopath: string, tag?: string): Promise<pxt.github.CachedPackage> {
             return this.loadAsync(repopath, tag, "tutorial", (r, t) => this.db.loadTutorialMarkdown(r, t));
         }
+
+        cacheReposAsync(resp: pxt.github.GHTutorialResponse) {
+            return this.db.cacheReposAsync(resp);
+        }
     }
 
     function pkgOverrideAsync(pkg: pxt.Package) {

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -170,7 +170,7 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                         })
                                     });
                             }
-case "renderxml": {
+                            case "renderxml": {
                                 const rendermsg = data as pxt.editor.EditorMessageRenderXmlRequest;
                                 return Promise.resolve()
                                     .then(() => {
@@ -302,6 +302,20 @@ case "renderxml": {
                                     throw new Error("no-blocks language restriction is not supported")
                                 }
                                 return projectView.setLanguageRestrictionAsync(msg.restriction);
+                            }
+                            case "precachetutorial": {
+                                const msg = data as pxt.editor.PrecacheTutorialRequest;
+                                const tutorialData = msg.data;
+                                const lang = msg.lang || pxt.Util.userLanguage();
+
+                                return pxt.github.db.cacheReposAsync(tutorialData)
+                                    .then(async () => {
+                                        if (typeof tutorialData.markdown === "string") {
+                                            // the markdown needs to be cached in the translation db
+                                            const db = await pxt.BrowserUtils.translationDbAsync();
+                                            await db.setAsync(lang, tutorialData.path, undefined, undefined, tutorialData.markdown);
+                                        }
+                                    });
                             }
                         }
                         return Promise.resolve();

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1409,6 +1409,24 @@ namespace pxt.BrowserUtils {
         return `${url}${url.indexOf('?') > 0 ? "&" : "?"}rnd=${Math.random()}`
     }
 
+    export function appendUrlQueryParams(url: string, params: URLSearchParams) {
+        const entries: string[] = [];
+        for (const [key, value] of params.entries()) {
+            entries.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
+        }
+
+        if (entries.length) {
+            if (url.indexOf("?") !== -1) {
+                url += "&" + entries.join("&");
+            }
+            else {
+                url += "?" + entries.join("&");
+            }
+        }
+
+        return url;
+    }
+
     export function legacyCopyText(element: HTMLInputElement | HTMLTextAreaElement) {
         element.focus();
         element.setSelectionRange(0, 9999);

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -39,4 +39,5 @@ namespace pxt.commands {
     export let webUsbPairDialogAsync: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<WebUSBPairResult>, implicitlyCalled?: boolean) => Promise<WebUSBPairResult> = undefined;
     export let onTutorialCompleted: () => void = undefined;
     export let workspaceLoadedAsync: () => Promise<void> = undefined;
+    export let onMarkdownActivityLoad: (path: string, title?: string, editorProjectName?: string) => Promise<void> = undefined;
 }

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -2,7 +2,7 @@
 namespace pxt.Cloud {
     import Util = pxtc.Util;
 
-    export let apiRoot = (pxt.BrowserUtils.isLocalHost() || Util.isNodeJS) ? "https://www.makecode.com/api/" : "/api/";
+    export let apiRoot = "https://arcade.riknoll.staging.pxt.io/api/";
 
     export let accessToken = "";
     export let localToken = "";
@@ -32,6 +32,7 @@ namespace pxt.Cloud {
     export function useCdnApi() {
         return pxt.webConfig && !pxt.webConfig.isStatic
             && !BrowserUtils.isLocalHost() && !!pxt.webConfig.cdnUrl
+            && !/nocdn=1/i.test(window.location.href);
     }
 
     export function cdnApiUrl(url: string) {
@@ -135,7 +136,7 @@ namespace pxt.Cloud {
         return resp.json;
     }
 
-    export async function markdownAsync(docid: string, locale?: string, propagateExceptions?: boolean): Promise<string> {
+    export async function markdownAsync(docid: string, locale?: string, propagateExceptions?: boolean, downloadTutorialBundle?: boolean): Promise<string> {
         // 1h check on markdown content if not on development server
         const MARKDOWN_EXPIRATION = pxt.BrowserUtils.isLocalHostDev() ? 0 : 1 * 60 * 60 * 1000;
         // 1w check don't use cached version and wait for new content
@@ -148,7 +149,7 @@ namespace pxt.Cloud {
 
         const downloadAndSetMarkdownAsync = async () => {
             try {
-                const r = await downloadMarkdownAsync(docid, locale, entry?.etag);
+                const r = await downloadMarkdownAsync(docid, locale, entry?.etag, downloadTutorialBundle);
                 // TODO directly compare the entry/response etags after backend change
                 if (!entry || (r.md && entry.md !== r.md)) {
                     await db.setAsync(locale, docid, r.etag, undefined, r.md);
@@ -189,10 +190,12 @@ namespace pxt.Cloud {
         return downloadAndSetMarkdownAsync();
     }
 
-    function downloadMarkdownAsync(docid: string, locale?: string, etag?: string): Promise<{ md: string; etag?: string; }> {
+    async function downloadMarkdownAsync(docid: string, locale?: string, etag?: string, downloadTutorialBundle?: boolean): Promise<{ md: string; etag?: string; }> {
         const packaged = pxt.webConfig?.isStatic;
         const targetVersion = pxt.appTarget.versions && pxt.appTarget.versions.target || '?';
         let url: string;
+
+        const searchParams = new URLSearchParams();
 
         if (packaged) {
             url = docid;
@@ -205,12 +208,17 @@ namespace pxt.Cloud {
             if (!hasExt) {
                 url = `${url}.md`;
             }
-        } else {
-            url = `md/${pxt.appTarget.id}/${docid.replace(/^\//, "")}?targetVersion=${encodeURIComponent(targetVersion)}`;
+        }
+        else {
+            url = `md/${pxt.appTarget.id}/${docid.replace(/^\//, "")}`;
+            searchParams.set("targetVersion", targetVersion);
         }
         if (locale != "en") {
-            url += `${packaged ? "?" : "&"}lang=${encodeURIComponent(locale)}`
+            searchParams.set("lang", locale);
         }
+
+        url = pxt.BrowserUtils.appendUrlQueryParams(url, searchParams);
+
         if (pxt.BrowserUtils.isLocalHost() && !pxt.Util.liveLocalizationEnabled()) {
             return localRequestAsync(url).then(resp => {
                 if (resp.statusCode == 404)
@@ -218,11 +226,33 @@ namespace pxt.Cloud {
                         .then(resp => { return { md: resp.text, etag: <string>resp.headers["etag"] }; });
                 else return { md: resp.text, etag: undefined };
             });
-        } else {
-            const headers: pxt.Map<string> = etag && !useCdnApi() ? { "If-None-Match": etag } : undefined;
-            return apiRequestWithCdnAsync({ url, method: "GET", headers })
-                .then(resp => { return { md: resp.text, etag: <string>resp.headers["etag"] }; });
         }
+
+        const headers: pxt.Map<string> = etag && !useCdnApi() ? { "If-None-Match": etag } : undefined;
+
+        let resp: Util.HttpResponse;
+        let md: string;
+
+        if (!packaged && downloadTutorialBundle) {
+            url = url.replace(/^md\//, "ghtutorial/docs/");
+            resp = await apiRequestWithCdnAsync({ url, method: "GET", headers });
+
+            const body = resp.json as pxt.github.GHTutorialResponse;
+            await pxt.github.db.cacheReposAsync(body);
+
+            md = body.markdown as string;
+        }
+        else {
+            resp = await apiRequestWithCdnAsync({ url, method: "GET", headers });
+            md = resp.text;
+        }
+
+        return (
+            {
+                md,
+                etag: (resp.headers["etag"] as string)
+            }
+        );
     }
 
     export function privateDeleteAsync(path: string) {

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -2,7 +2,7 @@
 namespace pxt.Cloud {
     import Util = pxtc.Util;
 
-    export let apiRoot = "https://arcade.riknoll.staging.pxt.io/api/";
+    export let apiRoot = (pxt.BrowserUtils.isLocalHost() || Util.isNodeJS) ? "https://www.makecode.com/api/" : "/api/";
 
     export let accessToken = "";
     export let localToken = "";

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -499,7 +499,11 @@ ${code}
 
     export function resolveLocalizedMarkdown(ghid: pxt.github.ParsedRepo, files: pxt.Map<string>, fileName?: string): string {
         // if non-default language, find localized file if any
-        const mfn = (fileName || ghid.fileName || "README") + ".md";
+        let mfn = (fileName || ghid.fileName || "README");
+
+        if (!mfn.endsWith(".md")) {
+            mfn += ".md";
+        }
 
         let md: string = undefined;
         const [initialLang, baseLang, initialLangLowerCase] = pxt.Util.normalizeLanguageCode(pxt.Util.userLanguage());

--- a/pxtservices/editorDriver.ts
+++ b/pxtservices/editorDriver.ts
@@ -446,6 +446,16 @@ export class EditorDriver extends IframeDriver {
         );
     }
 
+    async precacheTutorial(data: pxt.github.GHTutorialResponse) {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "precachetutorial",
+                data
+            } as pxt.editor.PrecacheTutorialRequest
+        );
+    }
+
     addEventListener(event: typeof MessageSentEvent, handler: (ev: pxt.editor.EditorMessage) => void): void;
     addEventListener(event: typeof MessageReceivedEvent, handler: (ev: pxt.editor.EditorMessage) => void): void;
     addEventListener(event: "event", handler: (ev: pxt.editor.EditorMessageEventRequest) => void): void;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4688,6 +4688,10 @@ export class ProjectView
 
         let markdown: string;
 
+        if (pxt.commands.onMarkdownActivityLoad) {
+            await pxt.commands.onMarkdownActivityLoad(path, title, editorProjectName);
+        }
+
         try {
             if (/^\//.test(path)) {
                 filename = title || path.split('/').reverse()[0].replace('-', ' '); // drop any kind of sub-paths

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4724,24 +4724,7 @@ export class ProjectView
                         break;
                 }
 
-                let githubTag: string;
-                if (ghid.tag) {
-                    githubTag = ghid.tag;
-                }
-                else {
-                    githubTag = await pxt.github.latestVersionAsync(ghid.slug, config, true);
-                }
-
-                let gh: pxt.github.CachedPackage;
-                if (!githubTag) {
-                    pxt.log(`tutorial github tag not found at ${ghid.fullName}`);
-                    gh = undefined;
-                }
-                else {
-                    ghid.tag = githubTag;
-                    pxt.log(`tutorial ${ghid.fullName} tag: ${githubTag}`);
-                    gh = await pxt.github.downloadPackageAsync(`${ghid.slug}#${ghid.tag}`, config);
-                }
+                let gh = await pxt.github.downloadTutorialMarkdownAsync(path, ghid.tag);
                 pxt.perf.measureEnd("downloadGitHubTutorial");
 
                 // check for cached tutorial info, save into IndexedDB if found
@@ -5846,7 +5829,7 @@ function clearHashChange() {
 
 function saveAsBlocks(): boolean {
     try {
-        return /saveblocks=1/.test(window.location.href) && !!pkg.mainPkg.readFile(pxt.MAIN_BLOCKS)
+        return /save(?:as)?blocks=1/i.test(window.location.href) && !!pkg.mainPkg.readFile(pxt.MAIN_BLOCKS)
     } catch (e) { return false; }
 }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4692,7 +4692,7 @@ export class ProjectView
             if (/^\//.test(path)) {
                 filename = title || path.split('/').reverse()[0].replace('-', ' '); // drop any kind of sub-paths
                 pxt.perf.measureStart("downloadMarkdown");
-                const rawMarkdown = await pxt.Cloud.markdownAsync(path);
+                const rawMarkdown = await pxt.Cloud.markdownAsync(path, undefined, undefined, true);
                 pxt.perf.measureEnd("downloadMarkdown");
                 autoChooseBoard = true;
                 markdown = processMarkdown(rawMarkdown);

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -393,6 +393,10 @@ function applyExtensionResult() {
         log(`extension showProgramTooLargeErrorAsync`);
         pxt.commands.showProgramTooLargeErrorAsync = res.showProgramTooLargeErrorAsync;
     }
+    if (res.onMarkdownActivityLoad) {
+        log(`extension onMarkdownActivityLoad`);
+        pxt.commands.onMarkdownActivityLoad = res.onMarkdownActivityLoad;
+    }
 }
 
 export async function initAsync() {


### PR DESCRIPTION
This consumes the newly proposed /api/ghtutorial/ endpoint. Opening as a draft PR because this endpoint isn't actually released yet.

When loading a tutorial from github, this takes the response from /api/ghtutorial/ and uses it to populate all of the caches that we maintain in indexeddb. The rest of the markdown loading pipeline is unchanged, the requests it makes simply hit the cache instead of actually making requests to the backend.

This PR also makes it so that we now cache the latest versions of github repos inside indexeddb just like we do everything else. Unlike the other things we cache, the entries for latest versions expire after an hour. I might end up increasing this period, though, since that isn't very much time at all.

I also added a `skipgithubcache=1` query parameter that bypasses all of our local github repo caches to make it easier for content creators to verify their changes.

also tacked on an unrelated change making it so that the `saveblocks` query param is now case insensitive and accepts `saveasblocks` since I always accidentally try that first.