### PR TITLE
Hide Redundant Undo/Redo and Zoom Controls in Python

### DIFF
--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -363,6 +363,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         const simOpts = pxt.appTarget.simulator;
         const headless = simOpts.headless;
         const flyoutOnly = editorState && editorState.hasCategories === false;
+        const hideToolbox = tutorial && tutorialOptions.metadata?.hideToolbox;
 
         const disableFileAccessinMaciOs = targetTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
         const disableFileAccessinAndroid = pxt.appTarget.appTheme.disableFileAccessinAndroid && pxt.BrowserUtils.isAndroid();
@@ -381,8 +382,8 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         const running = simState == SimState.Running;
         const starting = simState == SimState.Starting;
 
-        const showUndoRedo = !readOnly && !debugging && !flyoutOnly;
-        const showZoomControls = !flyoutOnly;
+        const showUndoRedo = !readOnly && !debugging && !flyoutOnly && !hideToolbox;
+        const showZoomControls = !flyoutOnly && !hideToolbox;
         const showGithub = !!pxt.appTarget.cloud
             && !!pxt.appTarget.cloud.githubPackages
             && targetTheme.githubEditor


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2602

These started appearing as a side-effect of my changes to hide the toolbox (https://github.com/microsoft/pxt/commit/9e6dd9e5e5ac372d6a043265dc79af48c0850e55), since it's no longer in flyoutOnly mode. Add extra check for hideToolbox as well.