### PR TITLE
improve music editor erase tool

### DIFF
--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1860,6 +1860,37 @@ namespace ts.pxtc.Util {
         return pxt.webConfig.ocv?.appId && pxt.webConfig.ocv?.iframeEndpoint;
     }
 
+    export function bresenhamLine(x0: number, y0: number, x1: number, y1: number, handler: (x: number, y: number) => void) {
+        const dx = x1 - x0;
+        const dy = y1 - y0;
+
+        if (dx === 0) {
+            const startY = dy >= 0 ? y0 : y1;
+            const endY = dy >= 0 ? y1 : y0;
+            for (let y = startY; y <= endY; y++) {
+                handler(x0, y);
+            }
+            return;
+        }
+
+        const xStep = dx > 0 ? 1 : -1;
+        const yStep = dy > 0 ? 1 : -1;
+        const dErr = Math.abs(dy / dx);
+
+        let err = 0;
+        let y = y0;
+        for (let x = x0; xStep > 0 ? x <= x1 : x >= x1; x += xStep) {
+            handler(x, y);
+            err += dErr;
+            while (err >= 0.5) {
+                if (yStep > 0 ? y <= y1 : y >= y1) {
+                    handler(x, y);
+                }
+                y += yStep;
+                err -= 1;
+            }
+        }
+    }
 }
 
 namespace ts.pxtc.BrowserImpl {

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1860,6 +1860,7 @@ namespace ts.pxtc.Util {
         return pxt.webConfig.ocv?.appId && pxt.webConfig.ocv?.iframeEndpoint;
     }
 
+    // https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
     export function bresenhamLine(x0: number, y0: number, x1: number, y1: number, handler: (x: number, y: number) => void) {
         const dx = x1 - x0;
         const dy = y1 - y0;

--- a/webapp/src/components/ImageEditor/toolDefinitions.ts
+++ b/webapp/src/components/ImageEditor/toolDefinitions.ts
@@ -386,37 +386,9 @@ export class PaintEdit extends Edit {
         this.startRow = row;
     }
 
-    // https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
     protected interpolate(x0: number, y0: number, x1: number, y1: number) {
-        const dx = x1 - x0;
-        const dy = y1 - y0;
         const draw = (c: number, r: number) => this.mask.set(c, r);
-        if (dx === 0) {
-            const startY = dy >= 0 ? y0 : y1;
-            const endY = dy >= 0 ? y1 : y0;
-            for (let y = startY; y <= endY; y++) {
-                this.drawCore(x0, y, draw);
-            }
-            return;
-        }
-
-        const xStep = dx > 0 ? 1 : -1;
-        const yStep = dy > 0 ? 1 : -1;
-        const dErr = Math.abs(dy / dx);
-
-        let err = 0;
-        let y = y0;
-        for (let x = x0; xStep > 0 ? x <= x1 : x >= x1; x += xStep) {
-            this.drawCore(x, y, draw);
-            err += dErr;
-            while (err >= 0.5) {
-                if (yStep > 0 ? y <= y1 : y >= y1) {
-                    this.drawCore(x, y, draw);
-                }
-                y += yStep;
-                err -= 1;
-            }
-        }
+        pxt.Util.bresenhamLine(x0, y0, x1, y1, (x, y) => this.drawCore(x, y, draw))
     }
 
     protected doEditCore(state: EditState) {
@@ -537,37 +509,9 @@ export class LineEdit extends SelectionEdit {
         this.bresenham(this.startCol, this.startRow, this.endCol, this.endRow, state);
     }
 
-    // https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
     protected bresenham(x0: number, y0: number, x1: number, y1: number, state: EditState) {
-        const dx = x1 - x0;
-        const dy = y1 - y0;
         const draw = (c: number, r: number) => state.activeLayer.set(c, r, this.color);
-        if (dx === 0) {
-            const startY = dy >= 0 ? y0 : y1;
-            const endY = dy >= 0 ? y1 : y0;
-            for (let y = startY; y <= endY; y++) {
-                this.drawCore(x0, y, draw);
-            }
-            return;
-        }
-
-        const xStep = dx > 0 ? 1 : -1;
-        const yStep = dy > 0 ? 1 : -1;
-        const dErr = Math.abs(dy / dx);
-
-        let err = 0;
-        let y = y0;
-        for (let x = x0; xStep > 0 ? x <= x1 : x >= x1; x += xStep) {
-            this.drawCore(x, y, draw);
-            err += dErr;
-            while (err >= 0.5) {
-                if (yStep > 0 ? y <= y1 : y >= y1) {
-                    this.drawCore(x, y, draw);
-                }
-                y += yStep;
-                err -= 1;
-            }
-        }
+        pxt.Util.bresenhamLine(x0, y0, x1, y1, (x, y) => this.drawCore(x, y, draw))
     }
 
     drawCursor(col: number, row: number, draw: (c: number, r: number) => void) {

--- a/webapp/src/components/musicEditor/utils.ts
+++ b/webapp/src/components/musicEditor/utils.ts
@@ -228,9 +228,10 @@ function setNoteEventLength(notes: pxt.assets.music.NoteEvent[], startTick: numb
     return res.filter(e => !!e);
 }
 
-export function fillDrums(song: pxt.assets.music.Song, trackIndex: number, row: number, startTick: number, endTick: number, tickSpacing: number) {
+export function fillDrums(song: pxt.assets.music.Song, trackIndex: number, row: number, isBassClef: boolean, startTick: number, endTick: number, tickSpacing: number) {
+    const note = rowToNote(0, row, isBassClef, true);
     for (let i = startTick; i < endTick; i += tickSpacing) {
-        song = addNoteToTrack(song, trackIndex, { note: row, enharmonicSpelling: "normal" }, i, i + 1)
+        song = addNoteToTrack(song, trackIndex, { note: note.note, enharmonicSpelling: "normal" }, i, i + 1)
     }
     return song;
 }
@@ -259,6 +260,22 @@ export function findPreviousNoteEvent(song: pxt.assets.music.Song, trackIndex: n
     }
 
     return lastNote;
+}
+
+export function findNoteEventsOverlappingRange(song: pxt.assets.music.Song, trackIndex: number, startTick: number, endTick: number) {
+    const track = song.tracks[trackIndex];
+
+    const result: pxt.assets.music.NoteEvent[] = [];
+    for (const note of track.notes) {
+        if (!(note.endTick < startTick || note.startTick > endTick)) {
+            result.push(note);
+        }
+        else if (note.startTick > endTick) {
+            break;
+        }
+    }
+
+    return result;
 }
 
 export function findNextNoteEvent(song: pxt.assets.music.Song, trackIndex: number, tick: number) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/5694

this PR does a few things to make the music editor erase tool more friendly:
* you can now start the drag for the erase tool in the area above the staff (the part where the measure numbers are). previously drags that started there were just ignored
* the erase cursor is now "wider", in other words we now check all notes that overlap with 1 tick before and after the drag coordinate
* the eraser now interpolates from the last coordinate in the drag which prevents us from skipping notes when the mouse is moving really fast

finally i also fixed an unrelated bug where dragging drum tracks on the bass clef was registering notes in the treble clef. i don't know if this is filed anywhere; i just noticed it while debugging.