### PR TITLE
stop sound effect editor dropdown css from affecting other components

### DIFF
--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -38,6 +38,10 @@
     .link-button {
         margin-left: 1.8rem;
     }
+
+    .common-menu-dropdown-pane {
+        width: 8rem !important;
+    }
 }
 
 .sound-effect-editor-content {
@@ -73,9 +77,6 @@
     margin-bottom: 0.5rem;
 }
 
-.common-menu-dropdown-pane {
-    width: 8rem !important;
-}
 
 /****************************************************
  *                      Graphs                      *


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6579

some css from the sound effect editor was tainting the color palette dropdown. fix is to nest it inside the sound effect editor's parent class