### PR TITLE
fix cdn check for node

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -32,7 +32,7 @@ namespace pxt.Cloud {
     export function useCdnApi() {
         return pxt.webConfig && !pxt.webConfig.isStatic
             && !BrowserUtils.isLocalHost() && !!pxt.webConfig.cdnUrl
-            && !/nocdn=1/i.test(window.location.href);
+            && (typeof window === "undefined" || !/nocdn=1/i.test(window.location.href));
     }
 
     export function cdnApiUrl(url: string) {


### PR DESCRIPTION
@thomasjball brought it to my attention that mkc was failing with a weird error when trying to fetch github repo dependencies. turns out it was crashing on this code because window isn't defined in node.

this will need to be ported over to micro:bit stable