### PR TITLE
Fix isFocusable for FocusList component

### DIFF
--- a/react-common/components/controls/FocusList.tsx
+++ b/react-common/components/controls/FocusList.tsx
@@ -59,7 +59,7 @@ export const FocusList = (props: FocusListProps) => {
 
     const isFocusable = (e: HTMLElement) => {
         return e.getAttribute("data-isfocusable") === "true"
-            && getComputedStyle(e).display !== "none";
+            && !!e.offsetParent;
     }
 
     const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {

--- a/react-common/components/controls/FocusList.tsx
+++ b/react-common/components/controls/FocusList.tsx
@@ -59,7 +59,7 @@ export const FocusList = (props: FocusListProps) => {
 
     const isFocusable = (e: HTMLElement) => {
         return e.getAttribute("data-isfocusable") === "true"
-            && !!e.offsetParent;
+            && e.offsetParent !== null;
     }
 
     const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {

--- a/react-common/components/util.tsx
+++ b/react-common/components/util.tsx
@@ -111,7 +111,7 @@ export function findNextFocusableElement(elements: HTMLElement[], focusedIndex: 
             index += increment;
         }
     }
-    return findNextFocusableElement(elements, focusedIndex, index, forward);
+    return findNextFocusableElement(elements, focusedIndex, index, forward, isFocusable);
 }
 
 export function isFocusable(e: HTMLElement) {


### PR DESCRIPTION
Focus appears to get stuck while using the keyboard to navigate the versions in the "Version History" feature when parent tree items are not expanded. See the point at which focus becomes stuck in the screenshot below:

![image](https://github.com/user-attachments/assets/0d5bacc8-a075-49a2-9a83-87e6ff0f0a05)

The `isFocusable` method checks the visibility of the sub-tree item using its computed display property, but this does not take into account that the item's parent div is hidden.

This PR uses `offsetParent` as an alternative approach to checking element visibility. In addition, `findNextFocusableElement` now passes the optional isFocusable argument to itself when called recursively.

The [`getComputedStyle` approach is still used in `findNextFocusableElement` as a fallback](https://github.com/microsoft/pxt/blob/master/react-common/components/util.tsx#L103), but perhaps not unreasonably so.

@microbit-matt-hillsdon 