### PR TITLE
filter serialized tilemaps to only include used ones

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -736,6 +736,19 @@ namespace pxt.sprite {
         pxt.sprite.trimTilemapTileset(result);
     }
 
+    export function isTilemapEmptyOrUnused(asset: ProjectTilemap, project: TilemapProject, projectFiles: pxt.Map<{content: string}>) {
+        const walls = sprite.Bitmap.fromData(asset.data.layers);
+        for (let x = 0; x < asset.data.tilemap.width; x++) {
+            for (let y = 0; y < asset.data.tilemap.height; y++) {
+                if (asset.data.tilemap.get(x, y) || walls.get(x, y)) {
+                    return false;
+                }
+            }
+        }
+
+        return !project.isAssetUsed(asset, projectFiles);
+    }
+
     function imageLiteralPrologue(fileType: "typescript" | "python", templateLiteral = "img"): string {
         let res = '';
         switch (fileType) {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -506,7 +506,7 @@ export class EditorPackage {
         const existingTS = this.lookupFile("this/" + pxt.TILEMAP_CODE);
         const existingJRES = this.lookupFile("this/" + pxt.TILEMAP_JRES);
 
-        const jres = this.tilemapProject.getProjectTilesetJRes();
+        const jres = this.tilemapProject.getProjectTilesetJRes(this.files);
 
         if (!existingTS && Object.keys(jres).length === 1) return Promise.resolve();
 


### PR DESCRIPTION
my riknoll/arcade-overworld extension has a block with a ton of tilemaps in it that you can expand using +/- mutator buttons. because of how our tilemap field editor works, an asset gets created for every one of these fields regardless of whether it's actually expanded in the project or not. as a result, your project gets flooded with hundred of tilemaps that you aren't even using.

this change isn't a proper fix for that issue, but it does at least prevent those tilemaps from being included in the compiled binary. the proper fix is to change how fields work so that those maps are lazily allocated. in any case, this is a good change even if we do eventually fix that root cause.