### PR TITLE
fix focus management for sound effect gallery when scrolled

### DIFF
--- a/webapp/src/components/soundEffectEditor/SoundGallery.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundGallery.tsx
@@ -24,17 +24,32 @@ interface SoundGalleryItemProps extends SoundGalleryItem {
     selectKeyDown: (evt: React.KeyboardEvent<HTMLElement>) => void;
 }
 
-type GalleryItem = Record<string, HTMLElement>;
 
 export const SoundGallery = (props: SoundGalleryProps) => {
     const { sounds, onSoundSelected, visible, useMixerSynthesizer } = props;
 
-    const selectItemRefs = React.useRef<[GalleryItem]>([{}]);
-    const playItemRefs = React.useRef<[GalleryItem]>([{}]);
+    const selectItemRefs = React.useRef<HTMLDivElement[]>([]);
+    const playItemRefs = React.useRef<HTMLButtonElement[]>([]);
     const selectedCoord = React.useRef<{row: number, col: "select" | "preview"}>({row: 0, col: "select"});
 
     const focusSelectOrPlayElement = React.useCallback((e: React.KeyboardEvent<HTMLElement> | React.FocusEvent) => {
-        (selectedCoord.current.col === "select" ? selectItemRefs : playItemRefs).current[0][selectedCoord.current.row].focus();
+        if (e.type === "focus") {
+            // Check to see if this focus event is coming from a click on a child element
+            const playIndex = playItemRefs.current.indexOf(e.target as HTMLButtonElement);
+            if (playIndex !== -1) {
+                selectedCoord.current = {col: "preview", row: playIndex};
+                return;
+            }
+
+            const selectIndex = selectItemRefs.current.indexOf(e.target as HTMLDivElement);
+            if (selectIndex !== -1) {
+                selectedCoord.current = {col: "select", row: selectIndex};
+                return;
+            }
+        }
+
+        const elements = (selectedCoord.current.col === "select" ? selectItemRefs : playItemRefs).current;
+        elements[selectedCoord.current.row].focus();
         e.preventDefault();
     }, []);
 
@@ -95,8 +110,8 @@ export const SoundGallery = (props: SoundGalleryProps) => {
                             {...item}
                             useMixerSynthesizer={useMixerSynthesizer}
 
-                            selectReference={ref => selectItemRefs.current[0][index] = ref}
-                            playReference={ref => playItemRefs.current[0][index] = ref}
+                            selectReference={ref => selectItemRefs.current[index] = ref}
+                            playReference={ref => playItemRefs.current[index] = ref}
 
                             previewKeyDown={evt => handleKeyDown(prev, next, index, evt)}
                             selectKeyDown={evt => handleKeyDown(prev, next, index, evt)}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6308

the issue here is that the onFocus event for the parent element fires _before_ the on click event for the child when clicking on an element in the gallery. as a result, the onFocus event will focus whatever is currently selected in the gallery, usually the first item unless the user moved around with the keyboard. that call to `.focus()` forced the list of gallery items to scroll to reveal the focused item which moved the gallery underneath the pointer so that the click event doesn't actually fire.

to fix, i reworked the focusSelectOrPlayElement function to check to see if focus events were fired on children of the scroller element. if so, i update the selected coordinate and bail. this has the added benefit of making it so that we follow the expected behavior where if you use the arrow keys to navigate after clicking on something, we pick up from wherever the click happened rather than from the first element.

i also refactored the refs a little bit because i believe there was a mistake made with the typings there.

@microbit-robert FYI