### PR TITLE
fix extra render trigger when initializing expandable blocks

### DIFF
--- a/pxtblocks/composableMutations.ts
+++ b/pxtblocks/composableMutations.ts
@@ -345,9 +345,18 @@ export function initExpandableBlock(info: pxtc.BlocksInfo, b: Blockly.Block, def
         Blockly.Events.disable();
 
         try {
-            const nb = Blockly.Xml.domToBlock(shadow, b.workspace);
-            if (nb) {
-                input.connection.connect(nb.outputConnection);
+            let newBlock: Blockly.Block;
+            if (!b.initialized) {
+                // use domToBlockInternal so that we don't trigger a render while
+                // the block is still being initialized
+                newBlock = Blockly.Xml.domToBlockInternal(shadow, b.workspace);
+            }
+            else {
+                newBlock = Blockly.Xml.domToBlock(shadow, b.workspace);
+            }
+
+            if (newBlock) {
+                input.connection.connect(newBlock.outputConnection);
             }
         } catch (e) { }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6580

another rendering bug that was very hard to track down but easy to fix. this one should maybe be hotfixed to minecraft but i don't think microbit has any expandable blocks...