### PR TITLE
Remove block dropdown menu separator from keyboard navigation

### DIFF
--- a/pxtblocks/plugins/newVariableField/fieldDropdownMixin.ts
+++ b/pxtblocks/plugins/newVariableField/fieldDropdownMixin.ts
@@ -109,6 +109,10 @@ class HorizontalRuleMenuItem extends Blockly.MenuItem {
     getId(): string {
         return this.element_.id;
     }
+
+    isEnabled(): boolean {
+        return false;
+    }
 }
 
 Blockly.Css.register(`


### PR DESCRIPTION
Blockly dropdown menus that include a `HorizontalRuleMenuItem` (menu separator) as a `MenuItem` have an issue where the menu separator becomes the selected menu item in a non-obvious way when navigating the dropdown via keyboard. 

See the video below for an example of this. Keyboard navigation should only visit the 4 'real' items in this dropdown, however, it also visits the menu separator as a 5th item.

https://github.com/user-attachments/assets/962f7043-bee6-4246-8810-f1a5aff5ae49

This PR disables the separator menu item so that it is ignored by keyboard navigation.