### PR TITLE
give extensions an optional display name

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -33,6 +33,7 @@ declare namespace pxt {
      */
     interface PackageConfig {
         name: string;
+        displayName?: string; // used for the codecard in the extension dialog
         version?: string;
         // installedVersion?: string; moved to Package class
         // url to icon -- support for built-in packages only

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -1751,11 +1751,12 @@ namespace ts.pxtc.service {
     }
 
     export interface ExtensionMeta {
-        name: string,
-        fullName?: string,
-        description?: string,
-        imageUrl?: string,
-        type?: ExtensionType
+        name: string;
+        displayName?: string;
+        fullRepo?: string;
+        description?: string;
+        imageUrl?: string;
+        type?: ExtensionType;
         learnMoreUrl?: string;
 
         pkgConfig?: pxt.PackageConfig; // Added if the type is Bundled

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -303,7 +303,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
             imageUrl: pxt.github.repoIconUrl(r),
             repo: r,
             description: r.description,
-            fullName: r.fullName
+            fullRepo: r.fullName
         }
     }
 
@@ -360,6 +360,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
     function packageConfigToExtensionMeta(p: pxt.PackageConfig): ExtensionMeta {
         return {
             name: p.name,
+            displayName: p.displayName,
             imageUrl: p.icon,
             type: ExtensionType.Bundled,
             learnMoreUrl: `/reference/${p.name}`,
@@ -458,22 +459,23 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         const { extensionInfo } = props;
         const {
             description,
-            fullName,
+            fullRepo,
             imageUrl,
             learnMoreUrl,
             loading,
             name,
+            displayName,
             repo,
             type,
         } = extensionInfo;
 
         return <ExtensionCard
-            title={name || fullName}
+            title={displayName || name || fullRepo}
             description={description}
             imageUrl={imageUrl}
             extension={extensionInfo}
             onClick={installExtension}
-            learnMoreUrl={learnMoreUrl || (fullName ? `/pkg/${fullName}` : undefined)}
+            learnMoreUrl={learnMoreUrl || (fullRepo ? `/pkg/${fullRepo}` : undefined)}
             loading={loading}
             label={pxt.isPkgBeta(extensionInfo) ? lf("Beta") : undefined}
             showDisclaimer={type != ExtensionType.Bundled && repo?.status != pxt.github.GitRepoStatus.Approved}


### PR DESCRIPTION
as the title says, this adds an optional displayName field in pxt.json that let's you set the name that appears in the extensions browser. this is needed to fix the mc bug with the file extension because they want a name that is different from the directory of the bundled extension