### PR TITLE
allow debug to be toggled from any file open in monaco editor

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -1045,7 +1045,7 @@ declare namespace pxt.editor {
         isEmbedSimActive(): boolean;
         isBlocksActive(): boolean;
         isJavaScriptActive(): boolean;
-        isJavaScriptEditorActive(): boolean;
+        isTextSourceCodeEditorActive(): boolean;
         isPythonActive(): boolean;
         isAssetsActive(): boolean;
 

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -1045,6 +1045,7 @@ declare namespace pxt.editor {
         isEmbedSimActive(): boolean;
         isBlocksActive(): boolean;
         isJavaScriptActive(): boolean;
+        isJavaScriptEditorActive(): boolean;
         isPythonActive(): boolean;
         isAssetsActive(): boolean;
 
@@ -1168,7 +1169,7 @@ declare namespace pxt.editor {
         perfMeasurementThresholdMs?: number;
         onPerfMilestone?: (payload: { milestone: string, time: number, params?: Map<string> }) => void;
         onPerfMeasurement?: (payload: { name: string, start: number, duration: number, params?: Map<string> }) => void;
-    
+
         // Used with the @tutorialCompleted macro. See docs/writing-docs/tutorials.md for more info
         onTutorialCompleted?: () => void;
         onMarkdownActivityLoad?: (path: string, title?: string, editorProjectName?: string) => Promise<void>;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -602,6 +602,11 @@ export class ProjectView
             && this.editorFile && this.editorFile.name == pxt.ASSETS_FILE;
     }
 
+    isJavaScriptEditorActive() {
+        return !this.state.embedSimView && this.editor == this.textEditor
+            && this.editorFile && !this.isPythonActive();
+    }
+
     private isAnyEditeableJavaScriptOrPackageActive(): boolean {
         return this.editor == this.textEditor
             && this.editorFile && !this.editorFile.isReadonly() && /(\.ts|pxt.json)$/.test(this.editorFile.name);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -602,9 +602,9 @@ export class ProjectView
             && this.editorFile && this.editorFile.name == pxt.ASSETS_FILE;
     }
 
-    isJavaScriptEditorActive() {
+    isTextSourceCodeEditorActive() {
         return !this.state.embedSimView && this.editor == this.textEditor
-            && this.editorFile && !this.isPythonActive();
+            && this.editorFile && /(\.ts|\.py)$/.test(this.editorFile.name);
     }
 
     private isAnyEditeableJavaScriptOrPackageActive(): boolean {

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -109,7 +109,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const isFullscreen = parentState.fullscreen;
         const inTutorial = !!parentState.tutorialOptions && !!parentState.tutorialOptions.tutorial;
         const isTabTutorial = inTutorial && !pxt.BrowserUtils.useOldTutorialLayout();
-        const inCodeEditor = parent.isBlocksActive() || parent.isJavaScriptEditorActive() || parent.isPythonActive();
+        const inCodeEditor = parent.isBlocksActive() || parent.isTextSourceCodeEditorActive() || parent.isPythonActive();
 
         const run = true;
         const restart = run && !simOpts.hideRestart;

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -109,7 +109,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const isFullscreen = parentState.fullscreen;
         const inTutorial = !!parentState.tutorialOptions && !!parentState.tutorialOptions.tutorial;
         const isTabTutorial = inTutorial && !pxt.BrowserUtils.useOldTutorialLayout();
-        const inCodeEditor = parent.isBlocksActive() || parent.isJavaScriptActive() || parent.isPythonActive();
+        const inCodeEditor = parent.isBlocksActive() || parent.isJavaScriptEditorActive() || parent.isPythonActive();
 
         const run = true;
         const restart = run && !simOpts.hideRestart;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6634

removes the restriction where the debug state can only be toggled from within main.py, main.ts, or main.blocks