### PR TITLE
Fix Scrolling in Minecraft HOC Tutorial View

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -141,6 +141,10 @@ body#docs.tutorial {
     padding: 0.5rem;
 }
 
+#tutorialcard.stepExpanded {
+    height: auto;
+}
+
 .tutorial #tutorialcard .ui.buttons {
     width: 100%;
     height: calc(@tutorialCardHeight - 1rem);

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -501,7 +501,6 @@ code.lang-filterblocks {
 }
 
 .editorlang-text.hideToolbox #tutorialcard.seemore .tutorialsegment > button {
-    margin-right: unset;
     margin-left: 1rem;
 }
 

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -487,21 +487,22 @@ code.lang-filterblocks {
 /*******************************
         See More Button
 *******************************/
-#tutorialcard.seemore {
-    .tutorialsegment > button {
-        flex-grow: 0;
-        position: relative;
-        width: auto;
-        margin: auto;
-        margin-top: -0.75rem;
-        padding: 0.5rem 0.8rem;
-    }
+#tutorialcard.seemore .tutorialsegment > button {
+    flex-grow: 0;
+    position: relative;
+    width: auto;
+    margin: auto;
+    margin-top: -0.75rem;
+    padding: 0.5rem 0.8rem;
 }
 
-.editorlang-text {
-    #tutorialcard.seemore .tutorialsegment > button {
-        margin-right: 1rem;
-    }
+.editorlang-text:not(.hideToolbox) #tutorialcard.seemore .tutorialsegment > button {
+    margin-right: 1rem;
+}
+
+.editorlang-text.hideToolbox #tutorialcard.seemore .tutorialsegment > button {
+    margin-right: unset;
+    margin-left: 1rem;
 }
 
 /*******************************

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -20,6 +20,7 @@ import { fireClickOnEnter } from "./util";
 import * as pxtblockly from "../../pxtblocks";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
+import { classList } from "../../react-common/components/util";
 
 
 interface ITutorialBlocks {
@@ -681,8 +682,17 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             hintOnClick = null;
         }
 
+        const tutorialCardClasses = classList(
+            "ui",
+            tutorialStepExpanded ? 'tutorialExpanded' : undefined,
+            tutorialReady ? 'tutorialReady' : undefined,
+            this.state.showSeeMore ? 'seemore' : undefined,
+            !this.state.showHint ? 'showTooltip' : undefined,
+            hasHint ? 'hasHint' : undefined,
+            tutorialStepExpanded ? 'stepExpanded' : undefined);
+
         const isRtl = pxt.Util.isUserLanguageRtl();
-        return <div id="tutorialcard" className={`ui ${tutorialStepExpanded ? 'tutorialExpanded' : ''} ${tutorialReady ? 'tutorialReady' : ''} ${this.state.showSeeMore ? 'seemore' : ''}  ${!this.state.showHint ? 'showTooltip' : ''} ${hasHint ? 'hasHint' : ''} ${tutorialStepExpanded ? 'stepExpanded' : ''}`} >
+        return <div id="tutorialcard" className={tutorialCardClasses} >
             {hasHint && this.state.showHint && !showDialog && <div className="mask" role="region" onClick={this.closeHint}></div>}
             <div className='ui buttons'>
                 {hasPrevious ? <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron large`} className={`prevbutton left attached ${!hasPrevious ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.previousTutorialStep} onKeyDown={fireClickOnEnter} /> : undefined}

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -608,17 +608,21 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
     private setShowSeeMore(autoexpand?: boolean) {
         // compare scrollHeight of inner text with height of card to determine showSeeMore
         const tutorialCard = this.refs['tutorialmessage'] as HTMLElement;
-        let initialCardHeight = this.state.initialCardHeight;
-        if (!initialCardHeight) {
-            initialCardHeight = this.getInteriorHeight(tutorialCard);
-            this.setState({ initialCardHeight });
+        let defaultCardHeight = this.state.initialCardHeight;
+        if (!defaultCardHeight) {
+            defaultCardHeight = this.getInteriorHeight(tutorialCard);
+            this.setState({ initialCardHeight: defaultCardHeight });
         }
 
         let show = false;
-        if (tutorialCard?.firstElementChild?.firstElementChild) {
-            show = initialCardHeight <= tutorialCard.firstElementChild.firstElementChild.scrollHeight;
-            if (show) {
-                if (autoexpand) this.props.parent.setTutorialInstructionsExpanded(true);
+        const contentChild = tutorialCard?.firstElementChild?.firstElementChild;
+        if (contentChild) {
+            // Check if we need to scroll to see full content when at the default card size.
+            // If we do, display the "see more" button, which allows the user to expand the card and see all content without the scrollbar.
+            show = defaultCardHeight <= contentChild.scrollHeight;
+            if (show && autoexpand) {
+                // Expand automatically if autoexpand is set.
+                this.props.parent.setTutorialInstructionsExpanded(true);
             }
         }
         this.setState({ showSeeMore: show });

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -594,18 +594,23 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         evt.stopPropagation();
     }
 
+    private getInteriorHeight(element: HTMLElement) {
+        let height = element?.clientHeight; // Includes padding
+        try {
+            const style = window.getComputedStyle(element);
+            height -= parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+        } catch (e) {
+            // ignore parse errors, etc...
+        }
+        return height;
+    }
+
     private setShowSeeMore(autoexpand?: boolean) {
         // compare scrollHeight of inner text with height of card to determine showSeeMore
         const tutorialCard = this.refs['tutorialmessage'] as HTMLElement;
         let initialCardHeight = this.state.initialCardHeight;
         if (!initialCardHeight) {
-            initialCardHeight = tutorialCard?.clientHeight; // Includes padding
-            try {
-                const tutorialCardStyle = window.getComputedStyle(tutorialCard);
-                initialCardHeight = initialCardHeight - parseFloat(tutorialCardStyle.paddingTop) - parseFloat(tutorialCardStyle.paddingBottom);
-            } catch (e) {
-                // ignore parse errors, etc...
-            }
+            initialCardHeight = this.getInteriorHeight(tutorialCard);
             this.setState({ initialCardHeight });
         }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2579

### Height Calculation
We were trying to compute the tutorial pane's height directly to the scroll height of the content plus a hard-coded buffer, and I think the fixed buffer eventually got out of date when the styles changed.

Rather than simply updated the buffer size to a different fixed value, I set the height to `auto` which just dynamically resizes to fit content (Googling tells me it's well supported across different browsers, so I think it's safe).

There was also an issue where the clientHeight / scrollHeight comparison was slightly off when determining if there was overflow because the clientHeight value contains padding, which eats into the actual "user visible" area for the child content. I've added a function to calculate the height without the padding to account for this

### Show More/Less
While testing, I noticed the "Show More"/"Less" toggle appeared and disappeared somewhat randomly (even without my changes). The check we were doing for this was always based on the current size of the element, so I believe the decision on whether to show it was being affected by whether the element was actually expanded (i.e. "Show More") or not. This led to inconsistent-feeling behavior.

I reworked this so it's now based on the initial size as a "default" and not just the latest current size. I also moved it to the left when the toolbox is hidden, since it was just empty space before and I think it's better than overlapping the undo/redo buttons.

### See It, Try It

**Upload Target**
- Blocks: https://minecraft.makecode.com/app/62b342af6416a3af8992dc9f8243b82ebc79f0e5-1a2203d425#tutorial:/hour-of-code/2024/tutorial?ingame=1&ipc=1&norunonx=1
- Python: https://minecraft.makecode.com/app/62b342af6416a3af8992dc9f8243b82ebc79f0e5-1a2203d425#tutorial:/hour-of-code/2024/tutorial_python?ingame=1&ipc=1&norunonx=1

**Screenshots**
![image](https://github.com/user-attachments/assets/3e3c7a65-f9c8-47e5-b186-9d8061d60046)
![image](https://github.com/user-attachments/assets/84f96025-ffcc-4d6b-b020-33572d527702)
![image](https://github.com/user-attachments/assets/f6a1671c-fe39-45c7-a2a7-876986710703)

![image](https://github.com/user-attachments/assets/696f0ead-b129-451a-bf0f-1387852454a8)
![image](https://github.com/user-attachments/assets/2d049de4-0a34-40ec-9bdd-b66e915041c2)
