### PR TITLE
use targetlight in asset editor

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2579,6 +2579,7 @@ async function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
         delete targetlight.compile.compilerExtension;
     const targetlightjson = nodeutil.stringify(targetlight);
     nodeutil.writeFileSync("built/targetlight.json", targetlightjson)
+    nodeutil.writeFileSync("built/targetlight.js", targetJsPrefix + targetlightjson)
     nodeutil.writeFileSync("built/sim.webmanifest", nodeutil.stringify(webmanifest))
 
     console.log("target.json built.");

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -229,13 +229,15 @@ namespace pxt {
         appTarget = replaceCdnUrlsInJsonBlob(appTarget);
 
         // patch icons in bundled packages
-        Object.keys(appTarget.bundledpkgs).forEach(pkgid => {
-            const res = appTarget.bundledpkgs[pkgid];
-            // path config before storing
-            const config = JSON.parse(res[pxt.CONFIG_NAME]) as pxt.PackageConfig;
-            if (config.icon) config.icon = pxt.BrowserUtils.patchCdn(config.icon);
-            res[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(config);
-        })
+        if (appTarget.bundledpkgs) {
+            Object.keys(appTarget.bundledpkgs).forEach(pkgid => {
+                const res = appTarget.bundledpkgs[pkgid];
+                // path config before storing
+                const config = JSON.parse(res[pxt.CONFIG_NAME]) as pxt.PackageConfig;
+                if (config.icon) config.icon = pxt.BrowserUtils.patchCdn(config.icon);
+                res[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(config);
+            });
+        }
 
         // patch any pre-configured query url appTheme overrides
         if (typeof window !== 'undefined') {

--- a/webapp/public/asseteditor.html
+++ b/webapp/public/asseteditor.html
@@ -24,7 +24,7 @@
         // This line gets patched up by the cloud
         var pxtConfig = null;
     </script>
-    <script type="text/javascript" src="/blb/target.js"></script>
+    <script type="text/javascript" src="/blb/targetlight.js"></script>
     <!-- <script type="text/javascript" src="https://cdn.makecode.com/blob/ec765d3ba50a09c8c8819ec80390b6ffa72e945a/target.js"></script> -->
     <script type="text/javascript" src="/blb/pxtapp.js"></script>
     <script>


### PR DESCRIPTION
as i was messing with the asset editor page in the vscode extension, i noticed that it was referencing target.js. that file is huge (it contains all of the source of the target) and we definitely don't need it in the asset editor so this PR swaps it out for the targetlight version instead. i had to add a step to the target build to actually write out a js version of that file because previously we only included the json form.

also put a guard in main.ts for when bundledpkgs isn't defined