### PR TITLE
Adding tutorial tool beta option to ev3 beta

### DIFF
--- a/docs/static/tutorial-tool/tutorial.js
+++ b/docs/static/tutorial-tool/tutorial.js
@@ -88,22 +88,22 @@ var targets = [
                 url: "https://maker.makecode.com/?controller=1"
             }
         ]
-    }
-    /* not supported
-    , {
+    }, {
         name: "LEGO EV3",
         id: "ev3",
         endpoints: [
+            /*
+            {
+                name: "",
+                url: "https://makecode.mindstorms.com?controller=1"
+            },
+            */
             {
                 name: "beta",
                 url: "https://makecode.mindstorms.com/beta?controller=1"
-            },
-            {
-                name: "released",
-                url: "https://makecode.mindstorms.com?controller=1"
             }
         ]
-    } */
+    }
 ];
 function shareScript(md, done) {
     function request(url, data) {


### PR DESCRIPTION
Add to tutorial tool ev3 beta.
https://github.com/microsoft/pxt/issues/10253#issuecomment-2513284973

I didn't understand if I need to change tutorial.ts
https://github.com/microsoft/pxt/blob/master/docs/static/tutorial-tool/tutorial.ts