### PR TITLE
add the option for targets to contribute checkboxes to pxtjson editor

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1895,6 +1895,12 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
         });
     }
 
+    if (cfg.appTheme?.pxtJsonOptions?.length) {
+        for (const option of cfg.appTheme.pxtJsonOptions) {
+            targetStrings[`{id:setting}${option.label}`] = option.label;
+        }
+    }
+
     // walk options in pxt.json
     // patch icons in bundled packages
     Object.keys(cfg.bundledpkgs).forEach(pkgid => {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -528,6 +528,7 @@ declare namespace pxt {
         timeMachineDiffInterval?: number; // An interval in milliseconds at which to take diffs to store in project history. Defaults to 5 minutes
         timeMachineSnapshotInterval?: number; // An interval in milliseconds at which to take full project snapshots in project history. Defaults to 15 minutes
         adjustBlockContrast?: boolean; // If set to true, all block colors will automatically be adjusted to have a contrast ratio of 4.5 with text
+        pxtJsonOptions?: PxtJsonOption[];
     }
 
     interface DownloadDialogTheme {
@@ -583,6 +584,12 @@ declare namespace pxt {
         path?: string;
         subitems?: TOCMenuEntry[];
         markdown?: string;
+    }
+
+    interface PxtJsonOption {
+        label: string;
+        property: string;
+        type: "checkbox";
     }
 
     interface TargetBundle extends AppTarget {


### PR DESCRIPTION
this pr allows targets to add extra non-compiler flag checkboxes to the pxtjson editor (aka the project settings dialog). the goal here is add a checkbox for the assetPack flag for arcade projects. for reference, this editor is only accessible in arcade by clicking on pxt.json in the file explorer so it's really just for content authors or power users.

currently this only supports boolean properties on the top level of pxt.json

![image](https://github.com/user-attachments/assets/9e8d2a1d-27dd-477f-b73c-584e870d7400)
