### PR TITLE
Don't close projects settings menu on toggle high contrast

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -250,7 +250,6 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
 
     toggleHighContrast() {
         pxt.tickEvent("home.togglecontrast", undefined, { interactiveConsent: true });
-        this.hide();
         core.toggleHighContrast();
     }
 


### PR DESCRIPTION
Toggling high contrast mode on the home screen currently closes the settings menu and moves browser focus to the body. This change keeps the settings menu open and maintains focus on the toggle button. This matches the behaviour of the high contrast toggle in the settings menu when the editor is open.