### PR TITLE
hide "open in vscode" and "host multiplayer" in time machine

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5440,7 +5440,7 @@ export class ProjectView
                     showSerialButtons={useSerialEditor}
                     showFileList={showFileList}
                     showFullscreenButton={!isHeadless}
-                    showHostMultiplayerGameButton={isMultiplayerSupported && isMultiplayerGame}
+                    isMultiplayerGame={isMultiplayerSupported && isMultiplayerGame}
                     collapseEditorTools={this.state.collapseEditorTools}
                     simSerialActive={this.state.simSerialActive}
                     devSerialActive={this.state.deviceSerialActive}

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -29,7 +29,7 @@ interface SidepanelProps extends ISettingsProps {
     showSerialButtons?: boolean;
     showFileList?: boolean;
     showFullscreenButton?: boolean;
-    showHostMultiplayerGameButton?: boolean;
+    isMultiplayerGame?: boolean;
     collapseEditorTools?: boolean;
     simSerialActive?: boolean;
     deviceSerialActive?: boolean;
@@ -197,12 +197,17 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     }
 
     renderCore() {
-        const { parent, inHome, showKeymap, showSerialButtons, showFileList, showFullscreenButton, showHostMultiplayerGameButton,
+        const { parent, inHome, showKeymap, showSerialButtons, showFileList, showFullscreenButton, isMultiplayerGame,
             collapseEditorTools, simSerialActive, deviceSerialActive, tutorialOptions,
             handleHardwareDebugClick, onTutorialStepChange, onTutorialComplete } = this.props;
 
         const hasSimulator = !pxt.appTarget.simulator?.headless;
-        const showOpenInVscodeButton = parent.isJavaScriptActive() && pxt.appTarget?.appTheme?.showOpenInVscode;
+        const showOpenInVscodeButton = parent.isJavaScriptActive()
+            && pxt.appTarget?.appTheme?.showOpenInVscode
+            && !pxt.shell.isTimeMachineEmbed();
+
+        const showHostMultiplayerGameButton = isMultiplayerGame
+            && !pxt.shell.isTimeMachineEmbed();
 
         const simContainerClassName = classList(
             "simulator-container",


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6747
fixes https://github.com/microsoft/pxt-arcade/issues/6305

just hiding some buttons in the version history preview!