### PR TITLE
Theme Keyboard Nav & Melody Editor Fix

### DIFF
--- a/react-common/components/theming/ThemeCard.tsx
+++ b/react-common/components/theming/ThemeCard.tsx
@@ -13,8 +13,10 @@ export const ThemeCard = (props: ThemeCardProps) => {
         <Card
             className="theme-card"
             role="listitem"
+            aria-label={theme.name}
             key={theme.id}
             onClick={() => onClick(theme)}
+            tabIndex={onClick && 0}
         >
             <div className="theme-info-box">
                 <ThemePreview theme={theme} />

--- a/theme/melodyeditor.less
+++ b/theme/melodyeditor.less
@@ -182,6 +182,7 @@
     border-radius: 2px;
     border: none;
     padding-left: 5px;
+    background-color: @white;
     color: @black;
 }
 


### PR DESCRIPTION
This adds keyboard nav support for the theme picker modal (just needed to add the cards into the tab ordering), and it fixes the bpm box in the melody editor (since the whole thing is hard-coded to block colors, we can just hardcode the input color as well).

Fixes https://github.com/microsoft/pxt-arcade/issues/6773
Fixes https://github.com/microsoft/pxt-arcade/issues/6758