### PR TITLE
disable unicode character filtering in binary.js compilation

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -2717,12 +2717,17 @@ ${lbl}: .short 0xffff
                             let mask = bin.usedChars
                             let buf = ""
                             let incl = ""
-                            for (let pos = 0; pos < data.length; pos += chsz) {
-                                let charcode = data.charCodeAt(pos) + (data.charCodeAt(pos + 1) << 8)
-                                if (charcode < 128 || (mask[charcode >> 5] & (1 << (charcode & 31)))) {
-                                    buf += data.slice(pos, pos + chsz)
-                                    incl += charcode + ", "
+                            if (opts.target.isNative) {
+                                for (let pos = 0; pos < data.length; pos += chsz) {
+                                    let charcode = data.charCodeAt(pos) + (data.charCodeAt(pos + 1) << 8)
+                                    if (charcode < 128 || (mask[charcode >> 5] & (1 << (charcode & 31)))) {
+                                        buf += data.slice(pos, pos + chsz)
+                                        incl += charcode + ", "
+                                    }
                                 }
+                            }
+                            else {
+                                buf = data;
                             }
                             s = U.toHex(U.stringToUint8Array(buf))
                         }


### PR DESCRIPTION
our compiler intelligently compiles unicode fonts such that the binary file only includes the characters that appear in the program text. this is great for hardware because it reduces the size of the compiled binary (our unicode font is fairly large) but it isn't necessary in the browser since we don't have that limitation.

you can try it out for yourself, try running this program in the simulator:

```ts
game.onShade(() => {
    screen.print(String.fromCharCode(38190), 30, 30, 1)
})
```

nothing will print out on the screen because the character with char code 38190 isn't being included in the binary. however, this program will print it out fine:

```ts
game.onShade(() => {
    screen.print("键", 30, 30, 1)
})
```

this PR removes that behavior from the binary.js compilation. the motivation here is the new keyboard support; for the first time we have a mechanism for the user to type in unicode characters that aren't part of the program text. likewise, any localized text we want to show for this feature might include unicode characters as well.

the downside here is that binary.js is now larger (not really a problem) and we now have a slight behavior difference between hardware and browser (though i doubt anyone will notice it)