### PR TITLE
Fix localisation of help docs for langs like 'fr'

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -2006,25 +2006,16 @@ function shouldEventHideFlyout(ev: Blockly.Events.Abstract) {
 function resolveLocalizedMarkdown(url: string) {
     const editorPackage = pkg.getEditorPkg(pkg.mainPkg);
 
-    const [initialLang, baseLang, initialLangLowerCase] = pxt.Util.normalizeLanguageCode(pxt.Util.userLanguage());
-
     const splitPath = url.split("/");
     const fileName = splitPath.pop();
     const dirName = splitPath.join("/");
 
-    let pathsToTest: string[];
-
-    if (initialLang && baseLang && initialLangLowerCase) {
-        pathsToTest = [
-            `${dirName}/_locales/${initialLang}/${fileName}`,
-            `${dirName}/_locales/${initialLangLowerCase}/${fileName}`,
-            `${dirName}/_locales/${baseLang}/${fileName}`,
-            url
-        ];
-    }
-    else {
-        pathsToTest = [url];
-    }
+    const [initialLang, baseLang, initialLangLowerCase] = pxt.Util.normalizeLanguageCode(pxt.Util.userLanguage());
+    const priorityOrder = [initialLang, initialLangLowerCase, baseLang].filter((lang) => typeof lang === "string")
+    const pathsToTest = [
+        ...priorityOrder.map(lang =>`${dirName}/_locales/${lang}/${fileName}`),
+        url
+    ]
 
     for (const path of pathsToTest) {
         const file = editorPackage.lookupFile(path);


### PR DESCRIPTION
For French the code is 'fr' which just returns a single part. We can just use whichever parts are returned for the paths.

@riknoll spotted this testing out #10307, we were lucky/unlucky enough to pick French to try it out.