### PR TITLE
Remove boardview tab stop when simulator is fullscreen

### DIFF
--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -247,7 +247,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
             {hasSimulator && <div id="editorSidebar" className={editorSidebarClassName} style={!this.props.tutorialSimSidebar ? { height: editorSidebarHeight } : undefined}>
                 <div className={simContainerClassName}>
                     <div className={`ui items simPanel ${showHostMultiplayerGameButton ? "multiplayer-preview" : ""}`} ref={this.handleSimPanelRef}>
-                        <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
+                        <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={(inHome || parent.state.fullscreen) ? -1 : 0} />
                         {showHostMultiplayerGameButton && <div className="ui item grid centered portrait multiplayer-presence">
                             <SimulatorPresenceBar />
                         </div>}


### PR DESCRIPTION
Approach to fixing https://github.com/microsoft/pxt-microbit/issues/6208

Can't think of a need for having a tab stop for board view when the simulator is full screen so I have removed it in this PR. Open for change if we think it is better to have a tab stop for board view in which case I can make the focus ring clearer when focus is at board view.

Try it out here: https://sim-fullscreen-tabstop.review-pxt.pages.dev/#editor