### PR TITLE
Fix Editor Tour in French

### DIFF
--- a/pxtlib/markdownMetadataParser.ts
+++ b/pxtlib/markdownMetadataParser.ts
@@ -99,7 +99,7 @@ namespace pxt {
                             }
                         }
 
-                        currentKey = keyMatch[1].toLowerCase();
+                        currentKey = keyMatch[1].trim().toLowerCase();
                         currentValue = keyMatch[2];
                     }
                     else if (currentKey) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6717

There were two issues happening causing the bug:

Firstly, some of the strings (location & highlight) should not be translated but were translated. They're used by the code to reference positions and elements in the DOM respectively, so when they're in french, they don't map to anything. I've gone through and removed the translations in crowdin.

Secondly, some of the properties had spaces before the semicolon, i.e: `location : center`, and that was being left in for the property name. For these, I think it's safe to trim the string, hence this PR.