### PR TITLE
fix several function bugs in new blockly

### DIFF
--- a/pxtblocks/plugins/flyout/verticalFlyout.ts
+++ b/pxtblocks/plugins/flyout/verticalFlyout.ts
@@ -1,5 +1,7 @@
 import * as Blockly from "blockly";
 
+const MAX_CACHED_FLYOUTS = 20;
+
 export class VerticalFlyout implements Blockly.IFlyout {
     horizontalLayout = false;
     RTL: boolean;
@@ -129,12 +131,21 @@ export class VerticalFlyout implements Blockly.IFlyout {
             this.activeFlyout = existing;
             this.activeFlyout.autoClose = this.autoClose;
             this.activeFlyout.setContainerVisible(this.containerVisible);
-            this.activeFlyout.show(flyoutDef)
+            this.activeFlyout.show(flyoutDef);
+
+            // move to most recently used in the cache
+            this.cached.splice(this.cached.indexOf(existing), 1);
+            this.cached.push(existing);
             return;
         }
 
         this.activeFlyout = new CachedFlyout(this.options);
         this.cached.push(this.activeFlyout);
+
+        if (this.cached.length >= MAX_CACHED_FLYOUTS) {
+            this.cached.shift().dispose();
+        }
+
         this.element.appendChild(this.activeFlyout.createDom("g"));
         this.activeFlyout.init(this.targetWorkspace);
 

--- a/pxtblocks/plugins/functions/blocks/functionCallBlocks.ts
+++ b/pxtblocks/plugins/functions/blocks/functionCallBlocks.ts
@@ -5,17 +5,24 @@ import {
     FUNCTION_CALL_OUTPUT_BLOCK_TYPE,
     FUNCTION_DEFINITION_BLOCK_TYPE,
 } from "../constants";
-import { getDefinition, getShadowBlockInfoFromType_, isVariableBlockType, mutateCallersAndDefinition } from "../utils";
+import { getArgMap, getDefinition, getShadowBlockInfoFromType_, isVariableBlockType, mutateCallersAndDefinition } from "../utils";
 import { MsgKey } from "../msg";
+
+export interface SerializedShadow {
+    inputName: string;
+    connectedShadow?: any;
+    connectedBlock?: string;
+}
 
 interface FunctionCallMixin extends CommonFunctionMixin {
     attachShadow_(input: Blockly.Input, typeName: string): void;
     buildShadowDom_(argumentType: string): Element;
     onchange(event: Blockly.Events.Abstract): void;
     afterWorkspaceLoad(): void;
+    serializeChangedInputs(newMutation: Element): SerializedShadow[];
 }
 
-type FunctionCallBlock = CommonFunctionBlock & FunctionCallMixin;
+export type FunctionCallBlock = CommonFunctionBlock & FunctionCallMixin;
 
 const FUNCTION_CALL_MIXIN: FunctionCallMixin = {
     ...COMMON_FUNCTION_MIXIN,
@@ -188,6 +195,34 @@ const FUNCTION_CALL_MIXIN: FunctionCallMixin = {
             }
         }
     },
+    serializeChangedInputs(this: FunctionCallBlock, newMutation: Element) {
+        const out: SerializedShadow[] = [];
+
+        const newIdToArg = getArgMap(newMutation, true);
+
+        for (const argument of this.arguments_) {
+            if (newIdToArg[argument.id]) continue;
+
+            const connection = this.getInput(argument.id).connection;
+
+            const targetBlock = connection.targetBlock() as Blockly.BlockSvg;
+
+            if (targetBlock.isShadow()) {
+                out.push({
+                    inputName: argument.id,
+                    connectedShadow: connection.getShadowState(true)
+                });
+            }
+            else {
+                out.push({
+                    inputName: argument.id,
+                    connectedBlock: targetBlock.id
+                });
+            }
+        }
+
+        return out;
+    }
 };
 
 Blockly.Blocks[FUNCTION_CALL_BLOCK_TYPE] = {

--- a/pxtblocks/plugins/functions/blocks/functionDefinitionBlock.ts
+++ b/pxtblocks/plugins/functions/blocks/functionDefinitionBlock.ts
@@ -65,20 +65,24 @@ const FUNCTION_DEFINITION_MIXIN: FunctionDefinitionMixin = {
     afterWorkspaceLoad: function(this: FunctionDefinitionBlock) {
         for (const input of this.inputList) {
             if (input.type !== Blockly.inputs.inputTypes.VALUE) continue;
-            const target = input.connection?.targetBlock();
+            const argument = this.arguments_.find(a => a.id === input.name);
 
-            if (target?.isShadow() && target.mutationToDom) {
-                const mutation = target.mutationToDom();
+            if (!argument) continue;
 
-                if (mutation.getAttribute(DUPLICATE_ON_DRAG_MUTATION_KEY)) {
-                    target.setShadow(false);
-                }
+            let target = input.connection.targetBlock();
+
+            if (!target) {
+                this.populateArgument_(argument, null, input);
+                target = input.connection.targetBlock();
             }
-            const shadowDom = input.connection && input.getShadowDom();
 
-            if (isVariableBlockType(shadowDom?.getAttribute("type"))) {
-                input.setShadowDom(null);
+            target.setFieldValue(argument.name, "VALUE");
+
+            if (target.isShadow()) {
+                target.setShadow(false);
             }
+
+            input.setShadowDom(null);
         }
     },
 

--- a/pxtblocks/plugins/functions/blocks/functionDefinitionBlock.ts
+++ b/pxtblocks/plugins/functions/blocks/functionDefinitionBlock.ts
@@ -15,13 +15,13 @@ import {
     FUNCTION_CALL_OUTPUT_BLOCK_TYPE,
     FUNCTION_DEFINITION_BLOCK_TYPE,
 } from "../constants";
-import { createCustomArgumentReporter, getDefinition, isVariableBlockType, mutateCallersAndDefinition, rename } from "../utils";
+import { createCustomArgumentReporter, getDefinition, mutateCallersAndDefinition, rename } from "../utils";
 import { FieldAutocapitalizeTextInput } from "../fields/fieldAutocapitalizeTextInput";
 import { MsgKey } from "../msg";
 import { FunctionManager } from "../functionManager";
 import { COLLAPSE_IMAGE_DATAURI } from "../svgs";
 import { ArgumentReporterBlock } from "./argumentReporterBlocks";
-import { DUPLICATE_ON_DRAG_MUTATION_KEY, setDuplicateOnDrag } from "../../duplicateOnDrag";
+import { setDuplicateOnDrag } from "../../duplicateOnDrag";
 
 interface FunctionDefinitionMixin extends CommonFunctionMixin {
     createArgumentReporter_(arg: FunctionArgument): ArgumentReporterBlock;

--- a/pxtblocks/plugins/functions/commonFunctionMixin.ts
+++ b/pxtblocks/plugins/functions/commonFunctionMixin.ts
@@ -143,49 +143,7 @@ export const COMMON_FUNCTION_MIXIN = {
         this.inputList = newInputList;
     },
 
-    disconnectOldBlocks_: function (this: CommonFunctionBlock) {
-        // Remove old stuff
-        let connectionMap: ConnectionMap = {};
-        for (let i = 0, input; (input = this.inputList[i]); i++) {
-            if (input.name !== "STACK" && input.connection) {
-                let target = input.connection.targetBlock();
-                let saveInfo = {
-                    shadow: input.connection.getShadowDom(),
-                    block: target,
-                };
-                connectionMap[input.name] = saveInfo;
-
-                // Remove the shadow DOM, then disconnect the block. Otherwise a shadow
-                // block will respawn instantly, and we'd have to remove it when we remove
-                // the input.
-                input.connection.setShadowDom(null);
-                if (input.connection.targetConnection) {
-                    input.connection.disconnect();
-                }
-            }
-        }
-        return connectionMap;
-    },
-
-    deleteShadows_: function (this: CommonFunctionBlock, connectionMap: ConnectionMap) {
-        // Get rid of all of the old shadow blocks if they aren't connected.
-        if (connectionMap) {
-            for (let id in connectionMap) {
-                let saveInfo = connectionMap[id];
-                if (saveInfo) {
-                    const block = saveInfo["block"];
-                    if (block?.isShadow()) {
-                        if (!block.isDeadOrDying()) {
-                            block.dispose(false);
-                        }
-                        delete connectionMap[id];
-                    }
-                }
-            }
-        }
-    },
-
-    createAllInputs_: function (this: CommonFunctionBlock, connectionMap?: ConnectionMap) {
+    createAllInputs_: function (this: CommonFunctionBlock) {
         let hasTitle = false;
         let hasName = false;
         let hasCollapseIcon = false;
@@ -222,22 +180,49 @@ export const COMMON_FUNCTION_MIXIN = {
             this.addFunctionLabel_(this.getName());
         }
 
-        // Create arguments.
-        let self = this;
-        this.arguments_.forEach(function (arg) {
-            // For custom types, the parameter type is appended to the UUID in the
-            // input name. This is needed to retrieve the function signature from the
-            // block inputs when the declaration block is modified.
-            let input = self.appendValueInput(arg.id);
+        // remove deleted arguments
+        for (const input of this.inputList) {
+            if (input.type !== Blockly.inputs.inputTypes.VALUE) continue;
+            if (!this.arguments_.some(a => a.id === input.name)) {
+
+                if (this.type === FUNCTION_DEFINITION_BLOCK_TYPE) {
+                    const target = input.connection.targetBlock();
+                    if (target) target.dispose();
+                }
+                this.removeInput(input.name);
+            }
+        }
+
+        // create and reorder inputs
+        let inputIndex = this.inputList.findIndex(i => i.type === Blockly.inputs.inputTypes.VALUE);
+        if (inputIndex === -1) {
+            inputIndex = this.inputList.length;
+        }
+        for (const arg of this.arguments_) {
+            let input = this.inputList.find(i => i.name === arg.id);
+            const newInput = !input;
+
+            if (newInput) {
+                input = this.appendValueInput(arg.id)
+            }
+
+            if (this.inputList.indexOf(input) !== inputIndex) {
+                this.moveInputBefore(input.name, this.inputList[inputIndex + 1]?.name);
+            }
+
             if (isCustomType(arg.type)) {
                 input.setCheck(arg.type);
-            } else {
+            }
+            else {
                 input.setCheck(arg.type.charAt(0).toUpperCase() + arg.type.slice(1));
             }
-            if (!self.isInsertionMarker()) {
-                self.populateArgument_(arg, connectionMap, input);
+
+            if (!this.isInsertionMarker() && newInput) {
+                this.populateArgument_(arg, undefined, input);
             }
-        });
+
+            inputIndex++;
+        }
 
         // If collapse button present, move after arguments
         if (hasCollapseIcon) {
@@ -252,11 +237,8 @@ export const COMMON_FUNCTION_MIXIN = {
 
     updateDisplay_: function (this: CommonFunctionBlock) {
         let wasRendered = this.rendered;
-        let connectionMap = this.disconnectOldBlocks_();
-        this.removeValueInputs_();
 
-        this.createAllInputs_(connectionMap);
-        this.deleteShadows_(connectionMap);
+        this.createAllInputs_();
 
         if (wasRendered && !this.isInsertionMarker() && this instanceof Blockly.BlockSvg) {
             this.initSvg();

--- a/pxtblocks/plugins/functions/commonFunctionMixin.ts
+++ b/pxtblocks/plugins/functions/commonFunctionMixin.ts
@@ -146,14 +146,11 @@ export const COMMON_FUNCTION_MIXIN = {
     createAllInputs_: function (this: CommonFunctionBlock) {
         let hasTitle = false;
         let hasName = false;
-        let hasCollapseIcon = false;
         this.inputList.forEach(function (i) {
             if (i.name == "function_title") {
                 hasTitle = true;
             } else if (i.name == "function_name") {
                 hasName = true;
-            } else if (i.name == "function_collapse") {
-                hasCollapseIcon = true;
             }
         });
 
@@ -180,6 +177,10 @@ export const COMMON_FUNCTION_MIXIN = {
             this.addFunctionLabel_(this.getName());
         }
 
+        this.updateArgumentInputs_();
+    },
+
+    updateArgumentInputs_(this: CommonFunctionBlock) {
         // remove deleted arguments
         for (const input of this.inputList) {
             if (input.type !== Blockly.inputs.inputTypes.VALUE) continue;
@@ -225,7 +226,7 @@ export const COMMON_FUNCTION_MIXIN = {
         }
 
         // If collapse button present, move after arguments
-        if (hasCollapseIcon) {
+        if (this.inputList.some(i => i.name === "function_collapse")) {
             this.moveInputBefore("function_collapse", null);
         }
 

--- a/pxtblocks/plugins/functions/utils.ts
+++ b/pxtblocks/plugins/functions/utils.ts
@@ -478,10 +478,46 @@ interface CallerChange {
     shadows: SerializedShadow[];
 }
 
+
+interface MutateFunctionEventJson extends Blockly.Events.AbstractEventJson {
+    definition: string;
+    callers: CallerChange[];
+    oldMutation: string;
+    newMutation: string;
+    descendantChanges: DescendantChange[];
+}
+
 class MutateFunctionEvent extends Blockly.Events.Abstract {
     isBlank: boolean;
 
     type = "pxt_mutate_function"
+
+    static fromJson(
+        json: MutateFunctionEventJson,
+        workspace: Blockly.Workspace,
+        event?: any,
+    ) {
+        event = super.fromJson(
+            json,
+            workspace,
+            event || new MutateFunctionEvent(
+                json.definition,
+                json.callers,
+                json.oldMutation,
+                json.newMutation,
+                json.descendantChanges
+            )
+        );
+
+        const existing = event as MutateFunctionEvent;
+        existing.definition = json.definition;
+        existing.callers = json.callers;
+        existing.oldMutation = json.oldMutation;
+        existing.newMutation = json.newMutation;
+        existing.descendantChanges = json.descendantChanges;
+
+        return event;
+    }
 
     constructor(
         protected definition: string,
@@ -491,6 +527,18 @@ class MutateFunctionEvent extends Blockly.Events.Abstract {
         protected descendantChanges: DescendantChange[]
     ) {
         super();
+    }
+
+    toJson(): MutateFunctionEventJson {
+        return {
+            type: this.type,
+            group: this.group,
+            definition: this.definition,
+            callers: this.callers,
+            oldMutation: this.oldMutation,
+            newMutation: this.newMutation,
+            descendantChanges: this.descendantChanges
+        }
     }
 
     run(forward: boolean) {
@@ -554,8 +602,6 @@ class MutateFunctionEvent extends Blockly.Events.Abstract {
                 targetConnection.connect(newBlock.outputConnection);
             }
         }
-
-        (def as unknown as Blockly.BlockSvg).queueRender();
 
         Blockly.Events.enable();
     }

--- a/pxtblocks/plugins/functions/utils.ts
+++ b/pxtblocks/plugins/functions/utils.ts
@@ -549,7 +549,7 @@ class MutateFunctionEvent extends Blockly.Events.Abstract {
         Blockly.Events.disable();
 
         def.domToMutation(mutation);
-        def.createAllInputs_();
+        def.updateArgumentInputs_();
         def.afterWorkspaceLoad();
 
         for (const change of this.callers) {

--- a/pxtblocks/plugins/functions/utils.ts
+++ b/pxtblocks/plugins/functions/utils.ts
@@ -15,6 +15,7 @@ import { FunctionManager } from "./functionManager";
 import { MsgKey } from "./msg";
 import { newFunctionMutation } from "./blocks/functionDeclarationBlock";
 import { FunctionDefinitionBlock } from "./blocks/functionDefinitionBlock";
+import { FunctionCallBlock, SerializedShadow } from "./blocks/functionCallBlocks";
 
 export type StringMap<T> = { [index: string]: T };
 
@@ -181,71 +182,60 @@ function incrementNameSuffix(name: string) {
 export function mutateCallersAndDefinition(name: string, ws: Blockly.Workspace, mutation: Element) {
     const definitionBlock = getDefinition(name, ws);
     if (definitionBlock) {
-        const callers = getCallers(name, definitionBlock.workspace);
-        callers.push(definitionBlock);
-        Blockly.Events.setGroup(true);
-        callers.forEach(function (caller) {
-            const oldMutationDom = caller.mutationToDom();
-            const oldMutation = oldMutationDom && Blockly.Xml.domToText(oldMutationDom);
-            caller.domToMutation(mutation);
-            const newMutationDom = caller.mutationToDom();
-            const newMutation = newMutationDom && Blockly.Xml.domToText(newMutationDom);
+        const oldMutation = definitionBlock.mutationToDom();
+        const oldArgNamesToIds = getArgMap(oldMutation, false);
+        const idsToNewArgNames = getArgMap(mutation, true);
 
-            if (oldMutation != newMutation) {
-                // Fire a mutation event to force the block to update.
-                Blockly.Events.fire(new Blockly.Events.BlockChange(caller, "mutation", null, oldMutation, newMutation));
+        const changedDescendants: DescendantChange[] = [];
 
-                // For the definition, we also need to update all arguments that are
-                // used inside the function.
-                if (caller.id == definitionBlock.id) {
-                    // First, build a map of oldArgName -> argId from the old mutation,
-                    // and a map of argId -> newArgName from the new mutation.
-                    const oldArgNamesToIds = getArgMap(oldMutationDom, false);
-                    const idsToNewArgNames = getArgMap(newMutationDom, true);
+        for (const block of definitionBlock.getDescendants(false)) {
+            if (!isFunctionArgumentReporter(block)) continue;
 
-                    // Then, go through all descendants of the function definition and
-                    // look for argument reporters to update.
-                    definitionBlock.getDescendants(false).forEach(function (d) {
-                        if (!isFunctionArgumentReporter(d)) {
-                            return;
-                        }
+            const oldName = block.getFieldValue("VALUE");
+            const oldArgId = oldArgNamesToIds[oldName];
+            const newName = idsToNewArgNames[oldArgId];
 
-                        // Find the argument ID corresponding to this old argument name.
-                        let argName = d.getFieldValue("VALUE");
-                        let argId = oldArgNamesToIds[argName];
+            // no change
+            if (oldName === newName) continue;
 
-                        // This argument reporter must belong to a different block. For example,
-                        // a block with handlerStatement=1 and draggableParameters=reporter
-                        if (argId === undefined) {
-                            return;
-                        }
+            const targetBlockId = block.outputConnection.targetBlock().id;
+            const targetInputName = block.outputConnection.targetConnection.getParentInput().name;
 
-                        if (!idsToNewArgNames[argId]) {
-                            // That arg ID no longer exists on the new mutation, delete this
-                            // arg reporter.
-                            d.dispose(true);
-                        } else if (idsToNewArgNames[argId] !== argName) {
-                            // That arg ID still exists, but the name was changed, so update
-                            // this reporter's display text.
-                            d.setFieldValue(idsToNewArgNames[argId], "VALUE");
-                        }
-                    });
-                } else {
-                    // For the callers, we need to bump blocks that were connected to any
-                    // argument that has since been deleted.
-                    setTimeout(function () {
-                        caller.bumpNeighbours();
-                    }, Blockly.config.bumpDelay);
-                }
-            }
-        });
-        Blockly.Events.setGroup(false);
+            changedDescendants.push({
+                id: block.id,
+                type: block.type,
+                oldName,
+                newName,
+                targetBlockId,
+                targetInputName,
+            });
+        }
+
+        const callerChanges = getCallers(name, definitionBlock.workspace)
+            .map(caller => ({
+                id: caller.id,
+                oldMutation: Blockly.utils.xml.domToText(caller.mutationToDom()),
+                shadows: (caller as FunctionCallBlock).serializeChangedInputs(mutation)
+            } as CallerChange))
+
+        const change = new MutateFunctionEvent(
+            definitionBlock.id,
+            callerChanges,
+            Blockly.Xml.domToText(oldMutation),
+            Blockly.Xml.domToText(mutation),
+            changedDescendants
+        );
+
+        change.workspaceId = ws.id;
+
+        change.run(true);
+        Blockly.Events.fire(change);
     } else {
         pxt.warn("Attempted to change function " + name + ", but no definition block was found on the workspace");
     }
 }
 
-function getArgMap(mutation: Element, inverse: boolean) {
+export function getArgMap(mutation: Element, inverse: boolean) {
     const map: StringMap<string> = {};
     for (let i = 0; i < mutation.childNodes.length; ++i) {
         const arg = mutation.childNodes[i] as Element;
@@ -471,4 +461,102 @@ export function isVariableBlockType(type: string) {
             return true;
     }
     return false;
+}
+
+interface DescendantChange {
+    id: string;
+    type: string;
+    oldName: string;
+    newName?: string;
+    targetBlockId: string;
+    targetInputName: string;
+}
+
+interface CallerChange {
+    id: string;
+    oldMutation: string;
+    shadows: SerializedShadow[];
+}
+
+class MutateFunctionEvent extends Blockly.Events.Abstract {
+    isBlank: boolean;
+
+    type = "pxt_mutate_function"
+
+    constructor(
+        protected definition: string,
+        protected callers: CallerChange[],
+        protected oldMutation: string,
+        protected newMutation: string,
+        protected descendantChanges: DescendantChange[]
+    ) {
+        super();
+    }
+
+    run(forward: boolean) {
+        const ws = this.getEventWorkspace_();
+        const mutation = Blockly.utils.xml.textToDom(forward ? this.newMutation : this.oldMutation);
+        const def = ws.getBlockById(this.definition) as FunctionDefinitionBlock;
+
+        Blockly.Events.disable();
+
+        def.domToMutation(mutation);
+        def.createAllInputs_();
+        def.afterWorkspaceLoad();
+
+        for (const change of this.callers) {
+            const caller = ws.getBlockById(change.id);
+
+            if (forward) {
+                caller.domToMutation(mutation);
+            }
+            else {
+                caller.domToMutation(Blockly.utils.xml.textToDom(change.oldMutation));
+
+                for (const inputChange of change.shadows) {
+                    if (inputChange.connectedBlock) {
+                        const block = ws.getBlockById(inputChange.connectedBlock);
+                        caller.getInput(inputChange.inputName).connection.connect(block.outputConnection);
+                    }
+                    else {
+                        caller.getInput(inputChange.inputName).connection.setShadowState(inputChange.connectedShadow);
+                    }
+                }
+            }
+        }
+
+        for (const change of this.descendantChanges) {
+            if (change.newName) {
+                const block = ws.getBlockById(change.id);
+                block.setFieldValue("VALUE", forward ? change.newName : change.oldName);
+            }
+            else if (forward) {
+                const block = ws.getBlockById(change.id);
+
+                if (block) {
+                    block.dispose();
+                }
+            }
+            else {
+                const newBlock = ws.newBlock(change.type, change.id) as Blockly.BlockSvg;
+                newBlock.setFieldValue(change.oldName, "VALUE");
+                newBlock.initSvg();
+                const target = ws.getBlockById(change.targetBlockId);
+
+                const targetConnection = target.getInput(change.targetInputName).connection;
+
+                const toBeReplaced = targetConnection.targetBlock();
+                if (toBeReplaced) {
+                    if (!toBeReplaced.isShadow()) {
+                        toBeReplaced.dispose();
+                    }
+                }
+                targetConnection.connect(newBlock.outputConnection);
+            }
+        }
+
+        (def as unknown as Blockly.BlockSvg).queueRender();
+
+        Blockly.Events.enable();
+    }
 }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -980,7 +980,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     showFunctionsFlyout() {
-        this.showFlyoutInternal_(pxtblockly.createFunctionsFlyoutCategory(this.editor), "functions");
+        this.showFlyoutInternal_(pxtblockly.createFunctionsFlyoutCategory(this.editor), "functions", true);
     }
 
     getViewState() {
@@ -1619,7 +1619,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 // Cache blocks xml list for later
                 this.flyoutBlockXmlCache[cacheKey] = this.flyoutXmlList;
             }
-            this.showFlyoutInternal_(this.flyoutXmlList, cachable && cacheKey);
+            this.showFlyoutInternal_(this.flyoutXmlList, cachable && cacheKey, !cachable);
         }
     }
 
@@ -1703,10 +1703,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.showFlyoutInternal_(this.flyoutXmlList);
     }
 
-    private showFlyoutInternal_(xmlList: Element[], flyoutName: string = "default") {
+    private showFlyoutInternal_(xmlList: Element[], flyoutName: string = "default", skipCache = false) {
         this.currentFlyoutKey = flyoutName;
         const flyout = this.editor.getFlyout() as pxtblockly.VerticalFlyout;
-        flyout.show(xmlList, flyoutName);
+        flyout.show(xmlList, skipCache ? undefined : flyoutName);
         flyout.scrollToStart();
     }
 


### PR DESCRIPTION
this fixes a few bugs with functions in new blockly that were discovered on livestream. namely:

1. the function toolbox flyout was being cached too aggressively causing it to not update when existing functions were edited
2. undoing/redoing edits to function definitions (e.g. right click + edit function) were not always working correctly
3. editing functions was causing any attached shadow blocks to have their state reset in the calls to those functions

to fix all these issues, i've overhauled how the mutation of function blocks works. firstly, our old implementation disposed all of the argument inputs when a function was edited and then recreated them which led to the shadow issue mentioned above. now, only the edited arguments are created/destroyed. the rest of the inputs on the block are simply reordered.

secondly, we no longer rely on the blockly events spawned by editing the inputs on all of the changed blocks to handle undo/redo because keeping all of those events in sync was causing a lot of issues with edge cases. instead, i've created a custom blockly event that wraps up all of the edits for the mutation in one tidy package.

finally, the function flyout is now cached on the hash of its blocks rather than by its name. since we're essentially busting the cache here, i also tweaked our flyout so that the cache doesn't grow indefinitely. old cache entries now get evicted once we get to 20

there were a ton of tiny bugs here, so i look forward to everyone really hammering on this code in testing!