### PR TITLE
Improve search category selected state

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -550,13 +550,15 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         };
         Blockly.Toolbox.prototype.clearSelection = function () {
             that.hideFlyout();
+            that.toolbox.clearExpandedItem();
         };
         const oldToolboxOnTreeBlur = Blockly.Toolbox.prototype.onTreeBlur;
         (Blockly.Toolbox as any).prototype.onTreeBlur = function (nextTree: Blockly.IFocusableTree | null) {
             // If the search box is focused and there are search results, the flyout is set to forceOpen.
             // Otherwise, the flyout closes and then re-opens causing an unpleasant visual effect.
             if ((that.editor.getFlyout() as pxtblockly.CachingFlyout).forceOpen) {
-                that.toolbox.selectFirstItem();
+                that.toolbox.clear();
+                that.toolbox.clearExpandedItem();
                 that.setFlyoutForceOpen(false);
                 return;
             }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1925,7 +1925,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const flyoutFocused = e.relatedTarget === this.flyout.refs.flyout || (this.flyout.refs.flyout as HTMLElement).contains(e.relatedTarget);
         if (((searchInputFocused && !hasSearch) || !searchInputFocused) && !flyoutFocused) {
             this.hideFlyout();
-        };
+        }
         if (!flyoutFocused) {
             this.toolbox.clear();
             this.toolbox.clearExpandedItem();

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1916,8 +1916,19 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             let firstBlock = document.querySelector(".monacoBlock") as HTMLElement;
             if (firstBlock) {
                 firstBlock.focus();
-                firstBlock.click();
             }
+        }
+    }
+
+    public onToolboxBlur(e: React.FocusEvent, hasSearch: boolean): void {
+        const searchInputFocused = e.relatedTarget === (this.toolbox.refs.searchbox as toolbox.ToolboxSearch).refs.searchInput;
+        const flyoutFocused = e.relatedTarget === this.flyout.refs.flyout || (this.flyout.refs.flyout as HTMLElement).contains(e.relatedTarget);
+        if (((searchInputFocused && !hasSearch) || !searchInputFocused) && !flyoutFocused) {
+            this.hideFlyout();
+        };
+        if (!flyoutFocused) {
+            this.toolbox.clear();
+            this.toolbox.clearExpandedItem();
         }
     }
 

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -83,13 +83,6 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
         this.positionDragHandle();
     }
 
-    protected getBlockClickHandler = (name: string) => {
-        return () => {
-            pxt.tickEvent("monaco.toolbox.itemclick", undefined, { interactiveConsent: true });
-            this.setState({ selectedBlock: name != this.state.selectedBlock ? name : undefined });
-        };
-    }
-
     protected getBlockMouseOver = (name: string) => {
         return () => {
             pxt.tickEvent("monaco.toolbox.itemmouseover");
@@ -175,14 +168,12 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
                 // Next item
                 let nextSibling = target.nextElementSibling as HTMLElement;
                 if (target && nextSibling) {
-                    nextSibling.click();
                     nextSibling.focus();
                 }
             } else if (charCode == 38) { // UP
                 // Previous item
                 let prevSibling = target.previousElementSibling as HTMLElement;
                 if (target && prevSibling) {
-                    prevSibling.click();
                     prevSibling.focus();
                 }
             } else if ((charCode == 37 && !isRtl) || (charCode == 38 && isRtl)) { // (LEFT & LTR) or (RIGHT & RTL)
@@ -207,6 +198,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
     }
 
     private handleFocus = (name: string) => {
+        pxt.tickEvent("monaco.toolbox.itemclick", undefined, { interactiveConsent: true });
         this.setState({
             selectedBlock: name
         });
@@ -378,7 +370,6 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
             style={this.getSelectedStyle()}
             title={block.attributes.jsDoc}
             key={`block_${qName}_${index}`} tabIndex={!this.state.selectedBlock && index === 0 ? 0 : selected ? 0 : -1} role="listitem"
-            onClick={this.getBlockClickHandler(qName)}
             onFocus={() => this.handleFocus(qName)}
             onBlur={() => this.handleBlur()}
             onMouseOver={this.getBlockMouseOver(qName)}
@@ -418,7 +409,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
         const { name, ns, color, icon, groups, selectedBlock } = this.state;
         const rgb = pxt.toolbox.getAccessibleBackground(pxt.toolbox.convertColor(color || (ns && pxt.toolbox.getNamespaceColor(ns)) || "255"));
         const iconClass = `blocklyTreeIcon${icon ? (ns || icon).toLowerCase() : "Default"}`.replace(/\s/g, "");
-        return <div id="monacoFlyoutWidget" className="monacoFlyout" style={this.getFlyoutStyle()}>
+        return <div id="monacoFlyoutWidget" className="monacoFlyout" style={this.getFlyoutStyle()} ref="flyout">
             <div id="monacoFlyoutWrapper" onScroll={this.scrollHandler} onWheel={this.wheelHandler} role="list">
                 <div className="monacoFlyoutLabel monacoFlyoutHeading">
                     <span className={`monacoFlyoutHeadingIcon blocklyTreeIcon ${iconClass}`} role="presentation" style={this.getIconStyle(rgb)}>

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -313,9 +313,6 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         if (this.state.hasSearch && this.state.searchBlocks != prevState.searchBlocks) {
             // Referesh search items
             this.refreshSearchItem();
-        } else if (prevState.hasSearch && !this.state.hasSearch && this.state.selectedItem == 'search') {
-            // No more search
-            this.closeFlyout();
         }
     }
 
@@ -470,8 +467,11 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
 
     handleCategoryTreeBlur = (e: React.FocusEvent<HTMLDivElement>) => {
         if (e.relatedTarget === (this.refs.searchbox as ToolboxSearch).refs.searchInput) {
-            this.props.parent.setFlyoutForceOpen(this.state.hasSearch)
+            this.props.parent.setFlyoutForceOpen(this.state.hasSearch);
         }
+        // This does nothing for Blocks which is handled by Blockly.Toolbox.prototype.onTreeBlur,
+        // but is required for the Monaco editor for feature parity.
+        this.props.parent.onToolboxBlur(e, this.state.hasSearch);
     }
 
     handlePointerDownCapture = (e: React.PointerEvent) => {
@@ -1175,6 +1175,9 @@ export class ToolboxSearch extends data.Component<ToolboxSearchProps, ToolboxSea
         newState.searchBlocks = blocks;
         newState.focusSearch = true;
         toolbox.setState(newState);
+        if (!hasSearch) {
+            toolbox.closeFlyout();
+        }
 
         this.setState({ searchAccessibilityLabel: searchAccessibilityLabel });
     }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -452,7 +452,6 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
     handleCategoryTreeFocus = (e: React.FocusEvent<HTMLDivElement>) => {
         // Don't handle focus events triggered by pointer events.
         if (!this.shouldHandleCategoryTreeFocus) {
-            this.shouldHandleCategoryTreeFocus = true;
             return;
         }
         if (!this.rootElement) return;
@@ -479,6 +478,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         e.preventDefault();
         this.shouldHandleCategoryTreeFocus = false;
         (this.refs.categoryTree as HTMLElement).focus();
+        this.shouldHandleCategoryTreeFocus = true;
     }
 
     isRtl() {
@@ -1129,7 +1129,15 @@ export class ToolboxSearch extends data.Component<ToolboxSearchProps, ToolboxSea
             // Don't trigger scroll behaviour inside the toolbox.
             e.preventDefault();
         } else if (charCode === 13 /* Enter */) {
-            this.searchImmediate().then(() => this.props.parent.moveFocusToFlyout());
+            this.searchImmediate().then(() => {
+                if (toolbox.state.hasSearch) {
+                    toolbox.setState({
+                        selectedItem: 'search'
+                    });
+                    toolbox.setSelectedItem(toolbox.refs.searchCategory as CategoryItem);
+                }
+                this.props.parent.moveFocusToFlyout();
+            });
         }
     }
 
@@ -1166,10 +1174,6 @@ export class ToolboxSearch extends data.Component<ToolboxSearchProps, ToolboxSea
         newState.hasSearch = hasSearch;
         newState.searchBlocks = blocks;
         newState.focusSearch = true;
-        if (hasSearch) {
-            newState.selectedItem = 'search';
-            toolbox.setSelectedItem(toolbox.refs.searchCategory as CategoryItem)
-        }
         toolbox.setState(newState);
 
         this.setState({ searchAccessibilityLabel: searchAccessibilityLabel });

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -391,4 +391,6 @@ export abstract class ToolboxEditor extends srceditor.Editor {
             this.toolbox.focus(itemToFocus);
         }
     }
+
+    onToolboxBlur(e: React.FocusEvent, keepFlyoutOpen: boolean) {};
 }


### PR DESCRIPTION
Only select / highlight the search category when it is actually selected by the user. This can happen if the user hits "Enter", "Tab", or "ArrowDown" from the search input. The previous behaviour resulted in users thinking they could use "ArrowRight" from the search input to move into the flyout and this PR aims to address that.

This PR also:
-  fixes a toolbox focus bug resulting from clicking on a toolbox category, then clicking on the sim, then re-focusing the toolbox again via keyboard and doing this more than once. This resulted in no category being selected by default.
- clicking on Monaco flyout entries no longer results in a focus event and a click event being handled. Only focus events are now handled and roving tab index is used to reduce tab stops and ensure that clicking on a flyout entry also focuses it.
- makes general changes to the Monaco toolbox and flyout to ensure feature and behaviour parity between blocks and text-based modes.