### PR TITLE
fix temporary asset ids when converting to named assets

### DIFF
--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -80,7 +80,7 @@ export class FieldAnimationEditor extends FieldAssetEditor<FieldAnimationOptions
             const frames = parseImageArrayString(text, this.params.taggedTemplate);
 
             if (frames && frames.length) {
-                const id = this.sourceBlock_.id;
+                const id = this.temporaryAssetId();
 
                 const newAnimation: pxt.Animation = {
                     internalID: -1,
@@ -97,7 +97,7 @@ export class FieldAnimationEditor extends FieldAssetEditor<FieldAnimationOptions
                 if (asset) return asset;
         }
 
-        const id = this.sourceBlock_.id;
+        const id = this.temporaryAssetId();
         const bitmap = new pxt.sprite.Bitmap(this.params.initWidth, this.params.initHeight).data()
 
         const newAnimation: pxt.Animation = {

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -264,7 +264,7 @@ export abstract class FieldAssetEditor<U extends FieldAssetEditorOptions, V exte
     }
 
     protected onFieldEditorHide(fv: pxt.react.FieldEditorView<pxt.Asset>) {
-        const result = fv.getResult();
+        let result = fv.getResult();
         const project = pxt.react.getTilemapProject();
 
         if (this.asset.type === pxt.AssetType.Song) {
@@ -275,15 +275,10 @@ export abstract class FieldAssetEditor<U extends FieldAssetEditorOptions, V exte
             const old = this.getValue();
             if (pxt.assetEquals(this.asset, result)) return;
 
-            const oldId = isTemporaryAsset(this.asset) ? null : this.asset.id;
-            let newId = isTemporaryAsset(result) ? null : result.id;
+            result = pxt.patchTemporaryAsset(this.asset, result, project);
 
-            if (!oldId && newId === this.sourceBlock_.id) {
-                // The temporary assets we create just use the block id as the id; give it something
-                // a little nicer
-                result.id = project.generateNewID(result.type);
-                newId = result.id;
-            }
+            const oldId = isTemporaryAsset(this.asset) ? null : this.asset.id;
+            const newId = isTemporaryAsset(result) ? null : result.id;
 
             this.pendingEdit = true;
 
@@ -551,6 +546,10 @@ export abstract class FieldAssetEditor<U extends FieldAssetEditorOptions, V exte
 
     protected isFullscreen() {
         return true;
+    }
+
+    protected temporaryAssetId() {
+        return this.sourceBlock_.id + "_" + this.name;
     }
 }
 

--- a/pxtblocks/fields/field_musiceditor.ts
+++ b/pxtblocks/fields/field_musiceditor.ts
@@ -61,7 +61,7 @@ export class FieldMusicEditor extends FieldAssetEditor<FieldMusicEditorOptions, 
 
         const newAsset: pxt.Song = {
             internalID: -1,
-            id: this.sourceBlock_.id,
+            id: this.temporaryAssetId(),
             type: pxt.AssetType.Song,
             meta: {
             },

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -70,7 +70,7 @@ export class FieldSpriteEditor extends FieldAssetEditor<FieldSpriteEditorOptions
 
         const newAsset: pxt.ProjectImage = {
             internalID: -1,
-            id: this.sourceBlock_.id,
+            id: this.temporaryAssetId(),
             type: pxt.AssetType.Image,
             jresData: pxt.sprite.base64EncodeBitmap(data),
             meta: {

--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -7,6 +7,7 @@ export class MonacoSpriteEditor extends MonacoReactFieldEditor<pxt.ProjectImage>
     protected isPython: boolean;
     protected isAsset: boolean;
     protected template: string;
+    protected editing: pxt.Asset;
 
     protected textToValue(text: string): pxt.ProjectImage {
         this.isPython = text.indexOf("`") === -1
@@ -14,12 +15,13 @@ export class MonacoSpriteEditor extends MonacoReactFieldEditor<pxt.ProjectImage>
 
         const match = pxt.parseAssetTSReference(text);
         if (match) {
-            const { type, name: matchedName } = match;
+            const { name: matchedName } = match;
             const name = matchedName.trim();
             const project = pxt.react.getTilemapProject();
             this.isAsset = true;
             const asset = project.lookupAssetByName(pxt.AssetType.Image, name);
             if (asset) {
+                this.editing = asset;
                 return asset;
             }
             else {
@@ -29,16 +31,23 @@ export class MonacoSpriteEditor extends MonacoReactFieldEditor<pxt.ProjectImage>
                     newAsset.meta.displayName = name;
                 }
 
+                this.editing = newAsset;
+
                 return newAsset;
             }
         }
 
-        return createFakeAsset(pxt.sprite.imageLiteralToBitmap(text, this.template));
+        this.editing = createFakeAsset(pxt.sprite.imageLiteralToBitmap(text, this.template));
+
+        return this.editing;
     }
 
     protected resultToText(result: pxt.ProjectImage): string {
+        const project = pxt.react.getTilemapProject();
+        project.pushUndo();
+        result = pxt.patchTemporaryAsset(this.editing, result, project) as pxt.ProjectImage;
+
         if (result.meta?.displayName) {
-            const project = pxt.react.getTilemapProject();
             if (this.isAsset || project.lookupAsset(result.type, result.id)) {
                 result = project.updateAsset(result)
             } else {

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -73,7 +73,7 @@ export class MonacoTilemapEditor extends MonacoReactFieldEditor<pxt.ProjectTilem
     protected resultToText(asset: pxt.ProjectTilemap): string {
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
-        asset = pxt.patchTemporaryAsset(this.editing, asset, project);
+        asset = pxt.patchTemporaryAsset(this.editing, asset, project) as pxt.ProjectTilemap;
         pxt.sprite.updateTilemapReferencesFromResult(project, asset);
 
         if (this.isTilemapLiteral) {

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -6,6 +6,7 @@ const fieldEditorId = "tilemap-editor";
 export class MonacoTilemapEditor extends MonacoReactFieldEditor<pxt.ProjectTilemap> {
     protected isTilemapLiteral: boolean;
     protected tilemapLiteral: string;
+    protected editing: pxt.Asset;
 
     protected textToValue(text: string): pxt.ProjectTilemap {
         const tm = this.readTilemap(text);
@@ -13,6 +14,7 @@ export class MonacoTilemapEditor extends MonacoReactFieldEditor<pxt.ProjectTilem
         const project = pxt.react.getTilemapProject();
         pxt.sprite.addMissingTilemapTilesAndReferences(project, tm);
 
+        this.editing = tm;
         return tm;
     }
 
@@ -31,7 +33,7 @@ export class MonacoTilemapEditor extends MonacoReactFieldEditor<pxt.ProjectTilem
                     // If the user is still typing, they might try to open the editor on an incomplete tilemap
                 }
                 return null;
-                }
+            }
         }
 
         this.isTilemapLiteral = true;
@@ -71,6 +73,7 @@ export class MonacoTilemapEditor extends MonacoReactFieldEditor<pxt.ProjectTilem
     protected resultToText(asset: pxt.ProjectTilemap): string {
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
+        pxt.patchTemporaryAsset(this.editing, asset, project);
 
         pxt.sprite.updateTilemapReferencesFromResult(project, asset);
 

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -73,8 +73,7 @@ export class MonacoTilemapEditor extends MonacoReactFieldEditor<pxt.ProjectTilem
     protected resultToText(asset: pxt.ProjectTilemap): string {
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
-        pxt.patchTemporaryAsset(this.editing, asset, project);
-
+        asset = pxt.patchTemporaryAsset(this.editing, asset, project);
         pxt.sprite.updateTilemapReferencesFromResult(project, asset);
 
         if (this.isTilemapLiteral) {

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1709,6 +1709,10 @@ namespace pxt {
 
     export function cloneAsset<U extends Asset>(asset: U): U {
         asset.meta = Object.assign({}, asset.meta);
+        if (asset.meta.temporaryInfo) {
+            asset.meta.temporaryInfo = Object.assign({}, asset.meta.temporaryInfo);
+        }
+
         switch (asset.type) {
             case AssetType.Tile:
             case AssetType.Image:
@@ -2086,5 +2090,22 @@ namespace pxt {
             case AssetType.Tilemap: return snapshot.tilemaps;
             case AssetType.Song: return snapshot.songs;
         }
+    }
+
+    export function patchTemporaryAsset(oldValue: pxt.Asset, newValue: pxt.Asset, project: TilemapProject) {
+        if (!oldValue || assetEquals(oldValue, newValue)) return newValue;
+
+        newValue = cloneAsset(newValue);
+        const wasTemporary = !oldValue.meta.displayName;
+        const isTemporary = !newValue.meta.displayName;
+
+        // if we went from being temporary to no longer being temporary,
+        // make sure we replace the junk id with a new value
+        if (wasTemporary && !isTemporary) {
+            newValue.id = project.generateNewID(newValue.type);
+            newValue.internalID = project.getNewInternalId();
+        }
+
+        return newValue;
     }
 }

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -95,12 +95,16 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
 
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
+        result = pxt.patchTemporaryAsset(this.props.asset, result, project);
+
+        if (result.meta.displayName) {
+            result = project.updateAsset(result);
+        }
+
         if (!this.props.asset.meta?.displayName && result.meta.temporaryInfo) {
             getBlocksEditor().updateTemporaryAsset(result);
             pkg.mainEditorPkg().lookupFile(`this/${pxt.MAIN_BLOCKS}`).setContentAsync(getBlocksEditor().getCurrentSource());
         }
-
-        if (result.meta.displayName) project.updateAsset(result);
 
         this.props.dispatchChangeGalleryView(GalleryView.User);
         this.updateAssets().then(() => simulator.setDirty());


### PR DESCRIPTION
fixing a bug i found while investigating asset errors. when converting temporary assets to named assets, the temporary asset id was not being updated correctly everywhere except in the blockly asset field editors. all other ways to edit assets (monaco field editors and the asset editor tab) were not updating the junk id that we use for temporary assets into a valid qualified name.