### PR TITLE
clean up shadow blocks in insertion markers for expandable blocks

### DIFF
--- a/pxtblocks/composableMutations.ts
+++ b/pxtblocks/composableMutations.ts
@@ -350,6 +350,17 @@ export function initExpandableBlock(info: pxtc.BlocksInfo, b: Blockly.Block, def
                 // use domToBlockInternal so that we don't trigger a render while
                 // the block is still being initialized
                 newBlock = Blockly.Xml.domToBlockInternal(shadow, b.workspace);
+
+                // we don't know at this time whether the parent block is an insertion marker
+                // or not. doing this check lets us clean up the block in the case that it is,
+                // though we get an annoying flicker
+                setTimeout(() => {
+                    if (newBlock.isInsertionMarker()) {
+                        Blockly.Events.disable();
+                        newBlock.dispose();
+                        Blockly.Events.enable();
+                    }
+                })
             }
             else {
                 newBlock = Blockly.Xml.domToBlock(shadow, b.workspace);


### PR DESCRIPTION
not an ideal solution, but this fixes the insertion marker bug i mentioned in standup. here's what the bug looks like:

![insertion-marker-expanded](https://github.com/user-attachments/assets/8ffdc7da-ef16-4034-8978-ebde68323f69)
