### PR TITLE
Fix "Enter" on dropdown to match mouse click behaviour

### DIFF
--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -292,7 +292,9 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
             if (activeChild) {
                 activeChild.click();
             } else {
-                this.toggle(true);
+                if (!this.props.onClick || this.props.onClick()) {
+                    this.toggle(true);
+                }
             }
         } else if (activeElementIndex === children.length - 1 && !e.shiftKey && charCode === core.TAB_KEY) {
             if (activeChild) {


### PR DESCRIPTION
This is minor tweak to the `sui.DropdownMenu` component to ensure that "Enter" or "Space" via the keyboard match mouse click behaviour. This discrepancy was noticed when using keyboard controls on the "Sign In" button which unexpectedly opened a menu. See screenshot below:

![image](https://github.com/user-attachments/assets/7cae5454-a363-46d2-8aae-c88c56126aab)
