### PR TITLE
put root z-index above blockly widgets when sim is fullscreen

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1374,6 +1374,8 @@ p.ui.font.small {
         fuyllscreensim
 *******************************/
 .fullscreensim {
+    z-index: @aboveEverythingZIndex;
+
     /* Full screen */
     .simPanel {
         position: fixed;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2410

this issue might be filed in a few more places, this was the only instance i knew of.
 fixes the bug where you can still see blockly field editors when the sim is made fullscreen