### PR TITLE
Add animation editor shortcuts for moving frames in the timeline

### DIFF
--- a/docs/asset-editor-shortcuts.md
+++ b/docs/asset-editor-shortcuts.md
@@ -63,4 +63,7 @@ These shortcuts are only available in the image and animation editors (not the t
 | **0-9**                            | Select a foreground color from the palette (first ten colors only) |
 | **.**                              | Advance forwards one frame in the current animation |
 | **,**                              | Advance backwards one frame in the current animation |
-
+| **PageDown**                       | Swap the current animation frame with the next frame in the timeline |
+| **PageUp**                         | Swap the current animation frame with the previous frame in the timeline |
+| **shift + PageDown**               | Rotate all frames in the animation forwards one frame |
+| **shift + PageUp**                 | Rotate all frames in the animation backwards one frame |

--- a/react-common/components/controls/Button.tsx
+++ b/react-common/components/controls/Button.tsx
@@ -80,11 +80,18 @@ export const Button = (props: ButtonProps) => {
     );
 
     let clickHandler = (ev: React.MouseEvent) => {
-        if (onRightClick && ev.button !== 0) onRightClick();
-        else if (onClick) onClick();
+        if (onClick) onClick();
         if (href) window.open(href, target || "_blank", "noopener,noreferrer")
         ev.stopPropagation();
         ev.preventDefault();
+    }
+
+    let rightClickHandler = (ev: React.MouseEvent) => {
+        if (onRightClick) {
+            onRightClick();
+            ev.stopPropagation();
+            ev.preventDefault();
+        }
     }
 
     return (
@@ -95,6 +102,7 @@ export const Button = (props: ButtonProps) => {
             title={title}
             ref={buttonRef}
             onClick={!disabled ? clickHandler : undefined}
+            onContextMenu={rightClickHandler}
             onKeyDown={onKeydown || fireClickOnEnter}
             onBlur={onBlur}
             role={role || "button"}

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -363,30 +363,6 @@ export function moveFrame(forwards: boolean, allFrames = false) {
     dispatchAction(dispatchSetFrames(newFrames, nextFrame));
 }
 
-export function moveAllFrames(forwards: boolean) {
-    const state = store.getState();
-
-    if (state.editor.isTilemap) return;
-
-    const present = state.store.present as AnimationState;
-
-    if (present.frames.length <= 1) return;
-
-    let nextFrame: number;
-    if (forwards) {
-        nextFrame = (present.currentFrame + 1) % present.frames.length;
-    }
-    else {
-        nextFrame = (present.currentFrame + present.frames.length - 1) % present.frames.length;
-    }
-
-    const newFrames = present.frames.slice();
-
-    newFrames
-
-    dispatchAction(dispatchSetFrames(newFrames, nextFrame));
-}
-
 function editAllFrames(singleFrameShortcut: () => void, doEdit: (editState: EditState) => EditState) {
     const state = store.getState();
 

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -148,6 +148,12 @@ function handleKeyDown(event: KeyboardEvent) {
         case ",":
             advanceFrame(false);
             break;
+        case "PageDown":
+            moveFrame(true, event.shiftKey);
+            break;
+        case "PageUp":
+            moveFrame(false, event.shiftKey);
+            break;
         case "r":
             doColorReplace();
             break;
@@ -318,6 +324,67 @@ export function advanceFrame(forwards: boolean) {
     }
 
     dispatchAction(dispatchChangeCurrentFrame(nextFrame));
+}
+
+export function moveFrame(forwards: boolean, allFrames = false) {
+    const state = store.getState();
+
+    if (state.editor.isTilemap) return;
+
+    const present = state.store.present as AnimationState;
+
+    if (present.frames.length <= 1) return;
+
+    let nextFrame: number;
+    if (forwards) {
+        nextFrame = (present.currentFrame + 1) % present.frames.length;
+    }
+    else {
+        nextFrame = (present.currentFrame + present.frames.length - 1) % present.frames.length;
+    }
+
+    const newFrames = present.frames.slice();
+
+
+    if (allFrames) {
+        if (forwards) {
+            newFrames.unshift(newFrames.pop());
+        }
+        else {
+            newFrames.push(newFrames.shift());
+        }
+    }
+    else {
+        const currentFrame = newFrames[present.currentFrame];
+        newFrames.splice(present.currentFrame, 1);
+        newFrames.splice(nextFrame, 0, currentFrame);
+    }
+
+    dispatchAction(dispatchSetFrames(newFrames, nextFrame));
+}
+
+export function moveAllFrames(forwards: boolean) {
+    const state = store.getState();
+
+    if (state.editor.isTilemap) return;
+
+    const present = state.store.present as AnimationState;
+
+    if (present.frames.length <= 1) return;
+
+    let nextFrame: number;
+    if (forwards) {
+        nextFrame = (present.currentFrame + 1) % present.frames.length;
+    }
+    else {
+        nextFrame = (present.currentFrame + present.frames.length - 1) % present.frames.length;
+    }
+
+    const newFrames = present.frames.slice();
+
+    newFrames
+
+    dispatchAction(dispatchSetFrames(newFrames, nextFrame));
 }
 
 function editAllFrames(singleFrameShortcut: () => void, doEdit: (editState: EditState) => EditState) {


### PR DESCRIPTION
adds four new shortcuts:

* **PageUp** - Swap the current animation frame with the previous frame in the timeline
* **PageDown** - Swap the current animation frame with the next frame in the timeline
* **shift + PageUp** - Rotate all frames in the animation backwards one frame
* **shift + PageDown** - Rotate all frames in the animation forwards one frame

also fixes the right click handler on react-common buttons which i guess i never tested