### PR TITLE
fix a couple of block rendering bugs

### DIFF
--- a/pxtblocks/compiler/compiler.ts
+++ b/pxtblocks/compiler/compiler.ts
@@ -239,13 +239,25 @@ function blockKey(b: Blockly.Block) {
     };
 }
 
+export const AUTO_DISABLED_REASON = "pxt_automatic_disabled";
+
 function setChildrenEnabled(block: Blockly.Block, enabled: boolean) {
-    block.setEnabled(enabled);
+    block.setDisabledReason(!enabled, AUTO_DISABLED_REASON);
     // propagate changes
     const children = block.getDescendants(false);
     for (const child of children) {
-        child.setEnabled(enabled);
+        child.setDisabledReason(!enabled, AUTO_DISABLED_REASON);
     }
+}
+
+function clearDisabled(block: Blockly.Block) {
+    block.setDisabledReason(false, AUTO_DISABLED_REASON);
+
+    // for legacy projects, the disabled reason will be MANUALLY_DISABLED
+    block.setDisabledReason(false, Blockly.constants.MANUALLY_DISABLED);
+
+    // this is the reason for blocks that are disabled via Blockly.Events.disableOrphans
+    block.setDisabledReason(false, "ORPHANED_BLOCK");
 }
 
 function updateDisabledBlocks(e: Environment, allBlocks: Blockly.Block[], topBlocks: Blockly.Block[]) {
@@ -257,7 +269,7 @@ function updateDisabledBlocks(e: Environment, allBlocks: Blockly.Block[], topBlo
     }
 
     // unset disabled
-    allBlocks.forEach(b => b.setEnabled(true));
+    allBlocks.forEach(clearDisabled);
 
     // update top blocks
     const events: pxt.Map<Blockly.Block> = {};
@@ -297,6 +309,13 @@ function updateDisabledBlocks(e: Environment, allBlocks: Blockly.Block[], topBlo
 
     if (eventsEnabled) {
         Blockly.Events.enable();
+    }
+}
+
+export function updateDisabledOnDrag(workspace: Blockly.WorkspaceSvg) {
+    for (const block of workspace.getTopBlocks(false)) {
+        if (block.hasDisabledReason(AUTO_DISABLED_REASON)) continue;
+        setChildrenEnabled(block, true);
     }
 }
 

--- a/pxtblocks/compiler/compiler.ts
+++ b/pxtblocks/compiler/compiler.ts
@@ -312,13 +312,6 @@ function updateDisabledBlocks(e: Environment, allBlocks: Blockly.Block[], topBlo
     }
 }
 
-export function updateDisabledOnDrag(workspace: Blockly.WorkspaceSvg) {
-    for (const block of workspace.getTopBlocks(false)) {
-        if (block.hasDisabledReason(AUTO_DISABLED_REASON)) continue;
-        setChildrenEnabled(block, true);
-    }
-}
-
 function compileStatementBlock(e: Environment, b: Blockly.Block): pxt.blocks.JsNode[] {
     if (b.isInsertionMarker()) {
         // Must have accidentally triggered a compile during a block drag

--- a/pxtblocks/diff.ts
+++ b/pxtblocks/diff.ts
@@ -77,6 +77,8 @@ function logger() {
 
 }
 
+const DIFF_DISABLED_REASON = "disabled_for_diff";
+
 function diffWorkspaceNoEvents(oldWs: Blockly.Workspace, newWs: Blockly.Workspace, options?: DiffOptions): DiffResult {
     pxt.tickEvent("blocks.diff", { started: 1 })
     options = options || {};
@@ -163,7 +165,7 @@ function diffWorkspaceNoEvents(oldWs: Blockly.Workspace, newWs: Blockly.Workspac
             done(b);
             const b2 = cloneIntoDiff(b);
             done(b2);
-            b2.setEnabled(false);
+            b2.setDisabledReason(true, DIFF_DISABLED_REASON);
         });
         logTodo('deleted top')
     }
@@ -272,7 +274,7 @@ function diffWorkspaceNoEvents(oldWs: Blockly.Workspace, newWs: Blockly.Workspac
     function stitch(b: Blockly.Block) {
         log(`stitching ${b.toDevString()}->${dids[b.id]}`)
         const wb = ws.getBlockById(dids[b.id]);
-        wb.setEnabled(false);
+        wb.setDisabledReason(true, DIFF_DISABLED_REASON);
         markUsed(wb);
         done(wb);
         // connect previous connection to delted or existing block

--- a/pxtblocks/plugins/renderer/pathObject.ts
+++ b/pxtblocks/plugins/renderer/pathObject.ts
@@ -17,6 +17,13 @@ export class PathObject extends Blockly.zelos.PathObject {
 
     protected connectionPointIndicators = new WeakMap<Blockly.RenderedConnection, SVGElement>();
 
+    override setPath(pathString: string): void {
+        super.setPath(pathString);
+        if (this.svgPathHighlighted) {
+            this.svgPathHighlighted.setAttribute('d', pathString);
+        }
+    }
+
 
     override updateHighlighted(enable: boolean) {
         // this.setClass_('blocklySelected', enable);
@@ -165,13 +172,6 @@ export class PathObject extends Blockly.zelos.PathObject {
 
     isHighlighted() {
         return !!this.svgPathHighlighted;
-    }
-
-    resizeHighlight() {
-        if (this.svgPathHighlighted) {
-            this.updateHighlighted(false);
-            this.updateHighlighted(true);
-        }
     }
 }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -694,21 +694,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.editor.addChangeListener((ev: any) => {
             Blockly.Events.disableOrphans(ev);
 
-            // Blockly doesn't automatically resize highlight outlines. If an event
-            // occurs that could have changed the size of a block, go ahead and refresh
-            // the associated highlights
-            if (ev.type === "block_field_intermediate_change" || ev.type === "change") {
-                if (ev.blockId) {
-                    const block = this.editor.getBlockById(ev.blockId);
-                    fixHighlight(block);
-                }
-            }
-            else if (ev.type === "drag") {
-                for (const block of this.editor.getAllBlocks(false)) {
-                    (block.pathObject as PathObject).resizeHighlight();
-                }
-            }
-
             const ignoredChanges = [
                 Blockly.Events.UI,
                 Blockly.Events.SELECTED,
@@ -2422,23 +2407,12 @@ async function setHighlightWarningAsync(block: Blockly.BlockSvg, enabled: boolea
     block.setHighlighted(enabled);
     if (enabled) {
         await Blockly.renderManagement.finishQueuedRenders();
-        (block.pathObject as PathObject).resizeHighlight();
     }
 }
 
 function isBreakpointSet(block: Blockly.BlockSvg) {
     const existing = block.getIcon(pxtblockly.BreakpointIcon.type) as pxtblockly.BreakpointIcon;
     return !!existing?.isEnabled();
-}
-
-function fixHighlight(block: Blockly.BlockSvg) {
-    (block.pathObject as PathObject).resizeHighlight();
-
-    const connectedTo = block.outputConnection?.targetBlock();
-
-    if (connectedTo) {
-        fixHighlight(connectedTo);
-    }
 }
 
 function shouldEventHideFlyout(ev: Blockly.Events.Abstract) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6147
fixes https://github.com/microsoft/pxt-microbit/issues/6242

fixes two unrelated rendering bugs for blocks

the first bug was because we weren't listening to the path changes correctly inside of PathObject for changes to the block path. I corrected that by overriding setPath and removed our old hack for fixing highlights manually in blocks.tsx

the second bug was caused by blockly deprecating the setEnabled function on blocks. blocks can now be disabled for multiple reasons, and we weren't clearing all of those reasons when we updated the disabled blocks on the workspace. in particular, the disabling caused by Blockly.Events.disableOrphans() (which we call in blocks.tsx) was sometimes sticking around. i fixed this and removed all calls to the deprecated function