### PR TITLE
fix animation timeline drag and drop and add edge scrolling

### DIFF
--- a/theme/image-editor/timeline.less
+++ b/theme/image-editor/timeline.less
@@ -23,7 +23,7 @@
     height: 6rem;
     margin: 0 0.4rem;
 
-    transition: border 0.2s, color 0.2s, background-color 0.2s;
+    transition: border 0.2s, color 0.2s;
     overflow: hidden;
     position: relative;
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6641

this fixes the issue where the click target for dragging an animation frame was off and adds automatic scrolling when you drag the animation frame to the edge.

enjoy this poorly cropped gif:

![edge-scroll](https://github.com/user-attachments/assets/8654e999-814a-4de5-ad27-61edb47d4eed)
