### PR TITLE
Remove unnecessary lf which was causing bugs

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -481,7 +481,7 @@ namespace ts.pxtc {
                     combinedProperties: []
                 }
                 ex.attributes.block =
-                    isGet ? U.lf("%{0} %property", paramName) :
+                    isGet ? `%${paramName} %property`:
                         isSet ? U.lf("set %{0} %property to %{1}", paramName, paramValue) :
                             U.lf("change %{0} %property by %{1}", paramName, paramValue)
                 updateBlockDef(ex.attributes)


### PR DESCRIPTION
Nothing in this string is actually supposed to be translated, but we have seen several occasions where the %property was translated incorrectly/accidentally, and that causes bugs. I think it's safe to just remove the lf altogether here.

Fixes https://github.com/microsoft/pxt-arcade/issues/6289 (though I also updated the broken translation, which should also fix it)