### PR TITLE
Only download zips if you have file access

### DIFF
--- a/pxtblocks/layout.ts
+++ b/pxtblocks/layout.ts
@@ -226,9 +226,7 @@ export function flow(ws: Blockly.WorkspaceSvg, opts?: FlowOptions) {
 }
 
 export function screenshotEnabled(): boolean {
-    const disableForMacIos = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isMac() || pxt.BrowserUtils.isIOS());
-    const disableForAndriod = pxt.appTarget.appTheme.disableFileAccessinAndroid && pxt.BrowserUtils.isAndroid();
-    return !disableForMacIos && !pxt.BrowserUtils.isIE() && !disableForAndriod;
+    return pxt.BrowserUtils.hasFileAccess() && !pxt.BrowserUtils.isIE();
 }
 
 export function screenshotAsync(ws: Blockly.WorkspaceSvg, pixelDensity?: number, encodeBlocks?: boolean): Promise<string> {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -173,6 +173,17 @@ namespace pxt.BrowserUtils {
         return window?.innerWidth > pxt.BREAKPOINT_TABLET;
     }
 
+    export function isInGame(): boolean {
+        const inGame = /inGame=1/i.exec(window.location.href);
+        return !!inGame;
+    }
+
+    export function hasFileAccess(): boolean {
+        const disableForMacIos = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isMac() || pxt.BrowserUtils.isIOS());
+        const disableForAndroid = pxt.appTarget.appTheme.disableFileAccessinAndroid && pxt.BrowserUtils.isAndroid();
+        return !disableForMacIos && !disableForAndroid;
+
+    }
     export function noSharedLocalStorage(): boolean {
         try {
             return /nosharedlocalstorage/i.test(window.location.href);

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -318,6 +318,17 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
         this.setState({ sortedAsc: !sortedAsc });
     }
 
+    renderDownloadDialog(fileName: string) {
+        return <>
+            <div>
+                {lf("Your projects were zipped and downloaded successfully!")}
+                <br />
+                <br />
+                {lf("Look for the file {0} on your computer. It might have a number before the .zip if you've downloaded before.", fileName)}
+            </div>
+        </>;
+    }
+
     handleDownloadAsync = async () => {
         pxt.tickEvent("scriptmanager.downloadZip", undefined, { interactiveConsent: true });
 
@@ -424,11 +435,25 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
 
         const zipName = `makecode-${targetNickname}-project-download.zip`
 
-        pxt.BrowserUtils.browserDownloadDataUri(datauri, zipName);
 
         this.setState({
             download: null
         });
+
+        pxt.BrowserUtils.browserDownloadDataUri(datauri, zipName);
+        if (pxt.BrowserUtils.isInGame()) {
+            const downloadJsx = this.renderDownloadDialog(zipName);
+
+            setTimeout(async () => {
+                await core.confirmAsync({
+                    header: lf("Projects Downloaded..."),
+                    jsx: downloadJsx,
+                    hasCloseIcon: true,
+                    hideAgree: true,
+                    className: 'zipdownloaddialog',
+                })
+            }, 2000);
+        }
     }
 
     handleDownloadProgressClose = () => {
@@ -529,7 +554,7 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
                 }
                 headerActions.push(<sui.Button key="delete" icon="trash" className="icon red"
                     text={lf("Delete")} textClass="landscape only" title={lf("Delete Project")} onClick={this.handleDelete} />);
-                if (numSelected > 1) {
+                if (numSelected > 1 && pxt.BrowserUtils.hasFileAccess()) {
                     headerActions.push(<sui.Button key="download-zip" icon="download" className="icon"
                         text={lf("Download Zip")} textClass="landscape only" title={lf("Download Zip")} onClick={this.handleDownloadAsync} />);
                 }

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -318,17 +318,6 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
         this.setState({ sortedAsc: !sortedAsc });
     }
 
-    renderDownloadDialog(fileName: string) {
-        return <>
-            <div>
-                {lf("Your projects were zipped and downloaded successfully!")}
-                <br />
-                <br />
-                {lf("Look for the file {0} on your computer. It might have a number before the .zip if you've downloaded before.", fileName)}
-            </div>
-        </>;
-    }
-
     handleDownloadAsync = async () => {
         pxt.tickEvent("scriptmanager.downloadZip", undefined, { interactiveConsent: true });
 
@@ -435,25 +424,12 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
 
         const zipName = `makecode-${targetNickname}-project-download.zip`
 
+        pxt.BrowserUtils.browserDownloadDataUri(datauri, zipName);
 
         this.setState({
             download: null
         });
 
-        pxt.BrowserUtils.browserDownloadDataUri(datauri, zipName);
-        if (pxt.BrowserUtils.isInGame()) {
-            const downloadJsx = this.renderDownloadDialog(zipName);
-
-            setTimeout(async () => {
-                await core.confirmAsync({
-                    header: lf("Projects Downloaded..."),
-                    jsx: downloadJsx,
-                    hasCloseIcon: true,
-                    hideAgree: true,
-                    className: 'zipdownloaddialog',
-                })
-            }, 2000);
-        }
     }
 
     handleDownloadProgressClose = () => {


### PR DESCRIPTION
I forgot that there were parts of this PR (https://github.com/microsoft/pxt/pull/10255) that were actually good fixes that I wanted to keep. I realize now that I could've just reopened  that PR, but here we are. 

We shouldn't let the user download a zip of their projects if they don't have access to the file system, so I added the check to the `Download Zip` button. I moved the `hasFileAccess` function to `BrowserUtils` because of this. If there are more places where we might want to check for file access, we now have the function in a more accessible place. 

The addition of the `inGame` check to `BrowserUtils` is no longer being used, however, there were a couple of scenarios where I almost needed a check like this and I think it's just nice to have in case there are needs for it.

Upload target: https://minecraft.makecode.com/app/d06e69d2392ce4bcc73cf7790a8632c0b38adc0a-8bc3309a1d