### PR TITLE
Prevent extensions page from being triggered unintentionally

### DIFF
--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -558,7 +558,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
         };
         _cachedBuiltinCategories[CategoryNameID.Extensions] = {
             name: pxt.toolbox.addPackageTitle(),
-            nameid: 'addpackage',
+            nameid: CategoryNameID.Extensions,
             blocks: [],
             custom: true,
             customClick: (theEditor: monaco.Editor) => {
@@ -566,6 +566,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 theEditor.showPackageDialog();
                 return true;
             },
+            onlyTriggerOnClick: true,
             attributes: {
                 advanced: false,
                 weight: -1,


### PR DESCRIPTION
When navigating the Toolbox using the keyboard arrow keys while in JavaScript or Python mode, as soon as the "Extensions" category is selected, it opens unexpectedly. This PR adds the `onlyTriggerOnClick` field to match the more expected behaviour in Blocks mode.