### PR TITLE
add a default option to the cannot pair dialog

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -143,6 +143,10 @@ namespace pxt.BrowserUtils {
         return isPxtElectron() || isIpcRenderer();
     }
 
+    export function isArcade() {
+        return pxt.appTarget.id === "arcade";
+    }
+
     declare let Windows: any;
     export let isWinRT = () => typeof (Windows as any) !== "undefined";
 

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -143,10 +143,6 @@ namespace pxt.BrowserUtils {
         return isPxtElectron() || isIpcRenderer();
     }
 
-    export function isArcade() {
-        return pxt.appTarget.id === "arcade";
-    }
-
     declare let Windows: any;
     export let isWinRT = () => typeof (Windows as any) !== "undefined";
 

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -339,6 +339,10 @@ namespace pxt {
             })
     }
 
+    export function getActiveHwVariant(): string {
+        return hwVariant
+    }
+
     export interface PxtOptions {
         debug?: boolean;
         light?: boolean; // low resource device

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -211,6 +211,12 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
     protected onCannotPairClick = async () => {
         pxt.tickEvent("editortools.pairunsupported", undefined, { interactiveConsent: true });
         const reasonUnsupported = await pxt.usb.getReasonUnavailable();
+
+        if (!reasonUnsupported && pxt.BrowserUtils.isArcade() && !pxt.getActiveHwVariant()) {
+            this.onHwItemClick()
+            return;
+        }
+
         let modalBody: string;
         switch (reasonUnsupported) {
             case "security":
@@ -226,12 +232,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
                 modalBody = lf("WebUSB is not supported by this browser; please check for updates.");
                 break;
             default:
-                if (pxt.BrowserUtils.isArcade()) {
-                    this.onHwItemClick();
-                    return;
-                } else {
-                    modalBody = lf("WebUSB device not detected. Make sure your device is connected and try again.");
-                }
+                modalBody = lf("WebUSB should be supported, but we're having trouble. Please try refreshing the page.");
                 break;
         }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -227,9 +227,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
                 break;
             default:
                 if (pxt.BrowserUtils.isArcade()) {
-                    modalBody = lf("WebUSB device not detected. Select your device in the 'Choose Hardware' menu option and try to connect again.");
+                    this.onHwItemClick();
+                    return;
                 } else {
-                    modalBody = lf("WebUSB device not detected. Make sure your device is connected to your computer and try again.");
+                    modalBody = lf("WebUSB device not detected. Make sure your device is connected and try again.");
                 }
                 break;
         }

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -225,6 +225,13 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
             case "notimpl":
                 modalBody = lf("WebUSB is not supported by this browser; please check for updates.");
                 break;
+            default:
+                if (pxt.BrowserUtils.isArcade()) {
+                    modalBody = lf("WebUSB device not detected. Select your device in the 'Choose Hardware' menu option and try to connect again.");
+                } else {
+                    modalBody = lf("WebUSB device not detected. Make sure your device is connected to your computer and try again.");
+                }
+                break;
         }
 
         dialogAsync({

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -227,7 +227,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
                 modalBody = lf("WebUSB is not supported by this browser; please check for updates.");
                 break;
             default:
-                modalBody = lf("WebUSB should be supported, but we're having trouble. Please try refreshing the page.");
+                modalBody = lf("Unable to connect to WebUSB. Please try refreshing the page.");
                 break;
         }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -212,11 +212,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         pxt.tickEvent("editortools.pairunsupported", undefined, { interactiveConsent: true });
         const reasonUnsupported = await pxt.usb.getReasonUnavailable();
 
-        if (!reasonUnsupported && pxt.BrowserUtils.isArcade() && !pxt.getActiveHwVariant()) {
-            this.onHwItemClick()
-            return;
-        }
-
         let modalBody: string;
         switch (reasonUnsupported) {
             case "security":
@@ -284,9 +279,11 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
         const boards = pxt.appTarget.simulator && !!pxt.appTarget.simulator.dynamicBoardDefinition;
         const editorSupportsWebUSB = pxt.appTarget?.compile?.webUSB;
+        const hardwareVariantSelected = (pxt.appTarget.alwaysMultiVariant || !pxt.appTarget.variants || !!(pxt.getActiveHwVariant()))
         const webUSBSupported = pxt.usb.isEnabled && editorSupportsWebUSB;
         const showUsbNotSupportedHint = editorSupportsWebUSB
             && !pxt.usb.isEnabled
+            && hardwareVariantSelected
             && pxt.shell.getControllerMode() !== pxt.shell.ControllerMode.App
             && !pxt.BrowserUtils.isPxtElectron()
             && (pxt.BrowserUtils.isChromiumEdge() || pxt.BrowserUtils.isChrome());


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6655

The `getReasonUnavailable` function that the switch statement relies on for the Cannot Pair dialog content can return undefined. There was no case covering the undefined option, so I added a default case for defining the modal body content. It looks like it would be pretty hard to hit this case in micro:bit with the playing that I did, but in case any other target also hits the undefined scenario, I wanted to make sure that we had some more generic messaging in the content.

As mentioned in the issue, on live the "Connect Device" button only shows up if you have a device connected and chosen in the hardware dialog. Changing the flags around to avoid showing this option before hardware was selected didn't seem to do anything, so I figured the instructions could guide the user to what they need to do to successfully connect a device with WebUSB.

![image](https://github.com/user-attachments/assets/a1fbaaff-a1c1-420c-aa81-f47c381e09f2)

Upload target: https://arcade.makecode.com/app/06dba66f98e73697706c802bf16000f9899d64c4-cf4ba796f5#