### PR TITLE
Match punctuation for code card descriptions

### DIFF
--- a/pxtblocks/codecardRenderer.ts
+++ b/pxtblocks/codecardRenderer.ts
@@ -100,7 +100,13 @@ export function renderCodeCard(card: pxt.CodeCard, options: CodeCardRenderOption
         }
         if (card.description) {
             const descr = div(ct, 'ui description');
-            const shortenedDescription = card.description.split('.')[0] + '.';
+            const regex = /((?:\.\.\.)|[\!\.\?…])/;
+            const match = regex.exec(card.description);
+            let shortenedDescription = card.description + ".";
+            if (match) {
+                const punctuation = match[1];
+                shortenedDescription = card.description.split(punctuation)[0] + punctuation;
+            }
 
             descr.appendChild(document.createTextNode(shortenedDescription));
         }

--- a/pxtblocks/codecardRenderer.ts
+++ b/pxtblocks/codecardRenderer.ts
@@ -100,7 +100,7 @@ export function renderCodeCard(card: pxt.CodeCard, options: CodeCardRenderOption
         }
         if (card.description) {
             const descr = div(ct, 'ui description');
-            const regex = /((?:\.\.\.)|[\!\.\?…])/;
+            const regex = /((?:\.{1,3})|[\!\?…])/;
             const match = regex.exec(card.description);
             let shortenedDescription = card.description + ".";
             if (match) {


### PR DESCRIPTION
Thanks to @riknoll for all the help.
Fixes https://github.com/microsoft/pxt-minecraft/issues/2508