### PR TITLE
add ability to specify share url directly for forum homepage cards

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -174,6 +174,7 @@ declare namespace pxt {
         actionIcon?: string; // icon to override default icon on the action button
         time?: number;
         url?: string;
+        shareUrl?: string;
         learnMoreUrl?: string;
         buyUrl?: string;
         feedbackUrl?: string;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1012,19 +1012,31 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
         return () => onClick(scr, action);
     }
 
-    handleOpenForumUrlInEditor() {
+    async handleOpenForumUrlInEditor() {
         pxt.tickEvent('projects.actions.forum', undefined, { interactiveConsent: true });
-        const { url } = this.props;
-        pxt.discourse.extractSharedIdFromPostUrl(url)
-            .then(projectId => {
-                // if we have a projectid, load it
-                if (projectId)
-                    window.location.hash = "pub:" + projectId; // triggers reload
-                else {
-                    core.warningNotification(lf("Oops, we could not find the program in the forum."));
-                }
-            })
-            .catch(core.handleNetworkError)
+        const { url, scr } = this.props;
+
+        let projectId: string;
+        if (scr?.shareUrl) {
+            projectId = pxt.Cloud.parseScriptId(scr.shareUrl);
+        }
+
+        if (!projectId) {
+            try {
+                projectId = await pxt.discourse.extractSharedIdFromPostUrl(url);
+            }
+            catch (e) {
+                core.handleNetworkError(e);
+                return;
+            }
+        }
+
+        if (projectId) {
+            window.location.hash = "pub:" + projectId; // triggers reload
+        }
+        else {
+            core.warningNotification(lf("Oops, we could not find the program in the forum."));
+        }
     }
 
     isYouTubeOnline(): boolean {


### PR DESCRIPTION
I was updating the community games section of the arcade homepage and noticed that our community row currently extracts the share link url from the linked discourse page at runtime. this is a bad idea because that link could be a persistent share link which the author could update independently of us at any time.

this PR adds an optional shareUrl property to the codecard which lets you specify a snapshotted share link that won't change.