### PR TITLE
Fix key handling after simulator is made full screen

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3651,9 +3651,8 @@ export class ProjectView
         if (this.state.collapseEditorTools) {
             this.expandSimulator();
         }
-        if (!enabled) {
+        if (enabled) {
             document.addEventListener('keydown', this.closeOnEscape);
-            simulator.driver.focus();
         } else {
             document.removeEventListener('keydown', this.closeOnEscape);
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3653,6 +3653,7 @@ export class ProjectView
         }
         if (enabled) {
             document.addEventListener('keydown', this.closeOnEscape);
+            simulator.driver.focus();
         } else {
             document.removeEventListener('keydown', this.closeOnEscape);
         }


### PR DESCRIPTION
After triggering the full screen simulator, the "escape" key does nothing. After minimising the simulator using the relevant button, the "escape" key now triggers the full screen simulator.

The logic in the code appears to be inverted. The call to focus the simulator also seems dubious as it feels like the best thing to do is leave focus on the fullscreen toggle button in both the expand and collapse case, however, I'd welcome feedback on this.

This PR fixes the inverted logic in the code ~~and removes the dubious focus call~~.

