### PR TITLE
try to validate assets before committing them

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -145,7 +145,7 @@ namespace pxt.sprite {
             }
         }
 
-        protected dataLength() {
+        dataLength() {
             return Math.ceil(this.width * this.height / 2);
         }
     }
@@ -179,7 +179,7 @@ namespace pxt.sprite {
             this.buf[index] = value;
         }
 
-        protected dataLength() {
+        dataLength() {
             return this.width * this.height;
         }
     }


### PR DESCRIPTION
this is me throwing spaghetti at the wall to prevent the weird asset disappearing bug from breaking projects. i still have no repro for that bug, but this change just puts in some common-sense checks to make sure that we don't ever overwrite assets with obviously invalid ones.

again, because i can't repro the actual issue, i'm not sure that this will actually fix anything. it's possible that when that bug occurs all of the assets get overwritten with perfectly valid transparent assets or all of the assets are just summarily deleted from the project. but the project in [this comment](https://github.com/microsoft/pxt-arcade/issues/6837#issuecomment-2770210833) at least has an invalid tilemap (it has a tile width of 0) so maybe this would have prevented that one specific problem. we'll see if that tick i added actually gets hit.