### PR TITLE
support copy/pasting assets between projects

### DIFF
--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -3,7 +3,7 @@
 import * as Blockly from "blockly";
 import { FieldImageDropdownOptions } from "./field_imagedropdown";
 import { FieldImages } from "./field_images";
-import { FieldCustom, getAllReferencedTiles, bitmapToImageURI, needsTilemapUpgrade } from "./field_utils";
+import { FieldCustom, getAllReferencedTiles, bitmapToImageURI, needsTilemapUpgrade, getAssetSaveState, loadAssetFromSaveState } from "./field_utils";
 
 export interface ImageJSON {
     src: string;
@@ -265,6 +265,39 @@ export class FieldTileset extends FieldImages implements FieldCustom {
     protected assetChangeListener = () => {
        this.doValueUpdate_(this.getValue());
        this.forceRerender();
+    }
+
+    saveState(_doFullSerialization?: boolean) {
+        let asset = this.localTile || this.selectedOption_?.[2];
+        const project = pxt.react.getTilemapProject();
+
+        if (!asset) {
+            const value = this.getValue();
+
+            const parsedTsReference = pxt.parseAssetTSReference(value);
+            if (parsedTsReference) {
+                asset = project.lookupAssetByName(pxt.AssetType.Tile, parsedTsReference.name);
+            }
+
+            if (!asset) {
+                asset = project.lookupAsset(pxt.AssetType.Tile, value);
+            }
+        }
+        if (asset?.isProjectTile) {
+            return getAssetSaveState(asset)
+        }
+        return super.saveState(_doFullSerialization);
+    }
+
+    loadState(state: any) {
+        if (typeof state === "string") {
+            super.loadState(state);
+            return;
+        }
+
+        const asset = loadAssetFromSaveState(state);
+        this.localTile = asset as pxt.Tile;
+        super.loadState(pxt.getTSReferenceForAsset(asset));
     }
 }
 

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -197,6 +197,15 @@ namespace pxt {
             return undefined;
         }
 
+        getByValue(toFind: U) {
+            for (const asset of this.assets) {
+                if (assetEquals(toFind, asset, true)) {
+                    return asset;
+                }
+            }
+            return undefined;
+        }
+
         isIDTaken(id: string) {
             return !!this.takenNames[id];
         }
@@ -894,6 +903,16 @@ namespace pxt {
         public lookupAssetByName(assetType: AssetType, name: string): Asset;
         public lookupAssetByName(assetType: AssetType, name: string) {
             return getAssetCollection(this.state, assetType).getByDisplayName(name);
+        }
+
+        public lookupAssetByValue(assetType: AssetType.Image, toFind: ProjectImage): ProjectImage;
+        public lookupAssetByValue(assetType: AssetType.Tile, toFind: Tile): Tile;
+        public lookupAssetByValue(assetType: AssetType.Tilemap, toFind: ProjectTilemap): ProjectTilemap;
+        public lookupAssetByValue(assetType: AssetType.Animation, toFind: Animation): Animation;
+        public lookupAssetByValue(assetType: AssetType.Song, toFind: Song): Song;
+        public lookupAssetByValue(assetType: AssetType, toFind: Asset): Asset;
+        public lookupAssetByValue(assetType: AssetType, toFind: Asset) {
+            return getAssetCollection(this.state, assetType).getByValue(toFind);
         }
 
         public getAssets(type: AssetType.Image): ProjectImage[];
@@ -1786,15 +1805,17 @@ namespace pxt {
 
     }
 
-    export function assetEquals(a: Asset, b: Asset): boolean {
+    export function assetEquals(a: Asset, b: Asset, valueOnly = false): boolean {
         if (a == b) return true;
-        if (!a && b || !b && a) return false;
-        if (a.id !== b.id || a.type !== b.type ||
-            !U.arrayEquals(a.meta.tags, b.meta.tags) ||
-            !U.arrayEquals(a.meta.blockIDs, b.meta.blockIDs) ||
-            a.meta.displayName !== b.meta.displayName
-        )
-            return false;
+        if (!a && b || !b && a || a.type !== b.type) return false;
+        if (!valueOnly) {
+            if (a.id !== b.id ||
+                !U.arrayEquals(a.meta.tags, b.meta.tags) ||
+                !U.arrayEquals(a.meta.blockIDs, b.meta.blockIDs) ||
+                a.meta.displayName !== b.meta.displayName
+            )
+                return false;
+        }
 
         switch (a.type) {
             case AssetType.Image:

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1206,6 +1206,14 @@ namespace pxt {
             return clone;
         }
 
+        saveGallerySnapshot() {
+            return this.gallery;
+        }
+
+        loadGallerySnapshot(snapshot: AssetSnapshot) {
+            this.gallery = snapshot;
+        }
+
         protected generateImage(entry: JRes, type: AssetType.Image): ProjectImage;
         protected generateImage(entry: JRes, type: AssetType.Tile): Tile;
         protected generateImage(entry: JRes, type: AssetType.Image | AssetType.Tile): ProjectImage | Tile {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6656

this changes the asset fields' serialization so that they also include any referenced assets when saving state. saveState/loadState aren't called on fields during XML serialization, but they are called during copy/paste so this handles that scenario nicely without changing the save format of our projects.

when loading the state of a saved asset, there are a few scenarios to consider:

1. pasting the asset into a project that doesn't have an existing asset with that id
2. pasting the asset into a project that does have an asset with that id, where the value of the existing asset matches that of the serialized asset
3. pasting the asset into a project that does have an asset with that id where the value of the existing asset does not match that of the serialized asset

for scenario 1, we simply create a new asset in the destination project. for scenario 2, we don't do anything since the asset is already in project.

scenario 3 is the tricky one. first we check to see if there is *another* asset in the destination project with the same value. if so, paste that one instead. if there isn't, then we need to create a new asset with a different id to avoid the collision. luckily, we already have code to do this for tilemaps since we have supported copying/pasting from within the tilemap editor for a while now