### PR TITLE
fix a couple bugs for blocks with the constantshim annotation

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1193,7 +1193,7 @@ ${output}</xml>`;
                 return r;
             }
 
-            let value = U.htmlEscape(attributes.blockId || callInfo.qName);
+            let value = U.htmlEscape(attributes.blockId) || callInfo.qName;
 
             const [parent,] = getParent(n);
             const parentCallInfo: pxtc.CallInfo = parent && pxtInfo(parent).callInfo;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -592,7 +592,8 @@ namespace ts.pxtc {
                 && s.kind != pxtc.SymbolKind.EnumMember
                 && s.kind != pxtc.SymbolKind.Module
                 && s.kind != pxtc.SymbolKind.Interface
-                && s.kind != pxtc.SymbolKind.Class) {
+                && s.kind != pxtc.SymbolKind.Class
+                && !s.attributes.blockIdentity) {
                 if (!s.attributes.blockId)
                     s.attributes.blockId = s.qName.replace(/\./g, "_")
                 if (s.attributes.block == "true") {


### PR DESCRIPTION
blocks with the `constantShim` annotation are used to collect all of the constants on a namespace. for example, all of the Math constants. we associate constants with this block by checking if they have a `blockIdentity` annotation pointing to the qualified name of the function marked as `constantShim`

this fixes two bugs:
* constants that have a `block="name"` annotation were creating extra blocks in the toolbox. fixed by changing the service to not add auto-generated block ids to constants that have the `blockIdentity` annotation
* fixed decompilation of these blocks, which was HTML escaping the qualified name. those should already be HTML safe, so no need to escape again!