### PR TITLE
fix argument order of setFieldValue

### DIFF
--- a/pxtblocks/plugins/functions/utils.ts
+++ b/pxtblocks/plugins/functions/utils.ts
@@ -574,7 +574,7 @@ class MutateFunctionEvent extends Blockly.Events.Abstract {
         for (const change of this.descendantChanges) {
             if (change.newName) {
                 const block = ws.getBlockById(change.id);
-                block.setFieldValue("VALUE", forward ? change.newName : change.oldName);
+                block.setFieldValue(forward ? change.newName : change.oldName, "VALUE");
             }
             else if (forward) {
                 const block = ws.getBlockById(change.id);


### PR DESCRIPTION
this was an issue reported on the forum [here](https://forum.makecode.com/t/code-deleting-randomly/35057/12?u=richard)

looks like i mixed up the arguments of setFieldValue. I checked out every other place we call setFieldValue and looks like this was the only one with this issue.