### PR TITLE
Collection of fixes for bugs found on livestream

### DIFF
--- a/pxtblocks/builtins/loops.ts
+++ b/pxtblocks/builtins/loops.ts
@@ -122,7 +122,8 @@ export function initLoops() {
                     {
                         "type": "field_variable",
                         "name": "VAR",
-                        "variable": controlsSimpleForDef.block["variable"]
+                        "variable": controlsSimpleForDef.block["variable"],
+                        "variableTypes": [""],
                         // Please note that most multilingual characters
                         // cannot be used as variable name at this point.
                         // Translate or decide the default variable name
@@ -328,7 +329,8 @@ export function initLoops() {
                         {
                             "type": "field_variable",
                             "name": "VAR",
-                            "variable": controlsForOfDef.block["variable"]
+                            "variable": controlsForOfDef.block["variable"],
+                            "variableTypes": [""],
                             // Please note that most multilingual characters
                             // cannot be used as variable name at this point.
                             // Translate or decide the default variable name

--- a/pxtblocks/builtins/variables.ts
+++ b/pxtblocks/builtins/variables.ts
@@ -1,14 +1,8 @@
 import * as Blockly from "blockly";
 import { createFlyoutGroupLabel, createFlyoutHeadingLabel, mkVariableFieldBlock } from "../toolbox";
 import { installBuiltinHelpInfo, setBuiltinHelpInfo } from "../help";
-import { provider } from "../constants";
 
 export function initVariables() {
-    // We only give types to "special" variables like enum members and we don't
-    // want those showing up in the variable dropdown so filter the variables
-    // that show up to only ones that have an empty type
-    (Blockly.FieldVariable.prototype as any).getVariableTypes_ = () => [""];
-
     let varname = lf("{id:var}item");
     Blockly.Variables.flyoutCategory = function (workspace: Blockly.WorkspaceSvg) {
         let xmlList: HTMLElement[] = [];
@@ -103,7 +97,31 @@ export function initVariables() {
     const variablesGetId = "variables_get";
     const variablesGetDef = pxt.blocks.getBlockDefinition(variablesGetId);
     msg.VARIABLES_GET_CREATE_SET = variablesGetDef.block["VARIABLES_GET_CREATE_SET"];
-    installBuiltinHelpInfo(variablesGetId);
+    Blockly.Blocks[variablesGetId] = {
+        init: function() {
+            this.jsonInit(
+                {
+                    "type": "variables_get",
+                    "message0": "%1",
+                    "args0": [
+                        {
+                            "type": "field_variable",
+                            "name": "VAR",
+                            "variable": "%{BKY_VARIABLES_DEFAULT_NAME}",
+                            "variableTypes": [""],
+                        },
+                    ],
+                    "output": null,
+                    "style": "variable_blocks",
+                    "helpUrl": "%{BKY_VARIABLES_GET_HELPURL}",
+                    "tooltip": "%{BKY_VARIABLES_GET_TOOLTIP}",
+                    "extensions": ["contextMenu_variableSetterGetter"],
+                }
+            );
+
+            setBuiltinHelpInfo(this, variablesGetId);
+        }
+    };
 
     const variablesReporterGetId = "variables_get_reporter";
     installBuiltinHelpInfo(variablesReporterGetId);
@@ -120,7 +138,36 @@ export function initVariables() {
     msg.VARIABLES_SET = variablesSetDef.block["VARIABLES_SET"];
     msg.VARIABLES_DEFAULT_NAME = varname;
     msg.VARIABLES_SET_CREATE_GET = lf("Create 'get %1'");
-    installBuiltinHelpInfo(variablesSetId);
+    Blockly.Blocks[variablesSetId] = {
+        init: function() {
+            this.jsonInit(
+                {
+                    "type": "variables_set",
+                    "message0": "%{BKY_VARIABLES_SET}",
+                    "args0": [
+                    {
+                        "type": "field_variable",
+                        "name": "VAR",
+                        "variable": "%{BKY_VARIABLES_DEFAULT_NAME}",
+                        "variableTypes": [""],
+                    },
+                    {
+                        "type": "input_value",
+                        "name": "VALUE",
+                    },
+                    ],
+                    "previousStatement": null,
+                    "nextStatement": null,
+                    "style": "variable_blocks",
+                    "tooltip": "%{BKY_VARIABLES_SET_TOOLTIP}",
+                    "helpUrl": "%{BKY_VARIABLES_SET_HELPURL}",
+                    "extensions": ["contextMenu_variableSetterGetter"],
+                }
+            );
+
+            setBuiltinHelpInfo(this, variablesSetId);
+        }
+    };
 
     // pxt variables_change
     const variablesChangeId = "variables_change";
@@ -133,7 +180,8 @@ export function initVariables() {
                     {
                         "type": "field_variable",
                         "name": "VAR",
-                        "variable": varname
+                        "variable": varname,
+                        "variableTypes": [""]
                     },
                     {
                         "type": "input_value",

--- a/pxtblocks/help.ts
+++ b/pxtblocks/help.ts
@@ -58,7 +58,6 @@ export function installHelpResources(id: string, name: string, tooltip: any, url
 
     block.init = function () {
         old.call(this);
-        let block = this;
         setHelpResources(this, id, name, tooltip, url, colour, colourSecondary, colourTertiary);
     }
 }

--- a/pxtblocks/plugins/duplicateOnDrag/variablesGetReporter.ts
+++ b/pxtblocks/plugins/duplicateOnDrag/variablesGetReporter.ts
@@ -39,7 +39,8 @@ Blockly.defineBlocksWithJsonArray([
           {
             "type": "field_variable",
             "name": "VAR",
-            "variable": "%{BKY_VARIABLES_DEFAULT_NAME}"
+            "variable": "%{BKY_VARIABLES_DEFAULT_NAME}",
+            "variableTypes": [""],
           }
         ],
         "output": null,

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -806,6 +806,8 @@ namespace pxt.sprite {
     }
 
     export function bitmapEquals(a: pxt.sprite.BitmapData, b: pxt.sprite.BitmapData) {
+        if (a === b) return true;
+        else if (!a && b || !b && a) return false;
         return pxt.sprite.Bitmap.fromData(a).equals(pxt.sprite.Bitmap.fromData(b));
     }
 

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -244,6 +244,7 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
         else {
             this.updateCursorLocation(coord);
             this.startEdit(!!isRightClick);
+            this.updateEdit(this.cursorLocation[0], this.cursorLocation[1]);
         }
     }
 

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -204,7 +204,7 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
         if (document.activeElement instanceof HTMLElement && document.activeElement !== this.refs["canvas-bounds"]) {
             document.activeElement.blur();
         }
-        (this.refs["canvas-bounds"] as HTMLDivElement).focus();
+        this.focus();
 
         if (this.isColorSelect()) {
             this.selectCanvasColor(coord, isRightClick);
@@ -230,6 +230,7 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
 
     onDragStart(coord: ClientCoordinates, isRightClick?: boolean): void {
         this.hasInteracted = true
+        this.focus();
         if (this.touchesResize(coord.clientX, coord.clientY)) {
             this.isResizing = true;
         }
@@ -247,6 +248,7 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
     }
 
     onDragMove(coord: ClientCoordinates): void {
+        this.focus();
         if (this.isPanning() && this.lastPanX != undefined && this.lastPanY != undefined) {
             this.panX += this.lastPanX - coord.clientX;
             this.panY += this.lastPanY - coord.clientY;
@@ -1090,6 +1092,10 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
         this.editState.layerOffsetY = 0;
 
         this.props.dispatchImageEdit(this.editState.toImageState());
+    }
+
+    protected focus() {
+        (this.refs["canvas-bounds"] as HTMLDivElement).focus();
     }
 }
 


### PR DESCRIPTION
each commit is a different fix!

abbf61b192c43cf7a32a28aef6688f880aaaeaee fixes https://github.com/microsoft/pxt-arcade/issues/6685 which was an issue with the bitmap equality function not handling the case where the floating layer's bitmap was set to undefined.

4061281f0013acdefe80c4e2c23135c24e184e35 fixes https://github.com/microsoft/pxt-arcade/issues/6686 by making sure that the image canvas properly takes focus when interacting with it.

dc6b429f79ec1dfd9d2eff1b78d1461a2040e661 fixes a longstanding issue where the first pixel was skipped when starting a drag

dd367051b6d2af88f9a28af669d9cc22bfddcf1e removes a monkey patch for the variable field that no longer works with latest blockly; this was causing sprite kinds to show up in the regular variable blocks. now we filter the variable dropdown properly by passing an array with an empty string in the JSON config of all our blocks that use this field.