### PR TITLE
A few blockly tutorial fixes

### DIFF
--- a/pxtblocks/fields/field_numberdropdown.ts
+++ b/pxtblocks/fields/field_numberdropdown.ts
@@ -108,7 +108,12 @@ class BaseFieldNumberDropdown extends BaseFieldTextDropdown {
             return null;
         }
         // Get the value in range.
-        n = Math.min(Math.max(n, this.min_), this.max_);
+        if (this.min_ !== undefined) {
+            n = Math.max(n, this.min_);
+        }
+        if (this.max_ !== undefined) {
+            n = Math.min(n, this.max_);
+        }
         // Round to nearest multiple of precision.
         if (this.precision_ && isFinite(n)) {
             n = Math.round(n / this.precision_) * this.precision_;

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -201,6 +201,9 @@ export class FieldTileset extends FieldImages implements FieldCustom {
                 else if (newValue.startsWith(pxt.sprite.TILE_NAMESPACE)) {
                     tile = project.lookupAsset(pxt.AssetType.Tile, newValue.trim());
                 }
+                else {
+                    tile = project.lookupAssetByName(pxt.AssetType.Tile, newValue.trim());
+                }
 
                 if (tile) {
                     this.localTile = tile;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1611,7 +1611,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 // Cache blocks xml list for later
                 this.flyoutBlockXmlCache[cacheKey] = this.flyoutXmlList;
             }
-            this.showFlyoutInternal_(this.flyoutXmlList, cacheKey);
+            this.showFlyoutInternal_(this.flyoutXmlList, cachable && cacheKey);
         }
     }
 


### PR DESCRIPTION
each commit is a different fix!

fixes https://github.com/microsoft/pxt-arcade/issues/6630
the issue here was that the min/max properties on the field were unset, which was causing it fail to parse values passed in as the default

fixes https://github.com/microsoft/pxt-arcade/issues/6643
this issue was that we weren't busting the flyout cache properly for tutorials where the contents of a flyout can change for each step

fixes https://github.com/microsoft/pxt-arcade/issues/6627
there are a ton of different ways to decompile to the tileset field and each one has slightly different syntax. adding a fallback case to the if statement that just tries to find the asset by name even if the value passed in isn't in the full asset reference format