### PR TITLE
don't fire type checks on blockly theme changes

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -649,6 +649,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 Blockly.Events.CLICK,
                 Blockly.Events.VIEWPORT_CHANGE,
                 Blockly.Events.BUBBLE_OPEN,
+                Blockly.Events.THEME_CHANGE,
                 pxtblockly.FIELD_EDITOR_OPEN_EVENT_TYPE
             ];
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2557

minecraft is our only editor that actually customizes the blockly theme. setting the theme was causing blockly to fire an event which in turn triggered a type check on the home screen. that type check fails because there is no project open when you're on the home screen