### PR TITLE
stricter connection checks for function and callback reporters

### DIFF
--- a/pxtblocks/compiler/typeChecker.ts
+++ b/pxtblocks/compiler/typeChecker.ts
@@ -5,6 +5,7 @@ import { countOptionals, getFunctionName, getInputTargetBlock, getLoopVariableFi
 import { getDefinition } from "../plugins/functions";
 import { CommonFunctionBlock } from "../plugins/functions/commonFunctionMixin";
 import { PXT_WARNING_ID } from "./compiler";
+import { DRAGGABLE_PARAM_INPUT_PREFIX } from "../loader";
 
 interface DeclaredVariable {
     name: string;
@@ -669,7 +670,7 @@ function getCBParameters(b: Blockly.Block, stdfun: StdFunc, e: Environment): Dec
         for (let i = 0; i < stdfun.comp.handlerArgs.length; i++) {
             const arg = stdfun.comp.handlerArgs[i];
             let varName: string;
-            const varBlock = getInputTargetBlock(e, b, "HANDLER_DRAG_PARAM_" + arg.name) as Blockly.Block;
+            const varBlock = getInputTargetBlock(e, b, DRAGGABLE_PARAM_INPUT_PREFIX + arg.name) as Blockly.Block;
 
             if (stdfun.attrs.draggableParameters === "reporter") {
                 varName = varBlock && varBlock.getFieldValue("VALUE");

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -27,6 +27,8 @@ import { setDraggableShadowBlocks, setDuplicateOnDrag, setDuplicateOnDragStrateg
 import { applyPolyfills } from "./polyfills";
 import { initCopyPaste } from "./copyPaste";
 
+export const DRAGGABLE_PARAM_INPUT_PREFIX = "HANDLER_DRAG_PARAM_";
+
 
 interface BlockDefinition {
     codeCard?: any;
@@ -255,7 +257,7 @@ function initBlock(block: Blockly.Block, info: pxtc.BlocksInfo, fn: pxtc.SymbolI
         }
         else if (fn.attributes.draggableParameters) {
             comp.handlerArgs.filter(a => !a.inBlockDef).forEach(arg => {
-                const i = block.appendValueInput("HANDLER_DRAG_PARAM_" + arg.name);
+                const i = block.appendValueInput(DRAGGABLE_PARAM_INPUT_PREFIX + arg.name);
                 if (fn.attributes.draggableParameters == "reporter") {
                     i.setCheck(getBlocklyCheckForType(arg.type, info));
                 } else {
@@ -265,7 +267,7 @@ function initBlock(block: Blockly.Block, info: pxtc.BlocksInfo, fn: pxtc.SymbolI
             });
 
             comp.handlerArgs.forEach(arg => {
-                setDuplicateOnDrag(block.type, "HANDLER_DRAG_PARAM_" + arg.name);
+                setDuplicateOnDrag(block.type, DRAGGABLE_PARAM_INPUT_PREFIX + arg.name);
             });
         }
         else {
@@ -395,7 +397,7 @@ function initBlock(block: Blockly.Block, info: pxtc.BlocksInfo, fn: pxtc.SymbolI
                     }
 
                     if (isHandlerArg(pr)) {
-                        inputName = "HANDLER_DRAG_PARAM_" + pr.name;
+                        inputName = DRAGGABLE_PARAM_INPUT_PREFIX + pr.name;
                         inputCheck = fn.attributes.draggableParameters === "reporter" ? getBlocklyCheckForType(pr.type, info) : "Variable";
                         return;
                     }

--- a/pxtblocks/plugins/duplicateOnDrag/connectionChecker.ts
+++ b/pxtblocks/plugins/duplicateOnDrag/connectionChecker.ts
@@ -1,5 +1,6 @@
 import * as Blockly from "blockly";
 import { isAllowlistedShadow, shouldDuplicateOnDrag } from "./duplicateOnDrag";
+import { doArgumentReporterDragChecks } from "../functions/utils";
 
 
 const OPPOSITE_TYPE: number[] = [];
@@ -21,6 +22,10 @@ export class DuplicateOnDragConnectionChecker extends Blockly.ConnectionChecker 
             shouldDuplicateOnDrag(replacedBlock) &&
             !(replacedBlock.isShadow() && isAllowlistedShadow(replacedBlock))
         ) {
+            return false;
+        }
+
+        if (!doArgumentReporterDragChecks(a, b, distance)) {
             return false;
         }
 

--- a/pxtblocks/plugins/functions/blocks/argumentReporterBlocks.ts
+++ b/pxtblocks/plugins/functions/blocks/argumentReporterBlocks.ts
@@ -7,7 +7,7 @@ import {
     ARGUMENT_REPORTER_CUSTOM_BLOCK_TYPE,
 } from "../constants";
 import { MsgKey } from "../msg";
-import { DUPLICATE_ON_DRAG_MUTATION_KEY, DuplicateOnDragStrategy, setDuplicateOnDragStrategy } from "../../duplicateOnDrag";
+import { DUPLICATE_ON_DRAG_MUTATION_KEY, setDuplicateOnDragStrategy } from "../../duplicateOnDrag";
 import { PathObject } from "../../renderer/pathObject";
 
 type ArgumentReporterMixinType = typeof ARGUMENT_REPORTER_MIXIN;

--- a/pxtblocks/toolbox.ts
+++ b/pxtblocks/toolbox.ts
@@ -3,6 +3,7 @@
 import * as Blockly from "blockly";
 import { flyoutCategory, getAllFunctionDefinitionBlocks } from "./plugins/functions";
 import { DUPLICATE_ON_DRAG_MUTATION_KEY } from "./plugins/duplicateOnDrag";
+import { DRAGGABLE_PARAM_INPUT_PREFIX } from "./loader";
 
 const primitiveTypeRegex = /^(string|number|boolean)$/;
 
@@ -420,7 +421,7 @@ export function createToolboxBlock(info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, c
                 const useReporter = fn.attributes.draggableParameters === "reporter";
 
                 const value = document.createElement("value");
-                value.setAttribute("name", "HANDLER_DRAG_PARAM_" + arg.name);
+                value.setAttribute("name", DRAGGABLE_PARAM_INPUT_PREFIX + arg.name);
 
                 const blockType = useReporter ? pxt.blocks.reporterTypeForArgType(arg.type) : "variables_get_reporter";
                 const shadow = document.createElement("block");


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5999

this fixes the connection checks for argument reporters so that they can't be dropped outside of a function definition, callback block, or event that defines them as a parameter. well, except if the block is disabled (i.e. orphaned on the workspace) because that is very useful when refactoring or copy+pasting code. argument reporters with the same name and type can also be shared between different functions/events.

here is a GIF showing off the behavior:

![argument-reporter-connection-checks](https://github.com/user-attachments/assets/e4b8b1d8-9b3b-43c6-ae59-c1ac58c7eac9)


not thrilled that this is increasing the coupling between our plugins... at some point i need to do a refactor to make everything a lot more modular if we ever want to release these plugins externally. it won't be a ton of work, but needs to be done.