### PR TITLE
Music blocks rtl fixes

### DIFF
--- a/pxtlib/melody-editor/melodyGallery.ts
+++ b/pxtlib/melody-editor/melodyGallery.ts
@@ -62,6 +62,8 @@ namespace pxtmelody {
                 return;
             }
             const [x, y] = this.selectedColRow;
+            const arrowToSelection = pxt.Util.isUserLanguageRtl() ? "ArrowRight" : "ArrowLeft";
+            const arrowToPreview = pxt.Util.isUserLanguageRtl() ? "ArrowLeft" : "ArrowRight";
             switch(e.code) {
                 case "ArrowUp": {
                     this.selectedColRow = [x, Math.max(0, y - 1)];
@@ -71,11 +73,11 @@ namespace pxtmelody {
                     this.selectedColRow = [x, Math.min(this.selectionButtons.length - 1, y + 1)];
                     break;
                 }
-                case "ArrowLeft": {
+                case arrowToSelection: {
                     this.selectedColRow = [Math.max(0, x - 1), y];
                     break;
                 }
-                case "ArrowRight": {
+                case arrowToPreview: {
                     // Only two columns.
                     this.selectedColRow = [Math.min(1, x + 1), y];
                     break;

--- a/react-common/components/controls/DraggableGraph.tsx
+++ b/react-common/components/controls/DraggableGraph.tsx
@@ -173,6 +173,8 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
                     !isNotLast && getValue(index - 1) > getValue(index)
                 );
 
+                const textAnchor = (isNotLast !== pxt.Util.isUserLanguageRtl()) ? "start" : "end"
+
                 return <g key={index} className="draggable-graph-column">
                         {isNotLast &&
                             <path
@@ -216,7 +218,7 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
                             className="common-draggable-graph-text"
                             x={isNotLast ? x + unit * 2 : x - unit}
                             y={shouldFlipLabel ? y + unit * 2 : Math.max(y - unit, unit)}
-                            textAnchor={isNotLast ? "start" : "end"}
+                            textAnchor={textAnchor}
                             fontSize={unit}>
                             {Math.round(getValue(index)) + (valueUnits || "")}
                         </text>

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -202,6 +202,12 @@
     }
 }
 
+.rtl .common-button.sound-effect-play-button {
+    .fas.fa-play, .fas.fa-stop {
+        margin: 0 0.25rem 0 0;
+    }
+}
+
 .common-button.sound-effect-play-button:focus-visible {
     outline: 3px solid var(--pxt-focus-border);
     outline-offset: 3px;

--- a/webapp/src/components/soundEffectEditor/SoundGallery.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundGallery.tsx
@@ -43,6 +43,8 @@ export const SoundGallery = (props: SoundGalleryProps) => {
         next: number,
         current: number,
         e: React.KeyboardEvent<HTMLElement>) => {
+        const arrowToSelection = pxt.Util.isUserLanguageRtl() ? "ArrowRight" : "ArrowLeft";
+        const arrowToPreview = pxt.Util.isUserLanguageRtl() ? "ArrowLeft" : "ArrowRight";
         switch(e.code) {
             case "ArrowDown":
                 selectedCoord.current.row = next;
@@ -50,10 +52,10 @@ export const SoundGallery = (props: SoundGalleryProps) => {
             case "ArrowUp":
                 selectedCoord.current.row = prev;
                 break;
-            case "ArrowLeft":
+            case arrowToSelection:
                 selectedCoord.current.col = "select";
                 break;
-            case "ArrowRight":
+            case arrowToPreview:
                 selectedCoord.current.col = "preview";
                 break;
             case "Space":


### PR DESCRIPTION
**Live demo:** https://music-blocks-rtl-fixes.review-pxt.pages.dev/

Multiple issues found while testing in Arabic

**Gallery views**

For the Sound Effect and Melody editors, both their gallery views have the left and right arrow keys reversed.

**Text anchoring issues in Sound Effect editor**

Draggable graphs, before:
![image](https://github.com/user-attachments/assets/a90a1c06-dd35-4051-913d-de78cbd4217b)

After:
<img width="111" alt="image" src="https://github.com/user-attachments/assets/f85ee476-f4f3-49c9-b903-a8ee8059eba4" />

Play button before:
![image](https://github.com/user-attachments/assets/a77874fd-ce61-4c44-aa23-a92c5af00303)

After:
<img width="49" alt="image" src="https://github.com/user-attachments/assets/63276b67-d6e0-4871-9988-af678be0710f" />