### PR TITLE
Fix overflowing instructions and horizontal scrolling

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -265,7 +265,7 @@ span.docs.inlinebutton {
 span.docs.inlineblock {
     padding: 0.05rem .2rem;
     padding-bottom: 0.1rem;
-    white-space: nowrap;
+    white-space: break-spaces;
     border-radius: 0;
     border-bottom: 3px solid var(--inline-namespace-color);
     color: black;

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -88,7 +88,7 @@
 }
 
 .tutorial.tutorialExpanded #tutorialcard {
-    max-height: 20rem;
+    max-height: 20rem; // Tightly coupled to `.tutorial.tutorialExpanded #tutorialcard .ui.buttons` max-height.
 }
 
 #root.dimmable.dimmed #tutorialcard.tutorialReady {
@@ -152,6 +152,7 @@ body#docs.tutorial {
 
 .tutorial.tutorialExpanded #tutorialcard .ui.buttons {
     height: 100%;
+    max-height: 19rem; // Tightly coupled to #tutorialcard max-height
 }
 
 #tutorialcard .ui.tutorialsegment {
@@ -492,7 +493,7 @@ code.lang-filterblocks {
     position: relative;
     width: auto;
     margin: auto;
-    margin-top: -0.75rem;
+    margin-top: -0.5rem;
     padding: 0.5rem 0.8rem;
 }
 

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -13,6 +13,7 @@
 @highlightLineClassColor: #007f00;
 @highlightLineKeywordColor: #0000ff;
 @tutorialCardHeight: 8rem;
+@tutorialCardMaxHeight: 20rem;
 @seeMoreButtonHeight: 4rem;
 @avatarSize: 4.5rem;
 @avatarMargin: @avatarSize + 0.5rem;
@@ -88,7 +89,7 @@
 }
 
 .tutorial.tutorialExpanded #tutorialcard {
-    max-height: 20rem; // Tightly coupled to `.tutorial.tutorialExpanded #tutorialcard .ui.buttons` max-height.
+    max-height: @tutorialCardMaxHeight;
 }
 
 #root.dimmable.dimmed #tutorialcard.tutorialReady {
@@ -152,7 +153,7 @@ body#docs.tutorial {
 
 .tutorial.tutorialExpanded #tutorialcard .ui.buttons {
     height: 100%;
-    max-height: 19rem; // Tightly coupled to #tutorialcard max-height
+    max-height: calc(@tutorialCardMaxHeight - 1rem);
 }
 
 #tutorialcard .ui.tutorialsegment {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2601
Fixes https://github.com/microsoft/pxt-minecraft/issues/2603

In commit https://github.com/microsoft/pxt/commit/a7e5cdee61f04a8c86a25bc6d7aaf4787ed231d3, I changed the height of the tutorial card to "auto" instead of a fixed value, and that meant the child (with height 100%) started overflowing when it exceeded the size of the parent. To fix this, I just set a max height on the child that's tied to the max height of the parent - basically the same setup we have for when the instructions are minimized, just at a bigger size.

I also made it so code snippets can wrap on spaces. There are some long-ish lines of code (or code-like) snippets in the Minecraft HOC tutorial, and they can cause horizontal scrolling on small widths, since code snippets are currently set to not wrap (for example, ``||hoc:HeadWear, MidWear, and LowerWear||`` in [costume_python_activity3.md](https://github.com/microsoft/pxt-minecraft/blob/master/docs/hour-of-code/2024/costume_python_activity3.md?plain=1#L12C193-L12C237)). I think it's okay to break these on spaces, at the very least.

Lastly, I moved the "Show More"/"Less..." toggle down just a smidge since it was overlapping the text.

![image](https://github.com/user-attachments/assets/6c0ccfd7-5165-4313-9b33-d5c36d1f2748)
![image](https://github.com/user-attachments/assets/08913400-bf96-486f-a38e-c6b8ab4bf21a)


