### PR TITLE
deprecate String.substr block in favor of one with optional length

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -312,6 +312,7 @@ declare interface String {
     //% this.shadow="text"
     //% this.defl="this"
     //% blockNamespace="text"
+    //% expandArgumentsInToolbox
     substr(start: number, length?: number): string;
 
     /**

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -307,8 +307,11 @@ declare interface String {
      */
     //% helper=stringSubstr
     //% help=text/substr
-    //% blockId="string_substr" block="substring of %this=text|from %start|of length %length" blockNamespace="text"
+    //% blockId=string_substr_new
+    //% block="substring of $this|from $start||of length $length"
+    //% this.shadow="text"
     //% this.defl="this"
+    //% blockNamespace="text"
     substr(start: number, length?: number): string;
 
     /**
@@ -402,6 +405,19 @@ declare interface String {
     //% helper=stringToLowerCase
     //% help=text/to-lower-case
     toLowerCase(): string;
+
+    /**
+     * Return a substring of the current string.
+     * @param start first character index; can be negative from counting from the end, eg:0
+     * @param length number of characters to extract, eg: 10
+     */
+    //% helper=stringSubstr
+    //% help=text/substr
+    //% blockId="string_substr" block="substring of %this=text|from %start|of length %length" blockNamespace="text"
+    //% this.defl="this"
+    //% blockAliasFor="String.substr"
+    //% deprecated
+    __substr(start: number, length?: number): string;
 
     [index: number]: string;
 }

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -948,6 +948,7 @@ declare namespace ts.pxtc {
         inlineInputModeLimit?: number; // the number of expanded arguments at which to switch from inline to external. only applies when inlineInputMode=variable and expandableArgumentsMode=enabled
         expandableArgumentMode?: string; // can be disabled, enabled, or toggle
         expandableArgumentBreaks?: string; // a comma separated list of how many arguments to reveal/hide each time + or - is pressed on a block. only applies when expandableArgumentsMode=enabled
+        expandArgumentsInToolbox?: boolean; // if true, the block will be fully expanded in the toolbox flyout
         compileHiddenArguments?: boolean; // if true, compiles the values in expandable arguments even when collapsed
         draggableParameters?: string; // can be reporter or variable; defaults to variable
 

--- a/pxtblocks/toolbox.ts
+++ b/pxtblocks/toolbox.ts
@@ -453,6 +453,24 @@ export function createToolboxBlock(info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, c
         }
     }
 
+    if (fn.attributes.expandArgumentsInToolbox) {
+        let mutation: Element;
+
+        for (const child of block.children) {
+            if (child.tagName === "mutation") {
+                mutation = child;
+                break;
+            }
+        }
+
+        if (!mutation) {
+            mutation = document.createElement("mutation");
+            block.appendChild(mutation);
+        }
+
+        mutation.setAttribute("_expanded", "" + fn.attributes._expandedDef.parameters.length);
+    }
+
     if (parent) {
         parentInput.appendChild(block);
         return parent;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -835,8 +835,15 @@ namespace ts.pxtc {
         return r;
     }
 
-    const numberAttributes = ["weight", "imageLiteral", "gridLiteral", "topblockWeight", "inlineInputModeLimit"]
-    const booleanAttributes = [
+    const numberAttributes: (keyof CommentAttrs)[] = [
+        "weight",
+        "imageLiteral",
+        "gridLiteral",
+        "topblockWeight",
+        "inlineInputModeLimit"
+    ];
+
+    const booleanAttributes: (keyof CommentAttrs)[] = [
         "advanced",
         "handlerStatement",
         "afterOnStart",
@@ -851,7 +858,8 @@ namespace ts.pxtc {
         "callInDebugger",
         "duplicateShadowOnDrag",
         "argsNullable",
-        "compileHiddenArguments"
+        "compileHiddenArguments",
+        "expandArgumentsInToolbox",
     ];
 
     export function parseCommentString(cmt: string): CommentAttrs {

--- a/tests/decompile-test/baselines/block_text.blocks
+++ b/tests/decompile-test/baselines/block_text.blocks
@@ -101,7 +101,8 @@
 <field name="VAR">f</field>
 <value name="VALUE">
 <shadow type="math_number"><field name="NUM">0</field></shadow>
-<block type="string_substr">
+<block type="string_substr_new">
+<mutation _expanded="1" />
 <value name="this">
 <shadow type="text">
 <field name="TEXT">abcdef</field>

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -662,7 +662,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     snippet: `"".substr(0, 0)`,
                     pySnippet: `""[0:1]`,
                     attributes: {
-                        blockId: 'string_substr',
+                        blockId: 'string_substr_new',
                         jsDoc: lf("Returns the part of a string starting at a given index with the given length")
                     },
                     retType: "string"


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6184

the length parameter of `String.substr` is optional, but it's not currently optional in blocks. this PR corrects that by deprecating the old block and creating a new one with an optional length parameter (with the usual + button to access optional parameters).

this change requires no upgrade rules. the old block definition has been moved on to `String.__substr` but will still convert to `String.substr` when switching to JavaScript because of the `blockAliasFor` annotation.

here is the old block:

![image](https://github.com/user-attachments/assets/b4cff40c-5c33-451d-b2f8-e05f182294e5)

and here is the new one:

![image](https://github.com/user-attachments/assets/e4bc6b0b-7300-4ada-9541-a6edb001461c)

the expanded text is exactly the same as the old one.