### PR TITLE
Fix legacy source-map compatibility issue with browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,9 @@
     "yargs": "^17.7.2"
   },
   "overrides": {
+    "combine-source-map": {
+      "source-map": "0.4.4"
+    },
     "@blockly/field-colour": {
       "blockly": "^12.0.0-beta.4"
     },


### PR DESCRIPTION
After upgrading Node.js from v18 to v22, running `gulp` began failing with the following error:

```
TypeError: base64VLQ.decode is not a function
    at SourceMapConsumer._parseMappings (.../source-map-consumer.js:469:23)
```

This error originates from `combine-source-map`, a transitive dependency of `browserify`, which relies on an internal `base64VLQ` API that was only available in `source-map@0.4.x`.

During the Node upgrade, `node_modules` was reinstalled, and `combine-source-map` picked up a newer `source-map@0.5.7`, which no longer exposes `base64VLQ`. This caused the internal call to fail at runtime.

**Solution**
Added a targeted override to `package.json` to force `combine-source-map` to use `source-map@0.4.4`, which restores compatibility:

```json
"overrides": {
  "combine-source-map": {
    "source-map": "0.4.4"
  }
}
```

This restores the build without needing to update (or swap out) browserify.