### PR TITLE
Terminate TOC recursion on full filepath match

### DIFF
--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -211,7 +211,7 @@ namespace pxt.docs {
                     return true
                 }
             }
-            if (d.filepath && !!m.path && d.filepath.indexOf(m.path) == 0) {
+            if (d.filepath && !!m.path && d.filepath == m.path) {
                 tocPath.push(m)
                 return true
             }


### PR DESCRIPTION
The TOC/breadcrumb match is relying on an `indexOf() == 0` check instead of a full string match. Therefore a path string of `code-eval-tool` will match both of the TOC entries for `code-eval-tool` and `code` with a recursive TOC lookup. This will render an aggregated breadcrumb of both the TOC entries.

**Note**: The fix included here is a suggestion for a full path match. You can offer better or more efficient check.

Closes https://github.com/microsoft/pxt-microbit/issues/6069 