### PR TITLE
Remove the loading state set when the iframe load event fires.

### DIFF
--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -154,7 +154,6 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
     protected handleFrameRef = (ref: HTMLIFrameElement) => {
         if (ref && ref.contentWindow) {
             window.addEventListener("message", this.onMessageReceived);
-            ref.addEventListener("load", this.handleFrameReload)
             this.ref = ref;
             // Hide Usabilla widget + footer when inside iframe view
             setElementVisible(".usabilla_live_button_container", false);
@@ -163,10 +162,6 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
             const root = document.getElementById("root");
             if (root) pxt.BrowserUtils.addClass(root, "editor");
         }
-    }
-
-    protected handleFrameReload = () => {
-        this.setState({frameState: "loading"})
     }
 
     protected updateTheme() {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6893 (Hopefully. I have a repro, but it's not exact...)

With the "Read&Write for Google Chrome" extension enabled, the load event on the skillmap iframe gets delayed, and we were actually setting state to `loading` _after_ the `newproject` event fired, so when the user tried to start an activity, the app still thought it was loading and failed.

I looked into why we were setting the loading state here (according to [docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event), the load event fires when a page is _finished_ loading, and it felt a little strange to set our state to loading when the iframe finishes loading). Turns out, it was to fix a bug several years ago (https://github.com/microsoft/pxt/pull/8398). It was a niche live -> beta scenario, and I'm unable to repro it now, so I've just removed the code. The only way (that I know of) to trigger the load event on the iframe is to refresh the page, which also triggers recreation of the `makecodeFrame`, so the state was already set to `loading` in the constructor.