### PR TITLE
don't parse junk tilemaps literally

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -248,7 +248,7 @@ namespace pxt.sprite {
     export function decodeTilemap(literal: string, fileType: "typescript" | "python", proj: TilemapProject): TilemapData {
         literal = Util.htmlUnescape(literal).trim();
 
-        if (!literal.trim()) {
+        if (!literal.trim() || literal.indexOf("(") === -1) {
             return null;
         }
 

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1683,9 +1683,17 @@ namespace pxt {
         const tmWidth = bytes[1] | (bytes[2] << 8);
         const tmHeight = bytes[3] | (bytes[4] << 8);
 
+        const tiles: Tile[] = jres.tileset.map(id => (resolveTile && resolveTile(id)) || { id } as any);
+        let tileWidth = bytes[0];
+
+        if (!tileWidth) {
+            tileWidth = tiles.length && tiles.find(t => t.bitmap?.width)?.bitmap.width;
+        }
+        tileWidth = tileWidth || 16;
+
         const tileset: TileSet = {
-            tileWidth: bytes[0],
-            tiles: jres.tileset.map(id => (resolveTile && resolveTile(id)) || { id } as any)
+            tileWidth,
+            tiles
         };
 
         const tilemapStart = 5;


### PR DESCRIPTION
this fixes the issue encountered by @UnsignedArduino [here](https://github.com/microsoft/pxt-arcade/issues/6837#issuecomment-2770210833) but doesn't fix the underlying issue that got the project into that state in the first place.