### PR TITLE
Editor snapshots: added extra check for mac and ios for allowing screenshots

### DIFF
--- a/pxtblocks/layout.ts
+++ b/pxtblocks/layout.ts
@@ -227,7 +227,8 @@ export function flow(ws: Blockly.WorkspaceSvg, opts?: FlowOptions) {
 
 export function screenshotEnabled(): boolean {
     const disableForMacIos = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isMac() || pxt.BrowserUtils.isIOS());
-    return !disableForMacIos && !pxt.BrowserUtils.isIE();
+    const disableForAndriod = pxt.appTarget.appTheme.disableFileAccessinAndroid && pxt.BrowserUtils.isAndroid();
+    return !disableForMacIos && !pxt.BrowserUtils.isIE() && !disableForAndriod;
 }
 
 export function screenshotAsync(ws: Blockly.WorkspaceSvg, pixelDensity?: number, encodeBlocks?: boolean): Promise<string> {

--- a/pxtblocks/layout.ts
+++ b/pxtblocks/layout.ts
@@ -226,7 +226,8 @@ export function flow(ws: Blockly.WorkspaceSvg, opts?: FlowOptions) {
 }
 
 export function screenshotEnabled(): boolean {
-    return !pxt.BrowserUtils.isIE()
+    const disableForMacIos = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isMac() || pxt.BrowserUtils.isIOS());
+    return !disableForMacIos && !pxt.BrowserUtils.isIE();
 }
 
 export function screenshotAsync(ws: Blockly.WorkspaceSvg, pixelDensity?: number, encodeBlocks?: boolean): Promise<string> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2613

Just wanted to note that the `disableFileAccessinMaciOs` flag is something that gets set in the `appTheme` when the `inGame=1` query variant exists. So there's a niceness because if the file access is disabled, we shouldn't allow for screenshots, but it also is a tell that we're in game for Minecraft. 

Another point is that we are also setting `disableFileAccessInAndroid` to true with the `inGame=1` query variant. I'm thinking about adding the check for that in the `enableSnapshot` function as well. However, I think leaving snapshots on for android is fine; at least testing in browser on my phone worked great. I would need to test on a Chromebook to see if it would work in game, though.

Upload target: https://minecraft.makecode.com/app/2255ed413beea760a738e01f155fc4d9e0fe2948-a1ffd9d0b1?inGame=1#editor
There should really only be a change with Mac/Ipad with this upload target, but, if you also want to check that nothing changes on windows/android, feel free to test!