### PR TITLE
Fix Sim Button Toggle, Card Outlines, and Keymap Theming

### DIFF
--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -13,6 +13,15 @@
     filter: invert(1);
 }
 
+/* Sim toolbar */
+#simulator .editor-sidebar .simtoolbar .debug-button.active,
+#simulator .editor-sidebar .simtoolbar .debug-button.active:hover,
+#simulator .editor-sidebar .simtoolbar .debug-button.active:hover i {
+    /* Make active state more apparent by inverting the colors */
+    background: var(--pxt-neutral-foreground2) !important;
+    color: var(--pxt-neutral-background2) !important;
+}
+
 /* Image Editor */
 .image-editor-topbar, .image-editor-bottombar, .image-editor-sidebar {
     background: var(--pxt-neutral-background1) !important;

--- a/theme/common.less
+++ b/theme/common.less
@@ -223,6 +223,15 @@ pre {
     -o-transition: opacity 0.2s; /* Opera */
     transition: opacity 0.2s;
     transition-timing-function: linear;
+
+    .debug-button.active,
+    .mute-button.active {
+        background-color: var(--pxt-secondary-accent);
+
+        &:focus, &:hover {
+            filter: none;
+        }
+    }
 }
 
 #downloadArea {
@@ -1438,7 +1447,7 @@ p.ui.font.small {
 }
 
 /*******************************
-        fuyllscreensim
+        fullscreensim
 *******************************/
 .fullscreensim {
     z-index: @aboveEverythingZIndex;

--- a/theme/keymap.less
+++ b/theme/keymap.less
@@ -8,10 +8,10 @@
     margin: 0 2rem;
     padding: 0.5rem;
     width: calc(~'100% - 4rem');
-    background-color: @white;
+    background-color: var(--pxt-neutral-background1);
+    color: var(--pxt-neutral-foreground1);
     border-radius: 0.25rem;
-    opacity: 0.95;
-    border: 1px solid @teal;
+    border: 1px solid var(--pxt-colors-teal-background);
     z-index: 1;
 }
 
@@ -20,7 +20,7 @@
     top: 0.5rem;
     right: 0.5rem;
     margin: 0;
-    color: @white;
+    color: var(--pxt-neutral-foreground1);
     cursor: pointer;
 }
 
@@ -50,10 +50,10 @@
     margin: 0.25rem;
     padding: 0 0.75rem;
     line-height: 2rem;
-    border: 1px solid darken(@teal, 10%);
+    border: 1px solid var(--pxt-colors-teal-alpha10);
     border-radius: 0.25rem;
-    background-color: @teal;
-    color: @white;
+    background-color: var(--pxt-colors-teal-background);
+    color: var(--pxt-colors-teal-foreground);
     text-transform: uppercase;
 }
 
@@ -73,7 +73,7 @@
     top: 5.5rem;
 
     .close {
-        color: @teal;
+        color: var(--pxt-colors-teal-background);
     }
 }
 

--- a/theme/semantic-ui-overrides.less
+++ b/theme/semantic-ui-overrides.less
@@ -63,6 +63,8 @@ body.pxt-theme-root {
     .ui.card, .ui.cards .card {
         background-color: var(--pxt-neutral-background1);
         color: var(--pxt-neutral-foreground1);
+        border-color: var(--pxt-neutral-stencil1);
+
         &:hover, &:focus {
             background-color: var(--pxt-neutral-background1-hover);
             color: var(--pxt-neutral-foreground1-hover);

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -159,7 +159,7 @@ a.ui.card:focus,
 }
 
 .gallerysegment .ui.card.link.cloudprojectscard {
-    background-color: var(--pxt-secondary-accent) !important;
+    background-color: var(--pxt-secondary-background) !important;
     color: var(--pxt-secondary-foreground) !important;
 
     .header {

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -143,7 +143,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
                 {run && !targetTheme.bigRunButton && <PlayButton parent={parent} simState={parentState.simState} debugging={parentState.debugging} />}
                 {fullscreen && <sui.Button key='fullscreenbtn' className="fullscreen-button tablet only hidefullscreen" icon="xicon fullscreen" title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}
                 {restart && <sui.Button disabled={!runControlsEnabled} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} />}
-                {run && debug && <sui.Button disabled={!debugBtnEnabled} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="icon bug" title={debugTooltip} onClick={this.toggleDebug} />}
+                {run && debug && <sui.Button disabled={!debugBtnEnabled} key='debugbtn' className={`debug-button ${debugging ? "active" : ""}`} icon="icon bug" title={debugTooltip} onClick={this.toggleDebug} />}
                 {audio && isTabTutorial && <MuteButton onClick={this.toggleMute} state={parent.state.mute} className="hidefullscreen tutorial"/>}
                 {collapse && <sui.Button
                     className={`expand-button portrait only editortools-btn hidefullscreen`}
@@ -239,7 +239,7 @@ const MuteButton = ({onClick, state, className}: MuteButtonProps) => {
     }
 
     return <sui.Button
-        className={`${className || ''} mute-button ${state === MuteState.Muted ? 'red' : ''}`}
+        className={`${className || ''} mute-button ${state === MuteState.Muted ? 'active' : ''}`}
         icon={`${state !== MuteState.Unmuted  ? 'volume off' : 'volume up'}`}
         disabled={state === MuteState.Disabled}
         title={tooltip}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6761
Mute and debug buttons now switch to a darker shade of the same color when toggled on, rather than a separate bright color. Requires changes in pxt-arcade also necessary to update secondary-accent colors.

Fixes https://github.com/microsoft/pxt-arcade/issues/6788
This just wasn't themed before. I've updated the css to use theme colors.

Fixes https://github.com/microsoft/pxt-arcade/issues/6789
Just needed to add a border in the semantic ui overrides.

Upload target: https://arcade.makecode.com/app/a2b90411277dc31bf416b4bc830035728af40d75-0cd92e0a68