### PR TITLE
Upgrade to Blockly 12.1.0-beta.0

### DIFF
--- a/ThirdPartyNotice
+++ b/ThirdPartyNotice
@@ -881,7 +881,7 @@ General Public License.
 863. dashjs 4.4.0 (https://www.npmjs.com/package/dashjs/v/4.4.0)
 864. @fortawesome/fontawesome-free 5.15.4 (https://www.npmjs.com/package/@fortawesome/fontawesome-free/v/5.15.4)
 865. @blockly/plugin-workspace-search 4.0.10 (https://www.npmjs.com/package/@blockly/plugin-workspace-search/v/4.0.10)
-866. @blockly/keyboard-experiment 0.0.7 (https://www.npmjs.com/package/@blockly/keyboard-experiment/v/0.0.7)
+866. @blockly/keyboard-navigation 1.0.0-beta.0 (https://www.npmjs.com/package/@blockly/keyboard-navigation/v/1.0.0-beta.0)
 
 
 
@@ -28749,7 +28749,7 @@ to represent the company, product, or service to which they refer.**
 END OF @blockly/plugin-workspace-search 4.0.10 NOTICES AND INFORMATION
 
 
-%% @blockly/keyboard-experiment 0.0.7 NOTICES AND INFORMATION BEGIN HERE (https://www.npmjs.com/package/@blockly/keyboard-experiment/v/0.0.7)
+%% @blockly/keyboard-navigation 1.0.0-beta.0 NOTICES AND INFORMATION BEGIN HERE (https://www.npmjs.com/package/@blockly/keyboard-navigation/v/1.0.0-beta.0)
 =========================================
 
                                  Apache License
@@ -28954,4 +28954,4 @@ END OF @blockly/plugin-workspace-search 4.0.10 NOTICES AND INFORMATION
    See the License for the specific language governing permissions and
    limitations under the License.
 =========================================
-END OF @blockly/keyboard-experiment 0.0.7 NOTICES AND INFORMATION
+END OF @blockly/keyboard-navigation 1.0.0-beta.0 NOTICES AND INFORMATION

--- a/localtypings/blockly-keyboard-navigation.d.ts
+++ b/localtypings/blockly-keyboard-navigation.d.ts
@@ -1,4 +1,4 @@
-declare module "@blockly/keyboard-experiment" {
+declare module "@blockly/keyboard-navigation" {
   import { WorkspaceSvg } from "blockly";
 
   class KeyboardNavigation {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@blockly/field-colour": "6.0.0",
-    "@blockly/keyboard-experiment": "0.0.9",
+    "@blockly/keyboard-navigation": "1.0.0-beta.0",
     "@blockly/plugin-workspace-search": "10.0.0",
     "@crowdin/crowdin-api-client": "^1.33.0",
     "@fortawesome/fontawesome-free": "^5.15.4",
@@ -72,7 +72,7 @@
     "@zip.js/zip.js": "2.4.20",
     "adm-zip": "^0.5.12",
     "axios": "^1.6.8",
-    "blockly": "12.0.1-beta.1",
+    "blockly": "12.1.0-beta.0",
     "browserify": "17.0.0",
     "chai": "^3.5.0",
     "chalk": "^4.1.2",
@@ -159,10 +159,10 @@
       "source-map": "0.4.4"
     },
     "@blockly/field-colour": {
-      "blockly": "^12.0.1-beta.1"
+      "blockly": "^12.1.0-beta.0"
     },
     "@blockly/plugin-workspace-search": {
-      "blockly": "^12.0.1-beta.1"
+      "blockly": "^12.1.0-beta.0"
     }
   },
   "scripts": {

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -96,9 +96,8 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
      */
     showEditor_() {
         this.selected = [0, 0];
-        this.matrixSvg.focus();
-        this.focusCell(0, 0);
         this.returnEphemeralFocusFn = Blockly.getFocusManager().takeEphemeralFocus(this.matrixSvg);
+        this.focusCell(0, 0);
         this.addKeyboardFocusHandlers();
     }
 

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -243,8 +243,12 @@ export abstract class FieldMatrix extends Blockly.Field {
 
     protected returnEphemeralFocus() {
         if (this.returnEphemeralFocusFn) {
-            this.returnEphemeralFocusFn();
+            // Clear field before running function. If this is called due to 'Escape',
+            // onNodeBlur will fire running this function again.
+            // onNodeBlur is required for mouse clicks in the workspace.
+            const returnEphemeralFocusFn = this.returnEphemeralFocusFn;
             this.returnEphemeralFocusFn = undefined;
+            returnEphemeralFocusFn();
         }
     }
 

--- a/pxtblocks/plugins/flyout/cachingFlyout.ts
+++ b/pxtblocks/plugins/flyout/cachingFlyout.ts
@@ -2,6 +2,8 @@ import * as Blockly from "blockly";
 import { MultiFlyoutRecyclableBlockInflater } from "./blockInflater";
 
 export class CachingFlyout extends Blockly.VerticalFlyout {
+    forceOpen: boolean = false;
+
     clearBlockCache() {
         const inflater = this.getInflaterForType("block");
 
@@ -12,5 +14,9 @@ export class CachingFlyout extends Blockly.VerticalFlyout {
 
     getFlyoutElement(): SVGElement {
         return this.svgGroup_
+    }
+
+    setForceOpen(forceOpen: boolean): void {
+        this.forceOpen = forceOpen;
     }
 }

--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -160,6 +160,12 @@
         color: var(--pxt-neutral-foreground3);
         font-size: 15px;
 
+        &:focus-visible {
+            border-color: var(--pxt-neutral-stencil3);
+            border-width: 4px 0px 4px 4px;
+            border-style: solid;
+            outline: none;
+        }
         .monacoFlyoutHeadingIcon {
             display: inline-block;
         }

--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -278,6 +278,7 @@
             border-width: 4px 0px 4px 4px;
             border-style: solid;
             cursor: grab;
+            outline: none;
 
             .blockHandle,
             .detail .params,

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -38,7 +38,7 @@ import SimState = pxt.editor.SimState;
 import { DuplicateOnDragConnectionChecker } from "../../pxtblocks/plugins/duplicateOnDrag";
 import { PathObject } from "../../pxtblocks/plugins/renderer/pathObject";
 import { Measurements } from "./constants";
-import { CachingFlyout, flow, initCopyPaste } from "../../pxtblocks";
+import { flow, initCopyPaste } from "../../pxtblocks";
 import { HIDDEN_CLASS_NAME } from "../../pxtblocks/plugins/flyout/blockInflater";
 import { AIFooter } from "../../react-common/components/controls/AIFooter";
 
@@ -546,7 +546,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         (Blockly as any).Toolbox.prototype.onTreeBlur = function (nextTree: Blockly.IFocusableTree | null) {
             // If the search box is focused and there are search results, the flyout is set to forceOpen.
             // Otherwise, the flyout closes and then re-opens causing an unpleasant visual effect.
-            if ((that.editor.getFlyout() as CachingFlyout).forceOpen) {
+            if ((that.editor.getFlyout() as pxtblockly.CachingFlyout).forceOpen) {
                 that.toolbox.selectFirstItem();
                 that.setFlyoutForceOpen(false);
                 return;
@@ -1747,7 +1747,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     public setFlyoutForceOpen(forceOpen: boolean) {
-        (this.editor.getFlyout() as CachingFlyout).setForceOpen(forceOpen);
+        (this.editor.getFlyout() as pxtblockly.CachingFlyout).setForceOpen(forceOpen);
     }
 
     ///////////////////////////////////////////////////////////

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../localtypings/blockly-keyboard-experiment.d.ts"/>
+/// <reference path="../../localtypings/blockly-keyboard-navigation.d.ts"/>
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
@@ -19,7 +19,7 @@ import { CreateFunctionDialog } from "./createFunction";
 import { initializeSnippetExtensions } from './snippetBuilder';
 
 import * as pxtblockly from "../../pxtblocks";
-import { KeyboardNavigation } from '@blockly/keyboard-experiment';
+import { KeyboardNavigation } from '@blockly/keyboard-navigation';
 import { WorkspaceSearch } from "@blockly/plugin-workspace-search";
 
 import Util = pxt.Util;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -608,6 +608,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private initAccessibleBlocks() {
         if (!this.keyboardNavigation) {
             this.keyboardNavigation = new KeyboardNavigation(this.editor);
+            Blockly.keyboardNavigationController.setIsActive(true);
 
             const listShortcuts = Blockly.ShortcutRegistry.registry.getRegistry()["list_shortcuts"];
             Blockly.ShortcutRegistry.registry.unregister(listShortcuts.name);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -38,7 +38,7 @@ import SimState = pxt.editor.SimState;
 import { DuplicateOnDragConnectionChecker } from "../../pxtblocks/plugins/duplicateOnDrag";
 import { PathObject } from "../../pxtblocks/plugins/renderer/pathObject";
 import { Measurements } from "./constants";
-import { flow, initCopyPaste } from "../../pxtblocks";
+import { CachingFlyout, flow, initCopyPaste } from "../../pxtblocks";
 import { HIDDEN_CLASS_NAME } from "../../pxtblocks/plugins/flyout/blockInflater";
 import { AIFooter } from "../../react-common/components/controls/AIFooter";
 
@@ -542,6 +542,23 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         };
         (Blockly as any).Toolbox.prototype.clearSelection = function () {
             that.hideFlyout();
+        };
+        (Blockly as any).Toolbox.prototype.onTreeBlur = function (nextTree: Blockly.IFocusableTree | null) {
+            // If the search box is focused and there are search results, the flyout is set to forceOpen.
+            // Otherwise, the flyout closes and then re-opens causing an unpleasant visual effect.
+            if ((that.editor.getFlyout() as CachingFlyout).forceOpen) {
+                that.toolbox.selectFirstItem();
+                that.setFlyoutForceOpen(false);
+                return;
+            }
+            // If navigating to anything other than the toolbox's flyout then clear the
+            // selection so that the toolbox's flyout can automatically close.
+            if (!nextTree || nextTree !== this.flyout?.getWorkspace()) {
+                this.clearSelection();
+                if (this.flyout && this.flyout.autoHide !== undefined) {
+                    this.flyout.autoHide(false);
+                }
+            }
         };
         (Blockly.WorkspaceSvg as any).prototype.refreshToolboxSelection = function () {
             let ws = this.isFlyout ? this.targetWorkspace : this;
@@ -1100,6 +1117,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     getToolboxDiv(): HTMLDivElement {
         return this.getBlocklyToolboxDiv();
+    }
+
+    getEditorAreaDiv(): HTMLElement {
+        return this.getBlocksAreaDiv();
     }
 
     handleToolboxRef = (c: toolbox.Toolbox) => {
@@ -1704,6 +1725,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.editor.getFlyout().hide();
         }
         if (this.toolbox) this.toolbox.clear();
+    }
+
+    public setFlyoutForceOpen(forceOpen: boolean) {
+        (this.editor.getFlyout() as CachingFlyout).setForceOpen(forceOpen);
     }
 
     ///////////////////////////////////////////////////////////

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -886,13 +886,17 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     getToolboxDiv(): HTMLElement | undefined {
-        const monacoArea = document.getElementById('monacoEditorArea');
+        const monacoArea = this.getEditorAreaDiv();
         if (!monacoArea) return undefined;
         return monacoArea.getElementsByClassName('monacoToolboxDiv')[0] as HTMLElement;
     }
 
+    getEditorAreaDiv(): HTMLElement {
+        return document.getElementById('monacoEditorArea');
+    }
+
     resize(e?: Event) {
-        let monacoArea = document.getElementById('monacoEditorArea');
+        let monacoArea = this.getEditorAreaDiv();
         if (!monacoArea) return;
         let monacoToolboxDiv = monacoArea.getElementsByClassName('monacoToolboxDiv')[0] as HTMLElement;
 
@@ -946,7 +950,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     private createLoadMonacoPromise(): Promise<void> {
         this.extraLibs = Object.create(null);
-        let editorArea = document.getElementById("monacoEditorArea");
         let editorElement = document.getElementById("monacoEditorInner");
 
         return pxteditor.monaco.initMonacoAsync(editorElement).then((editor) => {
@@ -1916,6 +1919,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             }
         }
     }
+
+    public setFlyoutForceOpen(_forceOpen: boolean): void {}
 
     ///////////////////////////////////////////////////////////
     ////////////         Flyout methods           /////////////

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -206,6 +206,18 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
         }
     }
 
+    private handleFocus = (name: string) => {
+        this.setState({
+            selectedBlock: name
+        });
+    }
+
+    private handleBlur = () => {
+        this.setState({
+            selectedBlock: undefined
+        });
+    }
+
     protected getHelpButtonClickHandler = (group?: string) => {
         return () => {
             pxt.debug(`${group} help icon clicked.`);
@@ -365,8 +377,10 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
         return <div className={`monacoBlock ${disabled ? "monacoDisabledBlock" : ""} ${selected ? "expand" : ""} ${hover ? "hover" : ""}`}
             style={this.getSelectedStyle()}
             title={block.attributes.jsDoc}
-            key={`block_${qName}_${index}`} tabIndex={0} role="listitem"
+            key={`block_${qName}_${index}`} tabIndex={!this.state.selectedBlock && index === 0 ? 0 : selected ? 0 : -1} role="listitem"
             onClick={this.getBlockClickHandler(qName)}
+            onFocus={() => this.handleFocus(qName)}
+            onBlur={() => this.handleBlur()}
             onMouseOver={this.getBlockMouseOver(qName)}
             onMouseOut={this.getBlockMouseOut(qName)}
             onKeyDown={this.getKeyDownHandler(block, snippet, isPython)}
@@ -401,7 +415,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
     }
 
     renderCore() {
-        const { name, ns, color, icon, groups } = this.state;
+        const { name, ns, color, icon, groups, selectedBlock } = this.state;
         const rgb = pxt.toolbox.getAccessibleBackground(pxt.toolbox.convertColor(color || (ns && pxt.toolbox.getNamespaceColor(ns)) || "255"));
         const iconClass = `blocklyTreeIcon${icon ? (ns || icon).toLowerCase() : "Default"}`.replace(/\s/g, "");
         return <div id="monacoFlyoutWidget" className="monacoFlyout" style={this.getFlyoutStyle()}>
@@ -417,7 +431,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
                     // Add group label, for non-default groups
                     if (g.name != pxt.DEFAULT_GROUP_NAME && groups.length > 1) {
                         group.push(
-                            <div className="monacoFlyoutLabel blocklyFlyoutGroup" key={`label_${i}`} tabIndex={0} onKeyDown={this.getKeyDownHandler()} role="separator">
+                            <div className="monacoFlyoutLabel blocklyFlyoutGroup" key={`label_${i}`} tabIndex={selectedBlock || i > 0 ? -1 : 0} onKeyDown={this.getKeyDownHandler()} role="separator">
                                 {g.icon && <span className={`monacoFlyoutHeadingIcon blocklyTreeIcon ${iconClass}`} role="presentation">{g.icon}</span>}
                                 <div className="monacoFlyoutLabelText">{pxtc.U.rlf(`{id:group}${g.name}`)}</div>
                                 {g.hasHelp && HELP_IMAGE_URI && <span>

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -187,6 +187,9 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
                 }
             } else if ((charCode == 37 && !isRtl) || (charCode == 38 && isRtl)) { // (LEFT & LTR) or (RIGHT & RTL)
                 // Focus back to toolbox
+                this.setState({
+                    selectedBlock: undefined
+                })
                 this.props.moveFocusToParent();
             } else if (charCode == 27) { // ESCAPE
                 // Focus back to toolbox and close Flyout

--- a/webapp/src/shortcut_formatting.ts
+++ b/webapp/src/shortcut_formatting.ts
@@ -5,6 +5,7 @@ const isMacPlatform = pxt.BrowserUtils.isMac();
 /**
  * Default keyboard navigation shortcut names.
  * Based from blockly-keyboard-experiment constants.ts.
+ * See https://github.com/google/blockly-keyboard-experimentation/blob/main/src/constants.ts
  */
 export enum ShortcutNames {
   UP = 'up',
@@ -42,6 +43,7 @@ export function getActionShortcut(action: string): string[] | null {
  * current platform or tagged them with a platform.
  * 
  * Copied from blockly-keyboard-experiment.
+ * See https://github.com/google/blockly-keyboard-experimentation/blob/main/src/shortcut_formatting.ts
  *
  * @param action The action name, e.g. "cut".
  * @param modifierNames The names to use for the Meta/Control/Alt modifiers.

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -84,6 +84,10 @@ export class Editor implements IEditor {
         return undefined;
     }
 
+    getEditorAreaDiv(): HTMLElement | undefined {
+        return undefined;
+    }
+
     hasHistory() { return true; }
     hasUndo() { return true; }
     hasRedo() { return true; }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -519,15 +519,6 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                 e.preventDefault();
                 e.stopPropagation();
             }
-        } else if (charCode == core.TAB_KEY && !e.shiftKey) {
-            if (this.selectedTreeRow.nameid !== "addpackage") {
-                // Manually focus inside flyout and set the flyout cursor.
-                // If we let Blockly handle this, focus can be restored to a cached block that
-                // is hidden and disabled. This results in broken keyboard navigation in the flyout.
-                this.moveFocusToFlyout();
-                e.preventDefault();
-                e.stopPropagation();
-            }
         } else if (charCode == core.TAB_KEY
             || charCode == 37 /* Left arrow key */
             || charCode == 39 /* Right arrow key */

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -248,6 +248,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
 
     abstract showFlyout(treeRow: toolbox.ToolboxCategory): void;
     abstract hideFlyout(): void;
+    abstract setFlyoutForceOpen(forceOpen: boolean): void;
     moveFocusToFlyout() { }
 
     protected abstract showFlyoutHeadingLabel(ns: string, name: string, subns: string, icon: string, color: string): void;


### PR DESCRIPTION
This PR upgrades Blockly to the latest beta and upgrades to the latest keyboard navigation plugin. 

The changes here mostly involve adapting to changes in the Blockly focus management code. The Monaco flyout behaviour has also been changed to better align with the blocks experience (mostly removing tab stops in the flyout).

There are two new issues noted in this upgrade that require fixes in Blockly:
- https://github.com/google/blockly/issues/9112
- https://github.com/google/blockly/issues/9111

and one minor issue for the ledmatrix where the passive focus indicator is no longer showing while editing individual LEDs using keyboard controls. 

There is one existing issue where Blockly are working on a fix which we hope to get in the next upgrade:
- https://github.com/google/blockly/issues/9101

This PR fixes some existing problems (e.g., escape to close dropdowns, removing unwanted tab stops), but introduces others as noted above. We hope to follow up quickly with another upgrade to address the issues noted here.