### PR TITLE
Fix Hint Popup Location in Tutorials

### DIFF
--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -31,6 +31,7 @@ export function TutorialCallout(props: TutorialCalloutProps) {
             } else {
                 setBottom("unset");
 
+                // Set the top of the hint to the bottom of wrapper div (which aligns to the hint button).
                 const popupBottom = popupRef.current?.getBoundingClientRect().bottom;
                 setTop(popupBottom ? `${popupBottom}px` : "unset");
             }

--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -30,6 +30,9 @@ export function TutorialCallout(props: TutorialCalloutProps) {
                 setMaxHeight("90vh");
             } else {
                 setBottom("unset");
+
+                const popupBottom = popupRef.current?.getBoundingClientRect().bottom;
+                setTop(popupBottom ? `${popupBottom}px` : "unset");
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2556

Previously, the top location of this popup was simply "unset". Sometimes it'd happen to be in the correct location (I think because of how other elements are laid out in the DOM), but often times it wouldn't line up correctly. Rather than relying on that somewhat ill-defined behavior, this just sets the top directly so it's underneath the tutorial window.

I spent half a day trying to get this more in the css and less in the typescript, but I wasn't making progress so I decided to leave it be for now. I have other bugs to work on :)

Upload Target: https://minecraft.makecode.com/app/b43f1cf83819e95134eb935cf604acf0318dbb44-669fb69e00

FYI you may notice this issue while playing around with the upload target (I did...). I'll be working on a fix for that separately: https://github.com/microsoft/pxt-minecraft/issues/2612