### PR TITLE
fix edited/deleted tile metadata being lost when patching temp assets

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -196,7 +196,7 @@ namespace pxt.sprite {
 
         constructor(public tilemap: Tilemap, public tileset: TileSet, public layers: BitmapData) {}
 
-        cloneData() {
+        cloneData(includeEditorData = false) {
             const tm = this.tilemap.copy();
             const tileset: TileSet = {
                 tileWidth: this.tileset.tileWidth,
@@ -207,7 +207,17 @@ namespace pxt.sprite {
             }
             const layers = Bitmap.fromData(this.layers).copy().data();
 
-            return new TilemapData(tm, tileset, layers);
+            const result = new TilemapData(tm, tileset, layers);
+
+            if (includeEditorData) {
+                result.nextId = this.nextId;
+                result.projectReferences = this.projectReferences?.slice();
+                result.tileOrder = this.tileOrder?.slice();
+                result.editedTiles = this.editedTiles?.slice();
+                result.deletedTiles = this.deletedTiles?.slice();
+            }
+
+            return result;
         }
 
         equals(other: TilemapData) {

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -142,9 +142,9 @@ namespace pxt {
 
         getSnapshot(filter?: (asset: U) => boolean) {
             if (filter) {
-                return this.assets.filter(a => filter(a)).map(cloneAsset);
+                return this.assets.filter(a => filter(a)).map(a => cloneAsset(a));
             }
-            return this.assets.map(cloneAsset);
+            return this.assets.map(a => cloneAsset(a));
         }
 
         update(id: string, newValue: U) {
@@ -1713,7 +1713,7 @@ namespace pxt {
         return new pxt.sprite.TilemapData(tilemap, tileset, layers);
     }
 
-    export function cloneAsset<U extends Asset>(asset: U): U {
+    export function cloneAsset<U extends Asset>(asset: U, includeEditorData = false): U {
         asset.meta = Object.assign({}, asset.meta);
         if (asset.meta.temporaryInfo) {
             asset.meta.temporaryInfo = Object.assign({}, asset.meta.temporaryInfo);
@@ -1734,7 +1734,7 @@ namespace pxt {
             case AssetType.Tilemap:
                 return {
                     ...asset,
-                    data: (asset as ProjectTilemap).data.cloneData()
+                    data: (asset as ProjectTilemap).data.cloneData(includeEditorData)
                 };
             case AssetType.Song:
                 return {
@@ -2158,7 +2158,7 @@ namespace pxt {
     export function patchTemporaryAsset(oldValue: pxt.Asset, newValue: pxt.Asset, project: TilemapProject) {
         if (!oldValue || assetEquals(oldValue, newValue)) return newValue;
 
-        newValue = cloneAsset(newValue);
+        newValue = cloneAsset(newValue, true);
         const wasTemporary = !oldValue.meta.displayName;
         const isTemporary = !newValue.meta.displayName;
 


### PR DESCRIPTION
this fixes the issue with the latest hot fix release.

the new code to patch the ids of temporary assets was causing us to lose the edited/deleted tile metadata that we store in the tilemap asset data (which was always a kind of hack). this PR simply adds a parameter to cloneAsset to make it so that the temporary editor data is also cloned