### PR TITLE
fix in game safari webview gridpicker height

### DIFF
--- a/pxtblocks/fields/field_gridpicker.ts
+++ b/pxtblocks/fields/field_gridpicker.ts
@@ -367,11 +367,11 @@ export class FieldGridPicker extends Blockly.FieldDropdown implements FieldCusto
             width: paddingContainer.offsetWidth,
             height: paddingContainer.offsetHeight
         };
-        const windowHeight = window.outerHeight;
+        const windowHeight = window.outerHeight || window.innerHeight;
 
         // Set width
         if (this.width_) {
-            const windowWidth = window.outerWidth;
+            const windowWidth = window.outerWidth || window.innerWidth;
             if (this.width_ > windowWidth) {
                 this.width_ = windowWidth;
             }


### PR DESCRIPTION
for whatever reason, the safari webview in minecraft is returning 0 for `window.outerHeight` but a correct number for `window.innerHeight`. this is definitely a browser bug given that the outerHeight should always be a bigger number than innerHeight as the name suggests.

this was causing both the block picker being too tall error and the animal picker being too short error. the difference between the two was that the block picker has the search bar, which was causing the div to be given a negative height whereas the animal picker was getting a height of 0