### PR TITLE
Add the 'Authoring MakeCode Extension' video to 'getting-started'

### DIFF
--- a/docs/extensions/getting-started.md
+++ b/docs/extensions/getting-started.md
@@ -4,6 +4,16 @@ This guide describes a simple setup that requires nothing, but a web browser.
 We have another guide, if you want to
 [use command line tools](/extensions/getting-started/vscode).
 
+### ~ hint
+
+#### Making an extension
+
+Watch this overview video on making your own MakeCode extension.
+
+https://youtu.be/XSskpMEHYlo
+
+### ~
+
 ## Step 1: Design blocks in the editor
 
 It is easiest to tinker and design your blocks from the editor itself. 


### PR DESCRIPTION
Add a hint section that includes the 'Authoring MakeCode Extension' video to the extension's "Getting Started" page.

https://youtu.be/XSskpMEHYlo

Closes #10230 