### PR TITLE
Add theme colors for success, warning, and error

### DIFF
--- a/react-common/styles/theming/base-theme.less
+++ b/react-common/styles/theming/base-theme.less
@@ -71,6 +71,21 @@
     --pxt-link-hover: #204467;
     --pxt-focus-border: #0078D4;
 
+    --pxt-success: #2ecc71;
+    --pxt-success-foreground: #FFFFFF;
+    --pxt-success-hover: #22be64;
+    --pxt-success-alpha10:  #2ecc7119;
+
+    --pxt-warning: #c0a000;
+    --pxt-warning-foreground: #FFFFFF;
+    --pxt-warning-hover: rgb(153, 132, 0);
+    --pxt-warning-alpha10: #c0a00019;
+
+    --pxt-error: #a80000;
+    --pxt-error-foreground: #FFFFFF;
+    --pxt-error-hover: #8f0000;
+    --pxt-error-alpha10:    #a8000019;
+
     --pxt-colors-purple-background: #9932cc;
     --pxt-colors-purple-foreground: #FFFFFF;
     --pxt-colors-purple-hover: #7a28a3;

--- a/react-common/styles/theming/base-theme.less
+++ b/react-common/styles/theming/base-theme.less
@@ -84,7 +84,7 @@
     --pxt-error: #a80000;
     --pxt-error-foreground: #FFFFFF;
     --pxt-error-hover: #8f0000;
-    --pxt-error-alpha10:    #a8000019;
+    --pxt-error-alpha10: #a8000019;
 
     --pxt-colors-purple-background: #9932cc;
     --pxt-colors-purple-foreground: #FFFFFF;

--- a/teachertool/src/components/styling/CatalogOverlay.module.scss
+++ b/teachertool/src/components/styling/CatalogOverlay.module.scss
@@ -117,7 +117,7 @@
                         }
 
                         .recently-added-indicator {
-                            color: var(--pxt-colors-green-background);
+                            color: var(--pxt-success);
                         }
                     }
                 }

--- a/teachertool/src/components/styling/EvalResultDisplay.module.scss
+++ b/teachertool/src/components/styling/EvalResultDisplay.module.scss
@@ -112,9 +112,9 @@
         position: relative;
         width: 100%;
         padding: 0.5rem;
-        border: 1px solid var(--pxt-colors-red-background);
+        border: 1px solid var(--pxt-error);
         border-radius: 1rem;
-        background-color: var(--pxt-colors-red-alpha10);
+        background-color: var(--pxt-error-alpha10);
         gap: 0.5rem;
 
         .error-info-container {

--- a/teachertool/src/components/styling/Toasts.module.scss
+++ b/teachertool/src/components/styling/Toasts.module.scss
@@ -26,7 +26,7 @@
     color: var(--pxt-neutral-foreground1);
 
     &.success {
-        border-color: var(--pxt-colors-green-background);
+        border-color: var(--pxt-success);
     }
 
     &.info {
@@ -34,11 +34,11 @@
     }
 
     &.warning {
-        border-color: var(--pxt-colors-yellow-background);
+        border-color: var(--pxt-warning);
     }
 
     &.error {
-        border-color: var(--pxt-colors-red-background);
+        border-color: var(--pxt-error);
     }
 
     .toast-content {
@@ -48,7 +48,7 @@
         font-size: 1.125rem;
 
         &.success {
-            background-color: var(--pxt-colors-green-alpha10);
+            background-color: var(--pxt-success-alpha10);
         }
 
         &.info {
@@ -56,11 +56,11 @@
         }
 
         &.warning {
-            background-color: var(--pxt-colors-yellow-alpha10);
+            background-color: var(--pxt-warning-alpha10);
         }
 
         &.error {
-            background-color: var(--pxt-colors-red-alpha10);
+            background-color: var(--pxt-error-alpha10);
         }
 
         .icon-container {
@@ -73,8 +73,8 @@
             height: 1.75rem;
 
             &.success {
-                background-color: var(--pxt-colors-green-background);
-                color: var(--pxt-colors-green-foreground);
+                background-color: var(--pxt-success);
+                color: var(--pxt-success-foreground);
             }
 
             &.info {
@@ -83,13 +83,13 @@
             }
 
             &.warning {
-                background-color: var(--pxt-colors-yellow-background);
-                color: var(--pxt-colors-yellow-foreground);
+                background-color: var(--pxt-warning);
+                color: var(--pxt-warning-foreground);
             }
 
             &.error {
-                background-color: var(--pxt-colors-red-background);
-                color: var(--pxt-colors-red-foreground);
+                background-color: var(--pxt-error);
+                color: var(--pxt-error-foreground);
             }
         }
 
@@ -135,7 +135,7 @@
 
     .slider-container {
         &.success {
-            background-color: var(--pxt-colors-green-alpha10);
+            background-color: var(--pxt-success-alpha10);
         }
 
         &.info {
@@ -143,11 +143,11 @@
         }
 
         &.warning {
-            background-color: var(--pxt-colors-yellow-alpha10);
+            background-color: var(--pxt-warning-alpha10);
         }
 
         &.error {
-            background-color: var(--pxt-colors-red-alpha10);
+            background-color: var(--pxt-error-alpha10);
         }
 
         .slider {
@@ -155,7 +155,7 @@
             transition: all 0.2s linear;
     
             &.success {
-                background-color: var(--pxt-colors-green-background);
+                background-color: var(--pxt-success);
             }
 
             &.info {
@@ -163,11 +163,11 @@
             }
 
             &.warning {
-                background-color: var(--pxt-colors-yellow-background);
+                background-color: var(--pxt-warning);
             }
 
             &.error {
-                background-color: var(--pxt-colors-red-background);
+                background-color: var(--pxt-error);
             }
         }
     }

--- a/teachertool/src/style.overrides/Button.scss
+++ b/teachertool/src/style.overrides/Button.scss
@@ -72,10 +72,10 @@
     }
     
     .fail > .common-button.common-dropdown-button {
-        border: 3px solid var(--pxt-colors-yellow-background);
+        border: 3px solid var(--pxt-warning);
     }
     
     .pass > .common-button.common-dropdown-button {
-        border: 3px solid var(--pxt-colors-green-hover);
+        border: 3px solid var(--pxt-success);
     }
 }

--- a/theme/color-themes/high-contrast.json
+++ b/theme/color-themes/high-contrast.json
@@ -79,6 +79,21 @@
         "pxt-link-hover": "#1b19ff",
         "pxt-focus-border": "#FFFF00",
 
+        "pxt-success": "#00FF00",
+        "pxt-success-foreground": "#000000",
+        "pxt-success-hover": "#00FF00",
+        "pxt-success-alpha10": "#00FF0019",
+
+        "pxt-warning": "#00FFFF",
+        "pxt-warning-foreground": "#FFFFFF",
+        "pxt-warning-hover": "#00FFFF",
+        "pxt-warning-alpha10": "#00FFFF19",
+
+        "pxt-error": "#880000",
+        "pxt-error-foreground": "#FFFFFF",
+        "pxt-error-hover": "#880000",
+        "pxt-error-alpha10": "#88000019",
+
         "pxt-colors-purple-background": "#FF00FF",
         "pxt-colors-purple-foreground": "#000000",
         "pxt-colors-purple-hover": "#FF00FF",


### PR DESCRIPTION
I was originally thinking we could just use the colors-green, colors-yellow, and colors-red variables for this, but as was noted in https://github.com/microsoft/pxt/pull/10481, those may be a bit too generic to work well for these scenarios. In the teacher tool, for example, the microbit green color is a little too dark to work well as a "success" color. Separating them will lead to some duplication in certain themes, but it's nice to have the flexibility.

As is the case for all theme colors, any themes that do not specify a value in their json file will default to the value in base-theme.less.

For now, I've only used these new colors in the teacher tool. We can swap them out in other areas as needed.

With the new colors:
![image](https://github.com/user-attachments/assets/55a034cd-f425-42c5-8561-148f70107708)

![image](https://github.com/user-attachments/assets/ff29d842-f464-4611-a2a1-37e40f0741da)

![image](https://github.com/user-attachments/assets/05f224aa-c7ac-4e15-8bd5-3bbfd5f7da7f)

Fixes https://github.com/microsoft/pxt-microbit/issues/6137