### PR TITLE
Make Theme Names Localizable

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1946,6 +1946,18 @@ ${gcards.map(gcard => `[${gcard.name}](${gcard.url})`).join(',\n')}
                 targetStrings[`{id:hardware-description}${opt.description}`] = opt.description;
         }
     }
+
+    const themeFiles = getThemeFilePaths();
+    for(const themePath of themeFiles) {
+        if (nodeutil.fileExistsSync(themePath)) {
+            const theme = nodeutil.readJson(themePath);
+            const name = theme["name"];
+            if (name) {
+                targetStrings[`{id:color-theme-name}${name}`] = name;
+            }
+        }
+    }
+
     // extract strings from editor
     ["editor", "fieldeditors", "cmds"]
         .filter(d => nodeutil.existsDirSync(d))
@@ -2284,14 +2296,13 @@ function updateTOC(cfg: pxt.TargetBundle) {
     }
 }
 
-function updateColorThemes(cfg: pxt.TargetBundle) {
-    pxt.log("Loading color themes...");
-
+function getThemeFilePaths() {
     const sharedThemeFiles = fs.existsSync("node_modules/pxt-core/theme/color-themes")
-        ? nodeutil
-              .allFiles("node_modules/pxt-core/theme/color-themes", { maxDepth: 1, includeDirs: false })
-              .filter((f) => /\.json$/i.test(f))
-        : [];
+    ? nodeutil
+          .allFiles("node_modules/pxt-core/theme/color-themes", { maxDepth: 1, includeDirs: false })
+          .filter((f) => /\.json$/i.test(f))
+    : [];
+
     const targetThemeFiles = fs.existsSync("theme/color-themes")
         ? nodeutil
             .allFiles("theme/color-themes", { maxDepth: 1, includeDirs: false })
@@ -2299,7 +2310,12 @@ function updateColorThemes(cfg: pxt.TargetBundle) {
         : [];
 
     // Target takes precedence, so include those at the end (will overwrite shared themes)
-    const themeFiles = sharedThemeFiles.concat(targetThemeFiles);
+    return sharedThemeFiles.concat(targetThemeFiles);
+}
+
+function updateColorThemes(cfg: pxt.TargetBundle) {
+    pxt.log("Loading color themes...");
+    const themeFiles = getThemeFilePaths();
 
     for (const themeFile of themeFiles) {
         const themeFileDir = path.dirname(themeFile);

--- a/react-common/components/theming/ThemeCard.tsx
+++ b/react-common/components/theming/ThemeCard.tsx
@@ -9,6 +9,8 @@ interface ThemeCardProps {
 export const ThemeCard = (props: ThemeCardProps) => {
     const { onClick, theme } = props;
 
+    const themeName = pxt.Util.rlf(`{id:color-theme-name}${theme.name}`);
+
     return (
         <Card
             className="theme-card"
@@ -20,7 +22,7 @@ export const ThemeCard = (props: ThemeCardProps) => {
         >
             <div className="theme-info-box">
                 <ThemePreview theme={theme} />
-                <div className="theme-picker-item-name">{theme.name}</div>
+                <div className="theme-picker-item-name">{themeName}</div>
             </div>
         </Card>
     );


### PR DESCRIPTION
This adds theme names to our target strings file for translation and adjusts our theme-picker modal to lookup the localized name, when available.

Fixes https://github.com/microsoft/pxt-arcade/issues/6806