### PR TITLE
special case for second main simulator

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -452,7 +452,9 @@ namespace pxsim {
                             isDeferrableBroadcastMessage = true;
                             // start secondary frame if needed
                             const mkcdFrames = frames.filter(frame => !frame.dataset[FRAME_DATA_MESSAGE_CHANNEL]);
-                            if (mkcdFrames.length == 0 || mkcdFrames.length == 1 && !this.singleSimulator) {
+                            if (<any>messageChannel === false && (mkcdFrames.length == 0 || mkcdFrames.length == 1 && !this.singleSimulator)) {
+                                // TODO: trace down why the messageChannel is set to false in this case
+                                // TODO: we don't want to start a message channel because of "jacdac" messages.
                                 this.container.appendChild(this.createFrame());
                                 frames = this.simFrames();
                                 // there might be an old frame


### PR DESCRIPTION
when we remove old jacdac simulator, the simdriver still gets "jacdac" messages. It's default behavior when there is no match is to start a second main simulator (such as mbit). But this only happens (it appears) when messageChannel has boolean value false (the case for radio). 