### PR TITLE
Zip downloading: added modal for successfully downloading zips in game

### DIFF
--- a/pxtblocks/layout.ts
+++ b/pxtblocks/layout.ts
@@ -226,9 +226,7 @@ export function flow(ws: Blockly.WorkspaceSvg, opts?: FlowOptions) {
 }
 
 export function screenshotEnabled(): boolean {
-    const disableForMacIos = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isMac() || pxt.BrowserUtils.isIOS());
-    const disableForAndriod = pxt.appTarget.appTheme.disableFileAccessinAndroid && pxt.BrowserUtils.isAndroid();
-    return !disableForMacIos && !pxt.BrowserUtils.isIE() && !disableForAndriod;
+    return pxt.BrowserUtils.hasFileAccess() && !pxt.BrowserUtils.isIE();
 }
 
 export function screenshotAsync(ws: Blockly.WorkspaceSvg, pixelDensity?: number, encodeBlocks?: boolean): Promise<string> {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -173,6 +173,17 @@ namespace pxt.BrowserUtils {
         return window?.innerWidth > pxt.BREAKPOINT_TABLET;
     }
 
+    export function isInGame(): boolean {
+        const inGame = /inGame=1/i.exec(window.location.href);
+        return !!inGame;
+    }
+
+    export function hasFileAccess(): boolean {
+        const disableForMacIos = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isMac() || pxt.BrowserUtils.isIOS());
+        const disableForAndroid = pxt.appTarget.appTheme.disableFileAccessinAndroid && pxt.BrowserUtils.isAndroid();
+        return !disableForMacIos && !disableForAndroid;
+
+    }
     export function noSharedLocalStorage(): boolean {
         try {
             return /nosharedlocalstorage/i.test(window.location.href);

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -318,6 +318,17 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
         this.setState({ sortedAsc: !sortedAsc });
     }
 
+    renderDownloadDialog(fileName: string) {
+        return <>
+            <div>
+                {lf("Your projects were zipped and downloaded successfully!")}
+                <br />
+                <br />
+                {lf("Look for the file {0} on your computer. It might have a number before the .zip if you've downloaded before.", fileName)}
+            </div>
+        </>;
+    }
+
     handleDownloadAsync = async () => {
         pxt.tickEvent("scriptmanager.downloadZip", undefined, { interactiveConsent: true });
 
@@ -424,11 +435,25 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
 
         const zipName = `makecode-${targetNickname}-project-download.zip`
 
-        pxt.BrowserUtils.browserDownloadDataUri(datauri, zipName);
 
         this.setState({
             download: null
         });
+
+        pxt.BrowserUtils.browserDownloadDataUri(datauri, zipName);
+        if (pxt.BrowserUtils.isInGame()) {
+            const downloadJsx = this.renderDownloadDialog(zipName);
+
+            setTimeout(async () => {
+                await core.confirmAsync({
+                    header: lf("Projects Downloaded..."),
+                    jsx: downloadJsx,
+                    hasCloseIcon: true,
+                    hideAgree: true,
+                    className: 'zipdownloaddialog',
+                })
+            }, 2000);
+        }
     }
 
     handleDownloadProgressClose = () => {
@@ -529,7 +554,7 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
                 }
                 headerActions.push(<sui.Button key="delete" icon="trash" className="icon red"
                     text={lf("Delete")} textClass="landscape only" title={lf("Delete Project")} onClick={this.handleDelete} />);
-                if (numSelected > 1) {
+                if (numSelected > 1 && pxt.BrowserUtils.hasFileAccess()) {
                     headerActions.push(<sui.Button key="download-zip" icon="download" className="icon"
                         text={lf("Download Zip")} textClass="landscape only" title={lf("Download Zip")} onClick={this.handleDownloadAsync} />);
                 }


### PR DESCRIPTION
When downloading zips in-game in Minecraft, there is no indicator that tells you that a download was successful like you get in-browser with browser built-ins. This PR adds a modal that pops up only if you are in game after downloading a zip. I also added a check for showing the download zip button because you shouldn't be able to download a zip of the projects if you can't interact with the filesystem, regardless of the target.

edit: Fixes https://github.com/microsoft/pxt-minecraft/issues/2437

![image](https://github.com/user-attachments/assets/8f56b8d2-6cfe-423c-93df-7e0e1e59bd4e)


Upload target: https://minecraft.makecode.com/app/b439897404713a96f9e8313e79029cbb195288ed-91a4b94271?inGame=1