### PR TITLE
add copy/paste to context menu and restrict tutorial pasting

### DIFF
--- a/pxtblocks/contextMenu/blockItems.ts
+++ b/pxtblocks/contextMenu/blockItems.ts
@@ -3,12 +3,13 @@ import * as Blockly from "blockly";
 import { openHelpUrl } from "../external";
 
 // Lower weight is higher in context menu
-enum BlockContextWeight {
+export enum BlockContextWeight {
     Duplicate = 10,
+    Copy = 15,
     AddComment = 20,
     ExpandCollapse = 30,
     DeleteBlock = 40,
-    Help = 50
+    Help = 50,
 }
 
 export function registerBlockitems() {

--- a/pxtblocks/contextMenu/workspaceItems.ts
+++ b/pxtblocks/contextMenu/workspaceItems.ts
@@ -4,7 +4,8 @@ import { flow, screenshotAsync, screenshotEnabled, setCollapsedAll } from "../la
 import { openWorkspaceSearch } from "../external";
 
 // Lower weight is higher in context menu
-enum WorkspaceContextWeight {
+export enum WorkspaceContextWeight {
+    Paste = 10,
     DeleteAll = 20,
     FormatCode = 30,
     CollapseBlocks = 40,

--- a/pxtblocks/copyPaste.ts
+++ b/pxtblocks/copyPaste.ts
@@ -1,5 +1,7 @@
 import * as Blockly from "blockly";
 import { getCopyPasteHandlers } from "./external";
+import { BlockContextWeight } from "./contextMenu/blockItems";
+import { WorkspaceContextWeight } from "./contextMenu/workspaceItems";
 
 let oldCopy: Blockly.ShortcutRegistry.KeyboardShortcut;
 let oldCut: Blockly.ShortcutRegistry.KeyboardShortcut;
@@ -21,6 +23,8 @@ export function initCopyPaste() {
     registerCopy();
     registerCut();
     registerPaste();
+    registerCopyContextMenu();
+    registerPasteContextMenu();
 }
 
 function registerCopy() {
@@ -29,15 +33,7 @@ function registerCopy() {
         preconditionFn(workspace) {
             return oldCopy.preconditionFn(workspace);
         },
-        callback(workspace, e, shortcut) {
-            const handler = getCopyPasteHandlers()?.copy;
-
-            if (handler) {
-                return handler(workspace, e);
-            }
-
-            return oldCopy.callback(workspace, e, shortcut);
-        },
+        callback: copy,
         // the registered shortcut from blockly isn't an array, it's some sort
         // of serialized object so we have to convert it back to an array
         keyCodes: [oldCopy.keyCodes[0], oldCopy.keyCodes[1], oldCopy.keyCodes[2]],
@@ -72,17 +68,122 @@ function registerPaste() {
         preconditionFn(workspace) {
             return oldPaste.preconditionFn(workspace);
         },
-        callback(workspace, e, shortcut) {
-            const handler = getCopyPasteHandlers()?.paste;
-
-            if (handler) {
-                return handler(workspace, e);
-            }
-
-            return oldPaste.callback(workspace, e, shortcut);
-        },
+        callback: paste,
         keyCodes: [oldPaste.keyCodes[0], oldPaste.keyCodes[1], oldPaste.keyCodes[2]],
     };
 
     Blockly.ShortcutRegistry.registry.register(pasteShortcut);
+}
+
+function registerCopyContextMenu() {
+    const copyOption: Blockly.ContextMenuRegistry.RegistryItem = {
+        displayText: () => lf("Copy"),
+        preconditionFn: scope => {
+            const block = scope.block;
+            if (block.isInFlyout || !block.isMovable() || !block.isEditable()) {
+                return "hidden";
+            }
+
+            const handlers = getCopyPasteHandlers();
+
+            if (handlers) {
+                return handlers.copyPrecondition(scope);
+            }
+
+            return "enabled";
+        },
+        callback: function (scope: Blockly.ContextMenuRegistry.Scope, e: PointerEvent): void {
+            const block = scope.block;
+
+            if (!block) return;
+
+            block.select();
+            copy(block.workspace, e);
+        },
+        scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+        weight: BlockContextWeight.Copy,
+        id: "makecode-copy-block"
+    };
+
+    const copyCommentOption: Blockly.ContextMenuRegistry.RegistryItem = {
+        displayText: () => lf("Copy"),
+        preconditionFn: scope => {
+            const comment = scope.comment;
+            if (!comment.isMovable() || !comment.isEditable()) {
+                return "hidden";
+            }
+
+            const handlers = getCopyPasteHandlers();
+
+            if (handlers) {
+                return handlers.copyPrecondition(scope);
+            }
+
+            return "enabled";
+        },
+        callback: function (scope: Blockly.ContextMenuRegistry.Scope, e: PointerEvent): void {
+            const comment = scope.comment;
+
+            if (!comment) return;
+
+            comment.select();
+            copy(comment.workspace, e);
+        },
+        scopeType: Blockly.ContextMenuRegistry.ScopeType.COMMENT,
+        weight: BlockContextWeight.Copy,
+        id: "makecode-copy-comment"
+    };
+
+    Blockly.ContextMenuRegistry.registry.register(copyOption);
+    Blockly.ContextMenuRegistry.registry.register(copyCommentOption);
+}
+
+function registerPasteContextMenu() {
+    const pasteOption: Blockly.ContextMenuRegistry.RegistryItem = {
+        displayText: () => lf("Paste"),
+        preconditionFn: scope => {
+            if (pxt.shell.isReadOnly() || scope.workspace.options.readOnly) {
+                return "hidden";
+            }
+
+            const handlers = getCopyPasteHandlers();
+
+            if (handlers) {
+                return handlers.pastePrecondition(scope);
+            }
+
+            return "enabled";
+        },
+        callback: function (scope: Blockly.ContextMenuRegistry.Scope, e: PointerEvent): void {
+            const workspace = scope.workspace;
+
+            if (!workspace) return;
+            paste(workspace, e);
+        },
+        scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+        weight: WorkspaceContextWeight.Paste,
+        id: "makecode-paste"
+    };
+
+    Blockly.ContextMenuRegistry.registry.register(pasteOption);
+}
+
+const copy = (workspace: Blockly.WorkspaceSvg, e: Event, shortcut?: Blockly.ShortcutRegistry.KeyboardShortcut) => {
+    const handler = getCopyPasteHandlers()?.copy;
+
+    if (handler) {
+        return handler(workspace, e);
+    }
+
+    return oldCopy.callback(workspace, e, shortcut);
+}
+
+const paste = (workspace: Blockly.WorkspaceSvg, e: Event, shortcut?: Blockly.ShortcutRegistry.KeyboardShortcut) => {
+    const handler = getCopyPasteHandlers()?.paste;
+
+    if (handler) {
+        return handler(workspace, e);
+    }
+
+    return oldPaste.callback(workspace, e, shortcut);
 }

--- a/pxtblocks/external.ts
+++ b/pxtblocks/external.ts
@@ -91,15 +91,20 @@ export function openWorkspaceSearch() {
 }
 
 type ShortcutHandler = (workspace: Blockly.Workspace, e: Event) => boolean;
+type PreconditionFn = (scope: Blockly.ContextMenuRegistry.Scope) => "enabled" | "disabled" | "hidden";
 
 let _handleCopy: ShortcutHandler;
 let _handleCut: ShortcutHandler;
 let _handlePaste: ShortcutHandler;
+let _copyPre: PreconditionFn;
+let _pastePre: PreconditionFn;
 
-export function setCopyPaste(copy: ShortcutHandler, cut: ShortcutHandler, paste: ShortcutHandler) {
+export function setCopyPaste(copy: ShortcutHandler, cut: ShortcutHandler, paste: ShortcutHandler, copyPrecondition: PreconditionFn, pastePrecondition: PreconditionFn ) {
     _handleCopy = copy;
     _handleCut = cut;
     _handlePaste = paste;
+    _copyPre = copyPrecondition;
+    _pastePre = pastePrecondition;
 }
 
 export function getCopyPasteHandlers() {
@@ -107,7 +112,9 @@ export function getCopyPasteHandlers() {
         return {
             copy: _handleCopy,
             cut: _handleCut,
-            paste: _handlePaste
+            paste: _handlePaste,
+            copyPrecondition: _copyPre,
+            pastePrecondition: _pastePre,
         };
     }
     return null;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6657
fixes https://github.com/microsoft/pxt-arcade/issues/6654

adds copy/paste to the context menu and tweaks where you can paste stuff. tutorials are now restricted so that you can only paste blocks that are copied from the same project.

i did not add "cut" to the context menu, but can if people feel strongly about it