### PR TITLE
use anchor element for social links when in game

### DIFF
--- a/react-common/components/share/SocialButton.tsx
+++ b/react-common/components/share/SocialButton.tsx
@@ -14,50 +14,51 @@ export const SocialButton = (props: SocialButtonProps) => {
 
     const classes = classList(className, "social-button", "type")
 
-    const handleClick = () => {
+    const getSocialUrl = () => {
         const socialOptions = pxt.appTarget.appTheme.socialOptions;
-        let socialUrl = '';
 
-        pxt.tickEvent(`share.social.${type}`);
         switch (type) {
             case "facebook": {
-                socialUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
-                break;
+                return `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
             }
             case "twitter": {
                 let twitterText = lf("Check out what I made!");
                 if (socialOptions.twitterHandle && socialOptions.orgTwitterHandle) {
                     twitterText = lf("Check out what I made with @{0} and @{1}!", socialOptions.twitterHandle, socialOptions.orgTwitterHandle);
-                } else if (socialOptions.twitterHandle) {
+                }
+                else if (socialOptions.twitterHandle) {
                     twitterText = lf("Check out what I made with @{0}!", socialOptions.twitterHandle);
-                } else if (socialOptions.orgTwitterHandle) {
+                }
+                else if (socialOptions.orgTwitterHandle) {
                     twitterText = lf("Check out what I made with @{0}!", socialOptions.orgTwitterHandle);
                 }
-                socialUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}` +
+                return `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}` +
                     `&text=${encodeURIComponent(twitterText)}` +
                     (socialOptions.hashtags ? `&hashtags=${encodeURIComponent(socialOptions.hashtags)}` : '') +
                     (socialOptions.related ? `&related=${encodeURIComponent(socialOptions.related)}` : '');
-                break;
             }
             case "discourse": {
                 // https://meta.discourse.org/t/compose-a-new-pre-filled-topic-via-url/28074
-                socialUrl = `${socialOptions.discourse || "https://forum.makecode.com/"}new-topic?title=${encodeURIComponent(url)}`;
-                if (socialOptions.discourseCategory)
-                socialUrl += `&category=${encodeURIComponent(socialOptions.discourseCategory)}`;
-                break;
+                let socialUrl = `${socialOptions.discourse || "https://forum.makecode.com/"}new-topic?title=${encodeURIComponent(url)}`;
+                if (socialOptions.discourseCategory) {
+                    socialUrl += `&category=${encodeURIComponent(socialOptions.discourseCategory)}`;
+                }
+                return socialUrl;
             }
             case "google-classroom":
-                socialUrl = `https://classroom.google.com/share?url=${encodeURIComponent(url)}`;
-                break;
+                return `https://classroom.google.com/share?url=${encodeURIComponent(url)}`;
             case "microsoft-teams":
-                socialUrl = `https://teams.microsoft.com/share?href=${encodeURIComponent(url)}`;
-                break;
+                return `https://teams.microsoft.com/share?href=${encodeURIComponent(url)}`;
             case "whatsapp":
-                socialUrl = `https://api.whatsapp.com/send?text=${encodeURIComponent(url)}`;
-                break;
+                return `https://api.whatsapp.com/send?text=${encodeURIComponent(url)}`;
         }
-        pxt.BrowserUtils.popupWindow(socialUrl, heading, 600, 600);
     }
+
+    const handleClick = () => {
+        pxt.tickEvent(`share.social.${type}`);
+    }
+
+    const useLink = pxt.BrowserUtils.isInGame();
 
     switch (type) {
         // Icon buttons
@@ -65,20 +66,30 @@ export const SocialButton = (props: SocialButtonProps) => {
         case "twitter":
         case "discourse":
         case "whatsapp":
-            return <Button className={classes}
-                ariaLabel={type}
-                title={heading}
-                leftIcon={`icon ${type}`}
-                onClick={handleClick} />
+            return (
+                <Button className={classes}
+                    ariaLabel={type}
+                    title={heading}
+                    leftIcon={`icon ${type}`}
+                    onClick={handleClick}
+                    asAnchorElement={useLink}
+                    href={getSocialUrl()}
+                />
+            );
 
         // Image buttons
         case "google-classroom":
         case "microsoft-teams":
-            return <Button className={classes}
-                ariaLabel={type}
-                title={heading}
-                label={<img src={`/static/logo/social-buttons/${type}.png`} alt={heading || pxt.U.rlf(type)} />}
-                onClick={handleClick} />
+            return (
+                <Button className={classes}
+                    ariaLabel={type}
+                    title={heading}
+                    label={<img src={`/static/logo/social-buttons/${type}.png`} alt={heading || pxt.U.rlf(type)} />}
+                    onClick={handleClick}
+                    href={getSocialUrl()}
+                    asAnchorElement={useLink}
+                />
+            )
     }
 
 

--- a/react-common/styles/controls/Button.less
+++ b/react-common/styles/controls/Button.less
@@ -279,6 +279,13 @@ a.common-button.menu-button {
     }
 }
 
+a.common-button.square-button {
+    appearance: button;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 
 /****************************************************
  *                   Circle Buttons                 *


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2668

the in-game webview on macos doesn't support any of the window open APIs that the browser provides.`<a>` elements work though, so this PR replaces the social buttons with `<a>` elements.

normally i would just replace these for all platforms since `<a>` elements are usually better for accessibility, but the only way to open a pop up window is with js and i think that's the expected behavior for social buttons. doesn't matter for the in-game experience given that those all open in the browser outside the game anyhow.