### PR TITLE
use bind instead of conditional bind

### DIFF
--- a/pxtblocks/fields/field_gridpicker.ts
+++ b/pxtblocks/fields/field_gridpicker.ts
@@ -193,7 +193,7 @@ export class FieldGridPicker extends Blockly.FieldDropdown implements FieldCusto
                 const xOffset = (this.sourceBlock_.RTL ? -this.tooltipConfig_.xOffset : this.tooltipConfig_.xOffset);
                 const yOffset = this.tooltipConfig_.yOffset;
 
-                Blockly.browserEvents.conditionalBind(menuItem, 'mousemove', this, (e: MouseEvent) => {
+                Blockly.browserEvents.bind(menuItem, 'pointermove', this, (e: PointerEvent) => {
                     if (hasImages) {
                         this.gridTooltip_.style.top = `${e.clientY + yOffset}px`;
                         this.gridTooltip_.style.left = `${e.clientX + xOffset}px`;
@@ -210,7 +210,7 @@ export class FieldGridPicker extends Blockly.FieldDropdown implements FieldCusto
                     tableContainer.setAttribute('aria-activedescendant', menuItem.id);
                 });
 
-                Blockly.browserEvents.conditionalBind(menuItem, 'mouseout', this, (e: MouseEvent) => {
+                Blockly.browserEvents.bind(menuItem, 'pointerout', this, (e: PointerEvent) => {
                     if (hasImages) {
                         // Hide the tooltip
                         this.gridTooltip_.style.visibility = 'hidden';


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2661

conditional bind is only used for events that are part of the current gesture (e.g. after the click has started). for hover, you need to use bind instead.