### PR TITLE
Show AI Criteria in Teacher Tool

### DIFF
--- a/common-docs/teachertool/catalog-shared.json
+++ b/common-docs/teachertool/catalog-shared.json
@@ -1,6 +1,30 @@
 {
     "criteria": [
         {
+            "id": "499F3572-E655-4DEE-953B-5F26BF0191D7",
+            "use": "ai_question",
+            "template": "Ask AI: ${question}",
+            "description": "Experimental: AI outputs may not be accurate. Use with caution and always review responses.",
+            "docPath": "/teachertool",
+            "maxCount": 5,
+            "tags": ["General"],
+            "requestFeedback": true,
+            "params": [
+                {
+                    "name": "question",
+                    "type": "longString",
+                    "maxCharacters": 1000,
+                    "paths": ["checks[0].question"]
+                },
+                {
+                    "name": "shareid",
+                    "type": "system",
+                    "key": "SHARE_ID",
+                    "paths": ["checks[0].shareId"]
+                }
+            ]
+        },
+        {
             "id": "59AAC5BA-B0B3-4389-AA90-1E767EFA8563",
             "use": "block_used_n_times",
             "template": "${Block} used at least ${count} time(s)",

--- a/common-docs/teachertool/test/catalog-shared.json
+++ b/common-docs/teachertool/test/catalog-shared.json
@@ -1,28 +1,3 @@
 {
-    "criteria": [
-        {
-            "id": "499F3572-E655-4DEE-953B-5F26BF0191D7",
-            "use": "ai_question",
-            "template": "Ask AI: ${question}",
-            "description": "Experimental: AI outputs may not be accurate. Use with caution and always review responses.",
-            "docPath": "/teachertool",
-            "maxCount": 5,
-            "tags": ["General"],
-            "requestFeedback": true,
-            "params": [
-                {
-                    "name": "question",
-                    "type": "longString",
-                    "maxCharacters": 1000,
-                    "paths": ["checks[0].question"]
-                },
-                {
-                    "name": "shareid",
-                    "type": "system",
-                    "key": "SHARE_ID",
-                    "paths": ["checks[0].shareId"]
-                }
-            ]
-        }
-    ]
+    "criteria": []
 }

--- a/common-docs/teachertool/test/validator-plans-shared.json
+++ b/common-docs/teachertool/test/validator-plans-shared.json
@@ -1,16 +1,3 @@
 {
-    "validatorPlans": [
-        {
-            ".desc": "Ask Copilot a question",
-            "name": "ai_question",
-            "threshold": -1,
-            "checks": [
-                {
-                    "validator": "aiQuestion",
-                    "question": "",
-                    "shareId": ""
-                }
-            ]
-        }
-    ]
+    "validatorPlans": []
 }

--- a/common-docs/teachertool/validator-plans-shared.json
+++ b/common-docs/teachertool/validator-plans-shared.json
@@ -294,6 +294,18 @@
                     "blockType": "math_number"
                 }
             ]
+        },
+        {
+            ".desc": "Ask Copilot a question",
+            "name": "ai_question",
+            "threshold": -1,
+            "checks": [
+                {
+                    "validator": "aiQuestion",
+                    "question": "",
+                    "shareId": ""
+                }
+            ]
         }
     ]
 }

--- a/teachertool/src/transforms/setEvalResult.ts
+++ b/teachertool/src/transforms/setEvalResult.ts
@@ -13,21 +13,21 @@ function reportChanges(criteriaId: string, result: CriteriaResult) {
     const previousResult = teacherTool.evalResults[criteriaId];
     const criteriaInstance = getCriteriaInstanceWithId(teacherTool, criteriaId);
 
-    if (previousResult.result != result.result) {
+    if (previousResult?.result != result?.result) {
         pxt.tickEvent(Ticks.SetEvalResultOutcome, {
             catalogCriteriaId: criteriaInstance?.catalogCriteriaId ?? "",
             newValue: EvaluationStatus[result.result],
             oldValue: previousResult?.result ? EvaluationStatus[previousResult.result] : "",
-            newValueIsManual: result.resultIsManual + "",
+            newValueIsManual: result?.resultIsManual + "",
             oldValueIsManual: previousResult?.resultIsManual + "",
         });
     }
 
-    if (previousResult.notes != result.notes) {
+    if (previousResult?.notes != result?.notes) {
         // Setting notes is debounced so this isn't too noisy.
         pxt.tickEvent(Ticks.SetEvalResultNotes, {
             catalogCriteriaId: criteriaInstance?.catalogCriteriaId ?? "",
-            newLength: result.notes?.length ?? 0,
+            newLength: result?.notes?.length ?? 0,
             oldLength: previousResult?.notes?.length ?? 0,
         });
     }

--- a/teachertool/src/transforms/setEvalResult.ts
+++ b/teachertool/src/transforms/setEvalResult.ts
@@ -13,21 +13,21 @@ function reportChanges(criteriaId: string, result: CriteriaResult) {
     const previousResult = teacherTool.evalResults[criteriaId];
     const criteriaInstance = getCriteriaInstanceWithId(teacherTool, criteriaId);
 
-    if (previousResult?.result != result?.result) {
+    if (previousResult.result != result.result) {
         pxt.tickEvent(Ticks.SetEvalResultOutcome, {
             catalogCriteriaId: criteriaInstance?.catalogCriteriaId ?? "",
             newValue: EvaluationStatus[result.result],
             oldValue: previousResult?.result ? EvaluationStatus[previousResult.result] : "",
-            newValueIsManual: result?.resultIsManual + "",
+            newValueIsManual: result.resultIsManual + "",
             oldValueIsManual: previousResult?.resultIsManual + "",
         });
     }
 
-    if (previousResult?.notes != result?.notes) {
+    if (previousResult.notes != result.notes) {
         // Setting notes is debounced so this isn't too noisy.
         pxt.tickEvent(Ticks.SetEvalResultNotes, {
             catalogCriteriaId: criteriaInstance?.catalogCriteriaId ?? "",
-            newLength: result?.notes?.length ?? 0,
+            newLength: result.notes?.length ?? 0,
             oldLength: previousResult?.notes?.length ?? 0,
         });
     }


### PR DESCRIPTION
This puts the AI criteria & validation plan in our normal (non-test) catalog for the teacher tool. <s>Also fixes a null-ref I hit while testing</s> (moving to separate PR).

After this change, users will no longer need to add the `tc=1` url param to see the criteria.