### PR TITLE
Editor focus borders on keyboard navigation

### DIFF
--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -98,6 +98,11 @@
         }
     }
 
+    .common-button:focus-visible {
+        outline: 2px solid var(--pxt-tertiary-foreground);
+        outline-offset: 3px;
+    }
+
     &.no-steps {
         flex-direction: row-reverse;
     }

--- a/theme/accessibility.less
+++ b/theme/accessibility.less
@@ -20,8 +20,17 @@
 }
 
 /* Toggle focus */
-#mainmenu .editor-menuitem .ui.item:focus {
-    background: rgba(0,0,0,0.1) !important;
+#mainmenu .editor-menuitem {
+    .ui.item:focus-visible {
+        background: transparent;
+        outline: 3px solid white;
+        outline-offset: -5px;
+        filter: none;
+    }
+
+    .ui.item.active:focus-visible {
+        outline-color: black;
+    }
 }
 
 .ui.item:focus, .ui.button:focus {

--- a/theme/common.less
+++ b/theme/common.less
@@ -235,7 +235,7 @@ pre {
 }
 
 .editor-sidebar .simtoolbar .ui.button:focus-visible {
-    outline: @editorFocusBorderSize solid var(--pxt-secondary-accent);
+    outline: @editorFocusBorderSize solid var(--pxt-focus-border);
 }
 
 #downloadArea {
@@ -256,7 +256,7 @@ pre {
 #downloadArea .button:focus-visible,
 #editortools .button:focus-visible
 {
-    outline: @editorFocusBorderSize solid var(--pxt-primary-background);
+    outline: @editorFocusBorderSize solid var(--pxt-focus-border);
     outline-offset: 2px;
 }
 
@@ -713,6 +713,10 @@ div.simframe > iframe {
     &:focus {
       opacity: 1;
     }
+
+    &:focus-visible {
+        outline: @editorFocusBorderSize solid  var(--pxt-focus-border);
+    }
 }
 #computertogglesim,
 #sidedocstoggle {
@@ -728,9 +732,6 @@ div.simframe > iframe {
     left: -21px;
     top: calc(~'40% - 2.4rem');
     height: calc(~'20% + 0.8rem');
-    &:focus-visible {
-        outline: @editorFocusBorderSize solid  var(--pxt-primary-background);
-    }
 }
 
 .collapsedEditorTools #computertogglesim,
@@ -1321,7 +1322,7 @@ Field editors
 }
 
 #serialPreview .label:focus {
-    outline: 3px solid var(--pxt-tertiary-background) !important;
+    outline: 3px solid var(--pxt-focus-border) !important;
     outline-offset: -15px;
 }
 

--- a/theme/common.less
+++ b/theme/common.less
@@ -234,6 +234,10 @@ pre {
     }
 }
 
+.editor-sidebar .simtoolbar .ui.button:focus-visible {
+    outline: @editorFocusBorderSize solid var(--pxt-secondary-accent);
+}
+
 #downloadArea {
     margin: unset;
 
@@ -247,6 +251,13 @@ pre {
         background-color: var(--pxt-primary-background-hover) !important;
         color: var(--pxt-primary-foreground-hover) !important;
     }
+}
+
+#downloadArea .button:focus-visible,
+#editortools .button:focus-visible
+{
+    outline: @editorFocusBorderSize solid var(--pxt-primary-background);
+    outline-offset: 2px;
 }
 
 #editorToolbarArea {
@@ -275,7 +286,7 @@ pre {
         color: var(--pxt-primary-foreground) !important; // override !important in semantic ui
         border-radius: inherit;
 
-        &:hover, &:focus {
+        &:hover {
             background: var(--pxt-primary-background-hover) !important;
             color: var(--pxt-primary-foreground-hover) !important;
         }
@@ -373,7 +384,7 @@ div.simframe > iframe {
 .menubar .ui.menu.fixed .ui.item.editor-menuitem .item.link:hover {
     background: none;
 }
-.menubar .ui.menu.fixed .ui.item.editor-menuitem .item:not(.active) {
+.menubar .ui.menu.fixed .ui.item.editor-menuitem .item:not(.active) * {
     opacity: 0.8;
 }
 .menubar .ui.menu.inverted.fixed .ui.item.editor-menuitem .active.item {
@@ -461,6 +472,15 @@ div.simframe > iframe {
     .toggle.dropdown-attached {
         border-top-right-radius: 0!important;
         border-bottom-right-radius: 0!important;
+    }
+
+    .base-menuitem:focus-visible {
+        outline: 3px solid white;
+        outline-offset: -5px;
+    }
+
+    .base-menuitem.active:focus-visible {
+        outline-color: var(--pxt-target-stencil1);
     }
 }
 
@@ -708,6 +728,9 @@ div.simframe > iframe {
     left: -21px;
     top: calc(~'40% - 2.4rem');
     height: calc(~'20% + 0.8rem');
+    &:focus-visible {
+        outline: @editorFocusBorderSize solid  var(--pxt-primary-background);
+    }
 }
 
 .collapsedEditorTools #computertogglesim,
@@ -1295,6 +1318,11 @@ Field editors
         color: @sidbarActiveTabIconColor;
         background-color: @sidebarPrimaryColor;
     }
+}
+
+#serialPreview .label:focus {
+    outline: 3px solid var(--pxt-tertiary-background) !important;
+    outline-offset: -15px;
 }
 
 /*******************************

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -58,7 +58,7 @@
     #monacoEditor .blocklyTreeRow,
     #monacoEditor .monacoDraggableBlock {
         &:focus, &:hover {
-            outline: 2px solid @selected !important;
+            outline: @editorFocusBorderSize solid @selected !important;
         }
     }
 
@@ -91,6 +91,16 @@
         }
     }
 
+    #editortoggle .active.item {
+        transition: none;
+        &:focus {
+            box-shadow: inset 0 0 0 6px @HCbackground !important;
+        }
+        >.icon {
+            color: @HCbackground !important;
+        }
+    }
+
     @media all and (pointer:coarse) { /* If touch screen */
         *[tabindex='0'],
         *[tabindex*='d1'],
@@ -102,7 +112,7 @@
         #monacoEditor .blocklyTreeRow,
         #monacoEditor .monacoDraggableBlock {
             &:focus, &:hover {
-                outline: 1px solid transparent !important;
+                outline: @editorFocusBorderSize solid transparent !important;
             }
         }
     }
@@ -356,7 +366,7 @@
 
         &:focus, &:hover {
             color: @HCtextColor !important;
-            border-color: @selected !important;
+            outline: @editorFocusBorderSize solid @selected;
             background: @HCbackground !important;
 
             i, span {
@@ -645,6 +655,10 @@
         border: 10px solid @HCtextColor !important;
         &:hover {
             border-color: darken(@HCtextColor, 10.0) !important;
+        }
+        &:focus {
+            outline: 3px solid @selected !important;
+            outline-offset: -15px;
         }
     }
 

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -217,6 +217,12 @@
 /* Detail view */
 @homeSelectedCardBorderSize: @homeCardBorderSize*2;
 @homeHeaderBorderSize: 3px;
+
+/*-------------------
+   Editor
+--------------------*/
+@editorFocusBorderSize: 4px;
+
 /*-------------------
    Tutorial
 --------------------*/


### PR DESCRIPTION
This makes the focus borders on buttons thicker and more noticeable in the default and high contrast themes.

Includes: the menu bar, editor selection, simulator transport, sidebar toggles, download and editor bottom bar buttons.

Does not include improvements to the simulator or workspace (Blockly et al).

Addresses https://github.com/microsoft/pxt-microbit/issues/5538#issuecomment-2694537592

There is discussion below around https://github.com/microsoft/pxt-microbit/issues/6082

Related work:
- Work on integrating the new Blockly keyboard navigation will remove the hidden tab stops due to the injection div and the Blockly workspace SVG. We also intend to remove the individual tab stops for the toolbox categories in favour of the arrow key navigation.
- Simulator tab sequence is OK here but gets weird with more controls visible, addressed on open PR https://github.com/microsoft/pxt-microbit/pull/6113
- [Similar PR for home page](https://github.com/microsoft/pxt/pull/10446) (approved, needs maintainer merge)

Demo: https://editor-tab-focus-borders.review-pxt.pages.dev/#editor

### Old appearance

![editor-tabs-old](https://github.com/user-attachments/assets/c5895c80-5517-4502-b482-e51d818dd797)

### New appearance

![editor-tabs-new](https://github.com/user-attachments/assets/e3eadcc4-dfdf-4fbf-baa1-ea792ed6cd69)

### New appearance in high contrast mode

![editor-tabs-new-hc](https://github.com/user-attachments/assets/48443677-bb20-488a-a8bf-888f18c4c645)

## UI questions

### Focus styles

The download button focus highlight, is less noticeable than the other highlights, due to the strong contrast already present on that button. We should discuss how to make this more obvious, particularly as this is the first tab stop after the workspace, and could be quite distant spatially from where the user is currently looking.

We've found in user testing with the work-in-progress Blockly keyboard navigation, folks can often not notice that they've tabbed away from the workspace as they're fixated there.

Current focus appearance
<img width="284" alt="Screenshot 2025-03-19 at 11 09 26" src="https://github.com/user-attachments/assets/83a21fb3-c34a-4b33-a5d0-b8c38e2b82da" />

One option would be to invert the colours of the button on focus, to make the visual change more prominent. This could be a general principle with the primary theme buttons, or just applied for this specific case where there is an issue. For example:
<img width="278" alt="Screenshot 2025-03-19 at 11 13 38" src="https://github.com/user-attachments/assets/4abd8bf6-8d33-4aec-b203-701959ba148f" />

Another option, if we treat it as a specific case and do not extend it to ordinary button focus, would be to give it a light transition animation as the user focuses the download button, to guide the user's gaze. We'll collect further input and suggestions here.

### Hover styles

The Semantic UI components represent focus style and hover style equivalently, which is inadequate on its own for accessibility purposes, but combined with the selection outline may still be desirable- there is no clear best practice here, just whatever is clear and consistent. For instance, with hover styles:

https://github.com/user-attachments/assets/490ee534-f779-4f88-a7d4-fa6fc46409d1

Without:

https://github.com/user-attachments/assets/ecbb5d10-8093-4277-834e-5e79c7d15faf

From a practical implementation perspective, we need to make a decision on this because there's a transition delay for the background that means it appears slightly after the outline. If we choose to keep hover animations on focus, making hover animations consistent will require extending the transitions in `react-common/controls/Button`. If we separate focus and hover visual styles, we have a simpler implementation.

The version in this PR uses the hover styling, but we've not done anything about the transition delay.

### Menubar Patterns

To simplify navigating with tab we suggest considering making the simulator a single tab stop using the menubar pattern. What do you think?

See: https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-navigation/

We can look at this on a separate PR.

## Wider changes

We've not considered pulling up/centralising these style changes and would welcome input on this.

CC @microbit-matt-hillsdon @microbit-robert 