### PR TITLE
Fix "See All Projects" Color

### DIFF
--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -177,6 +177,10 @@ a.ui.card:focus,
 .ui.card.link.scriptmanagercard {
     background-color: var(--pxt-secondary-background) !important;
     color: var(--pxt-secondary-foreground) !important;
+
+    .header {
+        color: var(--pxt-secondary-foreground) !important;
+    }
 }
 
 


### PR DESCRIPTION
Fixes the color in the "see all projects" card.

Before:
![image](https://github.com/user-attachments/assets/7bf1f0e1-2068-43d1-9ac5-8ed0ad7aae03)

After:
![image](https://github.com/user-attachments/assets/ecbc50a6-a0aa-47b5-b192-1182758e7af4)
