### PR TITLE
add some missing localization strings

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1830,6 +1830,9 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
             if (extraType.label) {
                 targetStrings[`{id:type}${extraType.label}`] = extraType.label;
             }
+            else {
+                targetStrings[`{id:type}${extraType.typeName}`] = extraType.typeName;
+            }
 
             if (extraType.defaultName) {
                 targetStrings[`{id:var}${extraType.defaultName}`] = extraType.defaultName;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -235,6 +235,7 @@ function updatestrings() {
         "pxtpy",
         "pxtsim",
         "webapp/src",
+        "react-common"
     ], true);
 }
 

--- a/pxtblocks/builtins/functions.ts
+++ b/pxtblocks/builtins/functions.ts
@@ -24,6 +24,9 @@ export function initFunctions() {
     msg.FUNCTIONS_DEFAULT_STRING_ARG_NAME = lf("text");
     msg.FUNCTIONS_DEFAULT_NUMBER_ARG_NAME = lf("num");
     msg.FUNCTIONS_DEFAULT_CUSTOM_ARG_NAME = lf("arg");
+    msg.FUNCTION_FLYOUT_LABEL = lf("Your Functions");
+    msg.FUNCTIONS_CREATE_CALL_OPTION = lf("Create 'call {0}'", "%1");
+    msg.FUNCTIONS_DEFNORETURN_TITLE = lf("function");
     msg.PROCEDURES_HUE = pxt.toolbox.getNamespaceColor("functions");
     msg.REPORTERS_HUE = pxt.toolbox.getNamespaceColor("variables");
 

--- a/webapp/src/createFunction.tsx
+++ b/webapp/src/createFunction.tsx
@@ -212,18 +212,19 @@ export class CreateFunctionDialog extends data.Component<ISettingsProps, CreateF
                 }
             ];
 
-            if (pxt.appTarget.runtime &&
-                pxt.appTarget.runtime.functionsOptions &&
-                pxt.appTarget.runtime.functionsOptions.extraFunctionEditorTypes &&
-                Array.isArray(pxt.appTarget.runtime.functionsOptions.extraFunctionEditorTypes)) {
+            const extraTypes = pxt.appTarget.runtime?.functionsOptions?.extraFunctionEditorTypes;
 
-                pxt.appTarget.runtime.functionsOptions.extraFunctionEditorTypes.forEach(t => {
+            if (Array.isArray(extraTypes)) {
+                for (const extraType of extraTypes) {
+                    const label = extraType.label || extraType.typeName;
+                    const defaultName = extraType.defaultName;
+
                     types.push({
-                        ...t,
-                        label: t.label && pxt.Util.rlf(`{id:type}${t.label}`),
-                        defaultName: t.defaultName && pxt.Util.rlf(`{id:var}${t.defaultName}`)
-                    })
-                });
+                        ...extraType,
+                        label: pxt.Util.rlf(`{id:type}${label}`),
+                        defaultName: defaultName && pxt.Util.rlf(`{id:var}${defaultName}`)
+                    });
+                }
             }
 
             types.forEach(t => {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6891

looks like we were never getting the strings from react-common which is wild if true?

also, @thsparks, i edited your extra function types code slightly so that it now also includes the types without labels