### PR TITLE
Save Skillmap Theme Settings

### DIFF
--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -175,7 +175,8 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
             {
                 type: "pxteditor",
                 action: "setcolorthemebyid",
-                colorThemeId
+                colorThemeId,
+                savePreference: true
             } as pxt.editor.EditorMessageSetColorThemeRequest
         );
     }

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -256,7 +256,7 @@ export async function setThemePrefAsync(themeId: string): Promise<void> {
     } else {
         // Identity not available, save this setting locally
         const currentPrefsStr = pxt.storage.getLocal(COLOR_THEME_IDS);
-        const currentPrefs = pxt.U.jsonTryParse(JSON.parse(currentPrefsStr)) as pxt.auth.ColorThemeIdsState ?? {};
+        const currentPrefs = pxt.U.jsonTryParse(currentPrefsStr) as pxt.auth.ColorThemeIdsState ?? {};
         const newColorThemePref = {
             ...currentPrefs,
             [targetId]: themeId


### PR DESCRIPTION
This change saves the user's preference when setting a theme in skillmaps, and it fixes an error where I was double-parsing the json string and hitting exceptions when it was empty.

It's a bit of a shot in the dark, but I'm hoping this will fix https://github.com/microsoft/pxt-arcade/issues/6808 by ensuring any skillmap-specific setting stays in-sync with the main editor setting. Hard to say for sure if that's what was happening though, since we don't have a concrete repro.