### PR TITLE
High Contrast Fixes

### DIFF
--- a/react-common/styles/controls/Button.less
+++ b/react-common/styles/controls/Button.less
@@ -290,7 +290,7 @@ a.common-button.menu-button {
 .high-contrast, .hc {
     .common-button {
         color: @highContrastTextColor !important;
-        background: @highContrastBackgroundColor !important;
+        background-color: @highContrastBackgroundColor !important;
         border-color: @highContrastTextColor !important;
 
         &:hover, &:focus {

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -1,7 +1,7 @@
 /* TODO */
 .common-button {
     color: var(--pxt-neutral-foreground2) !important;
-    background: var(--pxt-neutral-background2) !important;
+    background-color: var(--pxt-neutral-background2) !important;
     border-color: var(--pxt-neutral-foreground2) !important;
 }
 

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -27,3 +27,22 @@
 .image-editor-canvas, .image-editor-canvas:hover, .image-editor-canvas:focus {
     outline: none !important;
 }
+
+/* Toolbox */
+.pxtToolbox:not(.invertedToolbox) span.blocklyTreeLabel {
+    color: var(--pxt-target-foreground3);
+}
+
+.pxtToolbox:not(.invertedToolbox) .blocklyTreeSelected span.blocklyTreeLabel,
+.pxtToolbox:not(.invertedToolbox) .blocklyTreeSelected span.blocklyTreeIcon {
+    color: var(--pxt-target-foreground3);
+}
+
+.pxtToolbox:not(.invertedToolbox) .blocklyTreeRow:not(.blocklyTreeSelected) .blocklyTreeLabel {
+    color: var(--pxt-target-foreground3) !important;
+}
+
+.pxtToolbox:not(.invertedToolbox) .blocklyTreeRow:not(.blocklyTreeSelected):hover,
+.pxtToolbox:not(.invertedToolbox) .blocklyTreeRow:not(.blocklyTreeSelected):focus {
+    background-color: #404040 !important;
+}

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -13,3 +13,17 @@
 .barcharticon {
     filter: invert(1);
 }
+
+/* Image Editor */
+.image-editor-topbar, .image-editor-bottombar, .image-editor-sidebar {
+    background: var(--pxt-neutral-background1) !important;
+}
+.image-editor-tool-buttons {
+    background: none !important;
+}
+.image-editor-color-buttons .image-editor-button {
+    border: 1px solid var(--pxt-neutral-foreground1);
+}
+.image-editor-canvas, .image-editor-canvas:hover, .image-editor-canvas:focus {
+    outline: none !important;
+}

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -1,4 +1,3 @@
-/* TODO */
 .common-button {
     color: var(--pxt-neutral-foreground2) !important;
     background-color: var(--pxt-neutral-background2) !important;
@@ -21,11 +20,17 @@
 .image-editor-tool-buttons {
     background: none !important;
 }
-.image-editor-color-buttons .image-editor-button {
+.image-editor-button,
+.image-editor-input,
+.image-editor-confirm {
     border: 1px solid var(--pxt-neutral-foreground1);
 }
 .image-editor-canvas, .image-editor-canvas:hover, .image-editor-canvas:focus {
     outline: none !important;
+}
+.cursor-button {
+    /* remove margin since we now have a border around the cursor buttons and it looks better centered */
+    margin-right: 0;
 }
 
 /* Toolbox */

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -118,36 +118,6 @@
     }
 
     /* Toolbox */
-    .pxtToolbox:not(.invertedToolbox) {
-        span.blocklyTreeLabel, span.blocklyTreeIcon {
-            color: @HCblocklyTreeLabelColor;
-        }
-        .blocklyTreeSelected span.blocklyTreeLabel, .blocklyTreeSelected span.blocklyTreeIcon {
-            color: @HCblocklyTreeLabelSelectedColor;
-        }
-        .blocklyTreeRow:not(.blocklyTreeSelected) {
-            background-color: @HCblocklyToolboxColor !important;
-            .blocklyTreeIcon, .blocklyTreeLabel {
-                color: @HCblocklyTreeLabelColor !important;
-            }
-        }
-        .blocklyTreeRow:not(.blocklyTreeSelected):hover,
-        .blocklyTreeRow:not(.blocklyTreeSelected):focus {
-            background-color: lighten(@HCblocklyToolboxColor, 25.0) !important;
-        }
-    }
-
-    .pxtToolbox {
-        .blocklyTreeRow:not(.blocklyTreeSelected) {
-            background-color: @HCblocklyToolboxColor !important;
-        }
-    }
-
-    .toolbox-title {
-        background-color: @HCbackground;
-        color: @HCtextColor;
-    }
-
     #monacoEditor .monacoDraggableBlock {
         background: none !important;
 

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -119,10 +119,10 @@
 
     /* Toolbox */
     .pxtToolbox:not(.invertedToolbox) {
-        span.blocklyTreeLabel {
+        span.blocklyTreeLabel, span.blocklyTreeIcon {
             color: @HCblocklyTreeLabelColor;
         }
-        .blocklyTreeSelected span.blocklyTreeLabel {
+        .blocklyTreeSelected span.blocklyTreeLabel, .blocklyTreeSelected span.blocklyTreeIcon {
             color: @HCblocklyTreeLabelSelectedColor;
         }
         .blocklyTreeRow:not(.blocklyTreeSelected) {

--- a/theme/image-editor/imageCanvas.less
+++ b/theme/image-editor/imageCanvas.less
@@ -49,10 +49,10 @@
 }
 
 .checkerboard, .common-button.image-editor-button.checkerboard {
-    background-color: #aeaeae;
-    background-image: linear-gradient(45deg, #dedede 25%, transparent 25%), linear-gradient(-45deg, #dedede 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #dedede 75%), linear-gradient(-45deg, transparent 75%, #dedede 75%);
-    background-size: 0.75rem 0.75rem;
-    background-position: 0 0, 0 calc(0.75rem*0.5), calc(0.75rem*0.5) calc(0.75rem*-0.5), calc(0.75rem*-0.5) 0px;
+    background-color: #aeaeae !important;
+    background-image: linear-gradient(45deg, #dedede 25%, transparent 25%), linear-gradient(-45deg, #dedede 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #dedede 75%), linear-gradient(-45deg, transparent 75%, #dedede 75%) !important;
+    background-size: 0.75rem 0.75rem !important;
+    background-position: 0 0, 0 calc(0.75rem*0.5), calc(0.75rem*0.5) calc(0.75rem*-0.5), calc(0.75rem*-0.5) 0px !important;
 }
 
 .image-editor-floating-layer {

--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -313,12 +313,12 @@
 }
 
 .common-button.image-editor-confirm:hover {
-    background-color: var(--pxt-colors-green-background-hover);
+    background-color: var(--pxt-colors-green-hover);
     color: var(--pxt-colors-green-foreground);
 }
 
 .common-button.image-editor-confirm:active {
-    background-color: var(--pxt-colors-green-background-hover);
+    background-color: var(--pxt-colors-green-hover);
     color: var(--pxt-colors-green-foreground);
 }
 

--- a/theme/image-editor/sideBar.less
+++ b/theme/image-editor/sideBar.less
@@ -37,6 +37,10 @@
 .image-editor-color-buttons .image-editor-button {
     margin-left: 0;
     margin-top: 0;
+
+    &:not(.checkerboard) {
+        background-color: var(--preview-color) !important;
+    }
 }
 
 

--- a/theme/image-editor/topBar.less
+++ b/theme/image-editor/topBar.less
@@ -10,6 +10,7 @@
     margin-top: 0;
     margin-left: 0;
     height: 2rem;
+    border-radius: 0;
 }
 
 .image-editor-topbar > div {

--- a/webapp/src/components/ImageEditor/sprite/Palette.tsx
+++ b/webapp/src/components/ImageEditor/sprite/Palette.tsx
@@ -62,7 +62,7 @@ class PaletteImpl extends React.Component<PaletteProps,{}> {
                         key={index}
                         className={classList("image-editor-button", index === 0 && "checkerboard")}
                         title={colorTooltip(index, color)}
-                        style={index === 0 ? null : { backgroundColor: color }}
+                        style={index === 0 ? null : { "--preview-color": color } as React.CSSProperties}
                         onClick={() => this.props.dispatchChangeSelectedColor(index)}
                         onRightClick={() => this.props.dispatchChangeBackgroundColor(index)}
                     />


### PR DESCRIPTION
This fixes a couple of high contrast bugs:

Fixes https://github.com/microsoft/pxt-arcade/issues/6780
Now that this are using react-common buttons, some of the default button css was conflicting with the programmatically-set colors for the color selection tool, and a few of the other buttons just looked odd. As far as I could find, you can't set `!important` programmatically, so I used a var to set the preview color and set important in css. I also changed the top, bottom, and side bars to all have black backgrounds, which is different from the released version but I think more in-line with high contrast in general.

Fixes https://github.com/microsoft/pxt-arcade/issues/6771
This fix was just updating some of the .hc specific css, but while I was there, I also moved it into the high-contrast theme's override css, since I'd like to start moving all that special-case stuff into one theme-supported location. Behavior now matches live, where the icon is colored-in when unselected and turns white when selected.

Upload Target: <s>https://arcade.makecode.com/app/82cd97d78761676ef6ad9029b9a877d2c77f3d88-474593e9d6</s> https://arcade.makecode.com/app/3d46dab3d87f5e72c678ea1dcc0e161e4df02769-de076282e5