### PR TITLE
Add Element.checkVisibility polyfill for Blockly

### DIFF
--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -24,6 +24,7 @@ import { initContextMenu } from "./contextMenu";
 import { renderCodeCard } from "./codecardRenderer";
 import { FieldDropdown } from "./fields/field_dropdown";
 import { setDraggableShadowBlocks, setDuplicateOnDragStrategy } from "./plugins/duplicateOnDrag";
+import { applyPolyfills } from "./polyfills";
 
 
 interface BlockDefinition {
@@ -586,6 +587,8 @@ let blocklyInitialized = false;
 function init(blockInfo: pxtc.BlocksInfo) {
     if (blocklyInitialized) return;
     blocklyInitialized = true;
+
+    applyPolyfills();
 
     initFieldEditors();
     initContextMenu();

--- a/pxtblocks/polyfills.ts
+++ b/pxtblocks/polyfills.ts
@@ -1,16 +1,43 @@
+// all options default to true
+interface CheckVisibilityOptions {
+    contentVisibilityAuto?: boolean;
+    opacityProperty?: boolean;
+    visibilityProperty?: boolean;
+    checkOpacity?: boolean;
+    checkVisibilityCSS?: boolean;
+}
+
 export function applyPolyfills() {
     if (!(Element.prototype as any).checkVisibility) {
-        (Element.prototype as any).checkVisibility = function checkVisibility(this: Element): boolean {
+        (Element.prototype as any).checkVisibility = function checkVisibility(this: Element, options: CheckVisibilityOptions = {}): boolean {
+            let checkOpacity = true;
+
+            if (options.opacityProperty != undefined || options.checkOpacity != undefined) {
+                checkOpacity = !!(options.opacityProperty || options.checkOpacity);
+            }
+
+            let checkVisibility = true;
+
+            if (options.visibilityProperty != undefined || options.checkVisibilityCSS != undefined) {
+                checkVisibility = !!(options.visibilityProperty || options.checkVisibilityCSS);
+            }
+
+            let checkContentVisibility = true;
+
+            if (options.contentVisibilityAuto != undefined) {
+                checkContentVisibility = !!options.contentVisibilityAuto;
+            }
+            
             const computedStyle = getComputedStyle(this);
 
             // technically, this should also check for contentVisibility === "auto" and then
             // traverse the ancestors of this node to see if any have contentVisibility set
             // to "hidden", but Blockly doesn't use content-visibility AFAIK
             if (
-                computedStyle.opacity === "0" ||
-                computedStyle.visibility === "hidden" ||
                 computedStyle.display === "none" ||
-                (computedStyle as any).contentVisibility === "hidden"
+                (checkOpacity && computedStyle.opacity === "0") ||
+                (checkVisibility && computedStyle.visibility === "hidden") ||
+                (checkContentVisibility && (computedStyle as any).contentVisibility === "hidden")
             ) {
                 return false;
             }

--- a/pxtblocks/polyfills.ts
+++ b/pxtblocks/polyfills.ts
@@ -27,7 +27,7 @@ export function applyPolyfills() {
             if (options.contentVisibilityAuto != undefined) {
                 checkContentVisibility = !!options.contentVisibilityAuto;
             }
-            
+
             const computedStyle = getComputedStyle(this);
 
             // technically, this should also check for contentVisibility === "auto" and then

--- a/pxtblocks/polyfills.ts
+++ b/pxtblocks/polyfills.ts
@@ -1,6 +1,6 @@
 export function applyPolyfills() {
-    if (!Element.prototype.checkVisibility) {
-        Element.prototype.checkVisibility = function checkVisibility(this: Element): boolean {
+    if (!(Element.prototype as any).checkVisibility) {
+        (Element.prototype as any).checkVisibility = function checkVisibility(this: Element): boolean {
             const computedStyle = getComputedStyle(this);
 
             // technically, this should also check for contentVisibility === "auto" and then
@@ -10,7 +10,7 @@ export function applyPolyfills() {
                 computedStyle.opacity === "0" ||
                 computedStyle.visibility === "hidden" ||
                 computedStyle.display === "none" ||
-                computedStyle.contentVisibility === "hidden"
+                (computedStyle as any).contentVisibility === "hidden"
             ) {
                 return false;
             }

--- a/pxtblocks/polyfills.ts
+++ b/pxtblocks/polyfills.ts
@@ -1,0 +1,33 @@
+export function applyPolyfills() {
+    if (!Element.prototype.checkVisibility) {
+        Element.prototype.checkVisibility = function checkVisibility(this: Element): boolean {
+            const computedStyle = getComputedStyle(this);
+
+            // technically, this should also check for contentVisibility === "auto" and then
+            // traverse the ancestors of this node to see if any have contentVisibility set
+            // to "hidden", but Blockly doesn't use content-visibility AFAIK
+            if (
+                computedStyle.opacity === "0" ||
+                computedStyle.visibility === "hidden" ||
+                computedStyle.display === "none" ||
+                computedStyle.contentVisibility === "hidden"
+            ) {
+                return false;
+            }
+
+            try {
+                const rec = this.getBoundingClientRect();
+                if (rec.width === 0 || rec.height === 0) {
+                    return false;
+                }
+            }
+            catch {
+                // some versions of firefox throw if an element is not in the DOM
+                // and getBoundingClientRect is called
+                return false;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2555

this pr adds a simple polyfill for `Element.checkVisibility` to fix comment rendering in ancient browsers. i wrote the polyfill myself because a cursory search didn't find a suitable one and the method itself is pretty simple. the only thing mine doesn't do is traverse ancestors to check their `content-visibility`, but that's not needed for the linked bug.