### PR TITLE
add ability to localize callback parameters

### DIFF
--- a/pxtblocks/plugins/functions/blocks/argumentReporterBlocks.ts
+++ b/pxtblocks/plugins/functions/blocks/argumentReporterBlocks.ts
@@ -10,6 +10,8 @@ import { MsgKey } from "../msg";
 import { DUPLICATE_ON_DRAG_MUTATION_KEY, setDuplicateOnDragStrategy } from "../../duplicateOnDrag";
 import { PathObject } from "../../renderer/pathObject";
 
+export const LOCALIZATION_NAME_MUTATION_KEY = "localizationname";
+
 type ArgumentReporterMixinType = typeof ARGUMENT_REPORTER_MIXIN;
 
 interface ArgumentReporterMixin extends ArgumentReporterMixinType {}
@@ -18,16 +20,24 @@ export type ArgumentReporterBlock = Blockly.BlockSvg & ArgumentReporterMixin;
 
 const ARGUMENT_REPORTER_MIXIN = {
     typeName_: "",
+    localizationName_: "",
     duplicateOnDrag_: false,
 
     getTypeName(this: ArgumentReporterBlock) {
         return this.typeName_;
     },
 
+    getLocalizationName(this: ArgumentReporterBlock) {
+        return this.localizationName_ || this.getFieldValue("VALUE");
+    },
+
     mutationToDom(this: ArgumentReporterBlock) {
         const container = Blockly.utils.xml.createElement("mutation");
         if (this.duplicateOnDrag_) {
             container.setAttribute(DUPLICATE_ON_DRAG_MUTATION_KEY, "true");
+        }
+        if (this.localizationName_) {
+            container.setAttribute(LOCALIZATION_NAME_MUTATION_KEY, this.localizationName_);
         }
         return container;
     },
@@ -39,6 +49,9 @@ const ARGUMENT_REPORTER_MIXIN = {
                 (this.pathObject as PathObject).setHasDottedOutlineOnHover(this.duplicateOnDrag_);
             }
         }
+        if (xmlElement.hasAttribute(LOCALIZATION_NAME_MUTATION_KEY)) {
+            this.localizationName_ = xmlElement.getAttribute(LOCALIZATION_NAME_MUTATION_KEY);
+        }
     },
 };
 
@@ -49,7 +62,7 @@ Blockly.Blocks[ARGUMENT_REPORTER_BOOLEAN_BLOCK_TYPE] = {
             message0: " %1",
             args0: [
                 {
-                    type: "field_label_serializable",
+                    type: "field_argument_reporter",
                     name: "VALUE",
                     text: "",
                 },
@@ -69,7 +82,7 @@ Blockly.Blocks[ARGUMENT_REPORTER_STRING_BLOCK_TYPE] = {
             message0: " %1",
             args0: [
                 {
-                    type: "field_label_serializable",
+                    type: "field_argument_reporter",
                     name: "VALUE",
                     text: "",
                 },
@@ -89,7 +102,7 @@ Blockly.Blocks[ARGUMENT_REPORTER_NUMBER_BLOCK_TYPE] = {
             message0: " %1",
             args0: [
                 {
-                    type: "field_label_serializable",
+                    type: "field_argument_reporter",
                     name: "VALUE",
                     text: "",
                 },
@@ -109,7 +122,7 @@ Blockly.Blocks[ARGUMENT_REPORTER_ARRAY_BLOCK_TYPE] = {
             message0: " %1",
             args0: [
                 {
-                    type: "field_label_serializable",
+                    type: "field_argument_reporter",
                     name: "VALUE",
                     text: "",
                 },
@@ -129,7 +142,7 @@ Blockly.Blocks[ARGUMENT_REPORTER_CUSTOM_BLOCK_TYPE] = {
             message0: " %1",
             args0: [
                 {
-                    type: "field_label_serializable",
+                    type: "field_argument_reporter",
                     name: "VALUE",
                     text: "",
                 },

--- a/pxtblocks/plugins/functions/fields/fieldArgumentReporter.ts
+++ b/pxtblocks/plugins/functions/fields/fieldArgumentReporter.ts
@@ -1,0 +1,21 @@
+import * as Blockly from "blockly";
+import { isFunctionArgumentReporter } from "../utils";
+import { ArgumentReporterBlock } from "../blocks/argumentReporterBlocks";
+
+export class FieldArgumentReporter extends Blockly.FieldLabelSerializable {
+    protected override getDisplayText_(): string {
+        const source = this.getSourceBlock();
+        if (source && isFunctionArgumentReporter(source)) {
+            const localizeKey = (source as ArgumentReporterBlock).getLocalizationName();
+
+            const localized = localizeKey && pxt.U.rlf(localizeKey);
+            if (localized && localized !== localizeKey) {
+                return localized;
+            }
+        }
+
+        return super.getDisplayText_();
+    }
+}
+
+Blockly.registry.register(Blockly.registry.Type.FIELD, "field_argument_reporter", FieldArgumentReporter);

--- a/pxtblocks/plugins/functions/index.ts
+++ b/pxtblocks/plugins/functions/index.ts
@@ -1,6 +1,7 @@
 export * from "./msg";
 export * from "./extensions";
 export * from "./fields/fieldArgumentEditor";
+export * from "./fields/fieldArgumentReporter";
 export * from "./fields/fieldAutocapitalizeTextInput";
 export * from "./blocks/argumentEditorBlocks";
 export * from "./blocks/argumentReporterBlocks";

--- a/pxtblocks/toolbox.ts
+++ b/pxtblocks/toolbox.ts
@@ -436,7 +436,15 @@ export function createToolboxBlock(info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, c
 
                 const field = document.createElement("field");
                 field.setAttribute("name", useReporter ? "VALUE" : "VAR");
-                field.textContent = pxt.Util.htmlEscape(arg.name);
+
+                let localizedName = pxt.U.rlf(arg.localizationKey);
+
+                // if the strings are out of date, don't show the localization key
+                if (localizedName === arg.localizationKey) {
+                    localizedName = arg.name;
+                }
+
+                field.textContent = pxt.Util.htmlEscape(localizedName);
 
                 shadow.appendChild(field);
                 value.appendChild(shadow);

--- a/pxtblocks/toolbox.ts
+++ b/pxtblocks/toolbox.ts
@@ -1,7 +1,7 @@
 /// <reference path="../built/pxtlib.d.ts" />
 
 import * as Blockly from "blockly";
-import { flyoutCategory, getAllFunctionDefinitionBlocks } from "./plugins/functions";
+import { flyoutCategory, getAllFunctionDefinitionBlocks, LOCALIZATION_NAME_MUTATION_KEY } from "./plugins/functions";
 import { DUPLICATE_ON_DRAG_MUTATION_KEY } from "./plugins/duplicateOnDrag";
 import { DRAGGABLE_PARAM_INPUT_PREFIX } from "./loader";
 
@@ -433,18 +433,12 @@ export function createToolboxBlock(info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, c
                 if (useReporter && blockType === "argument_reporter_custom") {
                     mutation.setAttribute("typename", arg.type);
                 }
+                mutation.setAttribute(LOCALIZATION_NAME_MUTATION_KEY, arg.localizationKey);
 
                 const field = document.createElement("field");
                 field.setAttribute("name", useReporter ? "VALUE" : "VAR");
 
-                let localizedName = pxt.U.rlf(arg.localizationKey);
-
-                // if the strings are out of date, don't show the localization key
-                if (localizedName === arg.localizationKey) {
-                    localizedName = arg.name;
-                }
-
-                field.textContent = pxt.Util.htmlEscape(localizedName);
+                field.textContent = pxt.Util.htmlEscape(arg.name);
 
                 shadow.appendChild(field);
                 value.appendChild(shadow);

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -336,8 +336,6 @@ namespace ts.pxtc {
             }
             if (si.attributes.jsDoc)
                 jsdocStrings[si.qName] = si.attributes.jsDoc;
-            if (si.attributes.block)
-                locStrings[`${si.qName}|block`] = si.attributes.block;
             if (si.attributes.group)
                 locStrings[`{id:group}${si.attributes.group}`] = si.attributes.group;
             if (si.attributes.subcategory)
@@ -346,6 +344,16 @@ namespace ts.pxtc {
                 si.parameters.filter(pi => !!pi.description).forEach(pi => {
                     jsdocStrings[`${si.qName}|param|${pi.name}`] = pi.description;
                 })
+
+            if (si.attributes.block) {
+                locStrings[`${si.qName}|block`] = si.attributes.block;
+                const comp = pxt.blocks.compileInfo(si);
+                if (comp.handlerArgs?.length) {
+                    for (const arg of comp.handlerArgs) {
+                        locStrings[arg.localizationKey] = arg.name;
+                    }
+                }
+            }
         }
         const mapLocs = (m: pxt.Map<string>, name: string) => {
             if (!options.locs) return;

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -81,9 +81,10 @@ namespace pxt.blocks {
     }
 
     export interface HandlerArg {
-        name: string,
-        type: string,
-        inBlockDef: boolean
+        name: string;
+        type: string;
+        inBlockDef: boolean;
+        localizationKey: string;
     }
 
     // Information for blocks that compile to function calls but are defined by vanilla Blockly
@@ -215,7 +216,8 @@ namespace pxt.blocks {
                         res.handlerArgs.push({
                             name: arg.name,
                             type: arg.type,
-                            inBlockDef: defParameters ? defParameters.some(def => def.ref && def.name === arg.name) : false
+                            inBlockDef: defParameters ? defParameters.some(def => def.ref && def.name === arg.name) : false,
+                            localizationKey: `${fn.qName}|handlerParam|${arg.name}`
                         });
                     })
                 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/1507

this PR adds the ability to localize callback parameters in blocks with draggable reporters. the json entries for callback parameters look like this:

```
// qname|handlerParam|paramName
"radio.onReceivedString|handlerParam|receivedString": "receivedString",
```

i went with this format over the usual `{id:whatever}` thing we use for most `rlf` strings because i wanted to match what we do for the other block strings, which i guess predate the nicer curly brace syntax. 

in order to actually display these strings, i store this localization `rlf` key as a mutation in the block when generating XML for the toolbox. that means this will not retroactively apply to old projects, which will not have the mutation present. also, this will still compile to the actual parameter name when switching to javascript rather than the localized one