### PR TITLE
Clearer visual EditorToggle behaviour when keyboard navigation is used

### DIFF
--- a/react-common/components/controls/Button.tsx
+++ b/react-common/components/controls/Button.tsx
@@ -30,6 +30,7 @@ export interface ButtonProps extends ButtonViewProps {
     onClick: () => void;
     onRightClick?: () => void;
     onBlur?: () => void;
+    onFocus?: () => void;
     onKeydown?: (e: React.KeyboardEvent) => void;
 }
 
@@ -53,6 +54,7 @@ export const Button = (props: ButtonProps) => {
         onRightClick,
         onKeydown,
         onBlur,
+        onFocus,
         buttonRef,
         title,
         label,
@@ -105,6 +107,7 @@ export const Button = (props: ButtonProps) => {
             onContextMenu={rightClickHandler}
             onKeyDown={onKeydown || fireClickOnEnter}
             onBlur={onBlur}
+            onFocus={onFocus}
             role={role || "button"}
             tabIndex={tabIndex || (disabled ? -1 : 0)}
             disabled={hardDisabled}

--- a/react-common/styles/controls/EditorToggle.less
+++ b/react-common/styles/controls/EditorToggle.less
@@ -42,10 +42,6 @@
         margin: 0;
         width: 100%;
     }
-
-    .common-button:focus::after {
-        outline: none;
-    }
 }
 
 .common-editor-toggle-item.common-editor-toggle-item-dropdown {
@@ -66,6 +62,14 @@
 
     & > .common-button {
         color: var(--pxt-neutral-foreground2);
+    }
+}
+
+.common-editor-toggle-item.focused {
+    outline: 3px solid var(--pxt-neutral-foreground2);
+    outline-offset: -5px;
+    &.selected {
+        outline: 3px solid var(--pxt-focus-border);
     }
 }
 
@@ -135,13 +139,11 @@
  *                Accessibility Menu                 *
  ****************************************************/
 
+/* Hidden, duplicates the visible structure but for keyboard users */
 .common-toggle-accessibility {
     position: absolute;
-    z-index: 2;
     width: 0px;
     height: 0px;
-    left: 0;
-    background: white;
 
     .common-button {
         width: 0px;
@@ -154,16 +156,8 @@
         top: 0;
         left: 0;
     }
-    .common-button:focus {
-        width: 100%;
-        height: 100%;
-    }
 }
 
-.common-toggle-accessibility:focus-within {
-    width: 100%;
-    height: 100%;
-}
 
 
 /*****************************************************

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -63,6 +63,13 @@
     }
 }
 
+#sound-effect-editor-toggle > .common-editor-toggle-item.focused {
+    outline: 3px solid var(--pxt-neutral-background1);
+    &.selected {
+        outline: 3px solid var(--pxt-focus-border);
+    }
+}
+
 .common-button.link-button.generate-similar {
     margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
EditorToggle has a strange keyboard interaction mode, where, on keyboard focus, it covers the entire toggle with the button relating to the focused button, obscuring all other buttons. This is confusing for sighted keyboard users. This PR keeps the visual structure intact during interaction so that the user can see all buttons while they make a selection.

**Test branch** [https://editortoggle-keyboard-readab.review-pxt.pages.dev/](https://editortoggle-keyboard-readab.review-pxt.pages.dev/)

# Affected components

### Sound Effect header

**Before**

![editor-toggle-sound-old](https://github.com/user-attachments/assets/304e12a7-185f-4139-87b1-e73f45df9a0e)

**After**

![editor-toggle-sound-new](https://github.com/user-attachments/assets/c1c66534-3ae2-4dc1-b29a-3bde5b009c3f)

### Share Info

**Before**

![editor-toggle-share-old](https://github.com/user-attachments/assets/7065186b-5649-4cc5-a6d0-b8912332fac8)

**After**

![editor-toggle-share-new](https://github.com/user-attachments/assets/b1c2faf5-b6d7-4cf1-b492-d23c10996e12)

### Serial editor

**Before**

![editor-toggle-serial-old](https://github.com/user-attachments/assets/e36455b5-3f5f-4802-a4eb-c27147f41f80)

**After**

![editor-toggle-serial-new](https://github.com/user-attachments/assets/bb3bae7e-ec41-4408-9963-5a8605aee0bd)

### Image field editor

TODO: can't actually find a way to launch this

# Testing

This does not require the keyboard controls experiment, just tab to the end of the visible page and it will be the next tab stop after "Zoom In."

1. Load up [this test project](https://makecode.microbit.org/_MTkTsETJDf00), or simply add a "Play Wave (Until Done)" block from the music section of the flyout.
2. Click on the wave to open the editor.
3. Tab through to the end of the page and then one more, to reach the EditorToggle


# Implementation note

The EditorToggle is separated into a visual set of buttons for mouse users, and a separate hidden set of buttons for keyboard users (via FocusList). This PR preserves that behaviour. However it effectively means that all button controls are replicated in a hidden div, and changes to the hidden keyboard-accessible components have to be mirrored to the visual implementation.