### PR TITLE
hide download and sim screenshot in time machine

### DIFF
--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -358,6 +358,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
         const targetTheme = pxt.appTarget.appTheme;
         const isController = pxt.shell.isControllerMode();
+        const isTimeMachineEmbed = pxt.shell.isTimeMachineEmbed();
         const readOnly = pxt.shell.isReadOnly();
         const tutorial = tutorialOptions ? tutorialOptions.tutorial : false;
         const simOpts = pxt.appTarget.simulator;
@@ -425,10 +426,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
                     </div>
                 </div>}
                 {/* TODO clean this; make it just getCompileButton, and set the buttons fontsize to 0 / the icon itself back to normal to just hide text */}
-                {!headless && <div className="ui item portrait hide">
+                {!headless && !isTimeMachineEmbed && <div className="ui item portrait hide">
                     {compileBtn && this.getCompileButton(computer)}
                 </div>}
-                {!headless && <div className="ui portrait only">
+                {!headless && !isTimeMachineEmbed && <div className="ui portrait only">
                     {compileBtn && this.getCompileButton(mobile)}
                 </div>}
             </div>

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -119,7 +119,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const fullscreen = run && !simOpts.hideFullscreen && !sandbox;
         const audio = run && targetTheme.hasAudio;
         const isHeadless = simOpts.headless;
-        const screenshot = !!targetTheme.simScreenshot;
+        const screenshot = !!targetTheme.simScreenshot && !pxt.shell.isTimeMachineEmbed();
         const screenshotClass = !!parentState.screenshoting ? "loading" : "";
         const debugBtnEnabled = !isStarting && !isSimulatorPending && inCodeEditor;
         const runControlsEnabled = !debugging && !isStarting && !isSimulatorPending;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6661
fixes https://github.com/microsoft/pxt-arcade/issues/6664

hides the two remaining buttons that download files because you can't do that from within iframes, apparently.