### PR TITLE
Use widget div for ledmatrix field editor when editing via keyboard

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -98,13 +98,14 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     showEditor_() {
         this.selected = [0, 0];
 
+        const matrixRect = this.matrixSvg.getBoundingClientRect();
+
         const widgetDiv = Blockly.WidgetDiv.getDiv();
         widgetDiv.append(this.matrixSvg);
         this.addKeyboardFocusHandlers();
 
-        const fieldGroupRect = this.getScaledBBox()
-        widgetDiv.style.left = fieldGroupRect.left + "px";
-        widgetDiv.style.top = fieldGroupRect.top + "px";
+        widgetDiv.style.left = matrixRect.left + "px";
+        widgetDiv.style.top = matrixRect.top + "px";
         widgetDiv.style.transform = `scale(${(Blockly.getMainWorkspace() as Blockly.WorkspaceSvg).getScale()})`;
         widgetDiv.style.transformOrigin = "0 0";
 
@@ -124,7 +125,7 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
 
     private initMatrix() {
         if (!this.sourceBlock_.isInsertionMarker()) {
-            this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" width="${this.size_.width}px" height="${this.size_.height}px"/>`);
+            this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" width="${this.size_.width}" height="${this.size_.height}"/>`);
             this.matrixSvg.ariaLabel = lf("LED grid");
 
             // Initialize the matrix that holds the state
@@ -169,6 +170,17 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
                     lbl.textContent = this.getLabel(i, this.yAxisLabel);
                 }
             }
+
+            // Add rect so that different browsers interpret the matrixSvg clientBoundingRect
+            // in the same way. Required for the widget div position.
+            const rect = Blockly.utils.dom.createSvgElement('rect', {
+                'x': 0,
+                'y': 0,
+                'fill': 'none',
+                'width': this.size_.width,
+                'height': this.size_.height,
+            }, null) as SVGRectElement;
+            this.matrixSvg.append(rect);
 
             this.fieldGroup_.classList.add("blocklyFieldLedMatrixGroup");
             this.fieldGroup_.append(this.matrixSvg);

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -44,6 +44,7 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     private currentDragState_: boolean;
 
     protected clearSelectionOnBlur = true;
+    protected forceFocusVisible = true;
 
     constructor(text: string, params: any, validator?: Blockly.FieldValidator) {
         super(text, validator);
@@ -108,6 +109,8 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
         widgetDiv.style.transformOrigin = "0 0";
 
         Blockly.WidgetDiv.show(this, this.sourceBlock_.RTL, () => {
+            this.removeKeyboardFocusHandlers();
+            this.clearCellSelection();
             this.fieldGroup_.append(this.matrixSvg);
             widgetDiv.style.left = "";
             widgetDiv.style.top = "";

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -96,18 +96,32 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
      */
     showEditor_() {
         this.selected = [0, 0];
-        this.returnEphemeralFocusFn = Blockly.getFocusManager().takeEphemeralFocus(this.matrixSvg);
-        this.focusCell(0, 0);
-        this.addKeyboardFocusHandlers();
-    }
 
-    onNodeBlur() {
-        this.returnEphemeralFocus();
+        const widgetDiv = Blockly.WidgetDiv.getDiv();
+        widgetDiv.append(this.matrixSvg);
+        this.addKeyboardFocusHandlers();
+
+        const fieldGroupRect = this.getScaledBBox()
+        widgetDiv.style.left = fieldGroupRect.left + "px";
+        widgetDiv.style.top = fieldGroupRect.top + "px";
+        widgetDiv.style.transform = `scale(${(Blockly.getMainWorkspace() as Blockly.WorkspaceSvg).getScale()})`;
+        widgetDiv.style.transformOrigin = "0 0";
+
+        Blockly.WidgetDiv.show(this, this.sourceBlock_.RTL, () => {
+            this.fieldGroup_.append(this.matrixSvg);
+            widgetDiv.style.left = "";
+            widgetDiv.style.top = "";
+            widgetDiv.style.transform = "";
+            widgetDiv.style.transformOrigin = "";
+        });
+
+        this.matrixSvg.focus();
+        this.focusCell(0, 0);
     }
 
     private initMatrix() {
         if (!this.sourceBlock_.isInsertionMarker()) {
-            this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" />`);
+            this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" width="${this.size_.width}px" height="${this.size_.height}px"/>`);
             this.matrixSvg.ariaLabel = lf("LED grid");
 
             // Initialize the matrix that holds the state

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -23,6 +23,7 @@ export abstract class FieldMatrix extends Blockly.Field {
     protected abstract numMatrixCols: number;
     protected abstract numMatrixRows: number;
     protected abstract clearSelectionOnBlur: boolean;
+    protected forceFocusVisible: boolean = false;
     protected returnEphemeralFocusFn: Blockly.ReturnEphemeralFocus | undefined = undefined;
 
     protected createMatrixDisplay({
@@ -189,7 +190,7 @@ export abstract class FieldMatrix extends Blockly.Field {
     private setFocusIndicator(cell: SVGRectElement, useTwoToneFocusIndicator: boolean) {
         this.clearFocusIndicator();
         const focusVisible = this.matrixSvg.matches(":focus-visible");
-        if (!focusVisible) return;
+        if (!focusVisible && !this.forceFocusVisible) return;
         const cellG = cell.parentNode as SVGRectElement;
         const cellWidth = parseInt(cell.getAttribute("width"))
         const cornerRadius = parseInt(cell.getAttribute("rx"));


### PR DESCRIPTION
Attempting to use Blockly's `focusManager` to take ephemeral focus on an element inside the workspace focus tree causes numerous issues. Considering the unusual case of the `showLeds` block, it's better to workaround this problem by making use of the widget div when the led grid is selected for editing via the keyboard. 

This PR uses the widget div outside of the workspace focus tree and makes use of existing Blockly focus management that this div provides.

No changes are intended for mouse users and no visual changes are intended for keyboard users.