### PR TITLE
Increase max screenshot size to 10mb

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -510,7 +510,7 @@ namespace pxt.BrowserUtils {
         return outputCanvas.toDataURL("image/png");
     }
 
-    const MAX_SCREENSHOT_SIZE = 1e6; // max 1Mb
+    const MAX_SCREENSHOT_SIZE = 10e6; // max 10Mb
     export function encodeToPngAsync(dataUri: string,
         options?: {
             width?: number,


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6338

Here's what a screenshot of Jumpy Platformer looks like on live:
![jump-live](https://github.com/user-attachments/assets/8f5f5d56-5964-416a-ba38-155e42ee1aa9)

With the increase:
![jumpy-update](https://github.com/user-attachments/assets/dedbc8c4-0df2-42f7-8879-f0719e856b3e)

I played with the max size number, and this seemed to be the value that best suited really big games. Something like The MakeCode Forums 0.5 with the blocks spread around a bit (https://makecode.com/_HKvMx5AcviWd) still renders pretty clearly with 10mb. That's a pretty big game, though, and I'm not sure what sized games we're wanting to say "this will certainly render clearly."

One thing to note that I've seen is that the thing that really cuts down on the quality is halving the size of the image twice or more. It was very common that a screenshot reduces the size once, but twice really kills the quality of the image. Another thing to note is that even with the increase in size, I couldn't really tell of a time difference. The time to take the screenshot on live and with the increased size seemed pretty comparable.

Upload target: https://arcade.makecode.com/app/e5d65d25a34aed9cf64d17c29f87ad1b8b3f94cf-825902a49a#