### PR TITLE
make the file click compile rather than save as file as happens on live

### DIFF
--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -200,7 +200,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         // Matching the tick in the call to compile() above for historical reasons
         pxt.tickEvent("editortools.download", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
         pxt.tickEvent("editortools.downloadasfile", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
-        await (this.props.parent as ProjectView).saveProjectToFileAsync();
+        (this.props.parent as ProjectView).compile();
     }
 
     protected onPairClick = () => {


### PR DESCRIPTION
Reverts https://github.com/microsoft/pxt/pull/10408

Fixes https://github.com/microsoft/pxt-arcade/issues/6818