### PR TITLE
Clear Additional Info on Workspace Reset

### DIFF
--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -409,6 +409,9 @@ async function resetAsync(): Promise<void> {
     const db = await getCurrentDbAsync();
     await db.deleteAllAsync(TEXTS_TABLE);
     await db.deleteAllAsync(HEADERS_TABLE);
+    await db.deleteAllAsync(SCRIPT_TABLE);
+    await db.deleteAllAsync(HOSTCACHE_TABLE);
+    await db.deleteAllAsync(GITHUB_TABLE);
 }
 
 export async function getObjectStoreAsync<T>(storeName: string) {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1723,23 +1723,24 @@ export function syncAsync(): Promise<pxt.editor.EditorSyncState> {
         });
 }
 
-export function resetAsync() {
+export async function resetAsync() {
     allScripts = []
-    return impl.resetAsync()
-        .then(cloudsync.resetAsync)
-        .then(db.destroyAsync)
-        .then(pxt.BrowserUtils.clearTranslationDbAsync)
-        .then(pxt.BrowserUtils.clearTutorialInfoDbAsync)
-        .then(compiler.clearApiInfoDbAsync)
-        .then(() => {
-            pxt.storage.clearLocal();
-            data.clearCache();
-            // keep local token (localhost and electron) on reset
-            if (Cloud.localToken)
-                pxt.storage.setLocal("local_token", Cloud.localToken);
-        })
-        .then(() => syncAsync()) // sync again to notify other tabs
-        .then(() => { });
+
+    await impl.resetAsync();
+    await cloudsync.resetAsync();
+    await db.destroyAsync();
+    await pxt.BrowserUtils.clearTranslationDbAsync();
+    await pxt.BrowserUtils.clearTutorialInfoDbAsync();
+    await compiler.clearApiInfoDbAsync();
+    pxt.storage.clearLocal();
+    data.clearCache();
+
+    // keep local token (localhost and electron) on reset
+    if (Cloud.localToken) {
+        pxt.storage.setLocal("local_token", Cloud.localToken);
+    }
+
+    await syncAsync(); // sync again to notify other tabs
 }
 
 export function loadedAsync() {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2648

Most of the tables mentioned in the bug were already being cleared, but these were not.

During my initial investigation, I was looking into the resetAsync function, so I also converted that to async/await.

Upload target: https://minecraft.makecode.com/app/06aeece4ee1fde85d8cd6cae7c8f6a4d958c6efa-e055c7f346