### PR TITLE
Re-enable intellisense on android

### DIFF
--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -93,7 +93,6 @@ function setupMonaco() {
 export function createEditor(element: HTMLElement): monaco.editor.IStandaloneCodeEditor {
     const inverted = pxt.appTarget.appTheme.invertedMonaco;
     const hasFieldEditors = !!(pxt.appTarget.appTheme.monacoFieldEditors && pxt.appTarget.appTheme.monacoFieldEditors.length);
-    const isAndroid = pxt.BrowserUtils.isAndroid();
 
     let editor = monaco.editor.create(element, {
         model: null,
@@ -120,15 +119,14 @@ export function createEditor(element: HTMLElement): monaco.editor.IStandaloneCod
         theme: inverted ? 'vs-dark' : 'vs',
         renderIndentGuides: true,
         accessibilityHelpUrl: "", //TODO: Add help url explaining how to use the editor with a screen reader
-        // disable completions on android
         quickSuggestions: {
-            "other": !isAndroid,
-            "comments": !isAndroid,
-            "strings": !isAndroid
+            "other": true,
+            "comments": true,
+            "strings": true
        },
-        acceptSuggestionOnCommitCharacter: !isAndroid,
-        acceptSuggestionOnEnter: !isAndroid ? "on" : "off",
-        accessibilitySupport: !isAndroid ? "on" : "off"
+        acceptSuggestionOnCommitCharacter: true,
+        acceptSuggestionOnEnter: "on",
+        accessibilitySupport: "on"
     });
 
     editor.layout();

--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -378,18 +378,6 @@
     z-index: @monacoHintsZIndex !important;
 }
 
-#monacoEditorArea.android {
-    .monaco-editor .editor-widget {
-        display: none !important;
-        visibility: hidden !important;
-    }
-
-    // on android, the cursor / text area overlay gets offset
-    textarea.inputarea {
-        margin-left: .5rem;
-    }
-}
-
 .line-numbers {
     display:none;
 }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -636,10 +636,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     display(): JSX.Element {
         const showErrorList = pxt.appTarget.appTheme.errorList;
-        const isAndroid = pxt.BrowserUtils.isAndroid();
 
         return (
-            <div id="monacoEditorArea" className={`monacoEditorArea ${isAndroid ? "android" : ""}`} style={{ direction: 'ltr' }}>
+            <div id="monacoEditorArea" className={`monacoEditorArea`} style={{ direction: 'ltr' }}>
                 {this.isVisible && <div className={`monacoToolboxDiv ${(this.toolbox && !this.toolbox.state.visible && !this.isDebugging()) ? 'invisible' : ''}`}>
                     <toolbox.Toolbox ref={this.handleToolboxRef} editorname="monaco" parent={this} />
                     <div id="monacoDebuggerToolbox"></div>


### PR DESCRIPTION
We had disabled this because it didn't work, but now we need it, so I hope it just works? I'm afraid I can only test on my phone. If anyone can try to put it through its paces on a chromebook, that'd be helpful.

Upload target:<s> https://minecraft.makecode.com/app/e42873906d2ffabc19ec09ae999dfd28c7beeedf-7a6367562b</s> https://minecraft.makecode.com/app/8429027c1a6da2fe4ee6f7e271b5680a162dfc7e-cd7ec17b08

The change that disabled it was https://github.com/microsoft/pxt/pull/7099, which references bug https://github.com/microsoft/pxt-microbit/issues/3170. Thankfully, things are clearly better now than they were then, so there's a good chance this is fine. Will still need some testing, though.