### PR TITLE
perform tilemap upgrade on xml instead of workspace

### DIFF
--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -193,14 +193,18 @@ export class FieldTileset extends FieldImages implements FieldCustom {
             if (newValue) {
                 const project = pxt.react.getTilemapProject();
                 const match = /^\s*assets\s*\.\s*tile\s*`([^`]*)`\s*$/.exec(newValue);
+                let tile: pxt.Tile;
 
                 if (match) {
-                    const tile = project.lookupAssetByName(pxt.AssetType.Tile, match[1]);
+                    tile = project.lookupAssetByName(pxt.AssetType.Tile, match[1]);
+                }
+                else if (newValue.startsWith(pxt.sprite.TILE_NAMESPACE)) {
+                    tile = project.lookupAsset(pxt.AssetType.Tile, newValue.trim());
+                }
 
-                    if (tile) {
-                        this.localTile = tile;
-                        return newValue;
-                    }
+                if (tile) {
+                    this.localTile = tile;
+                    return pxt.getTSReferenceForAsset(tile, false);
                 }
             }
 

--- a/pxtblocks/importer.ts
+++ b/pxtblocks/importer.ts
@@ -31,7 +31,10 @@ export function domToWorkspaceNoEvents(dom: Element, workspace: Blockly.Workspac
     let newBlockIds: string[] = [];
     patchCommentIds(dom);
     patchShadows(dom, false);
-    updateTilemapXml(dom, pxt.react.getTilemapProject());
+
+    if (pxt.react.getTilemapProject) {
+        updateTilemapXml(dom, pxt.react.getTilemapProject());
+    }
 
     try {
         Blockly.Events.disable();

--- a/pxtblocks/importer.ts
+++ b/pxtblocks/importer.ts
@@ -3,7 +3,7 @@
 import * as Blockly from "blockly";
 import { blockSymbol, buildinBlockStatements, hasArrowFunction, initializeAndInject } from "./loader";
 import { extensionBlocklyPatch } from "./external";
-import { FieldBase } from "./fields";
+import { FieldBase, updateTilemapXml } from "./fields";
 
 export interface BlockSnippet {
     target: string; // pxt.appTarget.id
@@ -31,6 +31,8 @@ export function domToWorkspaceNoEvents(dom: Element, workspace: Blockly.Workspac
     let newBlockIds: string[] = [];
     patchCommentIds(dom);
     patchShadows(dom, false);
+    updateTilemapXml(dom, pxt.react.getTilemapProject());
+
     try {
         Blockly.Events.disable();
         newBlockIds = Blockly.Xml.domToWorkspace(dom, workspace);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -322,8 +322,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.cleanXmlForWorkspace(xml);
             pxtblockly.domToWorkspaceNoEvents(xml, this.editor);
 
-            pxtblockly.upgradeTilemapsInWorkspace(this.editor, pxt.react.getTilemapProject());
-
             this.initLayout(xml);
             this.editor.clearUndo();
             this.reportDeprecatedBlocks();

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -899,7 +899,6 @@ function upgradeFromBlocksAsync(): Promise<UpgradeResult> {
 
             const xml = Blockly.utils.xml.textToDom(text);
             pxtblockly.domToWorkspaceNoEvents(xml, ws);
-            pxtblockly.upgradeTilemapsInWorkspace(ws, pxt.react.getTilemapProject());
             const upgradedXml = pxtblockly.workspaceToDom(ws);
             patchedFiles[pxt.MAIN_BLOCKS] = Blockly.Xml.domToText(upgradedXml);
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6602
fixes https://github.com/microsoft/pxt-arcade/issues/6635
fixes https://github.com/microsoft/pxt-arcade/issues/6601

our old method of upgrading tilemaps doesn't seem to be working with the new blockly; when blockly sets the values of the created fields the field validation code is causing their values to be overwritten before we can perform our upgrades.

to bypass that issue, i converted the upgrade code to be performed directly on the blocks xml instead of the workspace.

also, since people might not be familiar with this ancient code, this is the upgrade logic that i put into place ages ago when we started having a concept of "assets" in projects. previously we stored the tileset in the variables of the blockly workspace and that's what the tileset field drew its options from. tilemap blocks also just inlined all of the tilemap data instead of compiling down to an asset reference