### PR TITLE
only push undo in asset editor if something changed

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -211,18 +211,9 @@ namespace pxt.sprite {
         }
 
         equals(other: TilemapData) {
-            if (!(this.tilemap.equals(other.tilemap)
-                && this.tileset.tileWidth == other.tileset.tileWidth
-                && this.tileset.tiles.length == other.tileset.tiles.length
-                && bitmapEquals(this.layers, other.layers))) {
-                    return false;
-            }
-
-            for (let i = 0; i < this.tileset.tiles.length; i++) {
-                if (!assetEquals(this.tileset.tiles[i], other.tileset.tiles[i])) return false;
-            }
-
-            return true;
+            return this.tilemap.equals(other.tilemap) &&
+                tilesetEquals(this.tileset, other.tileset) &&
+                bitmapEquals(this.layers, other.layers);
         }
     }
 
@@ -803,6 +794,11 @@ namespace pxt.sprite {
 
     export function bitmapEquals(a: pxt.sprite.BitmapData, b: pxt.sprite.BitmapData) {
         return pxt.sprite.Bitmap.fromData(a).equals(pxt.sprite.Bitmap.fromData(b));
+    }
+
+    export function tilesetEquals(a: TileSet, b: TileSet) {
+        return a.tileWidth === b.tileWidth &&
+            pxt.U.arrayEquals(a.tiles, b.tiles, assetEquals);
     }
 
     export function tileWidthToTileScale(tileWidth: number) {

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1769,8 +1769,9 @@ namespace pxt {
 
     }
 
-    export function assetEquals(a: Asset, b: Asset) {
+    export function assetEquals(a: Asset, b: Asset): boolean {
         if (a == b) return true;
+        if (!a && b || !b && a) return false;
         if (a.id !== b.id || a.type !== b.type ||
             !U.arrayEquals(a.meta.tags, b.meta.tags) ||
             !U.arrayEquals(a.meta.blockIDs, b.meta.blockIDs) ||

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -292,6 +292,8 @@ function doColorReplace() {
     const fromColor = state.editor.backgroundColor;
     const toColor = state.editor.selectedColor;
 
+    if (fromColor === toColor) return;
+
     const [ editState ] = currentEditState();
     const replaced = replaceColorEdit(editState, fromColor, toColor);
     dispatchAction(dispatchImageEdit(replaced.toImageState()));
@@ -302,6 +304,8 @@ function doColorReplaceAllFrames() {
 
     const fromColor = state.editor.backgroundColor;
     const toColor = state.editor.selectedColor;
+
+    if (fromColor === toColor) return;
 
     editAllFrames(doColorReplace, editState => replaceColorEdit(editState, fromColor, toColor))
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6645

it's just as the title says! plus a little refactoring of the various equals implementations