### PR TITLE
Several Theme Fixes - New Preference Format, Color Tweaks

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -104,7 +104,7 @@ declare namespace pxt.editor {
         | "serviceworkerregistered"
         | "runeval"
         | "precachetutorial"
-        | "setcolortheme"
+        | "setcolorthemebyid"
 
         // package extension messasges
         | ExtInitializeType
@@ -512,8 +512,9 @@ declare namespace pxt.editor {
     }
 
     export interface EditorMessageSetColorThemeRequest extends EditorMessageRequest {
-        action: "setcolortheme";
+        action: "setcolorthemebyid";
         colorThemeId: string;
+        savePreference?: boolean;
     }
 
     /**
@@ -1100,7 +1101,7 @@ declare namespace pxt.editor {
         hasHeaderBeenPersistentShared(): boolean;
         getSharePreferenceForHeader(): boolean;
         saveSharePreferenceForHeaderAsync(anonymousByDefault: boolean): Promise<void>;
-        setColorTheme(colorThemeId: string): void;
+        setColorThemeById(colorThemeId: string, savePreference: boolean): void;
     }
 
     export interface IHexFileImporter {

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -317,9 +317,9 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                         }
                                     });
                             }
-                            case "setcolortheme": {
+                            case "setcolorthemebyid": {
                                 const msg = data as pxt.editor.EditorMessageSetColorThemeRequest;
-                                projectView.setColorTheme(msg.colorThemeId);
+                                projectView.setColorThemeById(msg.colorThemeId, !!msg.savePreference);
                                 return Promise.resolve();
                             }
                         }

--- a/pxtlib/auth.ts
+++ b/pxtlib/auth.ts
@@ -44,6 +44,13 @@ namespace pxt.auth {
         badges: Badge[];
     }
 
+    /**
+     * Mapping of target id to preferred color theme id.
+     */
+    export type ColorThemeIdsState = {
+        [targetId: string]: string;
+    }
+
     export type SetPrefResult = {
         success: boolean;
         res: UserPreferences;
@@ -55,7 +62,7 @@ namespace pxt.auth {
     export type UserPreferences = {
         language?: string;
         highContrast?: boolean;
-        themeId?: string;
+        colorThemeIds?: ColorThemeIdsState;
         reader?: string;
         skillmap?: UserSkillmapState;
         badges?: UserBadgeState;
@@ -65,7 +72,7 @@ namespace pxt.auth {
     export const DEFAULT_USER_PREFERENCES: () => UserPreferences = () => ({
         language: pxt.appTarget.appTheme.defaultLocale,
         highContrast: false,
-        themeId: pxt.appTarget.appTheme.defaultColorTheme,
+        colorThemeIds: {}, // Will lookup pxt.appTarget.appTheme.defaultColorTheme for active target
         reader: "",
         skillmap: { mapProgress: {}, completedTags: {} },
         email: false

--- a/pxtservices/editorDriver.ts
+++ b/pxtservices/editorDriver.ts
@@ -456,12 +456,13 @@ export class EditorDriver extends IframeDriver {
         );
     }
 
-    async setColorTheme(colorThemeId: string) {
+    async setColorTheme(colorThemeId: string, savePreference: boolean) {
         await this.sendRequest (
             {
                 type: "pxteditor",
-                action: "setcolortheme",
-                colorThemeId
+                action: "setcolorthemebyid",
+                colorThemeId,
+                savePreference
             } as pxt.editor.EditorMessageSetColorThemeRequest
         );
     }

--- a/react-common/components/theming/themeManager.ts
+++ b/react-common/components/theming/themeManager.ts
@@ -31,7 +31,7 @@ export class ThemeManager {
     }
 
     public isKnownTheme(themeId: string): boolean {
-        return pxt.appTarget.colorThemeMap && themeId in pxt.appTarget.colorThemeMap;
+        return !!pxt.appTarget?.colorThemeMap?.[themeId];
     }
 
     public getAllColorThemes(): pxt.ColorThemeInfo[] {

--- a/react-common/components/theming/themeManager.ts
+++ b/react-common/components/theming/themeManager.ts
@@ -30,6 +30,10 @@ export class ThemeManager {
         return this.currentTheme;
     }
 
+    public isKnownTheme(themeId: string): boolean {
+        return pxt.appTarget.colorThemeMap && themeId in pxt.appTarget.colorThemeMap;
+    }
+
     public getAllColorThemes(): pxt.ColorThemeInfo[] {
         const allThemes = pxt.appTarget?.colorThemeMap ? Object.values(pxt.appTarget.colorThemeMap) : [];
         return allThemes.sort((a, b) => {

--- a/react-common/styles/theming/base-theme.less
+++ b/react-common/styles/theming/base-theme.less
@@ -60,6 +60,7 @@
     --pxt-neutral-stencil3: #FFFFFF;
     --pxt-neutral-background3-alpha90: #4E5758E5; /* Needed for monaco toolbox */
 
+    --pxt-neutral-base: rgba(0, 0, 0, 1);
     --pxt-neutral-alpha0: rgba(0, 0, 0, 0);
     --pxt-neutral-alpha10: rgba(0, 0, 0, 0.1);
     --pxt-neutral-alpha20: rgba(0, 0, 0, 0.2);

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -422,6 +422,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
     changeTheme(theme: pxt.ColorThemeInfo) {
         pxt.tickEvent(`skillmap.menu.theme.changetheme`, { theme: theme.id });
         this.themeManager.switchColorTheme(theme.id);
+        authClient.setColorThemeIdAsync(theme.id);
     }
 
     render() {

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -358,9 +358,11 @@ class AppImpl extends React.Component<AppProps, AppState> {
     protected async initColorThemeAsync() {
         // Load theme colors
         const prefThemeId = await authClient.getColorThemeIdAsync();
-        let initialTheme = this.props.highContrast ?
-                    pxt.appTarget?.appTheme?.highContrastColorTheme :
-                    prefThemeId ?? pxt.appTarget?.appTheme?.defaultColorTheme;
+        let initialTheme = this.props.highContrast
+            ? pxt.appTarget?.appTheme?.highContrastColorTheme
+            : prefThemeId && this.themeManager.isKnownTheme(prefThemeId)
+                ? prefThemeId
+                : pxt.appTarget?.appTheme?.defaultColorTheme;
 
         if (initialTheme) {
             if (initialTheme !== this.themeManager.getCurrentColorTheme()?.id) {
@@ -420,7 +422,6 @@ class AppImpl extends React.Component<AppProps, AppState> {
     changeTheme(theme: pxt.ColorThemeInfo) {
         pxt.tickEvent(`skillmap.menu.theme.changetheme`, { theme: theme.id });
         this.themeManager.switchColorTheme(theme.id);
-        this.props.dispatchSetUserPreferences({ themeId: theme.id });
     }
 
     render() {

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -360,7 +360,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
         const prefThemeId = await authClient.getColorThemeIdAsync();
         let initialTheme = this.props.highContrast
             ? pxt.appTarget?.appTheme?.highContrastColorTheme
-            : prefThemeId && this.themeManager.isKnownTheme(prefThemeId)
+            : (prefThemeId && this.themeManager.isKnownTheme(prefThemeId))
                 ? prefThemeId
                 : pxt.appTarget?.appTheme?.defaultColorTheme;
 

--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -42,8 +42,8 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
         if (this.props.preferences) {
             items.push({
                 id: "theme",
-                title: lf("Select Theme"),
-                label: lf("Select Theme"),
+                title: lf("Theme"),
+                label: lf("Theme"),
                 onClick: () => {
                     tickEvent("skillmap.theme");
                     this.props.dispatchShowSelectTheme();

--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -175,8 +175,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
             {
                 type: "pxteditor",
                 action: "setcolorthemebyid",
-                colorThemeId,
-                savePreference: true
+                colorThemeId
             } as pxt.editor.EditorMessageSetColorThemeRequest
         );
     }

--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -174,8 +174,9 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
         this.sendMessageAsync (
             {
                 type: "pxteditor",
-                action: "setcolortheme",
-                colorThemeId
+                action: "setcolorthemebyid",
+                colorThemeId,
+                savePreference: true
             } as pxt.editor.EditorMessageSetColorThemeRequest
         );
     }

--- a/skillmap/src/lib/authClient.ts
+++ b/skillmap/src/lib/authClient.ts
@@ -143,7 +143,7 @@ export async function getBadgeStateAsync(): Promise<pxt.auth.UserBadgeState | un
 
 export async function getColorThemeIdAsync(): Promise<string | undefined> {
     const prefs = await userPreferencesAsync();
-    if(prefs) {
+    if (prefs) {
         return prefs?.colorThemeIds?.[pxt.appTarget.id];
     }
 }

--- a/skillmap/src/lib/authClient.ts
+++ b/skillmap/src/lib/authClient.ts
@@ -142,9 +142,26 @@ export async function getBadgeStateAsync(): Promise<pxt.auth.UserBadgeState | un
 }
 
 export async function getColorThemeIdAsync(): Promise<string | undefined> {
+    const prefs = await userPreferencesAsync();
+    if(prefs) {
+        return prefs?.colorThemeIds?.[pxt.appTarget.id];
+    }
+}
+
+export async function setColorThemeIdAsync(themeId: string): Promise<void> {
     const cli = await clientAsync();
-    const prefs = await cli?.userPreferencesAsync();
-    return prefs?.colorThemeIds?.[pxt.appTarget.id];
+    if (cli) {
+        const currentPrefs = await cli.userPreferencesAsync();
+        const newColorThemePref = {
+            ...currentPrefs?.colorThemeIds,
+            [pxt.appTarget.id]: themeId
+        };
+        await cli.patchUserPreferencesAsync({
+            op: 'replace',
+            path: ['colorThemeIds'],
+            value: newColorThemePref
+        });
+    }
 }
 
 export async function userPreferencesAsync(): Promise<pxt.auth.UserPreferences | undefined> {

--- a/skillmap/src/lib/authClient.ts
+++ b/skillmap/src/lib/authClient.ts
@@ -144,7 +144,7 @@ export async function getBadgeStateAsync(): Promise<pxt.auth.UserBadgeState | un
 export async function getColorThemeIdAsync(): Promise<string | undefined> {
     const cli = await clientAsync();
     const prefs = await cli?.userPreferencesAsync();
-    return prefs?.themeId;
+    return prefs?.colorThemeIds?.[pxt.appTarget.id];
 }
 
 export async function userPreferencesAsync(): Promise<pxt.auth.UserPreferences | undefined> {

--- a/theme/color-themes/high-contrast.json
+++ b/theme/color-themes/high-contrast.json
@@ -68,6 +68,7 @@
         "pxt-neutral-stencil3": "#FFFFFF",
         "pxt-neutral-background3-alpha90": "#000000E5",
 
+        "pxt-neutral-base": "rgba(255, 255, 255, 1)",
         "pxt-neutral-alpha0": "rgba(255, 255, 255, 0)",
         "pxt-neutral-alpha10": "rgba(255, 255, 255, 0.1)",
         "pxt-neutral-alpha20": "rgba(255, 255, 255, 0.2)",

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -9,3 +9,7 @@
     outline: 2px solid var(--pxt-colors-yellow-background) !important;
     z-index: 1;
 }
+
+.barcharticon {
+    filter: invert(1);
+}

--- a/theme/common.less
+++ b/theme/common.less
@@ -258,6 +258,19 @@ pre {
     width: 100% !important;
     margin: 0;
     margin-top: 1rem;
+
+    background: var(--pxt-primary-background);
+    color: var(--pxt-primary-foreground);
+
+    .item, .link.item {
+        color: var(--pxt-primary-foreground) !important; // override !important in semantic ui
+        border-radius: inherit;
+
+        &:hover, &:focus {
+            background: var(--pxt-primary-background-hover) !important;
+            color: var(--pxt-primary-foreground-hover) !important;
+        }
+    }
 }
 
 .filemenu .nested.item {

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -125,9 +125,15 @@
         .blocklyTreeSelected span.blocklyTreeLabel {
             color: @HCblocklyTreeLabelSelectedColor;
         }
+        .blocklyTreeRow:not(.blocklyTreeSelected) {
+            background-color: @HCblocklyToolboxColor !important;
+            .blocklyTreeIcon, .blocklyTreeLabel {
+                color: @HCblocklyTreeLabelColor !important;
+            }
+        }
         .blocklyTreeRow:not(.blocklyTreeSelected):hover,
         .blocklyTreeRow:not(.blocklyTreeSelected):focus {
-            background-color: lighten(@HCblocklyToolboxColor, 25.0);
+            background-color: lighten(@HCblocklyToolboxColor, 25.0) !important;
         }
     }
 

--- a/theme/home.less
+++ b/theme/home.less
@@ -137,7 +137,7 @@
             margin: 0;
             padding-left: @carouselArrowSize;
             font-size: 20px;
-            color: var(--pxt-neutral-foreground1);
+            color: var(--pxt-target-foreground2);
             &.myproject-header {
                 cursor: pointer;
                 outline: none;

--- a/theme/semantic-ui-overrides.less
+++ b/theme/semantic-ui-overrides.less
@@ -9,7 +9,7 @@ This file overrides the default semantic ui theming with our own theme variables
 // Mixin allows easy setting for background, foreground, hover, and inverted colors for a button
 .buttonVariant(@bg; @fg; @hoverBg; @hoverFg; @border) {
     &:not(.disabled) {
-        background: @bg;
+        background-color: @bg;
         color: @fg;
         border: 1px solid @border;
     

--- a/theme/semantic-ui-overrides.less
+++ b/theme/semantic-ui-overrides.less
@@ -105,7 +105,8 @@ body.pxt-theme-root {
         > .header,
         > .actions,
         > .closeIcon,
-        > .closeIcon .close {
+        > .closeIcon .close,
+        > .content > .ui.items > .item > .content > .description {
             background-color: var(--pxt-neutral-background1);
             color: var(--pxt-neutral-foreground1);
         }

--- a/theme/semantic-ui-overrides.less
+++ b/theme/semantic-ui-overrides.less
@@ -140,7 +140,6 @@ body.pxt-theme-root {
         color: var(--pxt-neutral-foreground1);
     }
 
-
     .ui.menu {
         background: var(--pxt-neutral-background1);
         color: var(--pxt-neutral-foreground1);

--- a/theme/semantic-ui-overrides.less
+++ b/theme/semantic-ui-overrides.less
@@ -289,12 +289,12 @@ body.pxt-theme-root {
         }
 
         &.gray, &.grey, &.neutral {
-            background-color: var(--pxt-neutral-backgroundbackground2) !important;
-            color: var(--pxt-neutral-background-foreground2) !important;
+            background-color: var(--pxt-neutral-background2) !important;
+            color: var(--pxt-neutral-foreground2) !important;
 
             &.inverted {
-                background-color: var(--pxt-neutral-background-foreground2) !important;
-                color: var(--pxt-neutral-background-background2) !important;
+                background-color: var(--pxt-neutral-foreground2) !important;
+                color: var(--pxt-neutral-background2) !important;
             }
         }
 

--- a/theme/semantic-ui-overrides.less
+++ b/theme/semantic-ui-overrides.less
@@ -207,6 +207,10 @@ body.pxt-theme-root {
         }
     }
 
+    .ui.raised.segment, .ui.raised.segments {
+        box-shadow: 0 2px 4px 0 var(--pxt-neutral-alpha10),0 2px 10px 0 var(--pxt-neutral-alpha10);
+    }
+
     // Colors
     .blue {
         color: var(--pxt-colors-blue-background);

--- a/theme/semantic-ui-overrides.less
+++ b/theme/semantic-ui-overrides.less
@@ -8,25 +8,27 @@ This file overrides the default semantic ui theming with our own theme variables
 
 // Mixin allows easy setting for background, foreground, hover, and inverted colors for a button
 .buttonVariant(@bg; @fg; @hoverBg; @hoverFg; @border) {
-    background: @bg;
-    color: @fg;
-    border: 1px solid @border;
-
-    &.inverted {
-        background-color: @fg;
-        color: @bg;
-    }
-
-    &:hover, &:focus {
-        // Semantic UI darkens background using a filter, which isn't necessary when we have a hover color.
-        filter: none;
-
-        background-color: @hoverBg;
-        color: @hoverFg;
-
+    &:not(.disabled) {
+        background: @bg;
+        color: @fg;
+        border: 1px solid @border;
+    
         &.inverted {
-            background-color: @hoverFg;
-            color: @hoverBg;
+            background-color: @fg;
+            color: @bg;
+        }
+    
+        &:hover, &:focus {
+            // Semantic UI darkens background using a filter, which isn't necessary when we have a hover color.
+            filter: none;
+    
+            background-color: @hoverBg;
+            color: @hoverFg;
+    
+            &.inverted {
+                background-color: @hoverFg;
+                color: @hoverBg;
+            }
         }
     }
 }

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -149,8 +149,8 @@ a.ui.card:focus,
     border: @linkHoverBorder;
 }
 
-.ui.card.link.newprojectcard {
-    background: var(--pxt-primary-background) !important;
+.gallerysegment .ui.card.link.newprojectcard {
+    background-color: var(--pxt-primary-background) !important;
     color: var(--pxt-primary-foreground) !important;
 
     .header {
@@ -158,8 +158,8 @@ a.ui.card:focus,
     }
 }
 
-.ui.card.link.cloudprojectscard {
-    background: var(--pxt-secondary-accent) !important;
+.gallerysegment .ui.card.link.cloudprojectscard {
+    background-color: var(--pxt-secondary-accent) !important;
     color: var(--pxt-secondary-foreground) !important;
 
     .header {

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -579,7 +579,6 @@
         float: right;
         border: 2px solid var(--pxt-neutral-stencil1);
         margin-left: 1.5rem;
-        background: @white; // Cannot theme properly until we have a way to theme the immersive reader icon
     }
 }
 

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -74,6 +74,8 @@
 
     .lang-block .ui.segment.raised, .lang-blocks .ui.segment.raised, .ui.segment.raised.codewidget {
         overflow-x: auto;
+        background: var(--pxt-neutral-background2);
+        color: var(--pxt-neutral-foreground2);
 
         code, code.hljs {
             white-space: pre;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -6,7 +6,6 @@
 @tutorialSecondaryColor: var(--pxt-colors-blue-background);
 @tutorialBarForegroundColor: @tutorialPrimaryColor;
 @tutorialBarBackgroundColor: @tutorialSecondaryColor;
-@tutorialDarkGray: var(--pxt-neutral-background3);
 
 @tutorialLinkColor: var(--pxt-link);
 @tutorialLinkHoverColor: var(--pxt-link-hover);
@@ -172,7 +171,7 @@
     user-select: none;
     cursor: default;
     font-size: 1rem;
-    color: @tutorialDarkGray;
+    color: var(--pxt-neutral-foreground1);
 }
 
 .tutorial-step-title {

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -562,10 +562,9 @@ code.lang-filterblocks {
     background-image: @immersiveReaderIcon;
 }
 
-// TODO : Can't theme immersive reader without different versions of the reader icon
 #mainmenu .immersive-reader-button:focus,
 #mainmenu .immersive-reader-button:hover {
-    background-color: #00000059!important;
+    background-color: var(--pxt-neutral-alpha50);
     filter: brightness(0.8);
 }
 
@@ -575,7 +574,6 @@ code.lang-filterblocks {
     height: 2.8rem;
     background-repeat: no-repeat;
     background-size: 60%;
-    background-color: #f9fafb;
     background-position: center;
     box-shadow: none;
     transition: none;
@@ -591,7 +589,6 @@ code.lang-filterblocks {
     background-image: @immersiveReaderIcon;
     background-repeat: no-repeat;
     background-size: contain;
-    background-color: #f9fafb;
     background-position: center;
     background-size: 60%;
     filter: brightness(0.8);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -235,7 +235,7 @@ export class ProjectView
         this.initSimulatorMessageHandlers();
         this.showThemePicker = this.showThemePicker.bind(this);
         this.hideThemePicker = this.hideThemePicker.bind(this);
-        this.setColorTheme = this.setColorTheme.bind(this);
+        this.setColorThemeById = this.setColorThemeById.bind(this);
 
         // add user hint IDs and callback to hint manager
         if (pxt.BrowserUtils.useOldTutorialLayout()) this.hintManager.addHint(ProjectView.tutorialCardId, this.tutorialCardHintCallback.bind(this));
@@ -5159,14 +5159,17 @@ export class ProjectView
         this.setState({ bannerVisible: b });
     }
 
-    setColorTheme(colorThemeId: string) {
+    setColorThemeById(colorThemeId: string, savePreference: boolean) {
         if (this.themeManager.getCurrentColorTheme()?.id === colorThemeId) {
             return;
         }
 
-        pxt.tickEvent("app.setcolortheme", { theme: colorThemeId });
+        pxt.tickEvent("app.setcolortheme", { theme: colorThemeId, savePreference: `${savePreference}` });
         this.themeManager.switchColorTheme(colorThemeId);
-        this.updateThemePreference();
+
+        if (savePreference) {
+            this.updateThemePreference();
+        }
     }
 
     private updateThemePreference() {
@@ -5482,7 +5485,7 @@ export class ProjectView
                 {lightbox ? <sui.Dimmer isOpen={true} active={lightbox} portalClassName={'tutorial'} className={'ui modal'}
                     shouldFocusAfterRender={false} closable={true} onClose={this.hideLightbox} /> : undefined}
                 {this.state.onboarding && <Tour tourSteps={this.state.onboarding} onClose={this.hideOnboarding} />}
-                {this.state.themePickerOpen && <ThemePickerModal themes={this.themeManager.getAllColorThemes()} onThemeClicked={theme => this.setColorTheme(theme?.id)} onClose={this.hideThemePicker} />}
+                {this.state.themePickerOpen && <ThemePickerModal themes={this.themeManager.getAllColorThemes()} onThemeClicked={theme => this.setColorThemeById(theme?.id, true)} onClose={this.hideThemePicker} />}
             </div>
         );
     }
@@ -6226,8 +6229,10 @@ document.addEventListener("DOMContentLoaded", async () => {
         })
         .then(() => {
             // Load theme colors
-            let initialTheme = data.getData<string>(auth.THEMEID);
-            if (!initialTheme) {
+            const themeManager = ThemeManager.getInstance(document);
+            const initialThemePrefs = data.getData<pxt.auth.ColorThemeIdsState>(auth.COLOR_THEME_IDS);
+            let initialTheme = initialThemePrefs?.[pxt.appTarget.id];
+            if (!initialTheme || !themeManager.isKnownTheme(initialTheme)) {
                 initialTheme = pxt.appTarget?.appTheme?.defaultColorTheme;
             }
 
@@ -6238,11 +6243,8 @@ document.addEventListener("DOMContentLoaded", async () => {
                 initialTheme = pxt.appTarget?.appTheme?.highContrastColorTheme;
             }
 
-            if (initialTheme) {
-                const themeManager = ThemeManager.getInstance(document);
-                if (initialTheme !== themeManager.getCurrentColorTheme()?.id) {
-                    return themeManager.switchColorTheme(initialTheme);
-                }
+            if (initialTheme && initialTheme !== themeManager.getCurrentColorTheme()?.id) {
+                return themeManager.switchColorTheme(initialTheme);
             }
             return Promise.resolve();
         })

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -15,12 +15,12 @@ export const LOGGED_IN = `${MODULE}:${FIELD_LOGGED_IN}`;
 const USER_PREF_MODULE = "user-pref";
 const FIELD_USER_PREFERENCES = "preferences";
 const FIELD_HIGHCONTRAST = "high-contrast";
-const FIELD_THEMEID = "themeId";
+const FIELD_COLOR_THEME_IDS = "colorThemeIds";
 const FIELD_LANGUAGE = "language";
 const FIELD_READER = "reader";
 export const USER_PREFERENCES = `${USER_PREF_MODULE}:${FIELD_USER_PREFERENCES}`
 export const HIGHCONTRAST = `${USER_PREF_MODULE}:${FIELD_HIGHCONTRAST}`
-export const THEMEID = `${USER_PREF_MODULE}:${FIELD_THEMEID}`
+export const COLOR_THEME_IDS = `${USER_PREF_MODULE}:${FIELD_COLOR_THEME_IDS}`
 export const LANGUAGE = `${USER_PREF_MODULE}:${FIELD_LANGUAGE}`
 export const READER = `${USER_PREF_MODULE}:${FIELD_READER}`
 export const HAS_USED_CLOUD = "has-used-cloud"; // Key into local storage to see if this computer has logged in before
@@ -63,7 +63,7 @@ class AuthClient extends pxt.auth.AuthClient {
             switch (op.path.join('/')) {
                 case "language": data.invalidate(LANGUAGE); break;
                 case "highContrast": data.invalidate(HIGHCONTRAST); break;
-                case "themeId": data.invalidate(THEMEID); break;
+                case "colorThemeIds": data.invalidate(COLOR_THEME_IDS); break;
                 case "reader": data.invalidate(READER); break;
             }
         }
@@ -114,7 +114,7 @@ class AuthClient extends pxt.auth.AuthClient {
             // Identity not available, read from local storage
             switch (path) {
                 case HIGHCONTRAST: return /^true$/i.test(pxt.storage.getLocal(HIGHCONTRAST));
-                case THEMEID: return pxt.storage.getLocal(THEMEID);
+                case COLOR_THEME_IDS: return pxt.U.jsonTryParse(pxt.storage.getLocal(COLOR_THEME_IDS)) as pxt.auth.ColorThemeIdsState;
                 case LANGUAGE: return pxt.storage.getLocal(LANGUAGE);
                 case READER: return pxt.storage.getLocal(READER);
             }
@@ -130,7 +130,7 @@ class AuthClient extends pxt.auth.AuthClient {
             switch (field) {
                 case FIELD_USER_PREFERENCES: return { ...state.preferences };
                 case FIELD_HIGHCONTRAST: return state.preferences?.highContrast ?? pxt.auth.DEFAULT_USER_PREFERENCES().highContrast;
-                case FIELD_THEMEID: return state.preferences?.themeId ?? pxt.auth.DEFAULT_USER_PREFERENCES().themeId;
+                case FIELD_COLOR_THEME_IDS: return state.preferences?.colorThemeIds ?? pxt.auth.DEFAULT_USER_PREFERENCES().colorThemeIds;
                 case FIELD_LANGUAGE: return state.preferences?.language ?? pxt.auth.DEFAULT_USER_PREFERENCES().language;
                 case FIELD_READER: return state.preferences?.reader ?? pxt.auth.DEFAULT_USER_PREFERENCES().reader;
             }
@@ -240,16 +240,30 @@ export async function setHighContrastPrefAsync(highContrast: boolean): Promise<v
 
 export async function setThemePrefAsync(themeId: string): Promise<void> {
     const cli = await clientAsync();
+    const targetId = pxt.appTarget.id;
+
     if (cli) {
+        const currentPrefs = await cli.userPreferencesAsync();
+        const newColorThemePref = {
+            ...currentPrefs?.colorThemeIds,
+            [targetId]: themeId
+        };
         await cli.patchUserPreferencesAsync({
             op: 'replace',
-            path: ['themeId'],
-            value: themeId
+            path: ['colorThemeIds'],
+            value: newColorThemePref
         });
     } else {
         // Identity not available, save this setting locally
-        pxt.storage.setLocal(THEMEID, themeId);
-        data.invalidate(THEMEID);
+        const currentPrefsStr = pxt.storage.getLocal(COLOR_THEME_IDS);
+        const currentPrefs = pxt.U.jsonTryParse(JSON.parse(currentPrefsStr)) as pxt.auth.ColorThemeIdsState ?? {};
+        const newColorThemePref = {
+            ...currentPrefs,
+            [targetId]: themeId
+        };
+        const serialized = JSON.stringify(newColorThemePref);
+        pxt.storage.setLocal(COLOR_THEME_IDS, serialized);
+        data.invalidate(COLOR_THEME_IDS);
     }
 }
 

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -228,7 +228,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
 
     if (showImmersiveReader) {
         modalActions.push({
-            className: "immersive-reader-button",
+            className: "immersive-reader-button neutral",
             onclick: async () => { await launchImmersiveReaderAsync(currentStepInfo.contentMd, tutorialOptions) },
             ariaLabel: lf("Launch Immersive Reader"),
             title: lf("Launch Immersive Reader")

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -346,7 +346,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             {showSimCollapse ? <sui.Item role="menuitem" icon='toggle right' text={simCollapseText} onClick={this.toggleCollapse} /> : undefined}
             <div className="ui divider"></div>
             {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
-            <sui.Item role="menuitem" icon="paint brush" text={lf("Select Theme")} onClick={this.showThemePicker} />
+            <sui.Item role="menuitem" icon="paint brush" text={lf("Theme")} onClick={this.showThemePicker} />
             {targetTheme.accessibleBlocks ? <sui.Item role="menuitem" text={accessibleBlocks ? lf("Accessible Blocks Off") : lf("Accessible Blocks On")} onClick={this.toggleAccessibleBlocks} /> : undefined}
             {showGreenScreen ? <sui.Item role="menuitem" text={greenScreen ? lf("Green Screen Off") : lf("Green Screen On")} onClick={this.toggleGreenScreen} /> : undefined}
             {docItems && renderDocItems(this.props.parent, docItems, "setting-docs-item mobile only inherit")}

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -400,7 +400,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
             <div role="treeitem" aria-selected={showFiles} aria-expanded={showFiles} aria-label={lf("File explorer toolbar")} key="projectheader" className="link item" onClick={this.toggleVisibility} tabIndex={0} onKeyDown={fireClickOnEnter}>
                 {lf("Explorer")}
                 <sui.Icon icon={`chevron ${showFiles ? "up" : "down"} icon`} />
-                {plus ? <sui.Button className="primary label" icon="plus" title={lf("Add custom blocks?")} onClick={this.handleCustomBlocksClick} onKeyDown={this.handleButtonKeydown} /> : undefined}
+                {plus ? <sui.Button className="neutral label" icon="plus" title={lf("Add custom blocks?")} onClick={this.handleCustomBlocksClick} onKeyDown={this.handleButtonKeydown} /> : undefined}
                 {!meta.numErrors ? null : <span className='ui label red'>{meta.numErrors}</span>}
             </div>
             {showFiles ? pxt.Util.concat(pkg.allEditorPkgs().map(p => this.filesWithHeader(p))) : undefined}
@@ -524,14 +524,14 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
             onKeyDown={fireClickOnEnter}
             className={className}>
             {this.props.children}
-            {hasDelete && <sui.Button className="primary label" icon="trash"
+            {hasDelete && <sui.Button className="neutral label" icon="trash"
                 title={lf("Delete file {0}", file.name)}
                 onClick={this.handleRemove}
                 onKeyDown={this.handleButtonKeydown} />}
             {meta && meta.numErrors ? <span className='ui label red button' role="button" title={lf("Go to error")}>{meta.numErrors}</span> : undefined}
-            {shareUrl && <sui.Button className="button primary label" icon="share alternate" title={lf("Share")} onClick={this.handleShare} onKeyDown={fireClickOnEnter} />}
-            {previewUrl && <sui.Button className="button primary label" icon="flask" title={lf("Preview")} onClick={this.handlePreview} onKeyDown={fireClickOnEnter} />}
-            {!!addLocalizedFile && <sui.Button className="primary label" icon="xicon globe"
+            {shareUrl && <sui.Button className="button neutral label" icon="share alternate" title={lf("Share")} onClick={this.handleShare} onKeyDown={fireClickOnEnter} />}
+            {previewUrl && <sui.Button className="button neutral label" icon="flask" title={lf("Preview")} onClick={this.handlePreview} onKeyDown={fireClickOnEnter} />}
+            {!!addLocalizedFile && <sui.Button className="neutral label" icon="xicon globe"
                 title={lf("Add localized file")}
                 onClick={this.handleAddLocale}
                 onKeyDown={this.handleButtonKeydown} />}
@@ -587,10 +587,10 @@ class PackgeTreeItem extends sui.StatelessUIElement<PackageTreeItemProps> {
             aria-label={lf("{0}, {1}", p.getPkgId(), isActive ? lf("expanded") : lf("collapsed"))}
             onClick={this.handleClick} tabIndex={0} onKeyDown={fireClickOnEnter} {...rest}>
             <sui.Icon icon={`chevron ${isActive ? "up" : "down"} icon`} />
-            {hasRefresh ? <sui.Button className="primary label" icon="refresh" title={lf("Refresh extension {0}", p.getPkgId())}
+            {hasRefresh ? <sui.Button className="neutral label" icon="refresh" title={lf("Refresh extension {0}", p.getPkgId())}
                 onClick={this.handleRefresh} onKeyDown={this.handleButtonKeydown} text={version || ''}></sui.Button>
                 : version ? <span className="label" style={{background: 'transparent'}}>{version}</span> : undefined}
-            {hasDelete ? <sui.Button className="primary label" icon="trash" title={lf("Delete extension {0}", p.getPkgId())}
+            {hasDelete ? <sui.Button className="neutral label" icon="trash" title={lf("Delete extension {0}", p.getPkgId())}
                 onClick={this.handleRemove} onKeyDown={this.handleButtonKeydown} /> : undefined}
             {this.props.children}
         </div>

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -290,7 +290,7 @@ export class ImmersiveReaderButton extends data.Component<ImmersiveReaderProps, 
     }
 
     render() {
-        return <div className='immersive-reader-button ui item' onClick={this.buttonClickHandler}
+        return <div className='immersive-reader-button ui item neutral' onClick={this.buttonClickHandler}
             aria-label={lf("Launch Immersive Reader")} role="button" onKeyDown={fireClickOnEnter} tabIndex={0}
             title={lf("Launch Immersive Reader")}/>
     }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -312,7 +312,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
 
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("Settings")} className="item icon more-dropdown-menuitem" ref={ref => this.dropdown = ref}>
             {targetTheme.selectLanguage && <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} />}
-            <sui.Item role="menuitem" icon="paint brush" text={lf("Select Theme")} onClick={this.showThemePicker} />
+            <sui.Item role="menuitem" icon="paint brush" text={lf("Theme")} onClick={this.showThemePicker} />
             {githubUser && <div className="ui divider"></div>}
             {githubUser && <div className="ui item" title={lf("Unlink {0} from GitHub", githubUser.name)} role="menuitem" onClick={this.signOutGithub}>
                 <div className="avatar" role="presentation">

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -367,7 +367,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
             let actions: sui.ModalButton[] = [];
             if (immersiveReaderEnabled) {
                 actions.push({
-                    className: "immersive-reader-button",
+                    className: "immersive-reader-button neutral",
                     onclick: async () => { await ImmersiveReader.launchImmersiveReaderAsync(fullText, options) },
                     ariaLabel: lf("Launch Immersive Reader"),
                     title: lf("Launch Immersive Reader")


### PR DESCRIPTION
This contains a few theme fixes.

**Changed theme preference storage to be target-based** 
Fixes https://github.com/microsoft/pxt-arcade/issues/6735
Before, it was a single theme id regardless of target, so if you changed themes in arcade, that would clear your preference for microbit, and so on...

**Menu Text Change**
Change "Select Theme" to just "Theme" (more consistent with "Language" in the same menu)

**A Few Color Fixes**
1. Fixes https://github.com/microsoft/pxt-arcade/issues/6743
2. Fixes https://github.com/microsoft/pxt-arcade/issues/6748
3. Fixes https://github.com/microsoft/pxt-arcade/issues/6739
4. Fixes https://github.com/microsoft/pxt-arcade/issues/6745
5. Fixes https://github.com/microsoft/pxt-arcade/issues/6309
6. A few others that didn't have bugs filed... (disabled buttons, new/cloud project cards hover, neutral labels, fg/bg mismatch on home page categories)

**Additional Tweaks**   
Some additional changes & refactoring based on findings while working on theme builder, including:
1. Adding a neutral base color
2. Specifying `setColorThemeById` instead of just `setColorTheme`, leaving the door open for setting by theme object in the future
3. Making it optional to save the preference when setting the theme
4. Partial changes toward fixing https://github.com/microsoft/pxt-arcade/issues/6751 but also need arcade changes for that.

Upload Target: https://arcade.makecode.com/app/7d7ad2f89b8743f9b1e89290dfb6a8d17e39db85-d113d4beed

