### PR TITLE
don't decompile non-shadow blocks within shadows

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -175,6 +175,7 @@ namespace ts.pxtc.decompiler {
         value: OutputNode;
         shadowType?: string;
         shadowMutation?: pxt.Map<string>;
+        emitShadowOnly?: boolean;
     }
 
     interface MutationChild {
@@ -3929,6 +3930,10 @@ ${output}</xml>`;
     }
 
     function shouldEmitShadowOnly(n: ValueNode) {
+        if (n.emitShadowOnly !== undefined) {
+            return n.emitShadowOnly;
+        }
+
         let emitShadowOnly = false;
 
         if (n.value.kind === "expr") {
@@ -3948,10 +3953,21 @@ ${output}</xml>`;
                     case "logic_boolean":
                     case "text":
                         emitShadowOnly = !n.shadowType;
-                        break
+                        break;
+                }
+            }
+
+            if (emitShadowOnly && value.inputs) {
+                for (const input of value.inputs) {
+                    if (!shouldEmitShadowOnly(input)) {
+                        emitShadowOnly = false;
+                        break;
+                    }
                 }
             }
         }
+
+        n.emitShadowOnly = emitShadowOnly;
 
         return emitShadowOnly;
     }

--- a/tests/decompile-test/baselines/compile_hidden_arguments.blocks
+++ b/tests/decompile-test/baselines/compile_hidden_arguments.blocks
@@ -45,7 +45,8 @@
 <block type="soundExpression_playSoundEffect">
 <field name="mode">SoundExpressionPlayMode.UntilDone</field>
 <value name="sound">
-<shadow type="soundExpression_createSoundEffect">
+<shadow type="soundExpression_createSoundEffect"/>
+<block type="soundExpression_createSoundEffect">
 <mutation _expanded="5" />
 <field name="waveShape">WaveShape.Sine</field>
 <field name="effect">SoundExpressionEffect.None</field>
@@ -92,13 +93,14 @@
 <field name="SLIDER">50</field>
 </shadow>
 </value>
-</shadow>
+</block>
 </value>
 <next>
 <block type="soundExpression_playSoundEffect">
 <field name="mode">SoundExpressionPlayMode.UntilDone</field>
 <value name="sound">
-<shadow type="soundExpression_createSoundEffect">
+<shadow type="soundExpression_createSoundEffect"/>
+<block type="soundExpression_createSoundEffect">
 <mutation _expanded="3" />
 <field name="waveShape">WaveShape.Sine</field>
 <field name="effect">SoundExpressionEffect.None</field>
@@ -145,7 +147,7 @@
 </value>
 </block>
 </value>
-</shadow>
+</block>
 </value>
 </block>
 </next>


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6592

mainline blockly strictly enforces that shadow blocks cannot have non-shadow children, but there are still some cases where code like that is generated by the decompiler. it doesn't matter for project code since that code gets patched to fix this issue, but the block config decompiled code doesn't get patched.

rather than just apply the patches to the decompiled code here, i figured it was easy enough to just fix it from the source.