### PR TITLE
fix aria roles of brand logo and locked editor behavior

### DIFF
--- a/pxtlib/shell.ts
+++ b/pxtlib/shell.ts
@@ -111,4 +111,8 @@ namespace pxt.shell {
     export function setToolboxAnimation(): void {
         pxt.storage.setLocal("toolboxanimation", "1");
     }
+
+    export function hasHomeScreen(): boolean {
+        return !pxt.shell.isControllerMode() && !pxt.appTarget.appTheme.lockedEditor;
+    }
 }

--- a/theme/common.less
+++ b/theme/common.less
@@ -527,11 +527,8 @@ div.simframe > iframe {
     -webkit-touch-callout: none;
 }
 
-.ui.item.logo.brand:hover {
+.ui.item.logo.brand[role=menuitem] {
     cursor: pointer;
-}
-.inHome .ui.item.logo.brand:hover {
-    cursor: auto;
 }
 
 .ui.item.logo .name,

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2779,9 +2779,7 @@ export class ProjectView
     ///////////////////////////////////////////////////////////
 
     openHome() {
-        const hasHome = !pxt.shell.isControllerMode()
-            && !pxt.appTarget.appTheme.lockedEditor;
-        if (!hasHome) return;
+        if (!pxt.shell.hasHomeScreen()) return;
 
         this.unloadProjectAsync(true)
     }
@@ -3784,8 +3782,7 @@ export class ProjectView
             case SimState.Running:
                 return false; // already reunning
         }
-        const hasHome = !pxt.shell.isControllerMode();
-        if (!hasHome) return true;
+        if (!pxt.shell.hasHomeScreen()) return true;
         return !this.state.home;
     }
 
@@ -4619,7 +4616,9 @@ export class ProjectView
         });
     }
 
-    showExitAndSaveDialog() {
+    showExitAndSaveDialog() {;
+        if (!pxt.shell.hasHomeScreen()) return;
+
         this.setState({ debugging: false })
         if (this.isTutorial()) {
             pxt.tickEvent("tutorial.exit.home", { tutorial: this.state.header?.tutorial?.tutorial });

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -105,7 +105,8 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
         if (view === "time-machine") {
             return <></>;
         }
-        return <div className="ui item logo organization" role="menuitem">
+
+        return <div className="ui item logo organization" role="presentation">
             {targetTheme.organizationWideLogo || targetTheme.organizationLogo
                 ? <img className={`ui logo ${view !== "home" ? "mobile hide" : ""}`} src={targetTheme.organizationWideLogo || targetTheme.organizationLogo} alt={lf("{0} Logo", targetTheme.organization)} />
                 : <span className="name">{targetTheme.organization}</span>}
@@ -117,8 +118,14 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
         if (view === "time-machine") {
             return <></>;
         }
+
+        const shouldLinkHome = pxt.shell.hasHomeScreen() && view !== "home";
+
+        const role = shouldLinkHome ? "menuitem" : "presentation";
+        const onClickHandler = shouldLinkHome ? this.brandIconClick : undefined;
+
         // TODO: "sandbox" view components are temporary share page layout
-        return <div aria-label={lf("{0} Logo", targetTheme.boardName)} role="menuitem" className={`ui item logo brand ${view !== "sandbox" && view !== "home" ? "mobile hide" : ""}`} onClick={this.brandIconClick}>
+        return <div aria-label={lf("{0} Logo", targetTheme.boardName)} role={role} className={`ui item logo brand ${view !== "sandbox" && view !== "home" ? "mobile hide" : ""}`} onClick={onClickHandler}>
             {targetTheme.useTextLogo
             ? [ <span className="name" key="org-name">{targetTheme.organizationText}</span>,
                 <span className="name-short" key="org-name-short">{targetTheme.organizationShortText || targetTheme.organizationText}</span> ]


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6800

this fixes the click behavior of the brand logo so that we don't try to open the home screen when clicked if we are in controller mode or locked editor mode. while i was there, i also fixed the cursor css and the aria roles on the brand and organization logos