### PR TITLE
pxt bump tweaks

### DIFF
--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -70,9 +70,9 @@ jobs:
           sudo apt-get install xvfb
           sudo npm install -g pxt
           npm install
-      - name: npm test (and possibly publish to npm registry)
+      - name: npm test:publish
         run: |
-          npm test
+          npm test:publish
         env:
           CROWDIN_KEY: ${{ secrets.CROWDIN_KEY }}
           PXT_ACCESS_TOKEN: ${{ secrets.PXT_ACCESS_TOKEN }}

--- a/.github/workflows/pxt-buildvtag.yml
+++ b/.github/workflows/pxt-buildvtag.yml
@@ -29,9 +29,9 @@ jobs:
           sudo apt-get install xvfb
           sudo npm install -g pxt
           npm install
-      - name: npm test (and possibly publish to npm registry)
+      - name: npm test:publish
         run: |
-          npm test
+          npm test:publish
         env:
           CROWDIN_KEY: ${{ secrets.CROWDIN_KEY }}
           PXT_ACCESS_TOKEN: ${{ secrets.PXT_ACCESS_TOKEN }}

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -395,7 +395,8 @@ function checkIfTaggedCommitAsync() {
 
 let readJson = nodeutil.readJson;
 
-async function ciAsync() {
+async function ciAsync(parsed?: commandParser.ParsedCommand) {
+    const intentToPublish = parsed && parsed.flags["publish"];
     forceCloudBuild = true;
     const buildInfo = await ciBuildInfoAsync();
     pxt.log(`ci build using ${buildInfo.ci}`);
@@ -406,7 +407,7 @@ async function ciAsync() {
 
     const { tag, branch, pullRequest } = buildInfo
     const atok = process.env.NPM_ACCESS_TOKEN
-    const npmPublish = /^v\d+\.\d+\.\d+$/.exec(tag) && atok;
+    const npmPublish = (intentToPublish || /^v\d+\.\d+\.\d+$/.exec(tag)) && atok;
 
     if (npmPublish) {
         let npmrc = path.join(process.env.HOME, ".npmrc")
@@ -7431,7 +7432,12 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
     p.defineCommand({
         name: "ci",
         help: "run automated build in a continuous integration environment",
-        aliases: ["travis", "githubactions", "buildci"]
+        aliases: ["travis", "githubactions", "buildci"],
+        flags: {
+            "publish": {
+                description: "publish to npm regardless of whether this is a tagged release",
+            },
+        }
     }, ciAsync);
     advancedCommand("uploadfile", "upload file under <CDN>/files/PATH", uploadFileAsync, "<path>");
     advancedCommand("service", "simulate a query to web worker", serviceAsync, "<operation>");

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -360,7 +360,7 @@ export async function isBranchProtectedAsync(
     branch: string
 ): Promise<boolean> {
     const res = await Util.httpRequestCoreAsync({
-        url: `https://api.github.com/repos/${owner}/${repo}/branches/${encodeURIComponent(branch)}/protection`,
+        url: `https://api.github.com/repos/${owner}/${repo}/branches/${encodeURIComponent(branch)}`,
         method: "GET",
         headers: {
             Authorization: `token ${token}`,
@@ -374,7 +374,7 @@ export async function isBranchProtectedAsync(
 
     const data = await res.json;
 
-    const requiresPR = !!data.required_pull_request_reviews;
+    const requiresPR = data.protected;
 
     return requiresPR;
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,9 +9,11 @@ const concat = require("gulp-concat");
 const header = require("gulp-header");
 const replace = require("gulp-replace");
 const ju = require("./jakeutil");
+const yargs = require('yargs');
 
 const exec = ju.exec;
 const rimraf = ju.rimraf;
+const argv = yargs.argv;
 
 const isWin32 = os.platform() === "win32";
 
@@ -186,7 +188,7 @@ const targetjs = () => exec("node built/pxt.js buildtarget", true);
 
 const buildcss = () => exec("node built/pxt.js buildcss", true);
 
-const pxtTravis = () => exec("node built/pxt.js travis", true);
+const pxtTravis = () => exec(`node built/pxt.js travis ${argv.publish ? "--publish" : ""}`, true);
 
 function compileTsProject(dirname, destination, useOutdir, filename) {
     if (!destination) destination = "built";

--- a/package.json
+++ b/package.json
@@ -151,7 +151,8 @@
     "redux": "4.2.0",
     "smoothie": "1.35.0",
     "typescript": "4.8.3",
-    "uglifyify": "5.0.2"
+    "uglifyify": "5.0.2",
+    "yargs": "^17.7.2"
   },
   "overrides": {
     "@blockly/field-colour": {
@@ -167,6 +168,7 @@
   "scripts": {
     "build": "gulp",
     "test": "gulp travis",
+    "test:publish": "gulp travis --publish",
     "clean": "gulp clean",
     "lint": "gulp lint",
     "start": "gulp",


### PR DESCRIPTION
This pull request introduces changes to enhance the build and release process, improve flexibility in version bumping, and update dependencies. Key updates include adding support for conditional npm publishing, introducing new flags for version bumping, and updating branch protection checks.

### Build and Release Process Improvements:
* `.github/workflows/pxt-buildpush.yml` and `.github/workflows/pxt-buildvtag.yml`: Updated the npm test step to use `npm test:publish` for consistency with the new `test:publish` script. [[1]](diffhunk://#diff-faeeadae9c041a72aff1a45d90dd28d2431f90582953453de6f76c5dd2b4993eL73-R75) [[2]](diffhunk://#diff-07a664aee039fb6f0f6ab672a97a7da207410f2e026ea9764af334d7273b7186L32-R34)
* `gulpfile.js` and `package.json`: Added a `--publish` flag to the `travis` task and introduced a `test:publish` script in `package.json` to facilitate conditional npm publishing. [[1]](diffhunk://#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7L189-R191) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R171)

### Version Bumping Enhancements:
* [`cli/cli.ts`](diffhunk://#diff-27a1e29352de44fda3b963f97b4171445ebf8d6ad4b2d688ce6a0f2934a98863R638): Added `--nopr` flag to allow direct pushes during version bumps, overriding the `--pr` flag. Updated messages and logic to reflect the new behavior. [[1]](diffhunk://#diff-27a1e29352de44fda3b963f97b4171445ebf8d6ad4b2d688ce6a0f2934a98863R638) [[2]](diffhunk://#diff-27a1e29352de44fda3b963f97b4171445ebf8d6ad4b2d688ce6a0f2934a98863L655-R674) [[3]](diffhunk://#diff-27a1e29352de44fda3b963f97b4171445ebf8d6ad4b2d688ce6a0f2934a98863R694) [[4]](diffhunk://#diff-27a1e29352de44fda3b963f97b4171445ebf8d6ad4b2d688ce6a0f2934a98863L7081-R7093)
* [`cli/cli.ts`](diffhunk://#diff-27a1e29352de44fda3b963f97b4171445ebf8d6ad4b2d688ce6a0f2934a98863L7423-R7440): Enhanced the `ci` command with a `--publish` flag to allow npm publishing regardless of tagged releases.

### Branch Protection Updates:
* [`cli/nodeutil.ts`](diffhunk://#diff-2bdbd13c08b68a663844f76b38d9bcea5fdcdb12df455ee897aeb5ced282983dL363-R363): Simplified branch protection checks by directly using the `protected` field from the GitHub API response instead of checking for `required_pull_request_reviews`. [[1]](diffhunk://#diff-2bdbd13c08b68a663844f76b38d9bcea5fdcdb12df455ee897aeb5ced282983dL363-R363) [[2]](diffhunk://#diff-2bdbd13c08b68a663844f76b38d9bcea5fdcdb12df455ee897aeb5ced282983dL377-R377)

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L154-R155): Added `yargs` as a new dependency for parsing command-line arguments.
* [`gulpfile.js`](diffhunk://#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7R12-R16): Integrated `yargs` to handle the `--publish` flag in the `travis` task.

These changes streamline the build process, improve control over version bumping workflows, and simplify branch protection logic.