### PR TITLE
give preserve on blur a default

### DIFF
--- a/react-common/components/controls/Input.tsx
+++ b/react-common/components/controls/Input.tsx
@@ -59,7 +59,7 @@ export const Input = (props: InputProps) => {
         onBlur,
         onOptionSelected,
         handleInputRef,
-        preserveValueOnBlur,
+        preserveValueOnBlur = true,
         options
     } = props;
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6851

A lot of the inputs that are most commonly used don't use our react common input so it's a bit hard to catch, but the `preserveOnBlur` is falsey by default, so any use of the react common input that doesn't have `preserveOnBlur` defined would automatically lose the values on blur.

The other places I have seen this behavior in beta are: in the music editor name, the duration for the sound effect editor, the namer for the color picker, and maybe more.

 `preserveOnBlur` should default to true; a user shouldn't lose the text if they click off of the input.