### PR TITLE
Add new animation editor keyboard shortcuts

### DIFF
--- a/docs/asset-editor-shortcuts.md
+++ b/docs/asset-editor-shortcuts.md
@@ -15,7 +15,7 @@ These shortcuts allow you to quickly switch between the tools in the editor.
 | **u**          | Rectangle tool |
 | **c**          | Circle tool |
 | **m**          | Marquee tool |
-| **h**          | Pan tool |
+| **q**          | Pan tool |
 | **space**      | Temporarily enter pan mode (release space to return to previous tool) |
 | **alt**        | Temporarily enter eyedropper mode (release alt to return to previous tool)
 
@@ -40,16 +40,17 @@ These shortcuts are used to perform advanced edit operations on sprites or tilem
 
 Each of these shortcuts are affected by the marquee tool.
 If a portion of the asset is selected by the marquee tool, then the shortcut transformation will only apply to the selected area.
+If editing an animation, add the **shift** key to the shortcut to affect all frames at once.
 
 | Shortcut       | Description |
 | -------------- | ----------- |
-| **shift + h**  | Flip horizontally |
-| **shift + v**  | Flip vertically |
+| **Arrow Key**  | Move marquee tool selection by one pixel |
+| **backspace**  | Delete current marquee tool selection |
+| **h**          | Flip horizontally |
+| **v**          | Flip vertically |
 | **]**          | Rotate clockwise |
 | **[**          | Rotate counterclockwise |
-| **Arrow Key**  | Move marquee tool selection by one pixel |
-| **shift + r**  | Replace all instances of selected background color/tile with selected foreground color/tile |
-| **backspace**  | Delete current marquee tool selection |
+| **r**          | Replace all instances of selected background color/tile with selected foreground color/tile |
 
 
 ## Image/Animation editor-only shortcuts
@@ -60,4 +61,6 @@ These shortcuts are only available in the image and animation editors (not the t
 | ---------------------------------- | ----------- |
 | **shift + 1-9** or **shift + a-f** | Outline the current image with the color in the palette corresponding to the selected number. For example, **shift + f** will outline with color number 15 (black) |
 | **0-9**                            | Select a foreground color from the palette (first ten colors only) |
+| **.**                              | Advance forwards one frame in the current animation |
+| **,**                              | Advance backwards one frame in the current animation |
 

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -291,34 +291,6 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
 
         this.hasInteracted = true;
 
-        if (this.shouldHandleCanvasShortcut() && this.editState?.floating?.image) {
-            let moved = false;
-
-            switch (ev.key) {
-                case 'ArrowLeft':
-                    this.editState.layerOffsetX = Math.max(this.editState.layerOffsetX - 1, -this.editState.floating.image.width);
-                    moved = true;
-                    break;
-                case 'ArrowUp':
-                    this.editState.layerOffsetY = Math.max(this.editState.layerOffsetY - 1, -this.editState.floating.image.height);
-                    moved = true;
-                    break;
-                case 'ArrowRight':
-                    this.editState.layerOffsetX = Math.min(this.editState.layerOffsetX + 1, this.editState.width);
-                    moved = true;
-                    break;
-                case 'ArrowDown':
-                    this.editState.layerOffsetY = Math.min(this.editState.layerOffsetY + 1, this.editState.height);
-                    moved = true;
-                    break;
-            }
-
-            if (moved) {
-                this.props.dispatchImageEdit(this.editState.toImageState());
-                ev.preventDefault();
-            }
-        }
-
         if (!ev.repeat) {
             // prevent blockly's ctrl+c / ctrl+v handler
             if ((ev.ctrlKey || ev.metaKey) && (ev.key === 'c' || ev.key === 'v')) {
@@ -333,11 +305,6 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
             if (ev.key == "Escape" && this.editState?.floating?.image && this.shouldHandleCanvasShortcut()) {
                 // TODO: If there isn't currently a marqueed selection, escape should save and close the field editor
                 this.cancelSelection();
-                ev.preventDefault();
-            }
-
-            if ((ev.key === "Backspace" || ev.key === "Delete") && this.editState?.floating?.image && this.shouldHandleCanvasShortcut()) {
-                this.deleteSelection();
                 ev.preventDefault();
             }
 
@@ -980,11 +947,6 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
 
     protected cancelSelection() {
         this.editState.mergeFloatingLayer();
-        this.props.dispatchImageEdit(this.editState.toImageState());
-    }
-
-    protected deleteSelection() {
-        this.editState.floating = null;
         this.props.dispatchImageEdit(this.editState.toImageState());
     }
 

--- a/webapp/src/components/ImageEditor/actions/dispatch.ts
+++ b/webapp/src/components/ImageEditor/actions/dispatch.ts
@@ -43,4 +43,4 @@ export const dispatchDisableResize = () => ({ type: actions.DISABLE_RESIZE })
 export const dispatchChangeAssetName = (name: string) => ({ type: actions.CHANGE_ASSET_NAME, name });
 
 export const dispatchOpenAsset = (asset: pxt.Asset, keepPast: boolean, gallery?: GalleryTile[]) => ({ type: actions.OPEN_ASSET, asset, keepPast, gallery })
-export const dispatchSetFrames = (frames: pxt.sprite.ImageState[]) => ({ type: actions.SET_FRAMES, frames });
+export const dispatchSetFrames = (frames: pxt.sprite.ImageState[], currentFrame?: number) => ({ type: actions.SET_FRAMES, frames, currentFrame });

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -149,10 +149,10 @@ function handleKeyDown(event: KeyboardEvent) {
             advanceFrame(false);
             break;
         case "r":
-            doReplace();
+            doColorReplace();
             break;
         case "R":
-            doReplaceAllFrames();
+            doColorReplaceAllFrames();
             break;
         case "ArrowLeft":
             moveMarqueeSelection(-1, 0, event.shiftKey);
@@ -280,7 +280,7 @@ export function replaceColor(fromColor: number, toColor: number) {
     dispatchAction(dispatchImageEdit(replaced.toImageState()));
 }
 
-function doReplace() {
+function doColorReplace() {
     const state = store.getState();
 
     const fromColor = state.editor.backgroundColor;
@@ -291,13 +291,13 @@ function doReplace() {
     dispatchAction(dispatchImageEdit(replaced.toImageState()));
 }
 
-function doReplaceAllFrames() {
+function doColorReplaceAllFrames() {
     const state = store.getState();
 
     const fromColor = state.editor.backgroundColor;
     const toColor = state.editor.selectedColor;
 
-    editAllFrames(doReplace, editState => replaceColorEdit(editState, fromColor, toColor))
+    editAllFrames(doColorReplace, editState => replaceColorEdit(editState, fromColor, toColor))
 }
 
 export function advanceFrame(forwards: boolean) {

--- a/webapp/src/components/ImageEditor/store/imageReducer.ts
+++ b/webapp/src/components/ImageEditor/store/imageReducer.ts
@@ -432,7 +432,7 @@ const animationReducer = (state: AnimationState, action: any): AnimationState =>
             return {
                 ...state,
                 frames: action.frames,
-                currentFrame: 0
+                currentFrame: action.currentFrame || 0
             };
         default:
             return state;


### PR DESCRIPTION
this tweaks a lot of existing shortcuts and adds a few more that are specific to the animation editor. all of the shortcuts that are affected by the marquee tool can now be combined with the `shift` key to affect all animation frames at the same time. for example:

![new-anim-shortcuts](https://github.com/user-attachments/assets/d7fc23dc-8375-433a-8b04-242014b95fcf)

look at the timeline in that GIF to see all of the frames editing at once.

this also means that all of the shortcuts that were previously tied to uppercase letters have now been moved to the lowercase versions of those letters. the shifted versions will still work, but will affect all frames in animations. they are unchanged in the image/tilemap editor. also the pan tool shortcut was moved from `h` to `q` so as not to conflict with the horizontal flip shortcut. this breaks from the standard set by most image editors for pan, but i'm guessing most people use the spacebar anyhow.

finally, two new shortcuts were added for advancing the animation frame forwards and backwards