### PR TITLE
remove reference to JSX in pxtarget.d.ts

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1354,7 +1354,7 @@ declare namespace pxt.tour {
         steps: BubbleStep[];
         showConfetti?: boolean;
         numberFinalStep?: boolean; // The last step will only be included in the step count if this is true.
-        footer?: string | JSX.Element;
+        footer?: any; // actually 'string | JSX.Element', but this file is included in some compilations that don't include JSX
     }
     const enum BubbleLocation {
         Above,


### PR DESCRIPTION
removing a reference to JSX in pxtarget.d.ts as it was breaking the build of the simulator in pxt-common-packages which in turn broke the arcade build