### PR TITLE
Add global shortcuts to improve keyboard navigation

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -716,6 +716,8 @@ declare namespace pxt.editor {
         zoomOut(): void;
         resize(): void;
         setScale(scale: number): void;
+        focusWorkspace(): void;
+        focusToolbox(): void;
     }
 
     export interface IFile {
@@ -819,6 +821,7 @@ declare namespace pxt.editor {
         extensionsVisible?: boolean;
         isMultiplayerGame?: boolean; // Arcade: Does the current project contain multiplayer blocks?
         onboarding?: pxt.tour.BubbleStep[];
+        navigateRegions?: boolean;
         feedback?: FeedbackState;
         themePickerOpen?: boolean;
     }
@@ -1056,6 +1059,8 @@ declare namespace pxt.editor {
         hideLightbox(): void;
         showOnboarding(): void;
         hideOnboarding(): void;
+        showNavigateRegions(): void;
+        hideNavigateRegions(): void;
         showKeymap(show: boolean): void;
         toggleKeymap(): void;
         signOutGithub(): void;

--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -8,6 +8,31 @@ namespace pxsim.accessibility {
         elem.setAttribute("tabindex", "0");
     }
 
+    export function getKeyboardShortcutEditorAction(e: KeyboardEvent): pxsim.SimulatorAction | null {
+        const meta  = e.metaKey || e.ctrlKey;
+        if (e.key === "Escape") {
+            e.preventDefault();
+            return "escape"
+        } else if (e.key === "b" && meta) {
+            e.preventDefault();
+            return "navigateregions"
+        }
+        return null
+    }
+
+    export function postKeyboardEvent() {
+        document.addEventListener("keydown", (e) => {
+            const action = getKeyboardShortcutEditorAction(e)
+            if (action) {
+                const message = {
+                    type: "pxtsim",
+                    action
+                } as pxsim.SimulatorActionMessage;
+                Runtime.postMessage(message)
+            }
+        });
+    }
+
     export function enableKeyboardInteraction(elem: Element, handlerKeyDown?: () => void, handlerKeyUp?: () => void): void {
         if (handlerKeyDown) {
             elem.addEventListener('keydown', (e: KeyboardEvent) => {

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -75,6 +75,12 @@ namespace pxsim {
         url: string;
     }
 
+    export type SimulatorAction = "escape" | "navigateregions";
+
+    export interface SimulatorActionMessage extends SimulatorMessage {
+        action: SimulatorAction;
+    }
+
     export interface SimulatorStateMessage extends SimulatorMessage {
         type: "status";
         frameid?: string;

--- a/theme/common.less
+++ b/theme/common.less
@@ -347,6 +347,11 @@ div.simframe > iframe {
     top:0; left: 0; width:100%; height:100%;
 }
 
+#boardview:focus-visible {
+    outline: 3px solid var(--pxt-focus-border);
+    outline-offset: 3px;
+}
+
 .simHeadless {
     height: 0 !important;
     width: 0 !important;

--- a/theme/navigateregions.less
+++ b/theme/navigateregions.less
@@ -1,0 +1,72 @@
+/* Import all components */
+@import 'themes/default/globals/site.variables';
+@import 'themes/pxt/globals/site.variables';
+
+/* Reference import */
+@import (reference) "semantic.less";
+
+.navigate-regions-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0,0,0,0);
+    width: 100%;
+    height: 100%;
+    z-index: @modalDimmerZIndex;
+
+    .region-button {
+        position: absolute;
+        background-color: rgba(0, 0, 0, .6);
+        border-radius: 0;
+        border: 3px solid white;
+        padding: 0;
+
+        &.simulator-region {
+            z-index: 1;
+        }
+
+        &.simulator-collapsed {
+            border-start-end-radius: 100px;
+            border-end-end-radius: 100px;
+        }
+
+        &:focus-visible {
+            background-color: rgba(0, 0, 0, .3);
+
+            div {
+                border: 5px solid white;
+                background-color: black;
+            }
+
+            p {
+                font-weight: bold;
+            }
+        }
+
+        div {
+            background-color: rgba(0, 0, 0, .6);
+            border: 2px solid white;
+            width: fit-content;
+            margin: auto;
+            padding-right: 1em;
+            padding-left: 1em;
+            border-radius: 5px;
+
+            @media only screen and (max-width: @largestMobileScreen) {
+                padding-right: 0.5em;
+                padding-left: 0.5em;
+            }
+        }
+        p {
+            color: white;
+            font-size: 2rem;
+
+            @media only screen and (max-width: @largestTabletScreen), 
+            only screen and (max-height: @tallEditorBreakpoint) and (min-width: @largestMobileScreen) {
+                font-size: 1.5rem;
+            }
+        }
+    }
+}

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -32,6 +32,7 @@
 @import 'accessibility';
 @import 'highcontrast';
 @import 'greenscreen';
+@import 'navigateregions';
 
 @import 'extension';
 @import 'extensionErrors';

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -80,6 +80,7 @@ import Util = pxt.Util;
 import { HintManager } from "./hinttooltip";
 import { mergeProjectCode, appendTemporaryAssets } from "./mergeProjects";
 import { Tour } from "./components/onboarding/Tour";
+import { NavigateRegionsOverlay } from "./components/NavigateRegionsOverlay";
 import { parseTourStepsAsync } from "./onboarding";
 import { initGitHubDb } from "./idbworkspace";
 import { BlockDefinition, CategoryNameID } from "./toolbox";
@@ -5248,6 +5249,21 @@ export class ProjectView
     }
 
     ///////////////////////////////////////////////////////////
+    ////////////             Navigate regions     /////////////
+    ///////////////////////////////////////////////////////////
+
+    hideNavigateRegions() {
+        this.setState({ navigateRegions: false });
+    }
+
+    showNavigateRegions() {
+        const dialog = Array.from(document.querySelectorAll("[role=dialog]")).find(dialog => (dialog as any).checkVisibility());
+        if (!dialog) {
+            this.setState(state => state.home ? state : { navigateRegions: true })
+        }
+    }
+
+    ///////////////////////////////////////////////////////////
     ////////////             Key map              /////////////
     ///////////////////////////////////////////////////////////
 
@@ -5507,6 +5523,7 @@ export class ProjectView
                 {lightbox ? <sui.Dimmer isOpen={true} active={lightbox} portalClassName={'tutorial'} className={'ui modal'}
                     shouldFocusAfterRender={false} closable={true} onClose={this.hideLightbox} /> : undefined}
                 {this.state.onboarding && <Tour tourSteps={this.state.onboarding} onClose={this.hideOnboarding} />}
+                {accessibleBlocks && this.state.navigateRegions && <NavigateRegionsOverlay parent={this}/>}
                 {this.state.themePickerOpen && <ThemePickerModal themes={this.themeManager.getAllColorThemes()} onThemeClicked={theme => this.setColorThemeById(theme?.id, true)} onClose={this.hideThemePicker} />}
             </div>
         );

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -585,6 +585,35 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     return true
                 }
             });
+
+            const triggerEditorAction = (action: pxsim.SimulatorAction) => {
+                switch (action) {
+                    case "escape": {
+                        this.parent.setSimulatorFullScreen(false);
+                        return;
+                    }
+                    case "navigateregions" : {
+                        this.parent.showNavigateRegions();
+                        return
+                    }
+                }
+            }
+
+            const simulatorOrigins = [
+                window.location.origin,
+                // Simulator deployed origin.
+                "https://trg-microbit.userpxt.io"
+            ]
+            window.addEventListener("message", (e: MessageEvent) => {
+                // Listen to simulator iframe keydown post messages.
+                if (simulatorOrigins.includes(e.origin) && e.data.type === "pxtsim") {
+                    triggerEditorAction((e.data as pxsim.SimulatorActionMessage).action)
+                }
+            }, false)
+            document.addEventListener("keydown", (e: KeyboardEvent) => {
+                const action = pxsim.accessibility.getKeyboardShortcutEditorAction(e)
+                triggerEditorAction(action)
+            });
         }
     }
 

--- a/webapp/src/components/NavigateRegionsOverlay.tsx
+++ b/webapp/src/components/NavigateRegionsOverlay.tsx
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as ReactDOM from "react-dom";
+import { Button, ButtonProps } from "../../../react-common/components/controls/Button";
+import { FocusTrap } from "../../../react-common/components/controls/FocusTrap";
+
+import IProjectView = pxt.editor.IProjectView;
+
+interface NavigateRegionsOverlayProps {
+    parent: IProjectView;
+}
+
+interface RectBounds {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+    width: number;
+    height: number;
+}
+
+type RegionId = "mainmenu" | "simulator" | "toolbox" | "editor" | "editortools" | "tutorial";
+
+interface Region {
+    id: RegionId;
+    ariaLabel: string;
+    shortcutKey: string;
+    getClassName?(projectView: IProjectView): string | undefined;
+    getBounds(projectView: IProjectView): DOMRect | undefined;
+    focus(projectView: IProjectView): void;
+}
+
+const getToolboxBounds = (projectView: IProjectView): DOMRect | undefined => {
+    return document.querySelector(`${projectView.isBlocksActive() ? ".blocklyToolbox" : ".monacoToolboxDiv"}`)?.getBoundingClientRect();
+}
+
+const isSimMini = () => !!document.querySelector(".miniSim");
+
+const regions: Region[] = [
+    {
+        id: "mainmenu",
+        ariaLabel: lf("Main menu"),
+        shortcutKey: "1",
+        getBounds() {
+            return document.querySelector("#mainmenu")?.getBoundingClientRect();
+        },
+        focus() {
+            findFirstFocusableDescendant(
+                document.querySelector("#mainmenu")!,
+                (e) =>
+                    // This isn't actually focusable and has the same behavior as home.
+                    e.classList.contains("brand") ||
+                    // The menuitem containing the editor toggle.
+                    !!Array.from(e.children).find(e => e.id === "editortoggle")
+            )?.focus();
+        }
+    },
+    {
+        id: "simulator",
+        ariaLabel: lf("Simulator"),
+        shortcutKey: "2",
+        getBounds(projectView: IProjectView) {
+            const element = isSimMini()
+                ? document.querySelector(".simPanel")
+                : projectView.state.collapseEditorTools ?
+                    document.querySelector("#computertogglesim")
+                    : document.querySelector("#editorSidebar")
+            const bounds = element?.getBoundingClientRect();
+            if (projectView.state.collapseEditorTools) {
+                // Custom presentation for the collapsed sim.
+                const collapsedSimPadding = 30;
+                const copy = DOMRect.fromRect(bounds);
+                copy.y = bounds.top - collapsedSimPadding;
+                copy.width = 70;
+                copy.height = bounds.height + collapsedSimPadding * 2;
+                return copy;
+            }
+            return bounds;
+        },
+        focus(projectView: IProjectView) {
+            // Note that pxtsim.driver.focus() isn't the same as tabbing to the sim.
+            if (isSimMini()) {
+                projectView.setSimulatorFullScreen(true);
+            } else {
+                if (projectView.state.collapseEditorTools) {
+                    projectView.toggleSimulatorCollapse();
+                }
+                (document.querySelector("#boardview") as HTMLElement).focus();
+            }
+        },
+        getClassName(projectView: IProjectView) {
+            return `simulator-region ${projectView.state.collapseEditorTools ? "simulator-collapsed" : ""
+                }`;
+        },
+    },
+    {
+        id: "toolbox",
+        ariaLabel: lf("Toolbox"),
+        shortcutKey: "3",
+        getBounds(projectView: IProjectView) {
+            const bounds = getToolboxBounds(projectView);
+            if (projectView.state.collapseEditorTools) {
+                // Shift over for a clearer region when the toolbox is collapsed
+                const copy = DOMRect.fromRect(bounds);
+                copy.x = 0;
+                copy.width = bounds.left + bounds.width;
+                return copy;
+            }
+            return bounds;
+        },
+        focus(projectView: IProjectView) {
+            projectView.editor.focusToolbox();
+        }
+    },
+    {
+        id: "editor",
+        ariaLabel: lf("Editor"),
+        shortcutKey: "4",
+        getBounds(projectView: IProjectView) {
+            const editorSelectors = ["#pxtJsonEditor", "#githubEditor", "#blocksArea", "#serialEditor", "#assetEditor", "#monacoEditor"];
+            for (const selector of editorSelectors) {
+                const element = document.querySelector(selector) as HTMLElement | null;
+                if (element.offsetParent !== null) {
+                    console.log(element);
+                    const bounds = element.getBoundingClientRect();
+                    if (selector === "#monacoEditor" || selector === "#blocksArea") {
+                        // Use bounds that don't overlap the toolbox region.
+                        const toolbox = getToolboxBounds(projectView);
+                        const copied = DOMRect.fromRect(bounds);
+                        if (toolbox) {
+                            copied.x = toolbox.right;
+                            copied.width = bounds.width - toolbox.width;
+                        }
+                        return copied;
+                    }
+                    return bounds;
+                }
+            }
+            return undefined;
+        },
+        focus(projectView: IProjectView) {
+            if (projectView.isPxtJsonEditor()) {
+                findFirstFocusableDescendant(document.querySelector("#pxtJsonEditor"))?.focus();
+            } else {
+                projectView.editor.focusWorkspace();
+            }
+        }
+    },
+    {
+        id: "editortools",
+        ariaLabel: lf("Editor toolbar"),
+        shortcutKey: "5",
+        getBounds() {
+            return document.querySelector("#editortools")?.getBoundingClientRect();
+        },
+        focus() {
+            findFirstFocusableDescendant(document.querySelector("#editortools")!)?.focus();
+        }
+    },
+    {
+        id: "tutorial",
+        ariaLabel: lf("Tutorial"),
+        // This isn't really in sequence but it's not usually present.
+        shortcutKey: "0",
+        getBounds() {
+            return document.querySelector(".tutorialWrapper")?.getBoundingClientRect();
+        },
+        focus() {
+            findFirstFocusableDescendant(document.querySelector(".tutorialWrapper")!)?.focus();
+        }
+    },
+];
+
+export const NavigateRegionsOverlay = ({ parent }: NavigateRegionsOverlayProps) => {
+    const previouslyFocused = useRef<Element>(document.activeElement);
+    const getRects = (): Map<RegionId, DOMRect | undefined> => (
+        new Map(regions.map(region => [region.id, region.getBounds(parent)]))
+    );
+    const [regionRects, setRegionRects] = useState(getRects());
+
+    useEffect(() => {
+        if (parent.state.fullscreen) {
+            parent.setSimulatorFullScreen(false);
+        }
+
+        const listener = (e: KeyboardEvent) => {
+            const region = regions.find(region => region.shortcutKey === e.key);
+            if (region) {
+                e.preventDefault();
+                region.focus(parent);
+                parent.hideNavigateRegions();
+            }
+        }
+        document.addEventListener("keydown", listener)
+
+        const observer = new ResizeObserver(() => {
+            setRegionRects(getRects())
+        });
+        observer.observe(document.body);
+
+        return () => {
+            observer.disconnect()
+            document.removeEventListener("keydown", listener)
+        }
+    }, [])
+
+    const handleEscape = () => {
+        if (previouslyFocused.current) {
+            (previouslyFocused.current as HTMLElement).focus()
+        }
+        parent.hideNavigateRegions();
+    }
+
+    if (!regionRects.get("editor")) {
+        // Something is awry, bail out.
+        parent.hideNavigateRegions();
+        return null;
+    }
+
+    return ReactDOM.createPortal(
+        <FocusTrap dontRestoreFocus onEscape={handleEscape}>
+            <div className="navigate-regions-container">
+                {regions.map(region => {
+                    const rect = regionRects.get(region.id);
+                    return rect ? (<RegionButton
+                        key={region.id}
+                        title={region.ariaLabel}
+                        shortcutKey={region.shortcutKey}
+                        bounds={rect}
+                        onClick={() => {
+                            region.focus(parent);
+                            parent.hideNavigateRegions();
+                        }}
+                        ariaLabel={region.ariaLabel}
+                        className={region.getClassName?.(parent)}
+                    />) : null;
+                })}
+            </div>
+        </FocusTrap>,
+        document.getElementById("root") || document.body
+    );
+}
+
+interface RegionButtonProps extends ButtonProps {
+    shortcutKey: string;
+    bounds: RectBounds;
+}
+
+const RegionButton = ({ shortcutKey, bounds, ...props }: RegionButtonProps) => {
+    const buttonRef = useRef<HTMLButtonElement>()
+
+    useEffect(() => {
+        if (bounds) {
+            buttonRef.current.style.top = `${bounds.top}px`;
+            buttonRef.current.style.height = `${bounds.height}px`;
+            buttonRef.current.style.left = `${bounds.left}px`;
+            buttonRef.current.style.width = `${bounds.width}px`;
+        }
+    }, [bounds])
+
+    return <Button
+        buttonRef={(ref) => { buttonRef.current = ref }}
+        {...props}
+        className={`region-button ${props.className}`}
+    >
+        <div><p>{shortcutKey.toUpperCase()}</p></div>
+    </Button>
+}
+
+/**
+ * Find the first focusable descendant element within a given element.
+ */
+function findFirstFocusableDescendant(element: HTMLElement, skip?: (element: Element) => boolean): HTMLElement | null {
+    const nativelyFocusableSelectors = [
+        '[contenteditable]:not([contenteditable="false"])',
+        'a[href]',
+        'audio[controls]',
+        'button:not([disabled])',
+        'details > summary:first-of-type',
+        'iframe',
+        'input:not([disabled]):not([type="hidden"])',
+        'select:not([disabled])',
+        'textarea:not([disabled])',
+        'video[controls]',
+    ];
+    const ariaFocusableRoles = [
+        'button',
+        'checkbox',
+        'combobox',
+        'dialog',
+        'gridcell',
+        'link',
+        'menuitem',
+        'menuitemcheckbox',
+        'menuitemradio',
+        'option',
+        'radio',
+        'searchbox',
+        'slider',
+        'spinbutton',
+        'switch',
+        'tab',
+        'textbox',
+        'treeitem'
+    ];
+    const selectors = [
+        ...nativelyFocusableSelectors,
+        '[tabindex]:not([tabindex="-1"])',
+        ...ariaFocusableRoles.map(role => `[role="${role}"]`)
+    ];
+    const candidates = Array.from(
+        element.querySelectorAll<HTMLElement>(selectors.join(','))
+    );
+    // Could also sequence by tabindex here but assuming only 0/-1 used.
+    return candidates.find(candidate => {
+        // This can be replaced with checkVisibility when types/support allows.
+        if (candidate.offsetParent === null) {
+            return false;
+        }
+        if (candidate.ariaHidden === 'true') {
+            return false;
+        }
+        if (candidate.inert || candidate.closest('[inert]')) {
+            return false;
+        }
+        if (candidate.ariaDisabled === 'true') {
+            return false;
+        }
+        if (candidate.closest('fieldset[disabled]')) {
+            return false;
+        }
+        if (skip?.(candidate)) {
+            return false;
+        }
+        return true;
+    });
+}


### PR DESCRIPTION
See https://github.com/microsoft/pxt-microbit/issues/6151. We've moved to an approach where Ctrl-U shows an overlay with navigable regions labelled by number in an effort to move forward with this after some recent discussion.

See [accompanying change](https://github.com/microsoft/pxt-microbit/pull/6169) in `pxt-microbit` which ensures that global shortcuts are also enabled when focus is inside the simulator iframe (e.g., simulator buttons, etc).

[Link to demo](https://global-shortcuts.review-pxt.pages.dev/). Please note that 'accessible blocks' need to be set to 'on' in the settings menu. Use Ctrl-U to show the navigation overlay, and then a number to move to that region. Ctrl-U is a shortcut to view the page source code which feels like a seldom used shortcut and one we can safely override.

Issues to fix:
- [ ] Prevent the navigation overlay from running on the home page - it currently ends badly
- [ ] Ctrl-U does not working the Monaco text editor due to existing editor shortcuts

@microbit-matt-hillsdon 