### PR TITLE
store block param localization in translation cache

### DIFF
--- a/pxtblocks/plugins/functions/fields/fieldArgumentReporter.ts
+++ b/pxtblocks/plugins/functions/fields/fieldArgumentReporter.ts
@@ -2,20 +2,25 @@ import * as Blockly from "blockly";
 import { isFunctionArgumentReporter } from "../utils";
 import { ArgumentReporterBlock } from "../blocks/argumentReporterBlocks";
 
+let localizeFunction: (arg: FieldArgumentReporter, block: ArgumentReporterBlock) => string;
+
 export class FieldArgumentReporter extends Blockly.FieldLabelSerializable {
     protected override getDisplayText_(): string {
         const source = this.getSourceBlock();
-        if (source && isFunctionArgumentReporter(source)) {
-            const localizeKey = (source as ArgumentReporterBlock).getLocalizationName();
+        if (source && isFunctionArgumentReporter(source) && localizeFunction) {
+            const localized = localizeFunction(this, source as ArgumentReporterBlock);
 
-            const localized = localizeKey && pxt.U.rlf(localizeKey);
-            if (localized && localized !== localizeKey) {
+            if (localized) {
                 return localized;
             }
         }
 
         return super.getDisplayText_();
     }
+}
+
+export function setArgumentReporterLocalizeFunction(func: (arg: FieldArgumentReporter, block: ArgumentReporterBlock) => string) {
+    localizeFunction = func;
 }
 
 Blockly.registry.register(Blockly.registry.Type.FIELD, "field_argument_reporter", FieldArgumentReporter);

--- a/pxtblocks/plugins/functions/utils.ts
+++ b/pxtblocks/plugins/functions/utils.ts
@@ -278,7 +278,7 @@ export function doArgumentReporterDragChecks(a: Blockly.RenderedConnection, b: B
     return !!(getArgumentReporterParent(draggedBlock, destinationBlock));
 }
 
-function getArgumentReporterParent(reporter: Blockly.Block, location: Blockly.Block): Blockly.Block | undefined {
+export function getArgumentReporterParent(reporter: Blockly.Block, location: Blockly.Block): Blockly.Block | undefined {
     pxt.U.assert(isFunctionArgumentReporter(reporter));
 
     const varName = reporter.getFieldValue("VALUE");


### PR DESCRIPTION
in my earlier callback param localization pr, i mistakenly assumed that all block translation keys were included in the lookup table for `rlf()`. well, turns out they aren't, instead they get crammed into the symbol info of the corresponding function. that doesn't quite work for my scenario since i need them to be globally available

this pr works around that issue by storing them in our global translation cache. while i was fixing this, i also went ahead and did a little refactor to reduce the coupling between the plugin and pxt and also added some logic to lookup the translation for the containing block which fixes the issue i mentioned [here](https://github.com/microsoft/pxt/pull/10567#issuecomment-2860481254)