### PR TITLE
need to start the simulator after create to avoid race

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -810,8 +810,8 @@ namespace pxsim {
                 let wrapper = this.createFrame();
                 this.container.appendChild(wrapper);
                 frame = wrapper.firstElementChild as HTMLIFrameElement;
-            } else // reuse simulator
-                this.startFrame(frame);
+            }
+            this.startFrame(frame);
 
             this.debuggingFrame = frame.id;
 


### PR DESCRIPTION
A very infrequent race condition occurs where the extension's simulator appears and the micro:bit simulator never appears. This is very curious, as the extension simulator can only be invoked by static typescript (user-level code), which must be executing, which should bring up the micro:bit simulator.  The problem is that the start function of simulatorDriver does not start the simulator in the case when it is being created the first time.  Most often, some other path then creates the simulator, and the start function is called, which does start the simulator. But this change ensures the the micro:bit simulator will always appear first.

![Image](https://github.com/user-attachments/assets/08f3de47-a951-474d-8e38-0a15e157485e)