### PR TITLE
inline blockly sourcemaps in development builds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -336,6 +336,14 @@ function runUglify() {
     return Promise.resolve();
 }
 
+function inlineBlocklySourcemaps() {
+    if (process.env.PXT_ENV === 'production') {
+        return;
+    }
+
+    return exec("node ./scripts/inlineBlocklySourceMaps.js");
+}
+
 
 
 /********************************************************
@@ -733,7 +741,7 @@ function getMochaExecutable() {
 const buildAll = gulp.series(
     updatestrings,
     maybeUpdateWebappStrings(),
-    gulp.parallel(copyTypescriptServices, copyBlocklyMedia),
+    gulp.parallel(copyTypescriptServices, copyBlocklyMedia, inlineBlocklySourcemaps),
     gulp.parallel(pxtlib, pxtweb),
     gulp.parallel(pxtcompiler, pxtsim, backendutils),
     pxtpy,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -336,7 +336,7 @@ function runUglify() {
     return Promise.resolve();
 }
 
-function inlineBlocklySourcemaps() {
+async function inlineBlocklySourcemaps() {
     if (process.env.PXT_ENV === 'production') {
         return;
     }

--- a/scripts/inlineBlocklySourceMaps.js
+++ b/scripts/inlineBlocklySourceMaps.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const path = require("path");
+
+const blocklyRoot = path.resolve(__dirname, "..", "node_modules", "blockly");
+
+const files = [
+    "blockly_compressed.js",
+    "blocks_compressed.js"
+];
+
+for (const file of files) {
+    const fullPath = path.join(blocklyRoot, file);
+    const source = fs.readFileSync(fullPath, "utf8");
+    const maps = fs.readFileSync(fullPath + ".map", "utf8");
+
+    const dataUri = "data:application/json;charset=utf-8;base64," + Buffer.from(maps).toString("base64");
+
+    const patched = source.replace(/\/\/# sourceMappingURL=.*/, `//# sourceMappingURL=${dataUri}`);
+
+    fs.writeFileSync(fullPath, patched, "utf8");
+}


### PR DESCRIPTION
something changed in blockly that broke my old local debugging setup; i used to npm link my local clone of blockly and change their build files to inline the sourcemaps so that i could actually debug the compressed blockly code.

so i decided to solve the issue directly by writing my own script to inline the source maps from the released blockly npm package. i went ahead and added this to the gulpfile for non-production builds so that everyone can enjoy actually debugging blockly in a sane way.

one note: this does make it so that you correctly see the blockly source when stepping through files but it doesn't fix the names of variables that show up in the debugger; you still see the minified variable names. still it's a huge improvement over the old setup which didn't even point you to the right spot in the compressed file when sourcemaps were enabled.

also, in the past inline sourcemaps have caused the chrome debugger to be much slower when we tried using them for the entire app. i haven't noticed a problem with this but if it becomes an issue i can make this an optional thing for local builds.