### PR TITLE
Make "list" in for-of translatable

### DIFF
--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -83,7 +83,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </value>
                     <value name="LIST">
                         <block type="variables_get">
-                            <field name="VAR">list</field>
+                            <field name="VAR">${lf("{id:var}list")}</field>
                         </block>
                     </value>
                 </block>`


### PR DESCRIPTION
This pr is simple.
Like other blocks related to array variable, make "list" in for-of translatable.

Before (Japanese):
![tramslatableList_before](https://github.com/user-attachments/assets/337e596c-7f86-4eb2-9c09-988855abb4f6)

After:
![translatableList_after](https://github.com/user-attachments/assets/20d59ccf-0c30-4285-9163-19d3eaf4f231)

@riknoll 