### PR TITLE
allow packages to filter the toolbox

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -93,6 +93,10 @@ declare namespace pxt {
         theme?: string | pxt.Map<string>;
         assetPack?: boolean; // if set to true, only the assets of this project will be imported when added as an extension (no code)
         assetPacks?: Map<boolean>; // a map of dependency id to boolean that indicates which dependencies should be imported as asset packs
+        toolboxFilter?: {
+            namespaces: {[index: string]: "visible" | "hidden" | "disabled"},
+            blocks: {[index: string]: "visible" | "hidden" | "disabled"},
+        }
     }
 
     interface PackageExtension {

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -2,6 +2,7 @@
 import * as srceditor from "./srceditor";
 import * as toolbox from "./toolbox";
 import * as compiler from "./compiler";
+import { getProjectToolboxFilters } from "./package";
 
 export abstract class ToolboxEditor extends srceditor.Editor {
 
@@ -17,11 +18,32 @@ export abstract class ToolboxEditor extends srceditor.Editor {
     abstract getBlocksForCategory(ns: string, subns?: string): toolbox.BlockDefinition[];
 
     protected shouldShowBlock(blockId: string, ns: string, shadow?: boolean) {
-        const filters = this.parent.state.editorState && this.parent.state.editorState.filters;
+        let filters = this.parent.state.editorState && this.parent.state.editorState.filters;
+
+        const projectFilter = getProjectToolboxFilters();
+
+        if (projectFilter) {
+            if (filters) {
+                // tutorial filters override project filters
+                pxt.U.jsonMergeFrom(projectFilter, filters);
+            }
+
+            filters = projectFilter;
+        }
+
+
         if (filters) {
-            // block-level filters should not apply to shadow blocks (nested)
-            const blockFilter = filters.blocks && (filters.blocks[blockId] || (this.blockIdMap && this.blockIdMap[blockId]?.some(id => filters.blocks[id])));
+            let blockFilter: pxt.editor.FilterState | boolean;
+            if (filters.blocks) {
+                if (filters.blocks[blockId] !== undefined) {
+                    blockFilter = filters.blocks[blockId];
+                }
+                else {
+                    blockFilter = this.blockIdMap && this.blockIdMap[blockId]?.some(id => filters.blocks[id]);
+                }
+            }
             const categoryFilter = filters.namespaces && filters.namespaces[ns];
+            // block-level filters should not apply to shadow blocks (nested)
             // First try block filters
             if (blockFilter != undefined && blockFilter == pxt.editor.FilterState.Hidden && !shadow) return false;
             if (blockFilter != undefined) return true;


### PR DESCRIPTION
this adds the ability for projects and extensions to filter the toolbox. inspired by https://forum.makecode.com/t/creating-micro-bit-sandbox-restrict-available-blocks/32008

an extension or project can add a "toolboxFilter" entry in `pxt.json` like so:

```json
{
    "toolboxFilter": {
        "blocks": {
            "device_show_leds": "hidden"
        },
        "namespaces": {
            "pins": "hidden"
        }
    }
}
```

the possible values for each block or category are "hidden", "visible", and "disabled", though i don't think disabled actually does anything? i'm just matching the values we have available in our current toolbox filtering for tutorials and afaik disabled is just ignored.

toolbox filters are merged starting with the leaf extensions in the dependency tree and moving upwards to the main package. in other words, the top-level project overrides its dependencies, which override their dependencies, etc.

these filters can all be overridden by the filters that exist today. e.g., tutorial blocks filters will always trump project blocks filters.