### PR TITLE
Remove deprecated 'parseInt' from card pages

### DIFF
--- a/common-docs/reference/string.md
+++ b/common-docs/reference/string.md
@@ -6,11 +6,13 @@ Functions to combine, split, and search text strings.
 "".charAt(0)
 "".compare("")
 "".substr(0, 0)
-parseInt("")
+parseFloat("")
 "".indexOf("")
 "".includes("")
 "".split(",")
 "".isEmpty()
+"".charAt(0)
+"".charCodeAt(0)
 ```
 
 ## See also
@@ -18,4 +20,5 @@ parseInt("")
 [char at](/reference/text/char-at), [compare](/reference/text/compare),
 [substr](/reference/text/substr), [parse float](/reference/text/parse-float),
 [index of](/reference/text/index-of), [includes](/reference/text/includes),
-[split](/reference/text/split), [is empty](/reference/text/is-empty)
+[split](/reference/text/split), [is empty](/reference/text/is-empty),
+[char-at](/reference/text/char-at), [char-code-at](/reference/text/char-code-at)

--- a/common-docs/reference/text.md
+++ b/common-docs/reference/text.md
@@ -3,15 +3,22 @@
 Functions to combine, split, and search text strings.
 
 ```cards
-"".charAt(0);
-"".compare("");
-"".substr(0, 0);
-parseFloat("");
-parseInt("");
+"".charAt(0)
+"".compare("")
+"".substr(0, 0)
+parseFloat("")
+"".indexOf("")
+"".includes("")
+"".split(",")
+"".isEmpty()
+"".charAt(0)
+"".charCodeAt(0)
 ```
 
 ## See also
 
 [char at](/reference/text/char-at), [compare](/reference/text/compare),
-[substr](/reference/text/substr), [parse int](/reference/text/parse-int), 
-[parse float](/reference/text/parse-float)
+[substr](/reference/text/substr), [parse float](/reference/text/parse-float),
+[index of](/reference/text/index-of), [includes](/reference/text/includes),
+[split](/reference/text/split), [is empty](/reference/text/is-empty),
+[char-at](/reference/text/char-at), [char-code-at](/reference/text/char-code-at)


### PR DESCRIPTION
Remove the deprecated `parseInt()` function from card pages. Add in the newer `char-at()` methods.

Closes https://github.com/microsoft/pxt-arcade/issues/6576