### PR TITLE
redirect simx requests on localhost

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -1295,8 +1295,9 @@ export function serveAsync(options: ServeOptions) {
         }
 
         if (/simulator\.html/.test(pathname)) {
-            // "/simulator.html/simx/microbit-apps/display-shield/-/index.html"
 
+            // check for simx urls, e.g.:
+            //     /simulator.html/simx/microbit-apps/display-shield/-/index.html
             if (/simulator\.html\/simx\//.test(pathname)) {
                 res.writeHead(302, { location: `https://trg-${pxt.appTarget.id}.userpxt.io/simx${pathname.split("simx").pop()}` });
             }

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -1295,8 +1295,16 @@ export function serveAsync(options: ServeOptions) {
         }
 
         if (/simulator\.html/.test(pathname)) {
-            // Special handling for missing simulator: redirect to the live sim
-            res.writeHead(302, { location: `https://trg-${pxt.appTarget.id}.userpxt.io/---simulator` });
+            // "/simulator.html/simx/microbit-apps/display-shield/-/index.html"
+
+            if (/simulator\.html\/simx\//.test(pathname)) {
+                res.writeHead(302, { location: `https://trg-${pxt.appTarget.id}.userpxt.io/simx${pathname.split("simx").pop()}` });
+            }
+            else {
+                // Special handling for missing simulator: redirect to the live sim
+                res.writeHead(302, { location: `https://trg-${pxt.appTarget.id}.userpxt.io/---simulator` });
+            }
+
             res.end();
             return;
         }


### PR DESCRIPTION
we already have support for redirecting simx requests to a different url for local development and for redirecting simx requests to a local instance of the backend.

however, @tballmsft informed me that the basic scenario of just hitting normal non-dev simx endpoints fails! this adds a case to our server to fix that