### PR TITLE
fix centering behavior for blocks

### DIFF
--- a/pxtblocks/builtins/functions.ts
+++ b/pxtblocks/builtins/functions.ts
@@ -289,7 +289,7 @@ export function initFunctions() {
             let newBlock = workspace.getBlockById(newBlockIds[0]) as Blockly.BlockSvg;
             newBlock.select();
             // Center on the new block so we know where it is
-            workspace.centerOnBlock(newBlock.id);
+            workspace.centerOnBlock(newBlock.id, true);
         }
 
         workspace.registerButtonCallback('CREATE_FUNCTION', function (button) {

--- a/pxtblocks/plugins/functions/blocks/functionDeclarationBlock.ts
+++ b/pxtblocks/plugins/functions/blocks/functionDeclarationBlock.ts
@@ -104,7 +104,7 @@ const FUNCTION_DECLARATION_MIXIN: FunctionDeclarationMixin = {
                 const workspace = this.workspace;
 
                 if (workspace instanceof Blockly.WorkspaceSvg) {
-                    workspace.centerOnBlock(this.id);
+                    workspace.centerOnBlock(this.id, true);
                 }
                 newInput.fieldRow[0].showEditor();
             } else if (newInput.type == Blockly.inputs.inputTypes.VALUE) {
@@ -112,7 +112,7 @@ const FUNCTION_DECLARATION_MIXIN: FunctionDeclarationMixin = {
                 const target = newInput.connection!.targetBlock()!;
                 const workspace = target.workspace;
                 if (workspace instanceof Blockly.WorkspaceSvg) {
-                    workspace.centerOnBlock(target.id);
+                    workspace.centerOnBlock(target.id, true);
                 }
                 target.getField("TEXT")!.showEditor();
             }

--- a/pxtblocks/plugins/functions/extensions.ts
+++ b/pxtblocks/plugins/functions/extensions.ts
@@ -57,8 +57,9 @@ const contextMenuEditMixin = {
             callback: () => {
                 const functionName = this.getField("function_name")!.getText();
                 const definition = getDefinition(functionName, this.workspace);
-                if (definition && this.workspace instanceof Blockly.WorkspaceSvg)
-                    this.workspace.centerOnBlock(definition.id);
+                if (definition && this.workspace instanceof Blockly.WorkspaceSvg) {
+                    this.workspace.centerOnBlock(definition.id, true);
+                }
             },
         };
         menuOptions.push(gtdOption);

--- a/pxtblocks/plugins/functions/utils.ts
+++ b/pxtblocks/plugins/functions/utils.ts
@@ -435,7 +435,7 @@ function createFunctionCallbackFactory_(workspace: Blockly.WorkspaceSvg) {
                 block.scheduleSnapAndBump();
             }
 
-            workspace.centerOnBlock(block.id);
+            workspace.centerOnBlock(block.id, true);
             Blockly.Events.setGroup(false);
 
             setTimeout(() => {

--- a/webapp/src/createFunction.tsx
+++ b/webapp/src/createFunction.tsx
@@ -87,7 +87,7 @@ export class CreateFunctionDialog extends data.Component<ISettingsProps, CreateF
         functionBeingEdited.domToMutation(initialMutation);
         functionBeingEdited.initSvg();
         functionBeingEdited.render();
-        functionEditorWorkspace.centerOnBlock(functionBeingEdited.id);
+        functionEditorWorkspace.centerOnBlock(functionBeingEdited.id, true);
 
         functionEditorWorkspace.addChangeListener(() => {
             const { functionBeingEdited } = this.state;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6897

this PR changes everywhere we call centerOnBlock, which at some point was given a second argument that i did not know about! without that boolean passed, centerOnBlock will center the block and all blocks attached below it, which is pretty much never what we want.

the bulk of this PR, however, is in blocks.tsx, where i reworked our centering behavior for the debugger. previously we would check to see if the currently highlighted block was off screen and then center the screen on that block. now i've changed it so that we do the minimal scroll to put the block into view rather than jumping it to the center of the screen. overall, this feels much more natural since the workspace moves less.