### PR TITLE
Add theming for github repo descriptions

### DIFF
--- a/theme/semantic-ui-overrides.less
+++ b/theme/semantic-ui-overrides.less
@@ -54,10 +54,16 @@ body.pxt-theme-root {
         border-color: var(--pxt-neutral-stencil1);
     }
 
-    .ui.list > .item a.header {
-        color: var(--pxt-link) !important; // override !important in semantic ui
-        &:hover {
-            color: var(--pxt-link-hover) !important;
+    .ui.list > .item {
+        .description {
+            color: var(--pxt-neutral-alpha80);
+        }
+
+        a.header {
+            color: var(--pxt-link) !important; // override !important in semantic ui
+            &:hover {
+                color: var(--pxt-link-hover) !important;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6877

Before:
![image](https://github.com/user-attachments/assets/7ab26624-c13d-42f3-8e99-9d29148d2bb9)

After:
![image](https://github.com/user-attachments/assets/c169251a-6b60-4b09-9cae-d5d72090072d)

After (other themes):
![image](https://github.com/user-attachments/assets/459aec4e-0cc8-49fe-9ad2-990118474964)
![image](https://github.com/user-attachments/assets/987ff4b0-d337-4628-809a-5a22297ff16f)
![image](https://github.com/user-attachments/assets/513ec7ff-8d44-42af-aa91-b6c35f88ca95)
