### PR TITLE
Correctly handle link interactions on extension cards

### DIFF
--- a/react-common/components/controls/Card.tsx
+++ b/react-common/components/controls/Card.tsx
@@ -25,6 +25,26 @@ export const Card = (props: CardProps) => {
         tabIndex
     } = props;
 
+    
+    const handleLinkOrTriggerClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+        if (e.target && (e.target as HTMLElement).tagName == "A") {
+            return;
+        }
+        e.preventDefault();
+        onClick();
+    }
+
+    const handleClick = (e: React.MouseEvent) => {
+        handleLinkOrTriggerClick(e);
+    }
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        const charCode = (typeof e.which == "number") ? e.which : e.keyCode;
+        if (charCode === /*enter*/13 || charCode === /*space*/32) {
+            handleLinkOrTriggerClick(e);
+        }
+    }
+
     return <div
         id={id}
         className={classList("common-card", className)}
@@ -33,9 +53,9 @@ export const Card = (props: CardProps) => {
         aria-labelledby={ariaLabelledBy}
         aria-hidden={ariaHidden}
         aria-label={ariaLabel}
-        onClick={onClick}
+        onClick={handleClick}
         tabIndex={tabIndex}
-        onKeyDown={fireClickOnEnter}>
+        onKeyDown={handleKeyDown}>
             <div className="common-card-body">
                 {children}
             </div>


### PR DESCRIPTION
When using the keyboard, the "Learn More" links both open a link in a new tab and add the extension to the project when only the former should happen.

In the beta editor, the extension card "Learn More" links are now anchor tags instead of buttons. Some additional click handling is required to prevent the same keyboard error noted above also occuring when clicking these links.

This PR addresses both issues.

@microbit-matt-hillsdon 