### PR TITLE
Tball/check size

### DIFF
--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -1019,9 +1019,11 @@ ${hexfile.hexPrelude()}
         let b = mkProcessorFile(target)
         b.emit(src);
 
+        let flashUsableEnd = target.flashUsableEnd ? target.flashUsableEnd : target.flashEnd
+
         src = `; Interface tables: ${bin.itFullEntries}/${bin.itEntries} (${Math.round(100 * bin.itFullEntries / bin.itEntries)}%)\n` +
             `; Virtual methods: ${bin.numVirtMethods} / ${bin.numMethods}\n` +
-            b.getSource(!peepDbg, bin.numStmts, target.flashUsableEnd);
+            b.getSource(!peepDbg, bin.numStmts, flashUsableEnd);
 
         throwAssemblerErrors(b)
 

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -1021,7 +1021,7 @@ ${hexfile.hexPrelude()}
 
         src = `; Interface tables: ${bin.itFullEntries}/${bin.itEntries} (${Math.round(100 * bin.itFullEntries / bin.itEntries)}%)\n` +
             `; Virtual methods: ${bin.numVirtMethods} / ${bin.numMethods}\n` +
-            b.getSource(!peepDbg, bin.numStmts, target.flashEnd);
+            b.getSource(!peepDbg, bin.numStmts, target.flashUsableEnd);
 
         throwAssemblerErrors(b)
 

--- a/pxtlib/emitter/assembler.ts
+++ b/pxtlib/emitter/assembler.ts
@@ -1067,7 +1067,7 @@ namespace ts.pxtc.assembler {
             return r
         }
 
-        public getSource(clean: boolean, numStmts = 1, flashSize = 0) {
+        public getSource(clean: boolean, numStmts = 1, flashUsableEnd = 0) {
             let lenPrev = 0
             let size = (lbl: string) => {
                 let curr = this.labels[lbl] || lenPrev
@@ -1081,18 +1081,18 @@ namespace ts.pxtc.assembler {
             let lenVtables = size("_vtables_end")
             let lenLiterals = size("_literals_end")
             let lenAllCode = lenPrev
-            let totalSize = (lenTotal + this.baseOffset) & 0xffffff
+            let totalEnd = (lenTotal + this.baseOffset - 1) & 0xffffff
 
-            if (flashSize && totalSize > flashSize) {
-                const e = new Error(lf("program too big by {0} bytes!", totalSize - flashSize));
+            if (flashUsableEnd && totalEnd >= flashUsableEnd) {
+                const e = new Error(lf("program too big by {0} bytes!", totalEnd - flashUsableEnd));
                 (e as any).ksErrorCode = 9283;
                 throw e;
             }
 
-            flashSize = flashSize || 128 * 1024
+            flashUsableEnd = flashUsableEnd || 128 * 1024
             let totalInfo = lf("; total bytes: {0} ({1}% of {2}k flash with {3} free)",
-                totalSize, (100 * totalSize / flashSize).toFixed(1), (flashSize / 1024).toFixed(1),
-                flashSize - totalSize)
+                totalEnd, (100 * totalEnd / flashUsableEnd).toFixed(1), (flashUsableEnd / 1024).toFixed(1),
+                flashUsableEnd - totalEnd)
             let res =
                 // ARM-specific
                 lf("; generated code sizes (bytes): {0} (incl. {1} user, {2} helpers, {3} vtables, {4} lits); src size {5}\n",

--- a/pxtlib/emitter/assembler.ts
+++ b/pxtlib/emitter/assembler.ts
@@ -1081,10 +1081,10 @@ namespace ts.pxtc.assembler {
             let lenVtables = size("_vtables_end")
             let lenLiterals = size("_literals_end")
             let lenAllCode = lenPrev
-            let totalEnd = (lenTotal + this.baseOffset - 1) & 0xffffff
+            let totalEnd = (lenTotal + this.baseOffset) & 0xffffff
 
-            if (flashUsableEnd && totalEnd >= flashUsableEnd) {
-                const e = new Error(lf("program too big by {0} bytes!", totalEnd - flashUsableEnd + 1));
+            if (flashUsableEnd && totalEnd > flashUsableEnd) {
+                const e = new Error(lf("program too big by {0} bytes!", totalEnd - flashUsableEnd));
                 (e as any).ksErrorCode = 9283;
                 throw e;
             }

--- a/pxtlib/emitter/assembler.ts
+++ b/pxtlib/emitter/assembler.ts
@@ -1084,7 +1084,7 @@ namespace ts.pxtc.assembler {
             let totalEnd = (lenTotal + this.baseOffset - 1) & 0xffffff
 
             if (flashUsableEnd && totalEnd >= flashUsableEnd) {
-                const e = new Error(lf("program too big by {0} bytes!", totalEnd - flashUsableEnd));
+                const e = new Error(lf("program too big by {0} bytes!", totalEnd - flashUsableEnd + 1));
                 (e as any).ksErrorCode = 9283;
                 throw e;
             }


### PR DESCRIPTION
pxt-microbit defines flashUsableEnd, but our size check doesn't use it. This is a backwards compatible change that will take it into account (when it exists in pxtarget) and default to flashEnd otherwise. Related change:

https://github.com/microsoft/pxt-microbit/pull/6107
