### PR TITLE
set a default offset for block comments with no position data

### DIFF
--- a/pxtblocks/plugins/comments/blockComment.ts
+++ b/pxtblocks/plugins/comments/blockComment.ts
@@ -402,7 +402,7 @@ export class CommentIcon extends Blockly.icons.Icon {
             );
         }
 
-        return undefined;
+        return new Blockly.utils.Coordinate(16, 16);
     }
 
     private clearSavedOffsetData() {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6593

with the new blockly, the block comments i implemented now remember the position you leave them in. old projects, however, don't have any comment position data stored with them so they were just getting jostled around into random locations when being imported.

this pr sets an offset of 16 pixels for x/y to mimic the behavior of the old editor for old projects