### PR TITLE
Theme Fixes: Sound Effect Editor & Field Editor Header Bar

### DIFF
--- a/react-common/styles/controls/DraggableGraph.less
+++ b/react-common/styles/controls/DraggableGraph.less
@@ -1,10 +1,17 @@
+.common-draggable-graph {
+    background-color: var(--pxt-neutral-background1);
+    color: var(--pxt-neutral-foreground1);
+}
+
 .common-draggable-graph-text {
     user-select: none;
-    color: var(--pxt-neutral-foreground2);
+    color: var(--pxt-neutral-foreground1);
+    stroke: var(--pxt-neutral-foreground1);
 }
 
 .draggable-graph-point {
     fill: var(--pxt-neutral-background1);
+    stroke: var(--pxt-neutral-alpha50);
 }
 
 .draggable-graph-path {

--- a/theme/common.less
+++ b/theme/common.less
@@ -2651,6 +2651,30 @@ button.ui.button.hostmultiplayergame-button {
     }
 }
 
+#blocks-editor-field-div,
+.sound-effect-editor-widget {
+    // Header colors are hard-coded for field editors, so hard-code the toggle
+    // colors as well to ensure good contrast.
+    .common-editor-toggle {
+        border: 3px solid rgba(52, 73, 94, .2);
+        background: rgba(52, 73, 94, .4);
+
+        .common-editor-toggle-item {
+            &> .common-button {
+                color: #fff;
+            }
+
+            &.selected > .common-button {
+                color: #323130;
+            }
+        }
+
+        .common-editor-toggle-handle {
+            background: #fff;
+        }
+    }
+}
+
 .blocks-editor-field-overlay {
     position: absolute;
     z-index: @blocklyWidgetDivZIndex;

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -53,7 +53,7 @@
     justify-content: center;
     align-items: center;
 
-    background-color: var(--pxt-primary-background);
+    background-color: #e30fc0; // Matches block color
 
     & > .common-button {
         position: absolute;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6733
Fixes https://github.com/microsoft/pxt-arcade/issues/6705

The header bars for field editors are hard-coded to match the colors of the blocks (mostly, though I did have to fix this for the sound effect editor in this change). With this in mind, we should also hard-code the editor toggle color to ensure good contrast.

Also, the sound effect editor graphs had some elements that were hard to see in dark mode. This includes some changes that should make them more apparent.

Before:
![image](https://github.com/user-attachments/assets/f8d0b9f5-58c6-4d96-b23d-2927be868f94)

After:
![image](https://github.com/user-attachments/assets/1f9b9ad2-30d3-4c82-91fc-251b4eb604d7)
