### PR TITLE
backwards compatibility for github tutorial paths

### DIFF
--- a/tests/pxt-editor-test/editorrunner.ts
+++ b/tests/pxt-editor-test/editorrunner.ts
@@ -340,6 +340,33 @@ describe("updateHistory", () => {
     });
 });
 
+
+describe("pxt.github.normalizeTutorialPath", () => {
+    const testPath = "Mojang/EducationContent/computing/unit-2/lesson-1";
+
+    it("should parse repos of the format owner/repo/path/to/file", () => {
+        chai.expect(pxt.github.normalizeTutorialPath(testPath)).equals(testPath);
+    });
+
+    it("should parse repos of the format github:owner/repo/path/to/file", () => {
+        const path = "github:" + testPath;
+        chai.expect(pxt.github.normalizeTutorialPath(path)).equals(testPath);
+    });
+
+    it("should parse repos of the format https://github.com/owner/repo/path/to/file", () => {
+        const path = "https://github.com/" + testPath;
+        chai.expect(pxt.github.normalizeTutorialPath(path)).equals(testPath);
+
+        const path2 = "http://github.com/" + testPath;
+        chai.expect(pxt.github.normalizeTutorialPath(path2)).equals(testPath);
+    });
+
+    it("should parse actual links to markdown files in github", () => {
+        const url = "https://github.com/Mojang/EducationContent/blob/master/computing/unit-2/lesson-1.md";
+        chai.expect(pxt.github.normalizeTutorialPath(url)).equals(testPath);
+    });
+});
+
 function createProjectText(): pxt.workspace.ScriptText {
     // A realistic timeline of project edits
     const dates = [

--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -537,9 +537,8 @@ export function initGitHubDb() {
         }
 
         async loadTutorialMarkdown(repopath: string, tag?: string) {
-            if (repopath.indexOf(":") !== -1) {
-                repopath = repopath.split(":").pop();
-            }
+            repopath = pxt.github.normalizeTutorialPath(repopath);
+
             const cache = await getGitHubCacheAsync();
 
             const id = this.tutorialCacheKey(repopath, tag);


### PR DESCRIPTION
re: https://github.com/microsoft/pxt/issues/10279#issuecomment-2492435819

this restores compatibility with this tutorial URL format:

```
https://minecraft.makecode.com/#tutorial:https://github.com/mojang/educationcontent/computing/unit-2/lesson-1
```

note that the URL here is not a valid github url. going to https://github.com/mojang/educationcontent/computing/unit-2/lesson-1 will result in a 404. however, we used to support this format so i'm restoring that support.

i also added support for actual links to markdown files in github, for example https://github.com/Mojang/EducationContent/blob/master/computing/unit-2/lesson-1.md

and i added tests for all of these.

this will have to be ported to stable yet again