### PR TITLE
Load Theme in Version History Preview

### DIFF
--- a/webapp/src/timeMachine.tsx
+++ b/webapp/src/timeMachine.tsx
@@ -7,6 +7,7 @@ import { hideDialog, warningNotification } from "./core";
 import { FocusTrap } from "../../react-common/components/controls/FocusTrap";
 import { classList } from "../../react-common/components/util";
 import { HistoryFile, applySnapshot, patchConfigEditorVersion } from "../../pxteditor/history";
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 import ScriptText = pxt.workspace.ScriptText;
 
@@ -150,6 +151,18 @@ export const TimeMachine = (props: TimeMachineProps) => {
         };
 
         importProject.current = loadProject;
+
+        // Sync iframe theme with main theme.
+        const themeManager = ThemeManager.getInstance(document);
+        const currentTheme = themeManager.getCurrentColorTheme();
+        if (currentTheme) {
+            sendMessageAsync({
+                type: "pxteditor",
+                action: "setcolorthemebyid",
+                colorThemeId: currentTheme.id,
+                savePreference: false
+            } as pxt.editor.EditorMessageSetColorThemeRequest);
+        }
 
         window.addEventListener("message", onMessageReceived);
         return () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6303 by sending a set-theme message when initializing version history. 

Upload target: https://arcade.makecode.com/app/3529fb9d4b915467271bdff5a5b12045037a1ba8-a0b65f11b2