### PR TITLE
Fix matrix focus indicator on Safari

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -96,6 +96,7 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
      */
     showEditor_() {
         this.selected = [0, 0];
+        this.matrixSvg.focus();
         this.focusCell(0, 0);
         this.returnEphemeralFocusFn = Blockly.getFocusManager().takeEphemeralFocus(this.matrixSvg);
         this.addKeyboardFocusHandlers();

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -188,6 +188,8 @@ export abstract class FieldMatrix extends Blockly.Field {
 
     private setFocusIndicator(cell: SVGRectElement, useTwoToneFocusIndicator: boolean) {
         this.clearFocusIndicator();
+        const focusVisible = this.matrixSvg.matches(":focus-visible");
+        if (!focusVisible) return;
         const cellG = cell.parentNode as SVGRectElement;
         const cellWidth = parseInt(cell.getAttribute("width"))
         const cornerRadius = parseInt(cell.getAttribute("rx"));

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -191,9 +191,8 @@ export abstract class FieldMatrix extends Blockly.Field {
         const cellG = cell.parentNode as SVGRectElement;
         const cellWidth = parseInt(cell.getAttribute("width"))
         const cornerRadius = parseInt(cell.getAttribute("rx"));
-        const focusRects: SVGElement[] = [];
 
-        focusRects.push(pxsim.svg.child(cellG, "rect", {
+        pxsim.svg.child(cellG, "rect", {
             transform: 'translate(-2, -2)',
             width: cellWidth + 4,
             height: cellWidth + 4,
@@ -201,9 +200,9 @@ export abstract class FieldMatrix extends Blockly.Field {
             stroke: "#fff",
             "stroke-width": 4,
             fill: "none"
-        }));
+        });
         if (useTwoToneFocusIndicator) {
-            focusRects.push(pxsim.svg.child(cellG, "rect", {
+            pxsim.svg.child(cellG, "rect", {
                 transform: 'translate(-1, -1)',
                 width: cellWidth + 2,
                 height: cellWidth + 2,
@@ -211,7 +210,7 @@ export abstract class FieldMatrix extends Blockly.Field {
                 stroke: "#000",
                 "stroke-width": 2,
                 fill: "none"
-            }));
+            });
         }
     }
 

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -65,20 +65,6 @@ export abstract class FieldMatrix extends Blockly.Field {
                 };
                 const cellRect = pxsim.svg.child(cellG, "rect", rectOptions) as SVGRectElement;
                 this.cells[x][y] = cellRect;
-
-                // Borders and box-shadow do not work in this context and outlines do not follow border-radius.
-                // Stroke is harder to manage given the difference in stroke for a cell when it is toggled.
-                // This foreignObject/div is used to create a focus indicator for the cell when selected via keyboard navigation.
-                const foreignObject = pxsim.svg.child(cellG, "foreignObject", {
-                    transform: 'translate(-4, -4)',
-                    width: scale * cellWidth + 8,
-                    height: scale * cellWidth + 8,
-                });
-                foreignObject.style.pointerEvents = "none";
-                const div = document.createElement("div");
-                div.classList.add("blocklyCellFocusIndicator");
-                div.style.borderRadius = `${Math.max(2, scale * cornerRadius)}px`;
-                foreignObject.append(div);
             }
         }
     }
@@ -202,12 +188,39 @@ export abstract class FieldMatrix extends Blockly.Field {
 
     private setFocusIndicator(cell: SVGRectElement, useTwoToneFocusIndicator: boolean) {
         this.clearFocusIndicator();
-        const className = useTwoToneFocusIndicator ? "focusedTwoTone" : "focused"
-        cell.nextElementSibling.firstElementChild.classList.add(className);
+        const cellG = cell.parentNode as SVGRectElement;
+        const cellWidth = parseInt(cell.getAttribute("width"))
+        const cornerRadius = parseInt(cell.getAttribute("rx"));
+        const focusRects: SVGElement[] = [];
+
+        focusRects.push(pxsim.svg.child(cellG, "rect", {
+            transform: 'translate(-2, -2)',
+            width: cellWidth + 4,
+            height: cellWidth + 4,
+            rx: `${Math.max(2, cornerRadius)}px`,
+            stroke: "#fff",
+            "stroke-width": 4,
+            fill: "none"
+        }));
+        if (useTwoToneFocusIndicator) {
+            focusRects.push(pxsim.svg.child(cellG, "rect", {
+                transform: 'translate(-1, -1)',
+                width: cellWidth + 2,
+                height: cellWidth + 2,
+                rx: `${Math.max(2, cornerRadius)}px`,
+                stroke: "#000",
+                "stroke-width": 2,
+                fill: "none"
+            }));
+        }
     }
 
     protected clearFocusIndicator() {
-        this.cells.forEach(cell => cell.forEach(cell => cell.nextElementSibling.firstElementChild.classList.remove("focusedTwoTone", "focused")));
+        this.cells.forEach(cell => cell.forEach(cell => {
+            while (cell.nextElementSibling) {
+                cell.nextElementSibling.remove();
+            }
+        }));
     }
 
     protected addKeyboardFocusHandlers() {
@@ -259,27 +272,5 @@ export abstract class FieldMatrix extends Blockly.Field {
 Blockly.Css.register(`
     .blocklyMatrix:focus-visible {
         outline: none;
-    }
-
-    .blocklyMatrix .blocklyCellFocusIndicator {
-        border: 4px solid transparent;
-        height: 100%;
-    }
-
-    .blocklyMatrix:focus-visible .blocklyCellFocusIndicator.focusedTwoTone,
-    .blocklyMatrix:focus-visible .blocklyCellFocusIndicator.focused {
-        border-color: white;
-        transform: translateZ(0);
-    }
-
-    .blocklyMatrix:focus-visible .blocklyCellFocusIndicator.focusedTwoTone:after {
-        content: "";
-        position: absolute;
-        top: -2px;
-        left: -2px;
-        right: -2px;
-        bottom: -2px;
-        border: 2px solid black;
-        border-radius: inherit;
     }
 `);


### PR DESCRIPTION
Blocked on #10596 so draft for now. [Diff once that's merged](https://github.com/microbit-matt-hillsdon/pxt/compare/blockly-12...microbit-matt-hillsdon:pxt:focus-rect).

Fix matrix focus indicator on Safari

foreignObject leads to mysterious positioning issues.
Easier to just use more SVG.