### PR TITLE
Align new project skip link behaviour with new project button

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -926,7 +926,7 @@ declare namespace pxt.editor {
 
         newEmptyProject(name?: string, documentation?: string, preferredEditor?: string): void;
         newProject(options?: pxt.editor.ProjectCreationOptions): void;
-        newProjectMaybeWithProjectCreationOptions(firstProject: boolean): void;
+        newUserCreatedProject(firstProject: boolean): Promise<void>;
         createProjectAsync(options: pxt.editor.ProjectCreationOptions): Promise<void>;
         importExampleAsync(options: ExampleImportOptions): Promise<void>;
         showScriptManager(): void;

--- a/webapp/src/accessibility.tsx
+++ b/webapp/src/accessibility.tsx
@@ -104,11 +104,11 @@ export class HomeAccessibilityMenu extends data.Component<HomeAccessibilityMenuP
         this.toggleHighContrast = this.toggleHighContrast.bind(this);
     }
 
-    newProject() {
+    async newProject(): Promise<void> {
         pxt.tickEvent("accmenu.home.new", undefined, { interactiveConsent: true });
         const headers = this.getData(`headers:`);
         const firstProject = (!headers || headers?.length == 0);
-        this.props.parent.newProjectMaybeWithProjectCreationOptions(firstProject)
+        return this.props.parent.newUserCreatedProject(firstProject)
     }
 
     importProjectDialog() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2914,13 +2914,11 @@ export class ProjectView
             });
     }
 
-    newProjectMaybeWithProjectCreationOptions(firstProject: boolean) {
+    async newUserCreatedProject(firstProject: boolean): Promise<void> {
         if (pxt.appTarget.appTheme.nameProjectFirst || pxt.appTarget.appTheme.chooseLanguageRestrictionOnNewProject) {
-            this.askForProjectCreationOptionsAsync()
-                .then(projectSettings => {
-                    const { name, languageRestriction } = projectSettings
-                    this.newProject({ name, languageRestriction, firstProject });
-                })
+            const projectSettings = await this.askForProjectCreationOptionsAsync()
+            const { name, languageRestriction } = projectSettings
+            this.newProject({ name, languageRestriction, firstProject });
         } else {
             this.newProject({ firstProject });
         }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -755,7 +755,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
             const isFirstProject = (!headers || headers?.length == 0);
             return <carousel.Carousel tickId="myprojects" bleedPercent={20}>
                 {showNewProject && <div role="button" className="ui card link buttoncard newprojectcard" title={lf("Creates a new empty project")}
-                    onClick={() => this.props.parent.newProjectMaybeWithProjectCreationOptions(isFirstProject)} onKeyDown={fireClickOnEnter} >
+                    onClick={() => this.props.parent.newUserCreatedProject(isFirstProject)} onKeyDown={fireClickOnEnter} >
                     <div className="content">
                         <sui.Icon icon="huge add circle" />
                         <span className="header">{lf("New Project")}</span>


### PR DESCRIPTION
The new project skip link on the home page launches a new project without showing the "Create a Project" dialog (if  available depending on the `appTheme` settings) where as the "New Project" button does. This PR aligns these behaviours. 

@microbit-matt-hillsdon 