### PR TITLE
add localhost flag for skipping auth check in teacher tool

### DIFF
--- a/teachertool/README.md
+++ b/teachertool/README.md
@@ -13,6 +13,8 @@ Requests to the `/eval` endpoint will be routed to the Teacher Tool dev server.
 
 Debug and step through Teacher Tool code using the browser dev tools (F12 to open).
 
+To skip having to log in on localhost, add `?noauth=1` to the end of the url.
+
 
 ## Test in staging environment
 

--- a/teachertool/src/App.tsx
+++ b/teachertool/src/App.tsx
@@ -64,15 +64,23 @@ export const App = () => {
 
     useEffect(() => {
         async function checkAuthAsync() {
-            // On mount, check if user is signed in
-            try {
-                await authClient.authCheckAsync();
-            } catch (e) {
-                // Log error but continue
-                // Don't include actual error in error log in case PII
-                logError(ErrorCode.authCheckFailed);
-                logDebug("Auth check failed details", e);
+            if (pxt.BrowserUtils.isLocalHostDev() && /noauth=1/i.test(window.location.href)) {
+                dispatch(Actions.setUserProfile({
+                    id: "?"
+                }));
             }
+            else {
+                // On mount, check if user is signed in
+                try {
+                    await authClient.authCheckAsync();
+                } catch (e) {
+                    // Log error but continue
+                    // Don't include actual error in error log in case PII
+                    logError(ErrorCode.authCheckFailed);
+                    logDebug("Auth check failed details", e);
+                }
+            }
+
             setAuthCheckComplete(true);
         }
         checkAuthAsync();


### PR DESCRIPTION
msft login is currently broken on staging when serving on localhost so i had to put in this little workaround for bypassing the need to sign in to the teacher tool.