### PR TITLE
Use queueRender rather than render

### DIFF
--- a/pxtblocks/composableMutations.ts
+++ b/pxtblocks/composableMutations.ts
@@ -253,7 +253,7 @@ export function initExpandableBlock(info: pxtc.BlocksInfo, b: Blockly.Block, def
 
         updateButtons();
         if (variableInlineInputs) b.setInputsInline(visibleOptions < inlineInputModeLimit);
-        if (!skipRender) (b as Blockly.BlockSvg).render();
+        if (!skipRender) (b as Blockly.BlockSvg).queueRender();
     }
 
     function addButton(name: string, uri: string, alt: string, delta: number) {

--- a/pxtblocks/plugins/arrays/createList.ts
+++ b/pxtblocks/plugins/arrays/createList.ts
@@ -176,7 +176,7 @@ const LIST_CREATE_MIXIN = {
             }, Blockly.config.bumpDelay);
         }
         if (block.rendered && block instanceof Blockly.BlockSvg) {
-            block.render();
+            block.queueRender();
         }
         Blockly.Events.setGroup(false);
     },

--- a/pxtblocks/plugins/functions/blocks/functionCallBlocks.ts
+++ b/pxtblocks/plugins/functions/blocks/functionCallBlocks.ts
@@ -103,7 +103,7 @@ const FUNCTION_CALL_MIXIN: FunctionCallMixin = {
             newBlock.setShadow(shadowType !== "variables_get");
             if (!this.isInsertionMarker() && newBlock instanceof Blockly.BlockSvg) {
                 newBlock.initSvg();
-                newBlock.render();
+                newBlock.queueRender();
             }
         } finally {
             Blockly.Events.enable();

--- a/pxtblocks/plugins/functions/blocks/functionDeclarationBlock.ts
+++ b/pxtblocks/plugins/functions/blocks/functionDeclarationBlock.ts
@@ -93,6 +93,9 @@ const FUNCTION_DECLARATION_MIXIN: FunctionDeclarationMixin = {
     },
 
     async focusLastEditorAsync_(this: FunctionDeclarationBlock) {
+        // The argument editor block might still be rendering.
+        // Wait for the render queue to finish so that the centerOnBlock
+        // function is able to correctly position the editor scroll.
         await Blockly.renderManagement.finishQueuedRenders();
 
         if (this.inputList.length > 0) {

--- a/pxtblocks/plugins/functions/blocks/functionDeclarationBlock.ts
+++ b/pxtblocks/plugins/functions/blocks/functionDeclarationBlock.ts
@@ -16,7 +16,7 @@ import { MsgKey } from "../msg";
 
 interface FunctionDeclarationMixin extends CommonFunctionMixin {
     createArgumentEditor_(argumentType: string, displayName: string): Blockly.Block;
-    focusLastEditor_(): void;
+    focusLastEditorAsync_(): void;
     removeFieldCallback(field: Blockly.Field): void;
     addParam_(typeName: string, defaultName: string): void;
     addBooleanExternal(): void;
@@ -83,7 +83,7 @@ const FUNCTION_DECLARATION_MIXIN: FunctionDeclarationMixin = {
             newBlock.setShadow(true);
             if (!this.isInsertionMarker() && newBlock instanceof Blockly.BlockSvg) {
                 newBlock.initSvg();
-                newBlock.render();
+                newBlock.queueRender();
             }
         } finally {
             Blockly.Events.enable();
@@ -92,7 +92,9 @@ const FUNCTION_DECLARATION_MIXIN: FunctionDeclarationMixin = {
         return newBlock;
     },
 
-    focusLastEditor_(this: FunctionDeclarationBlock) {
+    async focusLastEditorAsync_(this: FunctionDeclarationBlock) {
+        await Blockly.renderManagement.finishQueuedRenders();
+
         if (this.inputList.length > 0) {
             let newInput = this.inputList[this.inputList.length - 2];
             if (newInput.type == Blockly.inputs.inputTypes.DUMMY) {
@@ -157,7 +159,7 @@ const FUNCTION_DECLARATION_MIXIN: FunctionDeclarationMixin = {
             type: typeName,
         });
         this.updateDisplay_();
-        this.focusLastEditor_();
+        /* await */ this.focusLastEditorAsync_();
     },
 
     addBooleanExternal(this: FunctionDeclarationBlock) {

--- a/pxtblocks/plugins/functions/blocks/functionDefinitionBlock.ts
+++ b/pxtblocks/plugins/functions/blocks/functionDefinitionBlock.ts
@@ -126,7 +126,7 @@ const FUNCTION_DEFINITION_MIXIN: FunctionDefinitionMixin = {
             newBlock.setShadow(true);
             if (!this.isInsertionMarker() && newBlock instanceof Blockly.BlockSvg) {
                 newBlock.initSvg();
-                newBlock.render();
+                newBlock.queueRender();
             }
         } finally {
             Blockly.Events.enable();

--- a/pxtblocks/plugins/functions/commonFunctionMixin.ts
+++ b/pxtblocks/plugins/functions/commonFunctionMixin.ts
@@ -260,7 +260,7 @@ export const COMMON_FUNCTION_MIXIN = {
 
         if (wasRendered && !this.isInsertionMarker() && this instanceof Blockly.BlockSvg) {
             this.initSvg();
-            this.render();
+            this.queueRender();
         }
     },
 

--- a/pxtblocks/plugins/logic/ifElse.ts
+++ b/pxtblocks/plugins/logic/ifElse.ts
@@ -122,7 +122,7 @@ const IF_ELSE_MIXIN = {
             }, Blockly.config.bumpDelay);
         }
         if (block.rendered && block instanceof Blockly.BlockSvg) {
-            block.render();
+            block.queueRender();
         }
         this.restoreConnections_();
         Blockly.Events.setGroup(false);

--- a/pxtblocks/plugins/text/join.ts
+++ b/pxtblocks/plugins/text/join.ts
@@ -96,7 +96,7 @@ const TEXT_JOIN_MUTATOR_MIXIN = {
             }, Blockly.config.bumpDelay);
         }
         if (block.rendered && block instanceof Blockly.BlockSvg) {
-            block.render();
+            block.queueRender();
         }
         Blockly.Events.setGroup(false);
     },

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -997,7 +997,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const m = this.editor.getMetrics();
         b.moveBy(m.viewWidth / 2, m.viewHeight / 3);
         b.initSvg();
-        b.render();
+        b.queueRender();
     }
 
     private _loadBlocklyPromise: Promise<void>;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5989

replaces all of our calls to `block.render()` with `block.queueRender()`.

for the linked bug, here's a timeline of what was happening:

1. the duplicate function is invoked
2. appendPrivate is called in Blockly to paste the blocks that are duplicated
3. the root block (in this case a forever block) starts to initialize which causes its children to be added to the render queue
4. each of the child blocks is initialized
5. as part of the function call block's initialization, `block.render()` is called which immediately flushes the render queue
6. the blocks in the render queue other than the function call are not actually rendered because they are marked as still initializing, but they are still removed from the queue
7. the child initialization continues and all of the other blocks except for the math_number are re-added to the queue
8. initialization completes and the final render takes place

the reason for step 7 where only math_number is left out of the render is pure coincidence caused by the order the blocks are initialized in; i'm sure there are many other setups that would have resulted in the same broken behavior. in any case, the fix is simple: queue the render instead of flushing the queue. i went ahead and made the same change everywhere we call `.render()` to prevent other similar bugs from cropping up (and hopefully improve perf slightly)

this definitely deserves some extra testing but i did a cursory pass over the affected blocks and fixed the only issue i encountered (the change to the focusLastEditor function in this PR).