### PR TITLE
[stable11.3] reverting asset fixes for patch release

### DIFF
--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -80,7 +80,7 @@ export class FieldAnimationEditor extends FieldAssetEditor<FieldAnimationOptions
             const frames = parseImageArrayString(text, this.params.taggedTemplate);
 
             if (frames && frames.length) {
-                const id = this.temporaryAssetId();
+                const id = this.sourceBlock_.id;
 
                 const newAnimation: pxt.Animation = {
                     internalID: -1,
@@ -97,7 +97,7 @@ export class FieldAnimationEditor extends FieldAssetEditor<FieldAnimationOptions
                 if (asset) return asset;
         }
 
-        const id = this.temporaryAssetId();
+        const id = this.sourceBlock_.id;
         const bitmap = new pxt.sprite.Bitmap(this.params.initWidth, this.params.initHeight).data()
 
         const newAnimation: pxt.Animation = {

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -264,7 +264,7 @@ export abstract class FieldAssetEditor<U extends FieldAssetEditorOptions, V exte
     }
 
     protected onFieldEditorHide(fv: pxt.react.FieldEditorView<pxt.Asset>) {
-        let result = fv.getResult();
+        const result = fv.getResult();
         const project = pxt.react.getTilemapProject();
 
         if (this.asset.type === pxt.AssetType.Song) {
@@ -275,10 +275,15 @@ export abstract class FieldAssetEditor<U extends FieldAssetEditorOptions, V exte
             const old = this.getValue();
             if (pxt.assetEquals(this.asset, result)) return;
 
-            result = pxt.patchTemporaryAsset(this.asset, result, project);
-
             const oldId = isTemporaryAsset(this.asset) ? null : this.asset.id;
-            const newId = isTemporaryAsset(result) ? null : result.id;
+            let newId = isTemporaryAsset(result) ? null : result.id;
+
+            if (!oldId && newId === this.sourceBlock_.id) {
+                // The temporary assets we create just use the block id as the id; give it something
+                // a little nicer
+                result.id = project.generateNewID(result.type);
+                newId = result.id;
+            }
 
             this.pendingEdit = true;
 
@@ -546,10 +551,6 @@ export abstract class FieldAssetEditor<U extends FieldAssetEditorOptions, V exte
 
     protected isFullscreen() {
         return true;
-    }
-
-    protected temporaryAssetId() {
-        return this.sourceBlock_.id + "_" + this.name;
     }
 }
 

--- a/pxtblocks/fields/field_musiceditor.ts
+++ b/pxtblocks/fields/field_musiceditor.ts
@@ -61,7 +61,7 @@ export class FieldMusicEditor extends FieldAssetEditor<FieldMusicEditorOptions, 
 
         const newAsset: pxt.Song = {
             internalID: -1,
-            id: this.temporaryAssetId(),
+            id: this.sourceBlock_.id,
             type: pxt.AssetType.Song,
             meta: {
             },

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -70,7 +70,7 @@ export class FieldSpriteEditor extends FieldAssetEditor<FieldSpriteEditorOptions
 
         const newAsset: pxt.ProjectImage = {
             internalID: -1,
-            id: this.temporaryAssetId(),
+            id: this.sourceBlock_.id,
             type: pxt.AssetType.Image,
             jresData: pxt.sprite.base64EncodeBitmap(data),
             meta: {

--- a/pxteditor/monaco-fields/field_musiceditor.ts
+++ b/pxteditor/monaco-fields/field_musiceditor.ts
@@ -7,7 +7,6 @@ export class MonacoSongEditor extends MonacoReactFieldEditor<pxt.Song> {
     protected isPython: boolean;
     protected isAsset: boolean;
     protected text: string;
-    protected editing: pxt.Asset;
 
     protected textToValue(text: string): pxt.Song {
         this.isPython = text.indexOf("`") === -1
@@ -15,13 +14,12 @@ export class MonacoSongEditor extends MonacoReactFieldEditor<pxt.Song> {
 
         const match = pxt.parseAssetTSReference(text);
         if (match) {
-            const { name: matchedName } = match;
+            const { type, name: matchedName } = match;
             const name = matchedName.trim();
             const project = pxt.react.getTilemapProject();
             this.isAsset = true;
             const asset = project.lookupAssetByName(pxt.AssetType.Song, name);
             if (asset) {
-                this.editing = asset;
                 return asset;
             }
             else {
@@ -30,8 +28,6 @@ export class MonacoSongEditor extends MonacoReactFieldEditor<pxt.Song> {
                 if (name && !project.isNameTaken(pxt.AssetType.Song, name) && pxt.validateAssetName(name)) {
                     newAsset.meta.displayName = name;
                 }
-
-                this.editing = newAsset;
 
                 return newAsset;
             }
@@ -43,24 +39,18 @@ export class MonacoSongEditor extends MonacoReactFieldEditor<pxt.Song> {
             const contents = hexLiteralMatch[1].trim();
 
             if (contents) {
-                this.editing = createFakeAsset(pxt.assets.music.decodeSongFromHex(contents));
-            }
-            else {
-                this.editing = createFakeAsset(pxt.assets.music.getEmptySong(2));
+                return createFakeAsset(pxt.assets.music.decodeSongFromHex(contents));
             }
 
-            return this.editing;
+            return createFakeAsset(pxt.assets.music.getEmptySong(2));
         }
 
         return undefined; // never
     }
 
     protected resultToText(result: pxt.Song): string {
-        const project = pxt.react.getTilemapProject();
-        project.pushUndo();
-
-        result = pxt.patchTemporaryAsset(this.editing, result, project) as pxt.Song;
         if (result.meta?.displayName) {
+            const project = pxt.react.getTilemapProject();
             if (this.isAsset || project.lookupAsset(result.type, result.id)) {
                 result = project.updateAsset(result)
             } else {

--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -7,7 +7,6 @@ export class MonacoSpriteEditor extends MonacoReactFieldEditor<pxt.ProjectImage>
     protected isPython: boolean;
     protected isAsset: boolean;
     protected template: string;
-    protected editing: pxt.Asset;
 
     protected textToValue(text: string): pxt.ProjectImage {
         this.isPython = text.indexOf("`") === -1
@@ -15,13 +14,12 @@ export class MonacoSpriteEditor extends MonacoReactFieldEditor<pxt.ProjectImage>
 
         const match = pxt.parseAssetTSReference(text);
         if (match) {
-            const { name: matchedName } = match;
+            const { type, name: matchedName } = match;
             const name = matchedName.trim();
             const project = pxt.react.getTilemapProject();
             this.isAsset = true;
             const asset = project.lookupAssetByName(pxt.AssetType.Image, name);
             if (asset) {
-                this.editing = asset;
                 return asset;
             }
             else {
@@ -31,23 +29,16 @@ export class MonacoSpriteEditor extends MonacoReactFieldEditor<pxt.ProjectImage>
                     newAsset.meta.displayName = name;
                 }
 
-                this.editing = newAsset;
-
                 return newAsset;
             }
         }
 
-        this.editing = createFakeAsset(pxt.sprite.imageLiteralToBitmap(text, this.template));
-
-        return this.editing;
+        return createFakeAsset(pxt.sprite.imageLiteralToBitmap(text, this.template));
     }
 
     protected resultToText(result: pxt.ProjectImage): string {
-        const project = pxt.react.getTilemapProject();
-        project.pushUndo();
-        result = pxt.patchTemporaryAsset(this.editing, result, project) as pxt.ProjectImage;
-
         if (result.meta?.displayName) {
+            const project = pxt.react.getTilemapProject();
             if (this.isAsset || project.lookupAsset(result.type, result.id)) {
                 result = project.updateAsset(result)
             } else {

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -6,7 +6,6 @@ const fieldEditorId = "tilemap-editor";
 export class MonacoTilemapEditor extends MonacoReactFieldEditor<pxt.ProjectTilemap> {
     protected isTilemapLiteral: boolean;
     protected tilemapLiteral: string;
-    protected editing: pxt.Asset;
 
     protected textToValue(text: string): pxt.ProjectTilemap {
         const tm = this.readTilemap(text);
@@ -14,7 +13,6 @@ export class MonacoTilemapEditor extends MonacoReactFieldEditor<pxt.ProjectTilem
         const project = pxt.react.getTilemapProject();
         pxt.sprite.addMissingTilemapTilesAndReferences(project, tm);
 
-        this.editing = tm;
         return tm;
     }
 
@@ -33,7 +31,7 @@ export class MonacoTilemapEditor extends MonacoReactFieldEditor<pxt.ProjectTilem
                     // If the user is still typing, they might try to open the editor on an incomplete tilemap
                 }
                 return null;
-            }
+                }
         }
 
         this.isTilemapLiteral = true;
@@ -73,7 +71,7 @@ export class MonacoTilemapEditor extends MonacoReactFieldEditor<pxt.ProjectTilem
     protected resultToText(asset: pxt.ProjectTilemap): string {
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
-        asset = pxt.patchTemporaryAsset(this.editing, asset, project) as pxt.ProjectTilemap;
+
         pxt.sprite.updateTilemapReferencesFromResult(project, asset);
 
         if (this.isTilemapLiteral) {

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -145,7 +145,7 @@ namespace pxt.sprite {
             }
         }
 
-        dataLength() {
+        protected dataLength() {
             return Math.ceil(this.width * this.height / 2);
         }
     }
@@ -179,7 +179,7 @@ namespace pxt.sprite {
             this.buf[index] = value;
         }
 
-        dataLength() {
+        protected dataLength() {
             return this.width * this.height;
         }
     }

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -196,7 +196,7 @@ namespace pxt.sprite {
 
         constructor(public tilemap: Tilemap, public tileset: TileSet, public layers: BitmapData) {}
 
-        cloneData(includeEditorData = false) {
+        cloneData() {
             const tm = this.tilemap.copy();
             const tileset: TileSet = {
                 tileWidth: this.tileset.tileWidth,
@@ -207,17 +207,7 @@ namespace pxt.sprite {
             }
             const layers = Bitmap.fromData(this.layers).copy().data();
 
-            const result = new TilemapData(tm, tileset, layers);
-
-            if (includeEditorData) {
-                result.nextId = this.nextId;
-                result.projectReferences = this.projectReferences?.slice();
-                result.tileOrder = this.tileOrder?.slice();
-                result.editedTiles = this.editedTiles?.slice();
-                result.deletedTiles = this.deletedTiles?.slice();
-            }
-
-            return result;
+            return new TilemapData(tm, tileset, layers);
         }
 
         equals(other: TilemapData) {

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -154,12 +154,6 @@ namespace pxt {
                 const existing = this.lookupByID(id);
 
                 if (!assetEquals(existing, newValue)) {
-                    if (!validateAsset(newValue) && validateAsset(existing)) {
-                        pxt.warn("Refusing to overwrite asset with invalid version");
-                        pxt.tickEvent("assets.invalidAssetOverwrite", { assetType: newValue.type });
-                        return existing;
-                    }
-
                     this.removeByID(id);
                     asset = this.add(newValue);
                     this.notifyListener(newValue.internalID);
@@ -1715,10 +1709,6 @@ namespace pxt {
 
     export function cloneAsset<U extends Asset>(asset: U): U {
         asset.meta = Object.assign({}, asset.meta);
-        if (asset.meta.temporaryInfo) {
-            asset.meta.temporaryInfo = Object.assign({}, asset.meta.temporaryInfo);
-        }
-
         switch (asset.type) {
             case AssetType.Tile:
             case AssetType.Image:
@@ -1958,69 +1948,6 @@ namespace pxt {
         return getShortIDCore(asset.type, asset.id);
     }
 
-    export function validateAsset(asset: pxt.Asset) {
-        if (!asset) return false;
-
-        switch (asset.type) {
-            case AssetType.Image:
-            case AssetType.Tile:
-                return validateImageAsset(asset as ProjectImage | Tile);
-            case AssetType.Tilemap:
-                return validateTilemap(asset as ProjectTilemap);
-            case AssetType.Animation:
-                return validateAnimation(asset as Animation)
-            case AssetType.Song:
-                return validateSong(asset as Song);
-        }
-    }
-
-    function validateImageAsset(asset: ProjectImage | Tile) {
-        if (!asset.bitmap) return false;
-
-        return validateBitmap(sprite.Bitmap.fromData(asset.bitmap));
-    }
-
-    function validateTilemap(tilemap: ProjectTilemap) {
-        if (
-            !tilemap.data ||
-            !tilemap.data.tilemap ||
-            !tilemap.data.tileset ||
-            !tilemap.data.tileset.tileWidth ||
-            !tilemap.data.tileset.tiles?.length ||
-            !tilemap.data.layers
-        ) {
-            return false;
-        }
-
-        return validateBitmap(sprite.Bitmap.fromData(tilemap.data.layers)) &&
-            validateBitmap(tilemap.data.tilemap);
-    }
-
-    function validateAnimation(animation: Animation) {
-        if (!animation.frames?.length || animation.interval <= 0) {
-            return false;
-        }
-
-        return !animation.frames.some(frame => !validateBitmap(sprite.Bitmap.fromData(frame)));
-    }
-
-    function validateBitmap(bitmap: sprite.Bitmap) {
-        return bitmap.width > 0 &&
-            bitmap.height > 0 &&
-            !Number.isNaN(bitmap.x0) &&
-            !Number.isNaN(bitmap.y0) &&
-            bitmap.data().data.length === bitmap.dataLength();
-    }
-
-    function validateSong(song: Song) {
-        return song.song &&
-            song.song.ticksPerBeat > 0 &&
-            song.song.beatsPerMeasure > 0 &&
-            song.song.measures > 0 &&
-            song.song.beatsPerMinute > 0 &&
-            !!song.song.tracks;
-    }
-
     function getShortIDCore(assetType: pxt.AssetType, id: string, allowNoPrefix = false) {
         let prefix: string;
         switch (assetType) {
@@ -2135,6 +2062,12 @@ namespace pxt {
         }
     }
 
+
+    function set16Bit(buf: Uint8ClampedArray, offset: number, value: number) {
+        buf[offset] = value & 0xff;
+        buf[offset + 1] = (value >> 8) & 0xff;
+    }
+
     function read16Bit(buf: Uint8ClampedArray, offset: number) {
         return buf[offset] | (buf[offset + 1] << 8)
     }
@@ -2153,22 +2086,5 @@ namespace pxt {
             case AssetType.Tilemap: return snapshot.tilemaps;
             case AssetType.Song: return snapshot.songs;
         }
-    }
-
-    export function patchTemporaryAsset(oldValue: pxt.Asset, newValue: pxt.Asset, project: TilemapProject) {
-        if (!oldValue || assetEquals(oldValue, newValue)) return newValue;
-
-        newValue = cloneAsset(newValue);
-        const wasTemporary = !oldValue.meta.displayName;
-        const isTemporary = !newValue.meta.displayName;
-
-        // if we went from being temporary to no longer being temporary,
-        // make sure we replace the junk id with a new value
-        if (wasTemporary && !isTemporary) {
-            newValue.id = project.generateNewID(newValue.type);
-            newValue.internalID = project.getNewInternalId();
-        }
-
-        return newValue;
     }
 }

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -142,9 +142,9 @@ namespace pxt {
 
         getSnapshot(filter?: (asset: U) => boolean) {
             if (filter) {
-                return this.assets.filter(a => filter(a)).map(a => cloneAsset(a));
+                return this.assets.filter(a => filter(a)).map(cloneAsset);
             }
-            return this.assets.map(a => cloneAsset(a));
+            return this.assets.map(cloneAsset);
         }
 
         update(id: string, newValue: U) {
@@ -1713,7 +1713,7 @@ namespace pxt {
         return new pxt.sprite.TilemapData(tilemap, tileset, layers);
     }
 
-    export function cloneAsset<U extends Asset>(asset: U, includeEditorData = false): U {
+    export function cloneAsset<U extends Asset>(asset: U): U {
         asset.meta = Object.assign({}, asset.meta);
         if (asset.meta.temporaryInfo) {
             asset.meta.temporaryInfo = Object.assign({}, asset.meta.temporaryInfo);
@@ -1734,7 +1734,7 @@ namespace pxt {
             case AssetType.Tilemap:
                 return {
                     ...asset,
-                    data: (asset as ProjectTilemap).data.cloneData(includeEditorData)
+                    data: (asset as ProjectTilemap).data.cloneData()
                 };
             case AssetType.Song:
                 return {
@@ -2158,7 +2158,7 @@ namespace pxt {
     export function patchTemporaryAsset(oldValue: pxt.Asset, newValue: pxt.Asset, project: TilemapProject) {
         if (!oldValue || assetEquals(oldValue, newValue)) return newValue;
 
-        newValue = cloneAsset(newValue, true);
+        newValue = cloneAsset(newValue);
         const wasTemporary = !oldValue.meta.displayName;
         const isTemporary = !newValue.meta.displayName;
 

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -95,16 +95,12 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
 
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
-        result = pxt.patchTemporaryAsset(this.props.asset, result, project);
-
-        if (result.meta.displayName) {
-            result = project.updateAsset(result);
-        }
-
         if (!this.props.asset.meta?.displayName && result.meta.temporaryInfo) {
             getBlocksEditor().updateTemporaryAsset(result);
             pkg.mainEditorPkg().lookupFile(`this/${pxt.MAIN_BLOCKS}`).setContentAsync(getBlocksEditor().getCurrentSource());
         }
+
+        if (result.meta.displayName) project.updateAsset(result);
 
         this.props.dispatchChangeGalleryView(GalleryView.User);
         this.updateAssets().then(() => simulator.setDirty());


### PR DESCRIPTION
we were still running into some flaky behavior with the new asset changes in stable. because these fixes were for minor bugs and not really needed for the hotfix, reverting them so that we can release the rest of the payload.