### PR TITLE
Keyboard accessibility for the MelodySandbox field.

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -100,7 +100,8 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
 
     private initMatrix() {
         if (!this.sourceBlock_.isInsertionMarker()) {
-            this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" aria-label="${lf("LED grid")}" />`);
+            this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" />`);
+            this.matrixSvg.ariaLabel = lf("LED grid");
 
             // Initialize the matrix that holds the state
             for (let i = 0; i < this.numMatrixCols; i++) {

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -2,6 +2,7 @@
 /// <reference path="../../built/pxtsim.d.ts" />
 
 import * as Blockly from "blockly";
+import { FieldMatrix } from "./field_matrix";
 import { FieldCustom } from "./field_utils";
 
 const rowRegex = /^.*[\.#].*$/;
@@ -12,7 +13,7 @@ enum LabelMode {
     Letter
 }
 
-export class FieldMatrix extends Blockly.Field implements FieldCustom {
+export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     private static CELL_WIDTH = 25;
     private static CELL_HORIZONTAL_MARGIN = 7;
     private static CELL_VERTICAL_MARGIN = 5;
@@ -31,21 +32,18 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
     private static DEFAULT_OFF_COLOR = "#000000";
 
     private scale = 1;
-    // The number of columns
-    private matrixWidth: number = 5;
 
-    // The number of rows
-    private matrixHeight: number = 5;
+    protected numMatrixCols: number = 5;
+    protected numMatrixRows: number = 5;
 
     private yAxisLabel: LabelMode = LabelMode.None;
     private xAxisLabel: LabelMode = LabelMode.None;
 
     private cellState: boolean[][] = [];
-    private cells: SVGRectElement[][] = [];
-    private elt: SVGSVGElement;
 
     private currentDragState_: boolean;
-    private selected: number[] | undefined = undefined;
+
+    protected clearSelectionOnBlur = true;
 
     constructor(text: string, params: any, validator?: Blockly.FieldValidator) {
         super(text, validator);
@@ -54,14 +52,14 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
         if (this.params.rows !== undefined) {
             let val = parseInt(this.params.rows);
             if (!isNaN(val)) {
-                this.matrixHeight = val;
+                this.numMatrixRows = val;
             }
         }
 
         if (this.params.columns !== undefined) {
             let val = parseInt(this.params.columns);
             if (!isNaN(val)) {
-                this.matrixWidth = val;
+                this.numMatrixCols = val;
             }
         }
 
@@ -75,111 +73,18 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
 
         if (this.params.scale !== undefined)
             this.scale = Math.max(0.6, Math.min(2, Number(this.params.scale)));
-        else if (Math.max(this.matrixWidth, this.matrixHeight) > 15)
+        else if (Math.max(this.numMatrixCols, this.numMatrixRows) > 15)
             this.scale = 0.85;
-        else if (Math.max(this.matrixWidth, this.matrixHeight) > 10)
+        else if (Math.max(this.numMatrixCols, this.numMatrixRows) > 10)
             this.scale = 0.9;
     }
 
-    private keyHandler(e: KeyboardEvent) {
-        if (!this.selected) {
-            return
-        }
-        const [x, y] = this.selected;
-        const ctrlCmd = pxt.BrowserUtils.isMac() ? e.metaKey : e.ctrlKey;
-        switch(e.code) {
-            case "KeyW":
-            case "ArrowUp": {
-                if (y !== 0) {
-                    this.selected = [x, y - 1]
-                }
-                break;
-            }
-            case "KeyS":
-            case "ArrowDown": {
-                if (y !== this.cells[0].length - 1) {
-                    this.selected = [x, y + 1]
-                }
-                break;
-            }
-            case "KeyA":
-            case "ArrowLeft": {
-                if (x !== 0) {
-                    this.selected = [x - 1, y]
-                } else if (y !== 0){
-                    this.selected = [this.matrixWidth - 1, y - 1]
-                }
-                break;
-            }
-            case "KeyD":
-            case "ArrowRight": {
-                if (x !== this.cells.length - 1) {
-                    this.selected = [x + 1, y]
-                } else if (y !== this.matrixHeight - 1) {
-                    this.selected = [0, y + 1]
-                }
-                break;
-            }
-            case "Home": {
-                if (ctrlCmd) {
-                    this.selected = [0, 0]
-                } else {
-                    this.selected = [0, y]
-                }
-                break;
-            }
-            case "End": {
-                if (ctrlCmd) {
-                    this.selected = [this.matrixWidth - 1, this.matrixHeight - 1]
-                } else {
-                    this.selected = [this.matrixWidth - 1, y]
-                }
-                break;
-            }
-            case "Enter":
-            case "Space": {
-                this.toggleRect(x, y, !this.cellState[x][y]);
-                break;
-            }
-            case "Escape": {
-                (this.sourceBlock_.workspace as Blockly.WorkspaceSvg).markFocused();
-                return;
-            }
-            default: {
-                return
-            }
-        }
-        const [newX, newY] = this.selected;
-        this.setFocusIndicator(this.cells[newX][newY], this.cellState[newX][newY]);
-        this.elt.setAttribute('aria-activedescendant', `${this.sourceBlock_.id}:${newX}${newY}`);
-        e.preventDefault();
-        e.stopPropagation();
+    protected getCellToggled(x: number, y: number): boolean {
+        return this.cellState[x][y];
     }
 
-    private clearSelection() {
-        if (this.selected) {
-            this.setFocusIndicator();
-            this.selected = undefined;
-        }
-        this.elt.removeAttribute('aria-activedescendant');
-    }
-
-    private removeKeyboardFocusHandlers() {
-        this.elt.removeEventListener("keydown", this.keyHandler)
-        this.elt.removeEventListener("blur", this.blurHandler)
-    }
-
-    private blurHandler() {
-        this.removeKeyboardFocusHandlers();
-        this.clearSelection();
-    }
-
-    private setFocusIndicator(cell?: SVGRectElement, ledOn?: boolean) {
-        this.cells.forEach(cell => cell.forEach(cell => cell.nextElementSibling.firstElementChild.classList.remove("selectedLedOn", "selectedLedOff")));
-        if (cell) {
-            const className = ledOn ? "selectedLedOn" : "selectedLedOff"
-            cell.nextElementSibling.firstElementChild.classList.add(className);
-        }
+    protected useTwoToneFocusIndicator(x: number, y: number): boolean {
+        return this.getCellToggled(x, y);
     }
 
     /**
@@ -188,60 +93,59 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
      */
     showEditor_() {
         this.selected = [0, 0];
-        this.setFocusIndicator(this.cells[0][0], this.cellState[0][0])
-        this.elt.setAttribute('aria-activedescendant', this.sourceBlock_.id + ":00");
-        this.elt.focus();
+        this.focusCell(0, 0);
+        this.matrixSvg.focus();
+        this.attachEventHandlersToMatrix();
     }
 
     private initMatrix() {
         if (!this.sourceBlock_.isInsertionMarker()) {
-            this.elt = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" aria-label="${lf("LED grid")}" />`);
+            this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" aria-label="${lf("LED grid")}" />`);
 
             // Initialize the matrix that holds the state
-            for (let i = 0; i < this.matrixWidth; i++) {
+            for (let i = 0; i < this.numMatrixCols; i++) {
                 this.cellState.push([])
-                this.cells.push([]);
-                for (let j = 0; j < this.matrixHeight; j++) {
+                for (let j = 0; j < this.numMatrixRows; j++) {
                     this.cellState[i].push(false);
                 }
             }
 
             this.restoreStateFromString();
 
-            // Create the cells of the matrix that is displayed
-            for (let y = 0; y < this.matrixHeight; y++) {
-                const row = this.createRow()
-                for (let x = 0; x < this.matrixWidth; x++) {
-                    this.createCell(x, y, row);
-                }
-            }
+            this.createMatrixDisplay({
+                cellWidth: FieldLedMatrix.CELL_WIDTH,
+                cellHeight: FieldLedMatrix.CELL_WIDTH,
+                cellLabel: lf("LED"),
+                cellHorizontalMargin: FieldLedMatrix.CELL_HORIZONTAL_MARGIN,
+                cellVerticalMargin: FieldLedMatrix.CELL_VERTICAL_MARGIN,
+                cornerRadius: FieldLedMatrix.CELL_CORNER_RADIUS,
+                cellFill: this.offColor,
+                padLeft: this.getYAxisWidth(),
+                scale: this.scale
+            });
 
             this.updateValue();
 
             if (this.xAxisLabel !== LabelMode.None) {
-                const y = this.scale * this.matrixHeight * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_VERTICAL_MARGIN) + FieldMatrix.CELL_VERTICAL_MARGIN * 2 + FieldMatrix.BOTTOM_MARGIN
-                const xAxis = pxsim.svg.child(this.elt, "g", { transform: `translate(${0} ${y})` });
-                for (let i = 0; i < this.matrixWidth; i++) {
-                    const x = this.getYAxisWidth() + this.scale * i * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_HORIZONTAL_MARGIN) + FieldMatrix.CELL_WIDTH / 2 + FieldMatrix.CELL_HORIZONTAL_MARGIN / 2;
+                const y = this.scale * this.numMatrixRows * (FieldLedMatrix.CELL_WIDTH + FieldLedMatrix.CELL_VERTICAL_MARGIN) + FieldLedMatrix.CELL_VERTICAL_MARGIN * 2 + FieldLedMatrix.BOTTOM_MARGIN
+                const xAxis = pxsim.svg.child(this.matrixSvg, "g", { transform: `translate(${0} ${y})` });
+                for (let i = 0; i < this.numMatrixCols; i++) {
+                    const x = this.getYAxisWidth() + this.scale * i * (FieldLedMatrix.CELL_WIDTH + FieldLedMatrix.CELL_HORIZONTAL_MARGIN) + FieldLedMatrix.CELL_WIDTH / 2 + FieldLedMatrix.CELL_HORIZONTAL_MARGIN / 2;
                     const lbl = pxsim.svg.child(xAxis, "text", { x, class: "blocklyText" })
                     lbl.textContent = this.getLabel(i, this.xAxisLabel);
                 }
             }
 
             if (this.yAxisLabel !== LabelMode.None) {
-                const yAxis = pxsim.svg.child(this.elt, "g", {});
-                for (let i = 0; i < this.matrixHeight; i++) {
-                    const y = this.scale * i * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_VERTICAL_MARGIN) + FieldMatrix.CELL_WIDTH / 2 + FieldMatrix.CELL_VERTICAL_MARGIN * 2;
+                const yAxis = pxsim.svg.child(this.matrixSvg, "g", {});
+                for (let i = 0; i < this.numMatrixRows; i++) {
+                    const y = this.scale * i * (FieldLedMatrix.CELL_WIDTH + FieldLedMatrix.CELL_VERTICAL_MARGIN) + FieldLedMatrix.CELL_WIDTH / 2 + FieldLedMatrix.CELL_VERTICAL_MARGIN * 2;
                     const lbl = pxsim.svg.child(yAxis, "text", { x: 0, y, class: "blocklyText" })
                     lbl.textContent = this.getLabel(i, this.yAxisLabel);
                 }
             }
 
-            this.fieldGroup_.replaceChild(this.elt, this.fieldGroup_.firstChild);
-            if (!this.sourceBlock_.isInFlyout) {
-                this.elt.addEventListener("keydown", this.keyHandler.bind(this));
-                this.elt.addEventListener("blur", this.blurHandler.bind(this));
-            }
+            this.fieldGroup_.replaceChild(this.matrixSvg, this.fieldGroup_.firstChild);
         }
     }
 
@@ -268,7 +172,7 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
 
         (Blockly as any).Touch.clearTouchIdentifier();
 
-        this.elt.removeEventListener(pxsim.pointerEvents.move, this.handleRootMouseMoveListener);
+        this.matrixSvg.removeEventListener(pxsim.pointerEvents.move, this.handleRootMouseMoveListener);
 
         ev.stopPropagation();
         ev.preventDefault();
@@ -289,44 +193,7 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
         super.updateEditable();
     }
 
-    private createRow() {
-        return pxsim.svg.child(this.elt, "g", { 'role': 'row' });
-    }
-
-    private createCell(x: number, y: number, row: SVGElement) {
-        const tx = this.scale * x * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_HORIZONTAL_MARGIN) + FieldMatrix.CELL_HORIZONTAL_MARGIN + this.getYAxisWidth();
-        const ty = this.scale * y * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_VERTICAL_MARGIN) + FieldMatrix.CELL_VERTICAL_MARGIN;
-
-        const cellG = pxsim.svg.child(row, "g", { transform: `translate(${tx} ${ty})`, 'role': 'gridcell' });
-        const cellRect = pxsim.svg.child(cellG, "rect", {
-            'id': `${this.sourceBlock_.id}:${x}${y}`, // For aria-activedescendant
-            'class': `blocklyLed${this.cellState[x][y] ? 'On' : 'Off'}`,
-            'aria-label': lf("LED"),
-            'role': 'switch',
-            'aria-checked': this.cellState[x][y].toString(),
-            width: this.scale * FieldMatrix.CELL_WIDTH, height: this.scale * FieldMatrix.CELL_WIDTH,
-            fill: this.getColor(x, y),
-            'data-x': x,
-            'data-y': y,
-            rx: Math.max(2, this.scale * FieldMatrix.CELL_CORNER_RADIUS) }) as SVGRectElement;
-        this.cells[x][y] = cellRect;
-
-        // Borders and box-shadow do not work in this context and outlines do not follow border-radius.
-        // Stroke is harder to manage given the difference in stroke for an LED when it is on vs off.
-        // This foreignObject/div is used to create a focus indicator for the LED when selected via keyboard navigation.
-        const foreignObject = pxsim.svg.child(cellG, "foreignObject", {
-            transform: 'translate(-4, -4)',
-            width: this.scale * FieldMatrix.CELL_WIDTH + 8,
-            height: this.scale * FieldMatrix.CELL_WIDTH + 8,
-        });
-        foreignObject.style.pointerEvents = "none";
-        const div = document.createElement("div");
-        div.classList.add("blocklyLedFocusIndicator");
-        div.style.borderRadius = `${Math.max(2, this.scale * FieldMatrix.CELL_CORNER_RADIUS)}px`;
-        foreignObject.append(div);
-
-        if ((this.sourceBlock_.workspace as any).isFlyout) return;
-
+    protected attachPointerEventHandlersToCell(x: number, y: number, cellRect: SVGElement) {
         pxsim.pointerEvents.down.forEach(evid => cellRect.addEventListener(evid, (ev: MouseEvent) => {
             if (!this.sourceBlock_.isEditable()) return;
 
@@ -337,7 +204,7 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
             Blockly.hideChaff();
             Blockly.common.setSelected(this.sourceBlock_ as Blockly.BlockSvg);
 
-            this.toggleRect(x, y);
+            this.toggleCell(x, y);
             pxsim.pointerEvents.down.forEach(evid => svgRoot.addEventListener(evid, this.dontHandleMouseEvent_));
             svgRoot.addEventListener(pxsim.pointerEvents.move, this.dontHandleMouseEvent_);
 
@@ -345,19 +212,17 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
             document.addEventListener(pxsim.pointerEvents.leave, this.clearLedDragHandler);
 
             // Begin listening on the canvas and toggle any matches
-            this.elt.addEventListener(pxsim.pointerEvents.move, this.handleRootMouseMoveListener);
+            this.matrixSvg.addEventListener(pxsim.pointerEvents.move, this.handleRootMouseMoveListener);
 
             ev.stopPropagation();
             ev.preventDefault();
             // Clear event listeners and selection used for keyboard navigation.
             this.removeKeyboardFocusHandlers();
-            this.clearSelection();
-            // This enables keyboard navigation in the Blockly workspace if not focused already.
-            (this.sourceBlock_.workspace as Blockly.WorkspaceSvg).markFocused();
+            this.clearCellSelection();
         }, false));
     }
 
-    private toggleRect = (x: number, y: number, value?: boolean) => {
+    protected toggleCell = (x: number, y: number, value?: boolean) => {
         this.cellState[x][y] = value ?? this.currentDragState_;
         this.updateValue();
     }
@@ -381,12 +246,12 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
         const x = target.getAttribute('data-x');
         const y = target.getAttribute('data-y');
         if (x != null && y != null) {
-            this.toggleRect(parseInt(x), parseInt(y));
+            this.toggleCell(parseInt(x), parseInt(y));
         }
     }
 
     private getColor(x: number, y: number) {
-        return this.cellState[x][y] ? this.onColor : (this.offColor || FieldMatrix.DEFAULT_OFF_COLOR);
+        return this.cellState[x][y] ? this.onColor : (this.offColor || FieldLedMatrix.DEFAULT_OFF_COLOR);
     }
 
     private getOpacity(x: number, y: number) {
@@ -404,11 +269,11 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
 
     setValue(newValue: string | number, restoreState = true) {
         super.setValue(String(newValue));
-        if (this.elt) {
+        if (this.matrixSvg) {
             if (restoreState) this.restoreStateFromString();
 
-            for (let x = 0; x < this.matrixWidth; x++) {
-                for (let y = 0; y < this.matrixHeight; y++) {
+            for (let x = 0; x < this.numMatrixCols; x++) {
+                for (let y = 0; y < this.numMatrixRows; y++) {
                     this.updateCell(x, y);
                 }
             }
@@ -421,24 +286,24 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
             return;
         }
 
-        if (!this.elt) {
+        if (!this.matrixSvg) {
             this.initMatrix();
         }
 
         // The height and width must be set by the render function
-        this.size_.height = this.scale * Number(this.matrixHeight) * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_VERTICAL_MARGIN) + FieldMatrix.CELL_VERTICAL_MARGIN * 2 + FieldMatrix.BOTTOM_MARGIN + this.getXAxisHeight()
-        this.size_.width = this.scale * Number(this.matrixWidth) * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_HORIZONTAL_MARGIN) + FieldMatrix.CELL_HORIZONTAL_MARGIN + this.getYAxisWidth();
+        this.size_.height = this.scale * Number(this.numMatrixRows) * (FieldLedMatrix.CELL_WIDTH + FieldLedMatrix.CELL_VERTICAL_MARGIN) + FieldLedMatrix.CELL_VERTICAL_MARGIN * 2 + FieldLedMatrix.BOTTOM_MARGIN + this.getXAxisHeight()
+        this.size_.width = this.scale * Number(this.numMatrixCols) * (FieldLedMatrix.CELL_WIDTH + FieldLedMatrix.CELL_HORIZONTAL_MARGIN) + FieldLedMatrix.CELL_HORIZONTAL_MARGIN + this.getYAxisWidth();
     }
 
     // The return value of this function is inserted in the code
     getValue() {
         // getText() returns the value that is set by calls to setValue()
         let text = removeQuotes(this.value_);
-        return `\`\n${FieldMatrix.TAB}${text}\n${FieldMatrix.TAB}\``;
+        return `\`\n${FieldLedMatrix.TAB}${text}\n${FieldLedMatrix.TAB}\``;
     }
 
     getFieldDescription(): string {
-        return lf("{0}x{1} LED Grid", this.matrixWidth, this.matrixHeight);
+        return lf("{0}x{1} LED Grid", this.numMatrixCols, this.numMatrixRows);
     }
 
     // Restores the block state from the text value of the field
@@ -447,11 +312,11 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
         if (r) {
             const rows = r.split("\n").filter(r => rowRegex.test(r));
 
-            for (let y = 0; y < rows.length && y < this.matrixHeight; y++) {
+            for (let y = 0; y < rows.length && y < this.numMatrixRows; y++) {
                 let x = 0;
                 const row = rows[y];
 
-                for (let j = 0; j < row.length && x < this.matrixWidth; j++) {
+                for (let j = 0; j < row.length && x < this.numMatrixCols; j++) {
                     if (isNegativeCharacter(row[j])) {
                         this.cellState[x][y] = false;
                         x++;
@@ -468,11 +333,11 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
     // Composes the state into a string an updates the field's state
     private updateValue() {
         let res = "";
-        for (let y = 0; y < this.matrixHeight; y++) {
-            for (let x = 0; x < this.matrixWidth; x++) {
+        for (let y = 0; y < this.numMatrixRows; y++) {
+            for (let x = 0; x < this.numMatrixCols; x++) {
                 res += (this.cellState[x][y] ? "#" : ".") + " "
             }
-            res += "\n" + FieldMatrix.TAB
+            res += "\n" + FieldLedMatrix.TAB
         }
 
         // Blockly stores the state of the field as a string
@@ -480,11 +345,11 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
     }
 
     private getYAxisWidth() {
-        return this.yAxisLabel === LabelMode.None ? 0 : FieldMatrix.Y_AXIS_WIDTH;
+        return this.yAxisLabel === LabelMode.None ? 0 : FieldLedMatrix.Y_AXIS_WIDTH;
     }
 
     private getXAxisHeight() {
-        return this.xAxisLabel === LabelMode.None ? 0 : FieldMatrix.X_AXIS_HEIGHT;
+        return this.xAxisLabel === LabelMode.None ? 0 : FieldLedMatrix.X_AXIS_HEIGHT;
     }
 }
 
@@ -507,31 +372,3 @@ function removeQuotes(str: string) {
     }
     return str;
 }
-
-Blockly.Css.register(`
-.blocklyMatrix:focus-visible {
-    outline: none;
-}
-
-.blocklyMatrix .blocklyLedFocusIndicator {
-    border: 4px solid transparent;
-    height: 100%;
-}
-
-.blocklyMatrix .blocklyLedFocusIndicator.selectedLedOn,
-.blocklyMatrix .blocklyLedFocusIndicator.selectedLedOff {
-    border-color: white;
-    transform: translateZ(0);
-}
-
-.blocklyMatrix .blocklyLedFocusIndicator.selectedLedOn:after {
-    content: "";
-    position: absolute;
-    top: -2px;
-    left: -2px;
-    right: -2px;
-    bottom: -2px;
-    border: 2px solid black;
-    border-radius: inherit;
-}
-`)

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -1,0 +1,267 @@
+import * as Blockly from "blockly";
+
+interface MatrixDisplayProps {
+    cellWidth: number;
+    cellHeight: number;
+    cellLabel: string;
+    cellHorizontalMargin: number;
+    cellVerticalMargin: number;
+    cornerRadius: number;
+    cellStroke?: string;
+    cellFill?: string;
+    padLeft?: number;
+    scale?: number;
+}
+
+export abstract class FieldMatrix extends Blockly.Field {
+    protected cells: SVGRectElement[][] = [];
+    protected matrixSvg: SVGSVGElement;
+    private keyDownBinding: Blockly.browserEvents.Data | null = null;
+    private blurBinding: Blockly.browserEvents.Data | null = null;
+    protected selected: [x: number, y: number] | undefined = undefined;
+
+    protected abstract numMatrixCols: number;
+    protected abstract numMatrixRows: number;
+    protected abstract clearSelectionOnBlur: boolean;
+
+    protected createMatrixDisplay({
+        cellWidth,
+        cellHeight,
+        cellLabel,
+        cellHorizontalMargin,
+        cellVerticalMargin,
+        cornerRadius = 0,
+        cellFill,
+        cellStroke,
+        padLeft = 0,
+        scale = 1
+    }: MatrixDisplayProps): void {
+        // Initialize the matrix that holds the state
+        for (let i = 0; i < this.numMatrixCols; i++) {
+            this.cells.push([]);
+        }
+
+        // Create the cells of the matrix that is displayed
+        for (let y = 0; y < this.numMatrixRows; y++) {
+            const row = pxsim.svg.child(this.matrixSvg, "g", { 'role': 'row' });
+            for (let x = 0; x < this.numMatrixCols; x++) {
+                const tx = scale * x * (cellWidth + cellHorizontalMargin) + cellHorizontalMargin + padLeft;
+                const ty = scale * y * (cellHeight + cellVerticalMargin) + cellVerticalMargin;
+
+                const cellG = pxsim.svg.child(row, "g", { transform: `translate(${tx} ${ty})`, 'role': 'gridcell' });
+                const rectOptions = {
+                    'id': `${this.sourceBlock_.id}:${x}${y}`,  // For aria-activedescendant
+                    'aria-label': cellLabel,
+                    'role': 'switch',
+                    'aria-checked': "false",
+                    'width': scale * cellWidth,
+                    'height': scale * cellHeight,
+                    'fill': cellFill ?? "none",
+                    'stroke': cellStroke,
+                    'data-x': x,
+                    'data-y': y,
+                    'rx': Math.max(2, scale * cornerRadius) };
+                const cellRect = pxsim.svg.child(cellG, "rect", rectOptions) as SVGRectElement;
+                this.cells[x][y] = cellRect;
+
+                // Borders and box-shadow do not work in this context and outlines do not follow border-radius.
+                // Stroke is harder to manage given the difference in stroke for a cell when it is toggled.
+                // This foreignObject/div is used to create a focus indicator for the cell when selected via keyboard navigation.
+                const foreignObject = pxsim.svg.child(cellG, "foreignObject", {
+                    transform: 'translate(-4, -4)',
+                    width: scale * cellWidth + 8,
+                    height: scale * cellWidth + 8,
+                });
+                foreignObject.style.pointerEvents = "none";
+                const div = document.createElement("div");
+                div.classList.add("blocklyCellFocusIndicator");
+                div.style.borderRadius = `${Math.max(2, scale * cornerRadius)}px`;
+                foreignObject.append(div);
+            }
+        }
+    }
+
+    protected handleArrowUp(x: number, y: number) {
+        this.selected = [x, y - 1]
+    }
+
+    protected handleArrowDown(x: number, y: number) {
+        this.selected = [x, y + 1]
+    }
+
+    protected handleArrowLeft(x: number, y: number) {
+        if (x !== 0) {
+            this.selected = [x - 1, y]
+        } else if (y !== 0){
+            this.selected = [this.numMatrixCols - 1, y - 1]
+        }
+    }
+
+    protected handleArrowRight(x: number, y: number) {
+        if (x !== this.cells.length - 1) {
+            this.selected = [x + 1, y]
+        } else if (y !== this.numMatrixRows - 1) {
+            this.selected = [0, y + 1]
+        }
+    }
+
+    private addKeyDownHandler() {
+        this.keyDownBinding = Blockly.browserEvents.bind(this.matrixSvg, 'keydown', this, (e: KeyboardEvent) => {
+            if (!this.selected) {
+                return
+            }
+            const [x, y] = this.selected;
+            const ctrlCmd = pxt.BrowserUtils.isMac() ? e.metaKey : e.ctrlKey;
+            switch(e.code) {
+                case "ArrowUp": {
+                    if (y !== 0) {
+                        this.handleArrowUp(x, y);
+                    }
+                    break;
+                }
+                case "ArrowDown": {
+                    if (y !== this.cells[0].length - 1) {
+                        this.handleArrowDown(x, y)
+                    }
+                    break;
+                }
+                case "ArrowLeft": {
+                    this.handleArrowLeft(x, y);
+                    break;
+                }
+                case "ArrowRight": {
+                    this.handleArrowRight(x, y)
+                    break;
+                }
+                case "Home": {
+                    if (ctrlCmd) {
+                        this.selected = [0, 0]
+                    } else {
+                        this.selected = [0, y]
+                    }
+                    break;
+                }
+                case "End": {
+                    if (ctrlCmd) {
+                        this.selected = [this.numMatrixCols - 1, this.numMatrixRows - 1]
+                    } else {
+                        this.selected = [this.numMatrixCols - 1, y]
+                    }
+                    break;
+                }
+                case "Enter":
+                case "Space": {
+                    this.toggleCell(x, y, !this.getCellToggled(x, y));
+                    break;
+                }
+                case "Escape": {
+                    (this.sourceBlock_.workspace as Blockly.WorkspaceSvg).markFocused();
+                    return;
+                }
+                default: {
+                    return
+                }
+            }
+            const [newX, newY] = this.selected;
+            this.focusCell(newX, newY);
+            e.preventDefault();
+            e.stopPropagation();
+        });
+    }
+
+    private addBlurHandler() {
+        this.blurBinding = Blockly.browserEvents.bind(this.matrixSvg, 'blur', this, (_e: FocusEvent) => {
+            if (this.clearSelectionOnBlur) {
+                this.removeKeyboardFocusHandlers();
+                this.clearCellSelection();
+            } else {
+                this.clearFocusIndicator();
+            }
+        });
+    }
+
+    protected focusCell(x: number, y: number) {
+        this.setCellSelection(x, y);
+        this.setFocusIndicator(this.cells[x][y], this.useTwoToneFocusIndicator(x, y));
+    }
+
+    private setCellSelection(x: number, y: number) {
+        this.matrixSvg.setAttribute('aria-activedescendant', this.sourceBlock_.id + `:${x}${y}`);
+    }
+
+    protected clearCellSelection() {
+        if (this.selected) {
+            this.clearFocusIndicator();
+            this.selected = undefined;
+        }
+        this.matrixSvg.removeAttribute('aria-activedescendant');
+    }
+
+    private setFocusIndicator(cell: SVGRectElement, useTwoToneFocusIndicator: boolean) {
+        this.clearFocusIndicator();
+        const className = useTwoToneFocusIndicator ? "focusedTwoTone" : "focused"
+        cell.nextElementSibling.firstElementChild.classList.add(className);
+    }
+
+    protected clearFocusIndicator() {
+        this.cells.forEach(cell => cell.forEach(cell => cell.nextElementSibling.firstElementChild.classList.remove("focusedTwoTone", "focused")));
+    }
+
+    protected attachEventHandlersToMatrix() {
+        if ((this.sourceBlock_.workspace as any).isFlyout) return;
+
+        this.addKeyDownHandler();
+        this.addBlurHandler();
+
+        for (let x = 0; x < this.numMatrixCols; ++x) {
+            for (let y = 0; y < this.numMatrixRows; ++y) {
+                this.attachPointerEventHandlersToCell(x, y, this.cells[x][y]);
+            }
+        }
+    }
+
+    protected removeKeyboardFocusHandlers() {
+        if (this.keyDownBinding) {
+            Blockly.browserEvents.unbind(this.keyDownBinding)
+        }
+        if (this.blurBinding) {
+            Blockly.browserEvents.unbind(this.blurBinding)
+        }
+    }
+
+    protected abstract attachPointerEventHandlersToCell(x: number, y: number, cellRect: SVGElement): void;
+
+    protected abstract useTwoToneFocusIndicator(x: number, y: number): boolean;
+
+    protected abstract toggleCell(x: number, y: number, value?: boolean): void;
+
+    protected abstract getCellToggled(x: number, y: number): boolean;
+}
+
+Blockly.Css.register(`
+    .blocklyMatrix:focus-visible {
+        outline: none;
+    }
+
+    .blocklyMatrix .blocklyCellFocusIndicator {
+        border: 4px solid transparent;
+        height: 100%;
+    }
+
+    .blocklyMatrix:focus-visible .blocklyCellFocusIndicator.focusedTwoTone,
+    .blocklyMatrix:focus-visible .blocklyCellFocusIndicator.focused {
+        border-color: white;
+        transform: translateZ(0);
+    }
+
+    .blocklyMatrix:focus-visible .blocklyCellFocusIndicator.focusedTwoTone:after {
+        content: "";
+        position: absolute;
+        top: -2px;
+        left: -2px;
+        right: -2px;
+        bottom: -2px;
+        border: 2px solid black;
+        border-radius: inherit;
+    }
+`);

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -50,7 +50,7 @@ export abstract class FieldMatrix extends Blockly.Field {
 
                 const cellG = pxsim.svg.child(row, "g", { transform: `translate(${tx} ${ty})`, 'role': 'gridcell' });
                 const rectOptions = {
-                    'id': `${this.sourceBlock_.id}:${x}${y}`,  // For aria-activedescendant
+                    'id': this.getCellId(x,y),  // For aria-activedescendant
                     'aria-label': cellLabel,
                     'role': 'switch',
                     'aria-checked': "false",
@@ -60,7 +60,8 @@ export abstract class FieldMatrix extends Blockly.Field {
                     'stroke': cellStroke,
                     'data-x': x,
                     'data-y': y,
-                    'rx': Math.max(2, scale * cornerRadius) };
+                    'rx': Math.max(2, scale * cornerRadius)
+                };
                 const cellRect = pxsim.svg.child(cellG, "rect", rectOptions) as SVGRectElement;
                 this.cells[x][y] = cellRect;
 
@@ -186,7 +187,7 @@ export abstract class FieldMatrix extends Blockly.Field {
     }
 
     private setCellSelection(x: number, y: number) {
-        this.matrixSvg.setAttribute('aria-activedescendant', this.sourceBlock_.id + `:${x}${y}`);
+        this.matrixSvg.setAttribute('aria-activedescendant', this.getCellId(x, y));
     }
 
     protected clearCellSelection() {
@@ -208,7 +209,7 @@ export abstract class FieldMatrix extends Blockly.Field {
     }
 
     protected attachEventHandlersToMatrix() {
-        if ((this.sourceBlock_.workspace as any).isFlyout) return;
+        if (this.sourceBlock_.isInFlyout) return;
 
         this.addKeyDownHandler();
         this.addBlurHandler();
@@ -228,6 +229,8 @@ export abstract class FieldMatrix extends Blockly.Field {
             Blockly.browserEvents.unbind(this.blurBinding)
         }
     }
+
+    protected getCellId = (x: number, y: number) => `${this.sourceBlock_.id}:${x}-${y}`;
 
     protected abstract attachPointerEventHandlersToCell(x: number, y: number, cellRect: SVGElement): void;
 

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -4,18 +4,19 @@ import * as Blockly from "blockly";
 
 import svg = pxt.svgUtil;
 import { clearDropDownDiv, FieldCustom, FieldCustomOptions, setMelodyEditorOpen } from "./field_utils";
+import { FieldMatrix } from "./field_matrix";
 export const HEADER_HEIGHT = 50;
 export const TOTAL_WIDTH = 300;
 
-export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Field implements FieldCustom {
+export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix implements FieldCustom {
     public isFieldCustom_ = true;
     public SERIALIZABLE = true;
 
     protected params: U;
     private melody: pxtmelody.MelodyArray;
     private soundingKeys: number = 0;
-    private numRow: number = 8;
-    private numCol: number = 8;
+    protected numMatrixRows: number = 8;
+    protected numMatrixCols: number = 8;
     private tempo: number = 120;
     private stringRep: string;
     private isPlaying: boolean = false;
@@ -32,14 +33,14 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
     private playButton: HTMLButtonElement;
     private playIcon: HTMLElement;
     private tempoInput: HTMLInputElement;
+    private firstFocusableElement: HTMLElement | SVGElement;
+    private lastFocusableElement: HTMLElement | SVGElement;
 
     // grid elements
     private static CELL_WIDTH = 25;
-    private static CELL_HORIZONTAL_MARGIN = 7;
-    private static CELL_VERTICAL_MARGIN = 5;
+    private static CELL_HORIZONTAL_MARGIN = 5;
+    private static CELL_VERTICAL_MARGIN = 7;
     private static CELL_CORNER_RADIUS = 5;
-    private elt: SVGSVGElement;
-    private cells: SVGRectElement[][];
     private static VIEWBOX_WIDTH: number;
     private static VIEWBOX_HEIGHT: number;
 
@@ -55,6 +56,9 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
     private toggle: Toggle;
     private root: svg.SVG;
     private gallery: pxtmelody.MelodyGallery;
+    protected clearSelectionOnBlur = false;
+    private matrixFocusBind: Blockly.browserEvents.Data | null = null;
+    private tabKeyBind: Blockly.browserEvents.Data | null = null;
 
     constructor(value: string, params: U, validator?: Blockly.FieldValidator) {
         super(value, validator);
@@ -67,7 +71,8 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
         this.onInit();
     }
 
-    showEditor_() {
+    showEditor_(e?: Event) {
+        const keyboardTriggered = !e;
         // If there is an existing drop-down someone else owns, hide it immediately and clear it.
         Blockly.DropDownDiv.hideWithoutAnimation();
         clearDropDownDiv();
@@ -79,6 +84,10 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
 
         this.gallery = new pxtmelody.MelodyGallery();
         this.renderEditor(contentDiv);
+
+        this.attachEventHandlersToMatrix();
+        this.matrixFocusBind = Blockly.browserEvents.bind(this.matrixSvg, 'focus', this, this.handleMatrixFocus.bind(this));
+        this.tabKeyBind = Blockly.browserEvents.bind(contentDiv, 'keydown', this, this.handleTabKey.bind(this));
 
         this.prevString = this.getValue();
 
@@ -94,6 +103,10 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
 
             setMelodyEditorOpen(this.sourceBlock_, false);
         });
+
+        if (keyboardTriggered) {
+            this.toggle.getRootElement().focus();
+        }
     }
 
     getValue() {
@@ -142,7 +155,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
     render_() {
         super.render_();
         if (!this.invalidString) {
-            this.size_.width = FieldCustomMelody.MUSIC_ICON_WIDTH + (FieldCustomMelody.COLOR_BLOCK_WIDTH + FieldCustomMelody.COLOR_BLOCK_SPACING) * this.numCol;
+            this.size_.width = FieldCustomMelody.MUSIC_ICON_WIDTH + (FieldCustomMelody.COLOR_BLOCK_WIDTH + FieldCustomMelody.COLOR_BLOCK_SPACING) * this.numMatrixCols;
         }
         this.sourceBlock_.setColour("#ffffff");
     }
@@ -166,8 +179,10 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
                 this.showGallery();
             }
         });
+        this.firstFocusableElement = this.toggle.getRootElement();
+
         this.toggle.layout();
-        this.toggle.translate((TOTAL_WIDTH - this.toggle.width()) / 2, 0);
+        this.toggle.translate((TOTAL_WIDTH - this.toggle.width()) / 2, TOGGLE_PADDING_TOP);
 
         div.appendChild(this.topDiv);
         div.appendChild(this.gallery.getElement());
@@ -187,6 +202,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
         this.doneButton.innerText = lf("Done");
         this.doneButton.addEventListener("click", () => this.onDone());
         this.doneButton.style.setProperty("background-color", color);
+        this.lastFocusableElement = this.doneButton;
 
         this.playButton = document.createElement("button");
         this.playButton.id = "melody-play-button";
@@ -219,6 +235,14 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
         if (this.gallery) {
             this.gallery.stopMelody();
         }
+        if (this.matrixFocusBind) {
+            Blockly.browserEvents.unbind(this.matrixFocusBind)
+        }
+        if (this.tabKeyBind) {
+            Blockly.browserEvents.unbind(this.tabKeyBind)
+        }
+        this.clearCellSelection();
+        this.removeKeyboardFocusHandlers();
         this.clearDomReferences();
 
         if (this.sourceBlock_ && Blockly.Events.isEnabled() && this.getValue() !== this.prevString) {
@@ -232,7 +256,6 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
     // when click done
     private onDone() {
         Blockly.DropDownDiv.hideIfOwner(this);
-        this.onEditorClose();
     }
 
     private clearDomReferences() {
@@ -244,10 +267,12 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
         this.playButton = null;
         this.playIcon = null;
         this.tempoInput = null;
-        this.elt = null;
-        this.cells = null;
+        this.matrixSvg = null;
+        this.cells = [];
         this.toggle = null;
         this.root = null;
+        this.firstFocusableElement = null;
+        this.lastFocusableElement = null;
         this.gallery.clearDomReferences();
     }
 
@@ -423,25 +448,35 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
         return false;
     }
 
-    private onNoteSelect(row: number, col: number): void {
+    protected toggleCell(x: number, y: number): void {
+        const [row, column] = [y, x];
         // update melody array
         this.invalidString = null;
-        this.melody.updateMelody(row, col);
+        this.melody.updateMelody(row, column);
 
-        if (this.melody.getValue(row, col) && !this.isPlaying) {
-            this.playNote(row, col);
+        if (this.melody.getValue(row, column) && !this.isPlaying) {
+            this.playNote(row, column);
         }
 
         this.updateGrid();
         this.updateFieldLabel();
     }
 
+    protected getCellToggled(x: number, y: number): boolean {
+        const [row, column] = [y, x];
+        return this.melody.getValue(row, column);
+    }
+
+    protected useTwoToneFocusIndicator(_x: number, _y: number): boolean {
+        return true;
+    }
+
     private updateGrid() {
-        for (let row = 0; row < this.numRow; row++) {
+        for (let row = 0; row < this.numMatrixRows; row++) {
             const rowClass = pxtmelody.getColorClass(row);
 
-            for (let col = 0; col < this.numCol; col++) {
-                const cell = this.cells[row][col];
+            for (let col = 0; col < this.numMatrixCols; col++) {
+                const cell = this.cells[col][row];
 
                 if (this.melody.getValue(row, col)) {
                     pxt.BrowserUtils.removeClass(cell, "melody-default");
@@ -481,7 +516,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
             ++this.soundingKeys;
             pxt.AudioContextManager.stop();
 
-            for (let i = 0; i < this.numRow; i++) {
+            for (let i = 0; i < this.numMatrixRows; i++) {
                 if (this.melody.getValue(i, column)) {
                     this.playToneCore(i);
                 }
@@ -518,7 +553,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
     }
 
     private highlightColumn(col: number, on: boolean) {
-        const cells = this.cells.map(row => row[col]);
+        const cells = this.cells[col];
 
         cells.forEach(cell => {
             if (on) pxt.BrowserUtils.addClass(cell, "playing")
@@ -527,52 +562,90 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
     }
 
     private createGridDisplay(): SVGSVGElement {
-        FieldCustomMelody.VIEWBOX_WIDTH = (FieldCustomMelody.CELL_WIDTH + FieldCustomMelody.CELL_VERTICAL_MARGIN) * this.numCol + FieldCustomMelody.CELL_VERTICAL_MARGIN;
+        FieldCustomMelody.VIEWBOX_WIDTH = (FieldCustomMelody.CELL_WIDTH + FieldCustomMelody.CELL_HORIZONTAL_MARGIN) * this.numMatrixCols + FieldCustomMelody.CELL_HORIZONTAL_MARGIN;
         if (pxt.BrowserUtils.isEdge()) FieldCustomMelody.VIEWBOX_WIDTH += 37;
-        FieldCustomMelody.VIEWBOX_HEIGHT = (FieldCustomMelody.CELL_WIDTH + FieldCustomMelody.CELL_HORIZONTAL_MARGIN) * this.numRow + FieldCustomMelody.CELL_HORIZONTAL_MARGIN;
-        this.elt = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" class="melody-grid-div" viewBox="0 0 ${FieldCustomMelody.VIEWBOX_WIDTH} ${FieldCustomMelody.VIEWBOX_HEIGHT}"/>`);
+        FieldCustomMelody.VIEWBOX_HEIGHT = (FieldCustomMelody.CELL_WIDTH + FieldCustomMelody.CELL_VERTICAL_MARGIN) * this.numMatrixRows + FieldCustomMelody.CELL_VERTICAL_MARGIN;
+        this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" class="melody-grid-div blocklyMatrix" role="grid"  aria-label="${lf("Melody grid")}" viewBox="0 0 ${FieldCustomMelody.VIEWBOX_WIDTH} ${FieldCustomMelody.VIEWBOX_HEIGHT}" tabindex="0" />`);
 
-        // Create the cells of the matrix that is displayed
-        this.cells = []; // initialize array that holds rect svg elements
-        for (let i = 0; i < this.numRow; i++) {
-            this.cells.push([]);
-        }
-        for (let i = 0; i < this.numRow; i++) {
-            for (let j = 0; j < this.numCol; j++) {
-                this.createCell(i, j);
-            }
-        }
-        return this.elt;
+        this.createMatrixDisplay({
+            cellWidth: FieldCustomMelody.CELL_WIDTH,
+            cellHeight: FieldCustomMelody.CELL_WIDTH,
+            cellLabel: lf("Note"),
+            cellStroke: "white",
+            cellHorizontalMargin: FieldCustomMelody.CELL_HORIZONTAL_MARGIN,
+            cellVerticalMargin: FieldCustomMelody.CELL_VERTICAL_MARGIN,
+            cornerRadius: FieldCustomMelody.CELL_CORNER_RADIUS,
+        });
+
+        this.updateGrid();
+        return this.matrixSvg;
     }
 
-    private createCell(x: number, y: number) {
-        const tx = x * (FieldCustomMelody.CELL_WIDTH + FieldCustomMelody.CELL_HORIZONTAL_MARGIN) + FieldCustomMelody.CELL_HORIZONTAL_MARGIN;
-        const ty = y * (FieldCustomMelody.CELL_WIDTH + FieldCustomMelody.CELL_VERTICAL_MARGIN) + FieldCustomMelody.CELL_VERTICAL_MARGIN;
+    private handleMatrixFocus(_e: FocusEvent) {
+        if (!this.selected) {
+            const startNote = this.getMelodyNote(0) ?? 0;
+            this.selected = [0, startNote];
+        }
+        const [x, y] = this.selected;
+        this.focusCell(x, y);
+    }
 
-        const cellG = pxsim.svg.child(this.elt, "g", { transform: `translate(${ty} ${tx})` }) as SVGGElement;
-        const cellRect = pxsim.svg.child(cellG, "rect", {
-            'cursor': 'pointer',
-            'width': FieldCustomMelody.CELL_WIDTH,
-            'height': FieldCustomMelody.CELL_WIDTH,
-            'stroke': 'white',
-            'data-x': x,
-            'data-y': y,
-            'rx': FieldCustomMelody.CELL_CORNER_RADIUS
-        }) as SVGRectElement;
+    // Used for focus trap
+    private handleTabKey(e: KeyboardEvent) {
+        if (e.code === "Tab") {
+            if (document.activeElement === this.lastFocusableElement && !e.shiftKey) {
+                this.firstFocusableElement.focus();
+                e.preventDefault();
+            } else if (document.activeElement === this.firstFocusableElement && e.shiftKey) {
+                this.lastFocusableElement.focus();
+                e.preventDefault();
+            }
+        }
+    }
 
-        // add appropriate class so the cell has the correct fill color
-        if (this.melody.getValue(x, y)) pxt.BrowserUtils.addClass(cellRect, pxtmelody.getColorClass(x));
-        else pxt.BrowserUtils.addClass(cellRect, "melody-default");
-
-        if ((this.sourceBlock_.workspace as any).isFlyout) return;
-
+    protected attachPointerEventHandlersToCell(x: number, y: number, cellRect: SVGElement) {
         pxsim.pointerEvents.down.forEach(evid => cellRect.addEventListener(evid, (ev: MouseEvent) => {
-            this.onNoteSelect(x, y);
+            this.toggleCell(x, y);
+            this.clearFocusIndicator();
             ev.stopPropagation();
             ev.preventDefault();
         }, false));
+    }
 
-        this.cells[x][y] = cellRect;
+    protected override handleArrowUp(x: number, y: number) {
+        const hasNote = this.getMelodyNote(x) !== undefined;
+        this.selected = [x, y - 1]
+        if (hasNote) {
+            this.toggleCell(this.selected[0], this.selected[1]);
+        }
+    }
+    protected override handleArrowDown(x: number, y: number) {
+        const hasNote = this.getMelodyNote(x) !== undefined;
+        this.selected = [x, y + 1]
+        if (hasNote) {
+            this.toggleCell(this.selected[0], this.selected[1]);
+        }
+    }
+
+    protected override handleArrowLeft(x: number, y: number) {
+        const newX = (x + this.numMatrixCols - 1) % this.numMatrixCols;
+        const existingY = this.getMelodyNote(newX) ?? y;
+        this.selected = [newX, existingY]
+    }
+
+    protected override handleArrowRight(x: number, y: number) {
+        const newX = (x + this.numMatrixCols + 1) % this.numMatrixCols;
+        const existingY = this.getMelodyNote(newX) ?? y;
+        this.selected = [newX, existingY]
+    }
+
+    private getMelodyNote(col: number) {
+        for (let i = 0; i < this.numMatrixRows; ++i) {
+            if (this.melody.getValue(i, col)) {
+                return i;
+            }
+        }
+        return undefined;
     }
 
     private togglePlay() {
@@ -599,11 +672,11 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
 
     private playMelody() {
         if (this.isPlaying) {
-            for (let i = 0; i < this.numCol; i++) {
+            for (let i = 0; i < this.numMatrixCols; i++) {
                 this.queueToneForColumn(i, i * this.getDuration(), this.getDuration());
             }
             this.timeouts.push(setTimeout( // call the melody again after it finishes
-                () => this.playMelody(), (this.numCol) * this.getDuration()));
+                () => this.playMelody(), (this.numMatrixCols) * this.getDuration()));
         } else {
             this.stopMelody();
         }
@@ -625,16 +698,20 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends Blockly.Fie
         this.gallery.show((result: string) => {
             if (result) {
                 this.melody.parseNotes(result);
-                this.gallery.hide();
                 this.toggle.toggle();
+                this.toggle.getRootElement().focus();
                 this.updateFieldLabel();
                 this.updateGrid();
             }
         });
+
+        this.lastFocusableElement = this.gallery.getLastFocusableElement();
     }
+
 
     private hideGallery() {
         this.gallery.hide();
+        this.lastFocusableElement = this.doneButton;
     }
 }
 
@@ -648,10 +725,7 @@ const TOGGLE_WIDTH = 200;
 const TOGGLE_HEIGHT = 40;
 const TOGGLE_BORDER_WIDTH = 2;
 const TOGGLE_CORNER_RADIUS = 4;
-
-const BUTTON_CORNER_RADIUS = 2;
-const BUTTON_BORDER_WIDTH = 1;
-const BUTTON_BOTTOM_BORDER_WIDTH = 2;
+const TOGGLE_PADDING_TOP = 6;
 
 interface ToggleProps {
     baseColor: string;
@@ -769,6 +843,14 @@ class Toggle {
         this.rightElement.appendChild(this.rightText);
 
         this.root.onClick(() => this.toggle());
+        this.root.el.tabIndex = 0;
+        this.root.el.classList.add("melody-editor-toggle-buttons");
+        this.root.el.addEventListener("keydown", (e) => {
+            if (["Space", "ArrowLeft", "ArrowRight", "Enter"].includes(e.code)) {
+                this.toggle();
+                e.preventDefault();
+            }
+        });
     }
 
     toggle(quiet = false) {
@@ -811,6 +893,10 @@ class Toggle {
 
     width() {
         return TOGGLE_WIDTH;
+    }
+
+    getRootElement() {
+        return this.root.el;
     }
 }
 

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -448,8 +448,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
         return false;
     }
 
-    protected toggleCell(x: number, y: number): void {
-        const [row, column] = [y, x];
+    protected toggleCell(column: number, row: number): void {
         // update melody array
         this.invalidString = null;
         this.melody.updateMelody(row, column);
@@ -462,8 +461,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
         this.updateFieldLabel();
     }
 
-    protected getCellToggled(x: number, y: number): boolean {
-        const [row, column] = [y, x];
+    protected getCellToggled(column: number, row: number): boolean {
         return this.melody.getValue(row, column);
     }
 
@@ -565,7 +563,8 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
         FieldCustomMelody.VIEWBOX_WIDTH = (FieldCustomMelody.CELL_WIDTH + FieldCustomMelody.CELL_HORIZONTAL_MARGIN) * this.numMatrixCols + FieldCustomMelody.CELL_HORIZONTAL_MARGIN;
         if (pxt.BrowserUtils.isEdge()) FieldCustomMelody.VIEWBOX_WIDTH += 37;
         FieldCustomMelody.VIEWBOX_HEIGHT = (FieldCustomMelody.CELL_WIDTH + FieldCustomMelody.CELL_VERTICAL_MARGIN) * this.numMatrixRows + FieldCustomMelody.CELL_VERTICAL_MARGIN;
-        this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" class="melody-grid-div blocklyMatrix" role="grid"  aria-label="${lf("Melody grid")}" viewBox="0 0 ${FieldCustomMelody.VIEWBOX_WIDTH} ${FieldCustomMelody.VIEWBOX_HEIGHT}" tabindex="0" />`);
+        this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" class="melody-grid-div blocklyMatrix" role="grid" viewBox="0 0 ${FieldCustomMelody.VIEWBOX_WIDTH} ${FieldCustomMelody.VIEWBOX_HEIGHT}" tabindex="0" />`);
+        this.matrixSvg.ariaLabel =  lf("Melody grid");
 
         this.createMatrixDisplay({
             cellWidth: FieldCustomMelody.CELL_WIDTH,

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -13,7 +13,7 @@ import { initLoops } from "./builtins/loops";
 import { initText } from "./builtins/text";
 import { createToolboxBlock, isArrayType } from "./toolbox";
 import { mkCard } from "./help";
-import { FieldMatrix } from "./fields";
+import { FieldLedMatrix } from "./fields";
 import { FieldStyledLabel } from "./fields";
 import { FieldUserEnum } from "./fields";
 import { createFieldEditor, initFieldEditors } from "./fields";
@@ -314,7 +314,7 @@ function initBlock(block: Blockly.Block, info: pxtc.BlocksInfo, fn: pxtc.SymbolI
         const onColor = fn.attributes.gridLiteralOnColor;
         const offColor = fn.attributes.gridLiteralOffColor;
         let ri = block.appendDummyInput();
-        ri.appendField(new FieldMatrix("", { columns, rows, scale, onColor, offColor }), "LEDS");
+        ri.appendField(new FieldLedMatrix("", { columns, rows, scale, onColor, offColor }), "LEDS");
     }
 
     if (fn.attributes.inlineInputMode === "external") {

--- a/pxtlib/melody-editor/melodyGallery.ts
+++ b/pxtlib/melody-editor/melodyGallery.ts
@@ -64,20 +64,20 @@ namespace pxtmelody {
             const [x, y] = this.selectedColRow;
             switch(e.code) {
                 case "ArrowUp": {
-                    this.selectedColRow = [x, y === 0 ? 0 : y - 1];
+                    this.selectedColRow = [x, Math.max(0, y - 1)];
                     break;
                 }
                 case "ArrowDown": {
-                    this.selectedColRow = [x, y === this.selectionButtons.length -1 ? y : y + 1];
+                    this.selectedColRow = [x, Math.min(this.selectionButtons.length - 1, y + 1)];
                     break;
                 }
                 case "ArrowLeft": {
-                    this.selectedColRow = [x === 0 ? 0 : x - 1, y];
+                    this.selectedColRow = [Math.max(0, x - 1), y];
                     break;
                 }
                 case "ArrowRight": {
                     // Only two columns.
-                    this.selectedColRow = [x === 1 ? 1 : x + 1, y];
+                    this.selectedColRow = [Math.min(1, x + 1), y];
                     break;
                 }
                 case "Enter":
@@ -99,7 +99,7 @@ namespace pxtmelody {
                 this.selectedElement = this.previewButtons[newY]
             }
             this.selectedElement.classList.add("selected");
-            this.contentDiv.setAttribute("aria-activedescendant", `:${newY}-${newX === 0 ? "selection" : "preview"}`);
+            this.contentDiv.setAttribute("aria-activedescendant", getCellId(newX, newY));
 
             const containerRect = this.contentDiv.getBoundingClientRect();
             const selectedElementRect = this.selectedElement.getBoundingClientRect()
@@ -120,7 +120,7 @@ namespace pxtmelody {
             }
             this.selectedElement.classList.add("selected");
             const [x, y] = this.selectedColRow;
-            this.contentDiv.setAttribute("aria-activedescendant", `:${x}-${y === 0 ? "selection" : "preview"}`);
+            this.contentDiv.setAttribute("aria-activedescendant", getCellId(x, y));
         }
 
         blurListener(_e: FocusEvent) {
@@ -252,7 +252,7 @@ namespace pxtmelody {
                 role: "menuitem",
                 title: sample.name,
                 tabIndex: -1,
-                id: `:${i}-selection`
+                id: getCellId(i, 0)
             }, () => this.handleSelection(sample))
 
             leftButton.appendChild(icon);
@@ -268,7 +268,7 @@ namespace pxtmelody {
                 role: "menuitem",
                 title: lf("Preview {0}", sample.name),
                 tabIndex: -1,
-                id: `:${i}-preview`
+                id: getCellId(i,1)
             }, () => this.togglePlay(sample, i));
 
             const playIcon = mkElement("i", {
@@ -412,3 +412,5 @@ namespace pxtmelody {
         return el;
     }
 }
+
+const getCellId = (x: number, y: number) => `:${x}-${y === 0 ? "selection" : "preview"}`;

--- a/theme/melodyeditor.less
+++ b/theme/melodyeditor.less
@@ -16,13 +16,15 @@
 }
 
 #melody-editor-header-controls {
-    height: 40px;
+    height: 52px;
+    display: block;
 }
 
 .melody-grid-div {
     margin: 10px 20px 0px;
     text-align: center;
     background-color: inherit;
+    outline: none;
 }
 
 .cell {
@@ -32,7 +34,6 @@
 }
 
 .melody-top-bar-div {
-    padding: 6px 0px 0px 0px;
     float: center;
     text-align: center;
 }
@@ -66,6 +67,7 @@
     padding: 0.75rem;
     background: #4f0643;
     max-height: 350px;
+    outline: none;
 }
 
 .melody-gallery-button {
@@ -106,15 +108,30 @@
     border-top: 1px #ffffff solid;
 }
 
+.melody-editor-toggle-buttons {
+    outline: none;
+}
+
+.melody-editor-toggle-buttons:focus-visible {
+    outline: 3px solid white;
+    border-radius: 2px;
+}
+
 .melody-editor-button {
     background-color: #dcdcdc;
     color: rgb(0, 0, 0, 0.6);
 
     transition: color .1s, background-color .1s;
 }
+
 .melody-editor-button:hover {
     background-color: #cacbcd;
     color: rgb(0, 0, 0, 0.8);
+}
+
+.melody-editor-button.selected {
+    outline: 3px solid var(--pxt-focus-border);
+    outline-offset: -5px;
 }
 
 .melody-editor-button.right-button .icon {
@@ -142,10 +159,6 @@
 .melody-confirm-button:hover {
     background-color: #9e0986;
     border: 1px solid #e30fc0;
-}
-
-.melody-confirm-button:focus {
-    outline: none !important;
 }
 
 .melody-editor-text {
@@ -207,8 +220,8 @@
     border: 1px solid #7f8c8d;
 }
 
-#melody-play-button:focus {
-    outline: none !important;
+.melody-bottom-bar-div button:focus-visible {
+    outline: 3px solid white;
 }
 
 .melody-bottom-bar-div {


### PR DESCRIPTION
**Demo link** https://melodysandbox-keyboard-acces.review-pxt.pages.dev/

This makes the MelodySandbox and gallery easily navigable with the keyboard, including
* keyboard handling
* Tab and arrow key navigation as appropriate and with reference to WAI-ARIA including role information.
* visible focus highlighting
* keyboard focus trapping while working in the editor

Architecturally, it now shares common code with the LED matrix field, to facilitate consistent changes across accessible matrix elements.

https://github.com/user-attachments/assets/c3c9ede7-6ed4-4fde-b6e9-a9dc22bc082f

### Melody Editor interaction changes

The melody editor is a single tab stop, navigating with the arrow keys following the WAI-ARIA grid pattern. Up and down arrow keys immediately change the pitch of a note if it is enabled, space enables or disables the note on a given column. We tried several approaches and sought feedback from our accessibility advisor, and this was the most intuitive and playful.

### Gallery interaction changes

The gallery is also in a grid pattern, and behaves similarly. It is a single tab stop with arrow navigation for selecting or previewing a note, and space to select.

Both the editor and gallery screens make use of a keyboard focus trap to ensure tabbing behaviour is consistent while using the component.

### Common matrix refactor

There is now an abstract `field_matrix` from which `field_ledmatrix` and `field_melodySandbox` inherit to extend their own matrix interfaces. Many of the accessibility changes were being duplicated across both elements, such that sharing the common concerns made sense.