### PR TITLE
fix connection checks for draggable shadows

### DIFF
--- a/pxtblocks/plugins/duplicateOnDrag/connectionChecker.ts
+++ b/pxtblocks/plugins/duplicateOnDrag/connectionChecker.ts
@@ -1,5 +1,5 @@
 import * as Blockly from "blockly";
-import { shouldDuplicateOnDrag } from "./duplicateOnDrag";
+import { isAllowlistedShadow, shouldDuplicateOnDrag } from "./duplicateOnDrag";
 
 
 const OPPOSITE_TYPE: number[] = [];
@@ -16,7 +16,13 @@ export class DuplicateOnDragConnectionChecker extends Blockly.ConnectionChecker 
 
         const replacedBlock = b.targetBlock();
 
-        if (replacedBlock && shouldDuplicateOnDrag(replacedBlock)) return false;
+        if (
+            replacedBlock &&
+            shouldDuplicateOnDrag(replacedBlock) &&
+            !(replacedBlock.isShadow() && isAllowlistedShadow(replacedBlock))
+        ) {
+            return false;
+        }
 
         return true;
     }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6640

needs to be cherry picked to minecraft and mbit. the connection checker was being a little overzealous in the connections it disallowed