### PR TITLE
jacdac bridge logic

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5628,16 +5628,13 @@ function initPacketIO() {
             }
         },
         (type, payload) => {
-            const messageSimulators = pxt.appTarget.simulator?.messageSimulators;
-            if (messageSimulators?.[type]) {
-                window.postMessage({
-                    type: "messagepacket",
-                    broadcast: false,
-                    channel: type,
-                    data: payload,
-                    sender: "packetio",
-                }, "*")
-            }
+            window.postMessage({
+                type: "messagepacket",
+                broadcast: false,
+                channel: type,
+                data: payload,
+                sender: "packetio",
+            }, "*")
         });
 
     window.addEventListener('message', (ev: MessageEvent) => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5644,7 +5644,6 @@ function initPacketIO() {
         const msg = ev.data
         if (msg.type === 'messagepacket'
             && msg.sender !== "packetio"
-            && pxt.appTarget.simulator?.messageSimulators?.[msg.channel]
             && msg.channel === pxt.HF2.CUSTOM_EV_JACDAC)
             pxt.packetio.sendCustomEventAsync(msg.channel, msg.data)
                 .then(() => { }, err => {


### PR DESCRIPTION
Eric,

So the major issue here is that with my fix to jacdac/pxt-jacdac (to use "jacdac" channel) raises an issue in pxt, which is that the logic in app.tsx causes the old simulator and new simulator both to appear.  Once the old simulator is removed from pxtarget.json, I think the new one may stop working. So, need to figure out how to generalize the logic here. 

Update:
- this happens without any real device on the jacdac bus
- it's purely a function of "jacdac" being sent around with iframes. what I am pretty sure happens is that the new simx sends a "jacdac" to the makecode sim, and that triggers the logic to bring up the old sim

the basic problem is the use of "jacdac" message that with the old sim makes the simulator appear. it doesn't separate initialization from this messaging, unlike the new simx framework

Our current solution

1. always bridge "jacdac" message from webusb to browser-based bus, regardless of existence of simulator; this means:
   - if a device is sending jacdac packets over webusb, the packets will be forwarded inside MakeCode and to window, even if there's no one to receive then
   - if a simulator is sending jacdac packets to MakeCode, they will be forwarded over webusb, even if no hardware is there to listen to them

2. separate initialization of jacdac simulators (via an extension) from the "jacdac" channel, so that we don't get multiple simulators

Together, this should do the job and keep everything working when we switch over. Happy to discuss more.
