### PR TITLE
A couple of function dialog fixes

### DIFF
--- a/pxtblocks/plugins/functions/fields/fieldArgumentEditor.ts
+++ b/pxtblocks/plugins/functions/fields/fieldArgumentEditor.ts
@@ -1,21 +1,18 @@
 import * as Blockly from "blockly";
 import { FunctionManager } from "../functionManager";
+import { ArgumentEditorBlock } from "../blocks/argumentEditorBlocks";
 
 export interface FieldArgumentEditorConfig extends Blockly.FieldTextInputConfig {
-    typeName?: string;
 }
 
 export class FieldArgumentEditor extends Blockly.FieldTextInput {
     static REMOVE_ARG_URI =
         "data:image/svg+xml;charset=UTF-8,%3c?xml version='1.0' encoding='UTF-8' standalone='no'?%3e%3csvg width='20px' height='20px' viewBox='0 0 20 20' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3e%3c!-- Generator: Sketch 48.1 (47250) - http://www.bohemiancoding.com/sketch --%3e%3ctitle%3edelete-argument v2%3c/title%3e%3cdesc%3eCreated with Sketch.%3c/desc%3e%3cdefs%3e%3c/defs%3e%3cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3e%3cg id='delete-argument-v2' stroke='%23FF661A'%3e%3cg id='Group' transform='translate(3.000000, 2.500000)'%3e%3cpath d='M1,3 L13,3 L11.8900496,14.0995037 C11.8389294,14.6107055 11.4087639,15 10.8950124,15 L3.10498756,15 C2.59123611,15 2.16107055,14.6107055 2.10995037,14.0995037 L1,3 Z' id='Rectangle' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3e%3c/path%3e%3cpath d='M7,11 L7,6' id='Line' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3e%3c/path%3e%3cpath d='M9.5,11 L9.5,6' id='Line-Copy' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3e%3c/path%3e%3cpath d='M4.5,11 L4.5,6' id='Line-Copy-2' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3e%3c/path%3e%3crect id='Rectangle-2' fill='%23FF661A' x='0' y='2.5' width='14' height='1' rx='0.5'%3e%3c/rect%3e%3cpath d='M6,0 L8,0 C8.55228475,-1.01453063e-16 9,0.44771525 9,1 L9,3 L5,3 L5,1 C5,0.44771525 5.44771525,1.01453063e-16 6,0 Z' id='Rectangle-3' stroke-width='1.5'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/g%3e%3c/svg%3e";
 
-    protected typeName?: string;
     protected removeButtonMouseWrapper_?: Blockly.browserEvents.Data;
 
     constructor(text: string, opt_validator: Blockly.FieldValidator, config: FieldArgumentEditorConfig) {
         super(text, opt_validator, config);
-
-        this.typeName = config.typeName;
     }
 
     showEditor(e?: Event | undefined): void {
@@ -34,10 +31,10 @@ export class FieldArgumentEditor extends Blockly.FieldTextInput {
             this.removeCallback
         );
         div.appendChild(removeButton);
-
-        if (this.typeName && this.sourceBlock_?.workspace) {
+        const typeName = (this.sourceBlock_ as ArgumentEditorBlock)?.getTypeName();
+        if (typeName && this.sourceBlock_?.workspace) {
             const iconClass = FunctionManager.getInstance().getIconForType(
-                this.typeName
+                typeName
             );
 
             if (iconClass) {
@@ -81,6 +78,7 @@ Blockly.Css.register(`
 }
 
 .functioneditor i.argumentEditorTypeIcon {
+    color: var(--pxt-primary-foreground);
     position: absolute;
     width: 24px;
     height: 24px;

--- a/pxtblocks/plugins/functions/functionManager.ts
+++ b/pxtblocks/plugins/functions/functionManager.ts
@@ -23,7 +23,7 @@ export class FunctionManager {
     }
 
     setIconForType(typeName: string, icon: string) {
-        this.typeIcons[icon] = typeName;
+        this.typeIcons[typeName] = icon;
     }
 
     setArgumentNameForType(typeName: string, name: string) {

--- a/pxtblocks/plugins/functions/utils.ts
+++ b/pxtblocks/plugins/functions/utils.ts
@@ -111,15 +111,13 @@ export function createCustomArgumentEditor(typeName: string, ws: Blockly.Workspa
 }
 
 function createCustomArgumentBlock(blockType: string, typeName: string, ws: Blockly.Workspace) {
-    const block = Blockly.utils.xml.createElement("block");
-    block.setAttribute("type", blockType);
-
+    const block = ws.newBlock(blockType);
     const mutation = Blockly.utils.xml.createElement("mutation");
     mutation.setAttribute("typename", typeName);
 
-    block.appendChild(mutation);
+    block.domToMutation(mutation);
 
-    return Blockly.Xml.domToBlock(block, ws);
+    return block;
 }
 
 export function findLegalName(name: string, ws: Blockly.Workspace, block?: CommonFunctionBlock) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6764
fixes https://github.com/microsoft/pxt-arcade/issues/6770

a couple of fixes for the function dialog! 

first one is a bug with the initialization of the argument editors for custom non-primitive types. i ran into the same thing when doing https://github.com/microsoft/pxt/pull/10402; basically initSvg was getting caused out of order which led to weirdness. this change just switches them to be the same as all of the other types rather than using domToBlock

second one was just an oversight when i rewrote the functions implementation during the great blockly swap. i guess i never tested this!