### PR TITLE
unifying the messaging for type errors and adding type checks for builtin types

### DIFF
--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -493,16 +493,19 @@ function ${id}(s) {
             }
         }
 
+        function vTableRef(info: ClassInfo) {
+            return `${info.id}_VT`
+        }
+
         function checkSubtype(info: ClassInfo, r0 = "r0") {
-            const vt = `${info.id}_VT`
-            return `checkSubtype(${r0}, ${vt})`
+            return `checkSubtype(${r0}, ${vTableRef(info)})`
         }
 
         function emitInstanceOf(info: ClassInfo, tp: string, r0 = "r0") {
             if (tp == "bool")
                 write(`r0 = ${checkSubtype(info)};`)
             else if (tp == "validate") {
-                write(`if (!${checkSubtype(info, r0)}) failedCast(${r0});`)
+                write(`if (!${checkSubtype(info, r0)}) failedCast(${r0}, ${vTableRef(info)});`)
             } else {
                 U.oops()
             }

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -653,6 +653,7 @@ namespace pxsim {
         }
 
         export function runInBackground(a: RefAction) {
+            typeCheck(a);
             runtime.runFiberAsync(a);
         }
 
@@ -662,10 +663,14 @@ namespace pxsim {
                     .then(() => U.delay(20))
                     .then(loop);
             }
-            pxtrt.nullCheck(a)
+            typeCheck(a);
             loop()
         }
     }
 
-
+    export function typeCheck(a: RefAction) {
+        if (!(a instanceof RefAction)) {
+            throwFailedCastError(a, "function");
+        }
+    }
 }

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -666,11 +666,11 @@ namespace pxsim {
             typeCheck(a);
             loop()
         }
-    }
 
-    export function typeCheck(a: RefAction) {
-        if (!(a instanceof RefAction)) {
-            throwFailedCastError(a, "function");
+        export function typeCheck(a: RefAction) {
+            if (!(a instanceof RefAction)) {
+                throwFailedCastError(a, "function");
+            }
         }
     }
 }

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -531,6 +531,9 @@ namespace pxsim {
         }
 
         export function mapGetByString(map: RefMap, key: string) {
+            if (!map) {
+                throwFailedPropertyAccessError(map, key);
+            }
             key += ""
             if (map instanceof RefRecord) {
                 let r = map as RefRecord
@@ -544,8 +547,14 @@ namespace pxsim {
         }
 
         export function mapDeleteByString(map: RefMap, key: string) {
-            if (!(map instanceof RefMap))
-                pxtrt.panic(923)
+            if (map === undefined || map === null) {
+                throwNullUndefinedAsObjectError();
+            }
+
+            if (!(map instanceof RefMap)) {
+                throwFailedCastError(map, "object");
+            }
+
             let i = map.findIdx(key);
             if (i >= 0)
                 map.data.splice(i, 1)
@@ -556,6 +565,9 @@ namespace pxsim {
         export const mapGetGeneric = mapGetByString
 
         export function mapSetByString(map: RefMap, key: string, val: any) {
+            if (!map) {
+                throwFailedPropertyAccessError(map, key);
+            }
             key += ""
             if (map instanceof RefRecord) {
                 let r = map as RefRecord
@@ -574,6 +586,9 @@ namespace pxsim {
         }
 
         export function keysOf(v: RefMap) {
+            if (v === undefined || v === null) {
+                throwNullUndefinedAsObjectError();
+            }
             let r = new RefCollection()
             if (v instanceof RefMap)
                 for (let k of v.data) {

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -668,7 +668,7 @@ namespace pxsim {
         }
 
         export function typeCheck(a: RefAction) {
-            if (!(a instanceof RefAction)) {
+            if (!a || !(a instanceof RefAction) && !(a as any).info) {
                 throwFailedCastError(a, "function");
             }
         }

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -107,36 +107,36 @@ namespace pxsim {
         }
 
         export function length(c: RefCollection) {
-            pxtrt.nullCheck(c)
+            typeCheck(c)
             return c.getLength();
         }
 
         export function setLength(c: RefCollection, x: number) {
-            pxtrt.nullCheck(c)
+            typeCheck(c)
             c.setLength(x);
         }
 
 
         export function push(c: RefCollection, x: any) {
-            pxtrt.nullCheck(c)
+            typeCheck(c)
             c.push(x);
         }
 
         export function pop(c: RefCollection, x: any) {
-            pxtrt.nullCheck(c)
+            typeCheck(c)
             let ret = c.pop();
             // no decr() since we're returning it
             return ret;
         }
 
         export function getAt(c: RefCollection, x: number) {
-            pxtrt.nullCheck(c)
+            typeCheck(c)
             let tmp = c.getAt(x);
             return tmp;
         }
 
         export function removeAt(c: RefCollection, x: number) {
-            pxtrt.nullCheck(c)
+            typeCheck(c)
             if (!c.isValidIndex(x))
                 return;
             // no decr() since we're returning it
@@ -144,28 +144,34 @@ namespace pxsim {
         }
 
         export function insertAt(c: RefCollection, x: number, y: number) {
-            pxtrt.nullCheck(c)
+            typeCheck(c)
             c.insertAt(x, y);
         }
 
         export function setAt(c: RefCollection, x: number, y: any) {
-            pxtrt.nullCheck(c)
+            typeCheck(c)
             c.setAt(x, y);
         }
 
         export function indexOf(c: RefCollection, x: any, start: number) {
-            pxtrt.nullCheck(c)
+            typeCheck(c)
             return c.indexOf(x, start)
         }
 
         export function removeElement(c: RefCollection, x: any) {
-            pxtrt.nullCheck(c)
+            typeCheck(c)
             let idx = indexOf(c, x, 0);
             if (idx >= 0) {
                 removeAt(c, idx);
                 return 1;
             }
             return 0;
+        }
+
+        export function typeCheck(c: RefCollection) {
+            if (!(c instanceof RefCollection)) {
+                throwFailedCastError(c, "Array");
+            }
         }
     }
 
@@ -319,31 +325,36 @@ namespace pxsim {
         }
 
         export function toNumber(s: string) {
+            typeCheck(s);
             return parseFloat(s);
         }
 
         // TODO check edge-conditions
 
         export function concat(a: string, b: string) {
+            typeCheck(a);
             return (a + b);
         }
 
         export function substring(s: string, i: number, j: number) {
-            pxtrt.nullCheck(s)
+            typeCheck(s);
             return (s.slice(i, i + j));
         }
 
         export function equals(s1: string, s2: string) {
+            typeCheck(s1);
             return s1 == s2;
         }
 
         export function compare(s1: string, s2: string) {
+            typeCheck(s1);
             if (s1 == s2) return 0;
             if (s1 < s2) return -1;
             return 1;
         }
 
         export function compareDecr(s1: string, s2: string) {
+            typeCheck(s1);
             if (s1 == s2) {
                 return 0;
             }
@@ -352,43 +363,52 @@ namespace pxsim {
         }
 
         export function length(s: string) {
+            typeCheck(s);
             return s.length
         }
 
         export function substr(s: string, start: number, length?: number) {
+            typeCheck(s);
             return (s.substr(start, length));
         }
 
         function inRange(s: string, i: number) {
-            pxtrt.nullCheck(s)
+            typeCheck(s)
             return 0 <= i && i < s.length
         }
 
         export function charAt(s: string, i: number) {
+            typeCheck(s);
             return (s.charAt(i));
         }
 
         export function charCodeAt(s: string, i: number) {
-            pxtrt.nullCheck(s)
+            typeCheck(s)
             return inRange(s, i) ? s.charCodeAt(i) : 0;
         }
 
         export function indexOf(s: string, searchValue: string, start?: number) {
-            pxtrt.nullCheck(s);
+            typeCheck(s);
             if (searchValue == null) return -1;
             return s.indexOf(searchValue, start);
         }
 
         export function lastIndexOf(s: string, searchValue: string, start?: number) {
-            pxtrt.nullCheck(s);
+            typeCheck(s);
             if (searchValue == null) return -1;
             return s.lastIndexOf(searchValue, start);
         }
 
         export function includes(s: string, searchValue: string, start?: number) {
-            pxtrt.nullCheck(s);
+            typeCheck(s);
             if (searchValue == null) return false;
             return s.includes(searchValue, start);
+        }
+
+        export function typeCheck(s: string) {
+            if (typeof s !== "string") {
+                throwFailedCastError(s, "string");
+            }
         }
     }
 
@@ -486,6 +506,7 @@ namespace pxsim {
         }
 
         export function getNumber(buf: RefBuffer, fmt: NumberFormat, offset: number) {
+            typeCheck(buf);
             let inf = fmtInfo(fmt)
             if (inf.isFloat) {
                 let subarray = buf.data.buffer.slice(offset, offset + inf.size)
@@ -513,6 +534,7 @@ namespace pxsim {
         }
 
         export function setNumber(buf: RefBuffer, fmt: NumberFormat, offset: number, r: number) {
+            typeCheck(buf);
             let inf = fmtInfo(fmt)
             if (inf.isFloat) {
                 let arr = new Uint8Array(inf.size)
@@ -540,6 +562,7 @@ namespace pxsim {
         }
 
         export function createBufferFromHex(hex: string) {
+            String_.typeCheck(hex);
             let r = createBuffer(hex.length >> 1)
             for (let i = 0; i < hex.length; i += 2)
                 r.data[i >> 1] = parseInt(hex.slice(i, i + 2), 16)
@@ -548,29 +571,33 @@ namespace pxsim {
         }
 
         export function isReadOnly(buf: RefBuffer) {
-            return buf.isStatic
+            typeCheck(buf);
+            return buf.isStatic;
         }
 
         export function getBytes(buf: RefBuffer) {
+            typeCheck(buf);
             // not sure if this is any useful...
             return buf.data;
         }
 
         function inRange(buf: RefBuffer, off: number) {
-            pxtrt.nullCheck(buf)
             return 0 <= off && off < buf.data.length
         }
 
         export function getUint8(buf: RefBuffer, off: number) {
+            typeCheck(buf);
             return getByte(buf, off);
         }
 
         export function getByte(buf: RefBuffer, off: number) {
+            typeCheck(buf);
             if (inRange(buf, off)) return buf.data[off]
             else return 0;
         }
 
         export function setUint8(buf: RefBuffer, off: number, v: number) {
+            typeCheck(buf);
             setByte(buf, off, v);
         }
 
@@ -579,6 +606,7 @@ namespace pxsim {
         }
 
         export function setByte(buf: RefBuffer, off: number, v: number) {
+            typeCheck(buf);
             if (inRange(buf, off)) {
                 checkWrite(buf)
                 buf.data[off] = v
@@ -586,10 +614,12 @@ namespace pxsim {
         }
 
         export function length(buf: RefBuffer) {
+            typeCheck(buf);
             return buf.data.length
         }
 
         export function fill(buf: RefBuffer, value: number, offset: number = 0, length: number = -1) {
+            typeCheck(buf);
             if (offset < 0 || offset > buf.data.length)
                 return;
             if (length < 0)
@@ -601,6 +631,7 @@ namespace pxsim {
         }
 
         export function slice(buf: RefBuffer, offset: number, length: number) {
+            typeCheck(buf);
             offset = Math.min(buf.data.length, offset);
             if (length < 0)
                 length = buf.data.length;
@@ -609,6 +640,7 @@ namespace pxsim {
         }
 
         export function toHex(buf: RefBuffer): string {
+            typeCheck(buf);
             const hex = "0123456789abcdef";
             let res = "";
             for (let i = 0; i < buf.data.length; ++i) {
@@ -619,6 +651,7 @@ namespace pxsim {
         }
 
         export function toString(buf: RefBuffer): string {
+            typeCheck(buf);
             return U.fromUTF8Array(buf.data);
         }
 
@@ -634,6 +667,7 @@ namespace pxsim {
         const INT_MIN = -0x80000000;
 
         export function shift(buf: RefBuffer, offset: number, start: number, len: number) {
+            typeCheck(buf);
             if (len < 0) len = buf.data.length - start;
             if (start < 0 || start + len > buf.data.length || start + len < start
                 || len == 0 || offset == 0 || offset == INT_MIN) return;
@@ -656,6 +690,7 @@ namespace pxsim {
         }
 
         export function rotate(buf: RefBuffer, offset: number, start: number, len: number) {
+            typeCheck(buf);
             if (len < 0) len = buf.data.length - start;
 
             if (start < 0 || start + len > buf.data.length || start + len < start
@@ -688,6 +723,8 @@ namespace pxsim {
         }
 
         export function write(buf: RefBuffer, dstOffset: number, src: RefBuffer, srcOffset = 0, length = -1) {
+            typeCheck(buf);
+            typeCheck(src);
             if (length < 0)
                 length = src.data.length;
 
@@ -702,11 +739,18 @@ namespace pxsim {
             checkWrite(buf)
             memmove(buf.data, dstOffset, src.data, srcOffset, length)
         }
+
+        export function typeCheck(buf: RefBuffer) {
+            if (!(buf instanceof RefBuffer)) {
+                throwFailedCastError(buf, "Buffer");
+            }
+        }
     }
 }
 
 namespace pxsim.control {
     export function createBufferFromUTF8(str: string) {
+        String_.typeCheck(str);
         return new pxsim.RefBuffer(U.toUTF8Array(str));
     }
 }

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1837,6 +1837,12 @@ namespace pxsim {
         if (vtable) {
             typename = vtable.name;
         }
+        else if (value === null) {
+            typename = "null";
+        }
+        else if (value === undefined) {
+            typename = "undefined";
+        }
         else if (value instanceof RefCollection) {
             typename = "Array";
         }

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1852,10 +1852,10 @@ namespace pxsim {
 
         if (expectedType) {
             if (value === null || value === undefined) {
-                throwTypeError(pxsim.localization.lf("Expected type {0} but received {1}. Did you forget to assign a variable?", expectedType, value + ""));
+                throwTypeError(pxsim.localization.lf("Expected type {0} but received type {1}. Did you forget to assign a variable?", expectedType, typename));
             }
             else {
-                throwTypeError(pxsim.localization.lf("Type {0} is not assignable to type {1}", typename, expectedType))
+                throwTypeError(pxsim.localization.lf("Expected type {0} but received type {1}", expectedType, typename))
             }
         }
         else {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1832,6 +1832,37 @@ namespace pxsim {
     }
 
     export function throwFailedCastError(value: any, expectedType?: string) {
+        const typename = getType(value);
+
+        if (expectedType) {
+            if (value === null || value === undefined) {
+                throwTypeError(pxsim.localization.lf("Expected type {0} but received type {1}. Did you forget to assign a variable?", expectedType, typename));
+            }
+            else {
+                throwTypeError(pxsim.localization.lf("Expected type {0} but received type {1}", expectedType, typename))
+            }
+        }
+        else {
+            throwTypeError(pxsim.localization.lf("Cannot read properties of {0}", typename));
+        }
+    }
+
+    export function throwFailedPropertyAccessError(value: any, propertyName?: string) {
+        const typename = getType(value);
+
+        if (propertyName) {
+            throwTypeError(pxsim.localization.lf("Cannot read properties of {0} (reading '{1}')", typename, propertyName));
+        }
+        else {
+            throwTypeError(pxsim.localization.lf("Cannot read properties of {0}", typename));
+        }
+    }
+
+    export function throwNullUndefinedAsObjectError() {
+        throwTypeError(pxsim.localization.lf("Cannot convert undefined or null to object"));
+    }
+
+    function getType(value: any) {
         let typename: string;
         const vtable = (value as RefRecord)?.vtable;
         if (vtable) {
@@ -1855,18 +1886,7 @@ namespace pxsim {
         else {
             typename = typeof value;
         }
-
-        if (expectedType) {
-            if (value === null || value === undefined) {
-                throwTypeError(pxsim.localization.lf("Expected type {0} but received type {1}. Did you forget to assign a variable?", expectedType, typename));
-            }
-            else {
-                throwTypeError(pxsim.localization.lf("Expected type {0} but received type {1}", expectedType, typename))
-            }
-        }
-        else {
-            throwTypeError(pxsim.localization.lf("Cannot access properties on {0}", typename));
-        }
+        return typename;
     }
 
     export function setParentMuteState(state: "muted" | "unmuted" | "disabled") {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1852,7 +1852,7 @@ namespace pxsim {
 
         if (expectedType) {
             if (value === null || value === undefined) {
-                throwNullTypeError(value, expectedType);
+                throwTypeError(pxsim.localization.lf("Expected type {0} but received {1}. Did you forget to assign a variable?", expectedType, value + ""));
             }
             else {
                 throwTypeError(pxsim.localization.lf("Type {0} is not assignable to type {1}", typename, expectedType))
@@ -1861,12 +1861,6 @@ namespace pxsim {
         else {
             throwTypeError(pxsim.localization.lf("Cannot access properties on {0}", typename));
         }
-    }
-
-    export function throwNullTypeError(value: any, expectedType: string) {
-        throwTypeError(
-            pxsim.localization.lf("Expected type {0} but received {1}. Did you forget to assign a variable?", expectedType, value + "")
-        );
     }
 
     export function setParentMuteState(state: "muted" | "unmuted" | "disabled") {


### PR DESCRIPTION
this pr surfaces some new functions in pxsim for reporting type errors like failed casts, accessing properties on null/undefined, etc. these new messages all actually go through localization and are generally more readable than what we have today.

i've also slightly tweaked our binary.js emitter to include the vtable information for failed casts so that we can include the expected type in the error message for that case.

finally, i went ahead and added type checking for all of our default sim implementations of the "native" types like strings, arrays, buffers, etc. i will have another pr in pxt-common-packages shortly that adds even more of these type checks.