### PR TITLE
Add blockly keyboard controls to accessibility menu

### DIFF
--- a/webapp/src/accessibility.tsx
+++ b/webapp/src/accessibility.tsx
@@ -6,6 +6,7 @@ import * as data from "./data";
 import * as sui from "./sui";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
+import { classList } from "../../react-common/components/util";
 
 export interface EditorAccessibilityMenuProps extends ISettingsProps {
     highContrast?: boolean;
@@ -29,6 +30,7 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
         this.showThemePicker = this.showThemePicker.bind(this);
         this.goHome = this.goHome.bind(this);
         this.openBlocks = this.openBlocks.bind(this);
+        this.toggleAccessibleBlocks = this.toggleAccessibleBlocks.bind(this);
     }
 
     openBlocks(e: React.MouseEvent<HTMLElement>) {
@@ -60,6 +62,19 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
         this.props.parent.showExitAndSaveDialog();
     }
 
+    toggleAccessibleBlocks() {
+        pxt.tickEvent(
+            "accmenu.editor.toggleAccessibleBlocks",
+            {
+                enabling: !this.getData<boolean>(auth.ACCESSIBLE_BLOCKS) ? "true" : "false"
+            },
+            {
+                interactiveConsent: true,
+            }
+        );
+        this.props.parent.toggleAccessibleBlocks();
+    }
+
     UNSAFE_componentWillReceiveProps(nextProps: EditorAccessibilityMenuProps) {
         const newState: EditorAccessibilityMenuState = {};
         if (nextProps.highContrast != undefined) {
@@ -73,17 +88,74 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
     }
 
     renderCore() {
-        let highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
         const targetTheme = pxt.appTarget.appTheme;
         const hasHome = !pxt.shell.isControllerMode();
 
+        const accessibleBlocksOn = this.getData<boolean>(auth.ACCESSIBLE_BLOCKS);
+        const menuClass = classList(targetTheme.invertedMenu && "inverted", "menu");
+
         return <div className="ui accessibleMenu borderless fixed menu" role="menubar">
-            {this.getData<boolean>(auth.ACCESSIBLE_BLOCKS) ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon blocks" text={lf("Skip to Blocks workspace")} onClick={this.openBlocks} /> : undefined}
-            <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon js" text={lf("Skip to JavaScript editor")} onClick={this.openJavaScript} />
-            {targetTheme.python ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon python" text={lf("Skip to Python editor")} onClick={this.openPython} /> : undefined}
-            {targetTheme.selectLanguage ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon globe" text={lf("Select Language")} onClick={this.showLanguagePicker} /> : undefined}
-            {targetTheme.defaultColorTheme ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="paint brush" text={lf("Select Theme")} onClick={this.showThemePicker} /> : undefined}
-            {hasHome ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="home" text={lf("Go Home")} onClick={this.goHome} /> : undefined}
+            {!accessibleBlocksOn &&
+                <sui.Item
+                    className={menuClass}
+                    role="menuitem"
+                    icon="xicon blocks"
+                    text={lf("Enable blocks keyboard controls")}
+                    onClick={this.toggleAccessibleBlocks}
+                />
+            }
+            {accessibleBlocksOn &&
+                <sui.Item
+                    className={menuClass}
+                    role="menuitem"
+                    icon="xicon blocks"
+                    text={lf("Skip to Blocks workspace")}
+                    onClick={this.openBlocks}
+                />
+            }
+            <sui.Item
+                className={menuClass}
+                role="menuitem"
+                icon="xicon js"
+                text={lf("Skip to JavaScript editor")}
+                onClick={this.openJavaScript}
+            />
+            {targetTheme.python &&
+                <sui.Item
+                    className={menuClass}
+                    role="menuitem"
+                    icon="xicon python"
+                    text={lf("Skip to Python editor")}
+                    onClick={this.openPython}
+                />
+            }
+            {targetTheme.selectLanguage &&
+                <sui.Item
+                    className={menuClass}
+                    role="menuitem"
+                    icon="xicon globe"
+                    text={lf("Select Language")}
+                    onClick={this.showLanguagePicker}
+                />
+            }
+            {targetTheme.defaultColorTheme &&
+                <sui.Item
+                    className={menuClass}
+                    role="menuitem"
+                    icon="paint brush"
+                    text={lf("Select Theme")}
+                    onClick={this.showThemePicker}
+                />
+            }
+            {hasHome &&
+                <sui.Item
+                    className={menuClass}
+                    role="menuitem"
+                    icon="home"
+                    text={lf("Go Home")}
+                    onClick={this.goHome}
+                />
+            }
         </div>;
     }
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6260

currently "skip to blocks editor" only shows up if keyboard nav is turned on. now, if it's turned off we have a new option "enable blocks keyboard controls" in its place to turn on the keyboard nav

@microbit-matt-hillsdon FYI

![acc-menu](https://github.com/user-attachments/assets/57067ab4-47a4-47dd-89e4-3580a707d201)
