### PR TITLE
Some link outs convert the delimiter :|: to :%7C: for being unsafe

### DIFF
--- a/webapp/public/multi.html
+++ b/webapp/public/multi.html
@@ -71,7 +71,12 @@
                 var hashLeft = ""
                 var hashRight = ""
                 var route = (window.location.hash || "#");
+                // Split using :|: as well as :%7C:
                 var parts = route.replace(/^#/, '').split(':|:', 2);
+                if (parts.length == 1) {
+                    //As some link out conver :|: to :%7C:
+                    parts = route.replace(/^#/, '').split(':%7C:', 2);
+                }
                 updateSrc(left, parts[0]);
                 updateSrc(right, parts[1]);
                 window.history.replaceState('', '', '#')


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5397

See details in the bug: https://github.com/microsoft/pxt-microbit/issues/5397#issuecomment-2440139832