### PR TITLE
Clearer visual EditorToggle behaviour when keyboard navigation is used

### DIFF
--- a/react-common/components/controls/Button.tsx
+++ b/react-common/components/controls/Button.tsx
@@ -30,6 +30,7 @@ export interface ButtonProps extends ButtonViewProps {
     onClick: () => void;
     onRightClick?: () => void;
     onBlur?: () => void;
+    onFocus?: () => void;
     onKeydown?: (e: React.KeyboardEvent) => void;
 }
 
@@ -53,6 +54,7 @@ export const Button = (props: ButtonProps) => {
         onRightClick,
         onKeydown,
         onBlur,
+        onFocus,
         buttonRef,
         title,
         label,
@@ -105,6 +107,7 @@ export const Button = (props: ButtonProps) => {
             onContextMenu={rightClickHandler}
             onKeyDown={onKeydown || fireClickOnEnter}
             onBlur={onBlur}
+            onFocus={onFocus}
             role={role || "button"}
             tabIndex={tabIndex || (disabled ? -1 : 0)}
             disabled={hardDisabled}

--- a/react-common/styles/controls/EditorToggle.less
+++ b/react-common/styles/controls/EditorToggle.less
@@ -42,10 +42,6 @@
         margin: 0;
         width: 100%;
     }
-
-    .common-button:focus::after {
-        outline: none;
-    }
 }
 
 .common-editor-toggle-item.common-editor-toggle-item-dropdown {
@@ -66,6 +62,14 @@
 
     & > .common-button {
         color: var(--pxt-neutral-foreground2);
+    }
+}
+
+.common-editor-toggle-item.focused {
+    outline: 3px solid var(--pxt-neutral-background2);
+    outline-offset: -5px;
+    &.selected {
+        outline: 3px solid var(--pxt-focus-border);
     }
 }
 
@@ -136,12 +140,8 @@
  ****************************************************/
 
 .common-toggle-accessibility {
-    position: absolute;
-    z-index: 2;
     width: 0px;
     height: 0px;
-    left: 0;
-    background: white;
 
     .common-button {
         width: 0px;
@@ -154,16 +154,8 @@
         top: 0;
         left: 0;
     }
-    .common-button:focus {
-        width: 100%;
-        height: 100%;
-    }
 }
 
-.common-toggle-accessibility:focus-within {
-    width: 100%;
-    height: 100%;
-}
 
 
 /*****************************************************


### PR DESCRIPTION
EditorToggle has a strange keyboard interaction mode, where, on keyboard focus, it covers the entire toggle with the button relating to the focused button, obscuring all other buttons. This is confusing for sighted keyboard users. This PR keeps the visual structure intact during interaction so that the user can see all buttons while they make a selection.

# Affected components

### Sound Effect header

**Before**

**After**

### Share Info

**Before**

**After**

### Serial editor

[TODO: how to reach]

### Image field editor

**Before**

**After**


# Testing

This does not require the keyboard controls experiment, just tab to the end of the visible page and it will be the next tab stop after "Zoom In."

# Implementation note

The EditorToggle is separated into a visual set of buttons for mouse users, and a separate hidden set of buttons for keyboard users (via FocusList). This PR preserves that behaviour. However it effectively means that all button controls are replicated in a hidden div, and changes to the hidden keyboard-accessible components have to be mirrored to the visual implementation.