### PR TITLE
Fix Python Toolbox Filtering with Tutorial Template Code

### DIFF
--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -148,7 +148,7 @@ namespace pxt.tutorial {
                         m2 = "";
                         break;
                 }
-                code.push(m1 == "python" ? `\n${m2}\n` : `{\n${m2}\n}`);
+                code.push(language === "python" ? `\n${m2}\n` : `{\n${m2}\n}`);
                 idx++
                 return "";
             });


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2578

When a tutorial specifies `python-template` code (i.e. https://github.com/microsoft/pxt-minecraft/blob/master/docs/hour-of-code/2024/setdesign_python_activity2.md?plain=1#L8-L12) we were not parsing it correctly and ended up adding curly braces around the code. In some scenarios, the compiler could recover from the unexpected curly braces and still produce a few statements (seemed to happen when loops / indentation was present in the snippet), but in other cases, it was not able to recover. As a result, toolbox filtering wouldn't work and an error toast would appear. (Note that without this fix, the error toast still appears, even with the toolbox hidden.) Technically, even when the compiler did recover, some statements would be missing, so the filtering could theoretically be off there too.

The curly braces were being placed because we do it for typescript, and in the check to determine typescript/pyhon, we were only checking the snippet regex match for `python` directly, not `python-template`. I've gone with the more general check on `language` instead, in the hopes that it will be more resilient if we add more keywords in the future.

Tested by removing the flyoutOnly field and looking at the toolbox. This was it before:
![image](https://github.com/user-attachments/assets/e30721c2-89ac-497f-ad77-26a2f511ea69)

This is it after:
![image](https://github.com/user-attachments/assets/d5b71b95-b8f7-4c00-9181-20c458477f9d)

I also confirmed the error no longer shows up when the toolbox is hidden.