### PR TITLE
Tweaks to performance metrics handling

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -1146,6 +1146,7 @@ declare namespace pxt.editor {
         webUsbPairDialogAsync?: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<number>) => Promise<number>;
         mkPacketIOWrapper?: (io: pxt.packetio.PacketIO) => pxt.packetio.PacketIOWrapper;
         onPostHostMessage?: (msg: pxt.editor.EditorMessageRequest) => void;
+        perfMeasurementThresholdMs?: number;
         onPerfMilestone?: (payload: { milestone: string, time: number, params?: Map<string> }) => void;
         onPerfMeasurement?: (payload: { name: string, start: number, duration: number, params?: Map<string> }) => void;
     

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -439,7 +439,7 @@ export function postHostMessageAsync(msg: pxt.editor.EditorMessageRequest): Prom
         // Note this is a one-way notification. Responses are not supported.
         if (pxt.commands.onPostHostMessage) {
             try {
-                pxt.commands.onPostHostMessage(msg);
+                pxt.commands.onPostHostMessage(env);
             } catch (err) {
                 pxt.reportException(err);
             }

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -39,6 +39,7 @@ namespace pxt.commands {
     export let webUsbPairDialogAsync: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<WebUSBPairResult>, implicitlyCalled?: boolean) => Promise<WebUSBPairResult> = undefined;
     export let onTutorialCompleted: () => void = undefined;
     export let onPostHostMessage: (msg: any /*pxt.editor.EditorMessageRequest*/) => void;
+    export let perfMeasurementThresholdMs: number = undefined;
     export let onPerfMilestone: (payload: { milestone: string, time: number, params?: Map<string> }) => void = undefined;
     export let onPerfMeasurement: (payload: { name: string, start: number, duration: number, params?: Map<string> }) => void = undefined;
     export let workspaceLoadedAsync: () => Promise<void> = undefined;

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -8,8 +8,9 @@
 
 namespace pxt.perf {
     export type EventSource<T> = {
-        subscribe(listener: (payload: T) => void): () => void;
-        //emit(payload: T): void; // not used externally
+        subscribe(listener: (ev: T) => void): () => void;
+        //emit(ev: T): void; // not used externally
+        //forEach(listener: (ev: T) => void): void; // not used externally
     };
 
     // These functions are defined in docfiles/pxtweb/cookieCompliance.ts
@@ -19,8 +20,11 @@ namespace pxt.perf {
     export declare function recordMilestone(msg: string, params?: Map<string>): void;
     export declare function measureStart(name: string): void;
     export declare function measureEnd(name: string, params?: Map<string>): void;
-    export declare const onMilestone: EventSource<{ milestone: string, time: number, params?: Map<string> }>;
-    export declare const onMeasurement: EventSource<{ name: string, start: number, duration: number, params?: Map<string> }>;
+    export declare let measurementThresholdMs: number;
+    export declare const stats: {
+        milestones: EventSource<{ milestone: string, time: number, params?: Map<string> }>;
+        durations: EventSource<{ name: string, start: number, duration: number, params?: Map<string> }>;
+    };
 }
 (function () {
     // Sometimes these aren't initialized, for example in tests. We only care about them

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2774,7 +2774,7 @@ export class ProjectView
     }
 
     private editorLoaded() {
-        pxt.tickEvent('app.editor');
+        pxt.tickEvent('app.editor', { projectHeaderId: this.state.header?.id });
     }
 
     unloadProjectAsync(home?: boolean) {
@@ -4982,7 +4982,8 @@ export class ProjectView
             this.postTutorialLoaded();
         }
 
-        pxt.perf.recordMilestone(Milestones.EditorContentLoaded);
+        pxt.perf.recordMilestone(Milestones.EditorContentLoaded, { projectHeaderId: this.state.header?.id });
+
         if (!this.autoRunOnStart()) {
             pxt.analytics.trackPerformanceReport();
         }
@@ -5893,11 +5894,14 @@ function initExtensionsAsync(): Promise<void> {
                     monacoToolbox.overrideToolbox(res.toolboxOptions.monacoToolbox);
                 }
             }
+            if (typeof res.perfMeasurementThresholdMs === "number") {
+                pxt.perf.measurementThresholdMs = res.perfMeasurementThresholdMs;
+            }
             if (res.onPerfMilestone) {
-                pxt.perf.onMilestone.subscribe(res.onPerfMilestone);
+                pxt.perf.stats.milestones.subscribe(res.onPerfMilestone);
             }
             if (res.onPerfMeasurement) {
-                pxt.perf.onMeasurement.subscribe(res.onPerfMeasurement);
+                pxt.perf.stats.durations.subscribe(res.onPerfMeasurement);
             }
             cmds.setExtensionResult(res);
         });

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -236,7 +236,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     } catch { }
                     this.loadingXml = false;
                     this.loadingXmlPromise = null;
-                    pxt.perf.measureEnd(Measurements.DomUpdateLoadBlockly)
+                    pxt.perf.measureEnd(Measurements.DomUpdateLoadBlockly, { projectHeaderId: this.parent.state.header?.id });
                     // Do Not Remove: This is used by the skillmap
                     this.parent.onEditorContentLoaded();
                 });

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -90,7 +90,7 @@ export class Projects extends auth.Component<ISettingsProps, ProjectsState> {
     }
 
     chgHeader(hdr: pxt.workspace.Header) {
-        pxt.tickEvent("projects.header");
+        pxt.tickEvent("projects.header", { projectHeaderId: hdr?.id });
         core.showLoading("changeheader", lf("loading..."));
         this.props.parent.loadHeaderAsync(hdr)
             .catch(e => {


### PR DESCRIPTION
Changes in this PR:
* **Caching change**: Allow previously logged performance events to be sent to listeners that subscribe after the fact.
* **Configurable duration threshold**: Made the threshold for measurement reporting dynamic and configurable by the target extension. This preserves the default behavior while allowing targets to change it once they're initialized.
* **Include project id**: When available, include project header id in perf events.
