### PR TITLE
General cleanups in the language pages

### DIFF
--- a/common-docs/blocks.md
+++ b/common-docs/blocks.md
@@ -3,7 +3,8 @@
 ### @description Language constructs for the Block editor.
 
 ## #blocksbase
-Blocks snap into each other to define the program that your @boardname@ will run.
+
+Blocks snap into each other to define the program that will run.
 Blocks can be event (buttons, shake, ...) or need to be snapped into an event to run.
 The [on-start](/blocks/on-start) event runs first.
 

--- a/common-docs/javascript/call.md
+++ b/common-docs/javascript/call.md
@@ -1,8 +1,8 @@
 # Call a function
 
-The simplest way to get started in JavaScript with your @boardname@ is to
-call one of the @boardname@'s built-in JavaScript functions. Just like how Blocks
-are organized into categories/drawers, the @boardname@ functions are organized by
+The simplest way to get started in JavaScript is to
+call one of the built-in JavaScript functions. Just like how Blocks
+are organized into categories/drawers, the functions are organized by
 namespaces, with names corresponding to the drawer names.
 
 ```typescript-ignore
@@ -10,6 +10,8 @@ Math.abs(-1)
 ```
 
 ### ~ hint
+
+#### Functions in a namespace
 
 If you want to see all functions available in the `Math` namespace, simply type `Math`
 followed by `.` and a list of all the functions will appear. 

--- a/common-docs/javascript/functions.md
+++ b/common-docs/javascript/functions.md
@@ -14,7 +14,9 @@ let sum = add(1, 2);
 
 ### ~ hint
 
-For the @boardname@, you must specify a [type](/javascript/types) for each function parameter. 
+#### Parameter types
+
+You must specify a [type](/javascript/types) for each function parameter. 
 
 ### ~ 
 

--- a/common-docs/javascript/operators.md
+++ b/common-docs/javascript/operators.md
@@ -1,6 +1,6 @@
 # Operators
 
-The following JavaScript operators are supported for the @boardname@.
+The following JavaScript operators are supported:
 
 ## Assignment, arithmetic and bitwise
 

--- a/common-docs/javascript/sequence.md
+++ b/common-docs/javascript/sequence.md
@@ -36,6 +36,8 @@ doSomething(); // THIS LINE WILL NEVER EXECUTE!
 
 ### ~hint
 
+#### No 'empty' statements
+
 To avoid this problem, we don't allow a program to contain an empty statement, such as shown above. 
 If you really want an empty statement, you need to use curly braces to delimit an empty statement block:
 ```typescript-ignore

--- a/common-docs/javascript/statements.md
+++ b/common-docs/javascript/statements.md
@@ -1,6 +1,6 @@
 # Statements
 
-The following JavaScript statements are supported for the @boardname@:
+The following JavaScript statements are supported:
 
 ## Variable declarations
 * [`const` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const)

--- a/common-docs/python/call.md
+++ b/common-docs/python/call.md
@@ -1,15 +1,17 @@
 # Call a function
 
-The simplest way to get started in Python with your @boardname@ is to
-call one of the @boardname@'s built-in Python functions. Just like how Blocks
-are organized into categories/drawers, the @boardname@ functions are organized by
-namespaces, with names corresponding to the drawer names.
+The simplest way to get started in Python is to
+call one of the built-in Python functions. Just like how Blocks
+are organized into categories/drawers, functions are organized by
+namespaces too, with names corresponding to the drawer names.
 
 ```python-ignore
 Math.abs(-1)
 ```
 
 ### ~ hint
+
+#### Functions in a namespace
 
 If you want to see all functions available in the `Math` namespace, simply type `Math`
 followed by `.` and a list of all the functions will appear. 

--- a/common-docs/python/functions.md
+++ b/common-docs/python/functions.md
@@ -96,7 +96,7 @@ The default value of `lastName` disappears in the type, only leaving behind the 
 Handler functions are functions that take some action when an event or change of state occurs. Usually, some other code saves, or registers, the handler function in a variable in order to call
 it at a later time. When an event happens, like a new input value or an elapsed timer, the handler is called to run a response action.
 
-As an example, the `Thermal` class will check for changes in temperature and run a registered handler when the temperature drops to a set thershold:
+As an example, the `Thermal` class will check for changes in temperature and run a registered handler when the temperature drops to a set threshold:
 
 ```python-ignore
 # the handler function when it's cold...
@@ -122,9 +122,9 @@ thermal.whenCold(whenCold)
 thermal.checkCold()
 ```
 
-## Lamda Functions
+## Lambda Functions
 
-Lamda functions serve as a kind of shortcut to return a result of an expression. A lamda is often saved to a variable and then used like a function to return the expression result:
+Lambda functions serve as a kind of shortcut to return a result of an expression. A lambda is often saved to a variable and then used like a function to return the expression result:
 
 ```python-ignore
 def square(x):

--- a/common-docs/python/operators.md
+++ b/common-docs/python/operators.md
@@ -1,6 +1,6 @@
 # Operators
 
-The following Python operators are supported for the @boardname@.
+The following Python operators are supported:
 
 ## Assignment, arithmetic and bitwise
 

--- a/common-docs/python/statements.md
+++ b/common-docs/python/statements.md
@@ -1,6 +1,6 @@
 # Statements
 
-The following Python statements are supported for the @boardname@:
+The following Python statements are supported:
 
 ## Variable declarations
 

--- a/common-docs/types.md
+++ b/common-docs/types.md
@@ -1,7 +1,7 @@
 # Types
 
 A *type* refers to a class of data and the operations permitted on that class of data. 
-The following built-in types are supported for the @boardname@:
+The following built-in types are supported:
 
 ## Basic (primitive) types #primitives
 

--- a/common-docs/types/array.md
+++ b/common-docs/types/array.md
@@ -12,14 +12,14 @@ Arrays are flexible, they can grow and shrink in size. You can add and remove it
 
 An array is created by making a list of items.
 
-```block
+```blocks
 let scores = [9, 8, 3, 5, 6, 8];
 ```
 Here the array automatically becomes an array of [numbers](/types/number) because it was created with items that are numbers.
 
 You can use different types, like [string](/types/string).
 
-```block
+```blocks
 let directions = ["East", "North", "South", "West"];
 ```
 
@@ -33,7 +33,7 @@ let scores: number[] = [];
 
 When an item is added to an array it becomes an _element_ of the array. Array elements are found using an _index_. This is the position in the array of the element, or the element's _order_ in the array. The positions in an array begin with the index of `0`. The first place in the array is `0`, the second place is `1`, and so on.
 
-```block
+```blocks
 let scores = [9, 8, 3, 5, 6, 8];
 let firstScore= scores[0];
 let secondScore = scores[1];
@@ -42,7 +42,7 @@ let secondScore = scores[1];
 
 Arrays always have a length. The last element of an array has an index that is _length of array - 1_. Indexes begin with `0` so the last element's index is one less than the array length.
 
-```block
+```blocks
 let directions = ["East", "North", "South", "West"];
 let count = directions.length;
 ```
@@ -53,7 +53,7 @@ Arrays are a very useful way to collect and organize information. There are more
 
 Here's an example using [**insertAt**](/reference/arrays/insert-at) to insert a number into the middle of an array.
 
-```block
+```blocks
 let scores = [8, 5, 9, 3, 2, 4];
 scores.insertAt(3, 1);
 ```

--- a/common-docs/types/boolean.md
+++ b/common-docs/types/boolean.md
@@ -2,18 +2,18 @@
 
 Something that is only true or false.
 
-A boolean has one of two possible values: `true` or `false`.  The boolean (logical) operators (*and*, *or*, *not*) take boolean inputs and make another boolean value. Comparing on other types ([numbers](/types/number), [strings](/types/string)) with logical operators create boolean values.
+A boolean has one of two possible values: `true` or `false`. The boolean (logical) operators (*and*, *or*, *not*) take boolean inputs and make another boolean value. Comparing on other types ([numbers](/types/number), [strings](/types/string)) with logical operators create boolean values.
 
 These blocks represent the `true` and `false` boolean values, which can be plugged in anywhere a boolean value is expected:
 
-```block
+```blocks
 let on = true;
 let off = false;
 off = false;
 ```
 You can set and compare other boolean values:
 
-```block
+```blocks
 let on = true;
 let off = !on;
 let switcher = on;
@@ -27,7 +27,7 @@ if (switcher) {
 ```
 Compare other types:
 
-```block
+```blocks
 let cool = 50;
 let temp = 65;
 let warming = temp > cool;


### PR DESCRIPTION
Do some clean-ups in the *language* pages.

* Remove `@boardname@` macro where no longer appropriate or needed.
* Fix some spelling.
* Fix some formatting. 

Closes https://github.com/microsoft/pxt-minecraft/issues/2710
