### PR TITLE
Fix broken link find "Code Evaluation Tool" blog post

### DIFF
--- a/docs/blog/tools/code-eval-tool.md
+++ b/docs/blog/tools/code-eval-tool.md
@@ -10,7 +10,7 @@ Watch this short video to see how to get started:
 
 https://youtu.be/7pA2EbG4QPk
 
-More documentation can be found on the [Code Evaluation Tool]([https://makecode.microbit.org/code-eval-tool) info page.
+More documentation can be found on the [Code Evaluation Tool](https://makecode.microbit.org/code-eval-tool) info page.
 
 The Code Evaluation tool has been released as a Beta – meaning that it’s still a work-in-progress. We have ideas on how we could improve it, but we want to hear from you! Please try it out and click on the Give Feedback button to let us know your thoughts - https://makecode.microbit.org/--eval.
 


### PR DESCRIPTION
Ugh, fix a messed up link in the blog post for "Code Evaluation Tool".

Closes #10338