### PR TITLE
prevent disabled pattern from leaking into the highlight path

### DIFF
--- a/pxtblocks/plugins/renderer/pathObject.ts
+++ b/pxtblocks/plugins/renderer/pathObject.ts
@@ -25,6 +25,7 @@ export class PathObject extends Blockly.zelos.PathObject {
                 const constants = this.constants as ConstantProvider;
                 const filterId = this.hasError ? constants.errorOutlineFilterId : constants.highlightOutlineFilterId;
                 this.svgPathHighlighted = this.svgPath.cloneNode(true) as SVGElement;
+                this.svgPathHighlighted.classList.add('pxtRendererHighlight');
                 this.svgPathHighlighted.setAttribute('fill', 'none');
                 this.svgPathHighlighted.setAttribute(
                     'filter',
@@ -186,5 +187,8 @@ Blockly.Css.register(`
     stroke-dasharray: 2;
     stroke: white;
     stroke-width: 2;
+}
+.blocklyDisabledPattern>.blocklyPath.pxtRendererHighlight {
+    fill: none;
 }
 `)


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6148

this was broken by blockly 12, but a pretty simple fix! the disabled pattern was overriding the `fill: none` attribute on the svg path of the error highlight