### PR TITLE
when compiling too-large programs include disabled variants if alwaysMultivariant

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -134,6 +134,7 @@ declare namespace pxt {
         uploadDocs?: boolean; // enable uploading to crowdin on master or v* builds
         variants?: Map<AppTarget>; // patches on top of the current AppTarget for different chip variants
         multiVariants?: string[];
+        disabledVariants?: string[];
         alwaysMultiVariant?: boolean;
         queryVariants?: Map<AppTarget>; // patches on top of the current AppTarget using query url regex
         unsupportedBrowsers?: BrowserOptions[]; // list of unsupported browsers for a specific target (eg IE11 in arcade). check browserutils.js browser() function for strings

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -1158,6 +1158,8 @@ namespace pxt {
                 }
             }
 
+            const disabledVariants = pxt.appTarget.disabledVariants;
+
             let shimsGenerated = false
 
             const fillExtInfoAsync = async (variant: string) => {
@@ -1216,10 +1218,14 @@ namespace pxt {
                     variants = [pxt.appTargetVariant]
                 } else if (pxt.appTarget.alwaysMultiVariant || pxt.appTarget.compile.switches.multiVariant) {
                     // multivariants enabled
-                    variants = pxt.appTarget.multiVariants
+                    variants = pxt.appTarget.multiVariants;
                 } else {
                     // not enbaled - default to first variant
                     variants = [pxt.appTarget.multiVariants[0]]
+                }
+
+                if (!pxt.appTarget.alwaysMultiVariant && disabledVariants) {
+                    variants = variants.filter(v => !disabledVariants.includes(v));
                 }
             } else {
                 // no multi-variants, use empty variant name,
@@ -1239,6 +1245,9 @@ namespace pxt {
                         const einfo = etarget.extinfo;
                         einfo.appVariant = v;
                         einfo.outputPrefix = variants.length == 1 || !v ? "" : v + "-";
+                        if (disabledVariants?.indexOf(v) > -1) {
+                            einfo.disabledDeps = einfo.disabledDeps || "user-disabled";
+                        }
                         if (ext) {
                             opts.otherMultiVariants.push(etarget);
                         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3395,15 +3395,15 @@ export class ProjectView
                         const res = await pxt.commands.showProgramTooLargeErrorAsync(attemptedVariants, core.confirmAsync, saveOnly);
                         if (res?.recompile) {
                             pxt.tickEvent("compile.programTooLargeDialog.recompile");
-                            const oldVariants = pxt.appTarget.multiVariants;
+                            const oldVariants = pxt.appTarget.disabledVariants;
                             this.setState({ compiling: false, isSaving: false });
                             try {
-                                pxt.appTarget.multiVariants = res.useVariants;
+                                pxt.appTarget.disabledVariants = pxt.appTarget.multiVariants.filter(v => !res.useVariants.includes(v));
                                 await this.compile(saveOnly);
                                 return;
                             }
                             finally {
-                                pxt.appTarget.multiVariants = oldVariants;
+                                pxt.appTarget.disabledVariants = oldVariants;
                             }
                         }
                         else {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6010

when compiling programs that are too large for a variant, we currently just omit the disabled variant from the compiled hex entirely. for targets with alwaysMultivariant set (just micro:bit) that means we end up generating a non-fat hex with only a program for v2 hardware. flashing that hex to v1 hardware gives you a blank screen instead of a panic code.

this pr makes it so that we instead respect that setting and emit a program for each variant; the disabled variant program will just be the usual 927 panic code that indicates unsupported hardware.