### PR TITLE
Fix inverted logic for dropdown aria

### DIFF
--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -310,13 +310,13 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
         const aria = {
             'role': role || 'combobox',
             'aria-disabled': disabled,
-            'aria-haspopup': !!disabled,
+            'aria-haspopup': !disabled,
             'aria-expanded': open
         }
         const menuAria = {
             'role': 'menu',
             'aria-label': lf("Dropdown menu {0}", title),
-            'aria-hidden': !!open
+            'aria-hidden': !open
         }
         const classes = cx([
             'ui',


### PR DESCRIPTION
The dropdown menu contents are currently `aria-hidden="true"` when the menu is open, and `aria-haspopup` has a similar inverted logic bug. This PR fixes the inverted logic for both attributes.