### PR TITLE
[Stable11.2] handle repopaths with github prefix

### DIFF
--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -537,6 +537,9 @@ export function initGitHubDb() {
         }
 
         async loadTutorialMarkdown(repopath: string, tag?: string) {
+            if (repopath.indexOf(":") !== -1) {
+                repopath = repopath.split(":").pop();
+            }
             const cache = await getGitHubCacheAsync();
 
             const id = this.tutorialCacheKey(repopath, tag);


### PR DESCRIPTION
cherry pick https://github.com/microsoft/pxt/pull/10282 to minecraft stable