### PR TITLE
Make the "Pair Now" button keyboard accessible

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1605,7 +1605,7 @@ p.ui.font.small {
         padding-top: .25rem;
     }
 
-    a.ui.button {
+    button.ui.button {
         margin-top: .5rem;
     }
 }

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -790,7 +790,7 @@ export function renderBrowserDownloadInstructions(saveonly?: boolean, redeploy?:
                                                     </div>
                                                     <div className="thirteen wide column">
                                                         {lf("Download your code faster by pairing with WebUSB!")}
-                                                        <a className="ui button purple" onClick={onPairClicked}>{lf("Pair Now")}</a>
+                                                        <sui.Button className="ui button purple" onClick={onPairClicked} text={lf("Pair Now")} />
                                                     </div>
                                                 </div>
                                             </div>


### PR DESCRIPTION
Anchor tags without href attributes are not keyboard accessible. This PR replaces the anchor tag with a button which is natively keyboard accessible.

@microbit-matt-hillsdon 