### PR TITLE
Fix Gray Bar on Tutorial Resize

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1416,7 +1416,7 @@ p.ui.font.small {
         display: none !important;
         z-index: -10 !important;
     }
-    #tutorialWrapper {
+    .tutorialWrapper {
         display: none;
     }
     .sandboxfooter {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5026,7 +5026,7 @@ export class ProjectView
         if (this.isTutorial()) {
             if (!pxt.BrowserUtils.useOldTutorialLayout()) {
                 const tutorialElements = document?.getElementsByClassName("tutorialWrapper");
-                const tutorialEl = tutorialElements?.length === 1 ? document.getElementById("tutorialWrapper") : undefined;
+                const tutorialEl = tutorialElements?.length === 1 ? (tutorialElements[0] as HTMLElement) : undefined;
                 if (tutorialEl && (pxt.BrowserUtils.isTabletSize() || pxt.appTarget.appTheme.tutorialSimSidebarLayout)) {
                     this.setState({ editorOffset: tutorialEl.offsetHeight + "px" });
                 } else {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5025,7 +5025,8 @@ export class ProjectView
     setEditorOffset() {
         if (this.isTutorial()) {
             if (!pxt.BrowserUtils.useOldTutorialLayout()) {
-                const tutorialEl = document?.getElementById("tutorialWrapper");
+                const tutorialElements = document?.getElementsByClassName("tutorialWrapper");
+                const tutorialEl = tutorialElements?.length === 1 ? document.getElementById("tutorialWrapper") : undefined;
                 if (tutorialEl && (pxt.BrowserUtils.isTabletSize() || pxt.appTarget.appTheme.tutorialSimSidebarLayout)) {
                     this.setState({ editorOffset: tutorialEl.offsetHeight + "px" });
                 } else {

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -104,7 +104,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         const shouldResize = pxt.BrowserUtils.isTabletSize() || this.props.tutorialSimSidebar;
         if (shouldResize != this.state.shouldResize) {
             let height = this.state.height;
-            if (shouldResize && this.state.height === undefined && this.state.lastResizeHeight !== undefined) {
+            if (shouldResize && !this.state.height && this.state.lastResizeHeight) {
                 height = this.state.lastResizeHeight;
             }
 
@@ -219,7 +219,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
             this.props.tutorialSimSidebar && "tutorial-sim"
         );
 
-        const editorSidebarHeight = this.state.shouldResize && this.state.height !== undefined ? `${this.state.height}px` : undefined; // Should we use this regardless of shouldResize?
+        const editorSidebarHeight = this.state.shouldResize && this.state.height ? `${this.state.height}px` : undefined;
 
         const tutorialContainer = tutorialOptions ? <TutorialContainer
             parent={parent}

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -169,7 +169,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         const shouldResize = pxt.BrowserUtils.isTabletSize() || this.props.tutorialSimSidebar;
         const editorSidebarHeight = shouldResize ? `${this.state.height}px` : undefined;
 
-        const tutorialContainer = <TutorialContainer
+        const tutorialContainer = tutorialOptions ? <TutorialContainer
             parent={parent}
             tutorialId={tutorialOptions.tutorial}
             name={tutorialOptions.tutorialName}
@@ -183,7 +183,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
             hasBeenResized={this.state.resized && shouldResize}
             onTutorialStepChange={onTutorialStepChange}
             onTutorialComplete={onTutorialComplete}
-            setParentHeight={newSize => this.setComponentHeight(newSize, false)} />;
+            setParentHeight={newSize => this.setComponentHeight(newSize, false)} /> : undefined;
 
         return <div id="simulator" className="simulator">
             {!hasSimulator && <div id="boardview" className="headless-sim" role="region" aria-label={lf("Simulator")} tabIndex={-1} />}

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -192,6 +192,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         );
         const outerTutorialContainerClassName = classList(
             "editor-sidebar",
+            "tutorialWrapper",
             "tutorial-container-outer",
             this.props.tutorialSimSidebar && "topInstructions"
         );
@@ -252,7 +253,6 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                 <div className={this.props.tutorialSimSidebar ? "topInstructionsWrapper" : ""}>
                     {this.state.shouldResize ?
                         <VerticalResizeContainer
-                            id="tutorialWrapper"
                             className={outerTutorialContainerClassName}
                             maxHeight="500px"
                             minHeight="100px"
@@ -262,7 +262,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                             onResizeEnd={this.onResizeEnd}>
                                 {tutorialContainer}
                         </VerticalResizeContainer> :
-                        <div id="tutorialWrapper" className={outerTutorialContainerClassName}>
+                        <div className={outerTutorialContainerClassName}>
                             {tutorialContainer}
                         </div>}
                 </div>}

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -169,6 +169,22 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         const shouldResize = pxt.BrowserUtils.isTabletSize() || this.props.tutorialSimSidebar;
         const editorSidebarHeight = shouldResize ? `${this.state.height}px` : undefined;
 
+        const tutorialContainer = <TutorialContainer
+            parent={parent}
+            tutorialId={tutorialOptions.tutorial}
+            name={tutorialOptions.tutorialName}
+            steps={tutorialOptions.tutorialStepInfo}
+            currentStep={tutorialOptions.tutorialStep}
+            tutorialOptions={tutorialOptions}
+            hideIteration={tutorialOptions.metadata?.hideIteration}
+            hasTemplate={!!tutorialOptions.templateCode}
+            preferredEditor={tutorialOptions.metadata?.preferredEditor}
+            tutorialSimSidebar={this.props.tutorialSimSidebar}
+            hasBeenResized={this.state.resized && shouldResize}
+            onTutorialStepChange={onTutorialStepChange}
+            onTutorialComplete={onTutorialComplete}
+            setParentHeight={newSize => this.setComponentHeight(newSize, false)} />;
+
         return <div id="simulator" className="simulator">
             {!hasSimulator && <div id="boardview" className="headless-sim" role="region" aria-label={lf("Simulator")} tabIndex={-1} />}
             <div id="editorSidebar" className={editorSidebarClassName} style={!this.props.tutorialSimSidebar ? { height: editorSidebarHeight } : undefined}>
@@ -201,31 +217,21 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
             </div>
             {tutorialOptions &&
                 <div className={this.props.tutorialSimSidebar ? "topInstructionsWrapper" : ""}>
-                    <VerticalResizeContainer
-                        id="tutorialWrapper"
-                        className={outerTutorialContainerClassName}
-                        maxHeight="500px"
-                        minHeight="100px"
-                        initialHeight={editorSidebarHeight}
-                        resizeEnabled={shouldResize}
-                        onResizeDrag={this.onResizeDrag}
-                        onResizeEnd={this.onResizeEnd}>
-                        <TutorialContainer
-                            parent={parent}
-                            tutorialId={tutorialOptions.tutorial}
-                            name={tutorialOptions.tutorialName}
-                            steps={tutorialOptions.tutorialStepInfo}
-                            currentStep={tutorialOptions.tutorialStep}
-                            tutorialOptions={tutorialOptions}
-                            hideIteration={tutorialOptions.metadata?.hideIteration}
-                            hasTemplate={!!tutorialOptions.templateCode}
-                            preferredEditor={tutorialOptions.metadata?.preferredEditor}
-                            tutorialSimSidebar={this.props.tutorialSimSidebar}
-                            hasBeenResized={this.state.resized && shouldResize}
-                            onTutorialStepChange={onTutorialStepChange}
-                            onTutorialComplete={onTutorialComplete}
-                            setParentHeight={newSize => this.setComponentHeight(newSize, false)} />
-                    </VerticalResizeContainer>
+                    {shouldResize ?
+                        <VerticalResizeContainer
+                            id="tutorialWrapper"
+                            className={outerTutorialContainerClassName}
+                            maxHeight="500px"
+                            minHeight="100px"
+                            initialHeight={editorSidebarHeight}
+                            resizeEnabled={shouldResize}
+                            onResizeDrag={this.onResizeDrag}
+                            onResizeEnd={this.onResizeEnd}>
+                                {tutorialContainer}
+                        </VerticalResizeContainer> :
+                        <div id="tutorialWrapper" className={outerTutorialContainerClassName}>
+                            {tutorialContainer}
+                        </div>}
                 </div>}
         </div>
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2612

In the tutorial view, we were using the same `VerticalResizeContainer` component regardless of whether the tutorial was at the top (where you can actually resize the container) or the side (where resizing was disabled), and when switching between the two modes, that container was retaining state. As a result, if the user switched from top-bar to side-bar and then back to top-bar, the resize container would immediately pop back to its former height, but it didn't signal that change to the rest of the elements, so things were not positioning themselves to account for it.

I toyed with a few ways to fix this, but ultimately, I think it's odd for us to keep the `VerticalResizeContainer` around at all when the tutorial is in the side-bar (non-resizable) view. Feels like asking for weird disabled-resize-related bugs in the future. So I've gone with an approach that fully swaps out the container depending on whether or not resizing is enabled. The downside to this is that we actually _do_ want to remember the height the user set when we swap back, so I've added a new state var to track the last user-set height, and then we can set the initial height accordingly if we re-enter resize mode. This required pushing the shouldResize check into state as well.

Finally, since I now have two possible "tutorialWrapper" components, I changed the id to a className. I'm not sure if it's _actually_ an antipattern to give both components the same id when it's guaranteed that only one will be present at any given time, but it seemed like it'd be safer to switch it, just in case.

Upload Target: https://minecraft.makecode.com/app/f9a50f1535f3ae09120d070d8d6a3f68e4e9121f-c606faa4a3
Also tested micro-bit since it's using the same code path: https://makecode.microbit.org/app/967bfc5309fa70bba2e64f4eeb10e21d451746a4-42823891fa