### PR TITLE
Keyboard nav style fixes

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -473,13 +473,24 @@ div.blocklyTreeRoot > div[role="tree"]:focus-visible {
 /* Flyout buttons and labels */
 .blocklyKeyboardNavigation .blocklyFlyout .blocklyFlyoutLabel.blocklyActiveFocus,
 .blocklyKeyboardNavigation .blocklyFlyout .blocklyFlyoutButton.blocklyActiveFocus {
+    outline: none;
+}
+/* Use the backgrounds because the group can't have an outline on Safari */
+.blocklyKeyboardNavigation .blocklyFlyout .blocklyFlyoutLabel.blocklyActiveFocus > .blocklyFlyoutLabelBackground,
+.blocklyKeyboardNavigation .blocklyFlyout .blocklyFlyoutButton.blocklyActiveFocus > .blocklyFlyoutButtonBackground {
+    outline-offset: 2px;
     outline: var(--blockly-selection-width) solid
         var(--blockly-active-node-color);
     border-radius: 2px;
-    outline-offset: 2px;
+}
+.blocklyKeyboardNavigation .blocklyFlyout .blocklyFlyoutLabel.blocklyActiveFocus > .blocklyFlyoutLabelBackground {
+    // Swap opactity for transparent fill so we can see the focus indicator.
+    opacity: 1;
+    fill: transparent;
 }
 
 /* Workspace */
+.blocklyKeyboardNavigation .blocklySvg:has(~ .blocklyBlockDragSurface .blocklyActiveFocus) .blocklyWorkspaceFocusRing,
 .blocklyKeyboardNavigation .blocklyWorkspace:has(.blocklyActiveFocus) .blocklyWorkspaceFocusRing,
 .blocklyKeyboardNavigation .blocklyWorkspace.blocklyActiveFocus .blocklyWorkspaceFocusRing {
     stroke: var(--blockly-active-tree-color);


### PR DESCRIPTION
- Can't have an outline on a group for Safari, so switch to styling background rects for flyout buttons/labels. Means the icon isn't included so might be worth asking for a DOM change to have a suitable rect in the group.
- Maintain workspace outline style when a block is in move mode. I'll upstream this change soon but we need a copy of the CSS anyway. See https://github.com/google/blockly-keyboard-experimentation/issues/569#issuecomment-2928138311