### PR TITLE
Don't show prompt when editing a slider or text dropdown on mobile

### DIFF
--- a/pxtblocks/fields/field_textdropdown.ts
+++ b/pxtblocks/fields/field_textdropdown.ts
@@ -68,13 +68,21 @@ export class BaseFieldTextDropdown extends Blockly.FieldTextInput {
     }
 
     protected showEditor_(e?: Event, quietInput?: boolean): void {
-        super.showEditor_(e, quietInput);
+        // Align with Blockly's approach in https://github.com/google/blockly-samples/blob/master/plugins/field-slider/src/field_slider.ts
+        // Always quiet the input for the super constructor, as we don't want to
+        // focus on the text field, and we don't want to display the modal
+        // editor on mobile devices.
+        super.showEditor_(e, true);
 
         if (!this.dropDownOpen_) this.showDropdown_();
         Blockly.Touch.clearTouchIdentifier();
 
         this.inputKeydownHandler = this.inputKeydownListener.bind(this);
         this.htmlInput_.addEventListener('keydown', this.inputKeydownHandler);
+
+        if (!quietInput) {
+            this.htmlInput_.focus();
+        }
     }
 
     override doValueUpdate_(newValue: string) {

--- a/pxtblocks/plugins/math/fieldSlider.ts
+++ b/pxtblocks/plugins/math/fieldSlider.ts
@@ -175,7 +175,11 @@ export class FieldSlider extends Blockly.FieldNumber {
     }
 
     protected showEditor_(_e?: Event, quietInput?: boolean): void {
-        super.showEditor_(_e, quietInput);
+        // Align with Blockly's approach in https://github.com/google/blockly-samples/blob/master/plugins/field-slider/src/field_slider.ts
+        // Always quiet the input for the super constructor, as we don't want to
+        // focus on the text field, and we don't want to display the modal
+        // editor on mobile devices.
+        super.showEditor_(_e, true);
 
         Blockly.DropDownDiv.hideWithoutAnimation();
         Blockly.DropDownDiv.clearContent();
@@ -194,6 +198,10 @@ export class FieldSlider extends Blockly.FieldNumber {
         Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_ as Blockly.BlockSvg, undefined, undefined, false);
 
         this.addEventListeners();
+
+        if (!quietInput) {
+            this.htmlInput_.focus();
+        }
     }
 
     protected addSlider_(contentDiv: Element) {


### PR DESCRIPTION
On mobile / Android / iPad, a prompt is used to change the value of a `FieldInput`. If the prompt is used, the text input is not rendered into the widget div. We then try to add event handlers to an input that doesn't exist which results in an error. There may also be Blockly focus manager issues that result from this. 

This PR aligns with Blockly's [`field_slider`](https://github.com/google/blockly-samples/blob/master/plugins/field-slider/src/field_slider.ts) implementation by never calling the prompt for these fields. Instead, users can use the dropdown or slider to edit the values.

The text dropdown is a slightly different case to the slider as only a subset of values can be selected via the dropdown.

This can be tested on a real mobile / Android / iPad device, or use Chrome dev tools -> three dots menu in top right -> more tools -> network conditions -> choose “Chrome - Android Mobile” as user agent.