### PR TITLE
Only quote commit messages if bumping in windows command prompt

### DIFF
--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -284,7 +284,7 @@ export async function npmVersionBumpAsync(
 ): Promise<string> {
     const output = await spawnWithPipeAsync({
         cmd: addCmd("npm"),
-        args: ["version", bumpType, "--message", `[pxt-cli] bump version to %s`, "--git-tag-version", tagCommit ? "true" : "false"],
+        args: ["version", bumpType, "--message", quoteIfNeeded(`[pxt-cli] bump version to %s`), "--git-tag-version", tagCommit ? "true" : "false"],
         cwd: ".",
         silent: true,
     });
@@ -299,12 +299,19 @@ export async function npmVersionBumpAsync(
         });
         await spawnAsync({
             cmd: "git",
-            args: ["commit", "-m", `[pxt-cli] bump version to ${ver}`],
+            args: ["commit", "-m", quoteIfNeeded(`[pxt-cli] bump version to ${ver}`)],
             cwd: ".",
             silent: true,
         });
     }
     return ver;
+}
+
+function quoteIfNeeded(arg: string) {
+    if (os.platform() === "win32") {
+        return `"${arg}"`;
+    }
+    return arg;
 }
 
 export function gitPushAsync(followTags: boolean = true) {

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -284,7 +284,7 @@ export async function npmVersionBumpAsync(
 ): Promise<string> {
     const output = await spawnWithPipeAsync({
         cmd: addCmd("npm"),
-        args: ["version", bumpType, "--message", `"[pxt-cli] bump version to %s"`, "--git-tag-version", tagCommit ? "true" : "false"],
+        args: ["version", bumpType, "--message", `[pxt-cli] bump version to %s`, "--git-tag-version", tagCommit ? "true" : "false"],
         cwd: ".",
         silent: true,
     });
@@ -299,7 +299,7 @@ export async function npmVersionBumpAsync(
         });
         await spawnAsync({
             cmd: "git",
-            args: ["commit", "-m", `"[pxt-cli] bump version to ${ver}"`],
+            args: ["commit", "-m", `[pxt-cli] bump version to ${ver}`],
             cwd: ".",
             silent: true,
         });


### PR DESCRIPTION
`child_process.spawn` handles the escaping of arguments in bash, but not in windows. this meant that we were getting double quotes in prs made from WSL (see https://github.com/microsoft/pxt/pull/10575) which in turn broke the regex in our github action that detected whether the merged commit should be tagged or not.