### PR TITLE
catch exception when double registering comment context menu items

### DIFF
--- a/pxtblocks/contextMenu/contextMenu.ts
+++ b/pxtblocks/contextMenu/contextMenu.ts
@@ -28,13 +28,13 @@ export function initContextMenu() {
 }
 
 export function setupWorkspaceContextMenu(workspace: Blockly.WorkspaceSvg) {
-    Blockly.ContextMenuItems.registerCommentOptions();
+    try {
+        Blockly.ContextMenuItems.registerCommentOptions();
+    }
+    catch (e) {
+        // will throw if already registered. ignore
+    }
     workspace.configureContextMenu = (options, e) => {
-        if (workspace.options.comments && !workspace.options.readOnly) {
-            // options.unshift(Blockly.ContextMenu.workspaceCommentOption(workspace, e))
-
-        }
-
         onWorkspaceContextMenu(workspace, options);
     };
 }


### PR DESCRIPTION
potential fix for https://github.com/microsoft/pxt-minecraft/issues/2560

when refreshing the blockly workspace, we call prepare blockly a second time which was throwing because of double registration of the workspace comment context menu options