### PR TITLE
move github init after app target setup

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5963,10 +5963,11 @@ document.addEventListener("DOMContentLoaded", async () => {
         pxt.blocks.showBlockIdInTooltip = true;
     }
 
-    initGitHubDb();
 
     pxt.perf.measureStart("setAppTarget");
     pkg.setupAppTarget((window as any).pxtTargetBundle);
+
+    initGitHubDb();
 
     // DO NOT put any async code before this line! The serviceworker must be initialized before
     // the window load event fires


### PR DESCRIPTION
noticed this exception in the console; initGithubDb is called before the app target is being set which was throwing an exception. the exception happens in an async context so it wasn't actually causing any errors but it does prevent the indexeddb from purging  expired entries