### PR TITLE
fix shadow block generation for non-array blocks that return arrays

### DIFF
--- a/pxtblocks/toolbox.ts
+++ b/pxtblocks/toolbox.ts
@@ -100,7 +100,7 @@ export function createShadowValue(info: pxtc.BlocksInfo, p: pxt.blocks.BlockPara
     const value = document.createElement("value");
     value.setAttribute("name", p.definitionName);
 
-    const isArray = isArrayType(p.type);
+    const isArray = (shadowId === "lists_create_with" || !shadowId) ? isArrayType(p.type) : undefined;
 
     const shadow = document.createElement(((isVariable || isArray) && !parentIsShadow) ? "block" : "shadow");
 


### PR DESCRIPTION
we had a bug where a toolbox block would not be recursively expanded if a shadow block within it happened to return something with an array type. this pr simply prevents the logic we have for the lists_create_with block from running if the shadow block id is not lists_create_with