### PR TITLE
Address high contrast issues with Sound Effect editor and EditorToggles

### DIFF
--- a/react-common/components/controls/DraggableGraph.tsx
+++ b/react-common/components/controls/DraggableGraph.tsx
@@ -179,7 +179,6 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
                         {isNotLast &&
                             <path
                                 className="draggable-graph-path"
-                                stroke="black"
                                 fill="none"
                                 strokeWidth="2px"
                                 d={getInterpolationPath(

--- a/react-common/styles/controls/DraggableGraph.less
+++ b/react-common/styles/controls/DraggableGraph.less
@@ -28,3 +28,12 @@
 .draggable-graph-svg {
     touch-action: none;
 }
+
+.hc {
+    .draggable-graph-path, .draggable-graph-point {
+        stroke: @highContrastTextColor;
+    }
+    .common-draggable-graph-text {
+        color: @highContrastTextColor;
+    }
+}

--- a/react-common/styles/controls/EditorToggle.less
+++ b/react-common/styles/controls/EditorToggle.less
@@ -77,14 +77,6 @@
     }
 }
 
-.common-editor-toggle-item.focused {
-    outline: 3px solid var(--pxt-neutral-foreground2);
-    outline-offset: -5px;
-    &.selected {
-        outline: 3px solid var(--pxt-focus-border);
-    }
-}
-
 /*****************************************************
  *                  Toggle Handle                    *
  ****************************************************/
@@ -280,5 +272,21 @@
             .common-editor-toggle-item + .common-editor-toggle-item.common-editor-toggle-item-dropdown.selected ~ .common-editor-toggle-handle { margin-left: 25%; }
             .common-editor-toggle-item + .common-editor-toggle-item.common-editor-toggle-item-dropdown + .common-editor-toggle-item.selected ~ .common-editor-toggle-handle { margin-left: 75%; }
         }
+    }
+}
+
+.hc {
+    .sound-gallery-preview-wave {
+        stroke: @highContrastTextColor;
+    }
+    .common-editor-toggle.focused {
+        outline: 3px solid var(--pxt-focus-border) !important;
+    }
+    .common-toggle-accessibility > button.common-button:focus {
+        outline: none !important;
+    }
+    .common-editor-toggle-item.selected > button {
+        outline: 3px solid @highContrastTextColor;
+        outline-offset: -5px;
     }
 }

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -156,7 +156,7 @@
 
 #waveform-select .common-radio-choice {
     input:focus-visible {
-        outline: 3px solid var(--pxt-focus-border);
+        outline: 3px solid var(--pxt-focus-border) !important;
     }
 }
 
@@ -207,7 +207,7 @@
 }
 
 .common-button.sound-effect-play-button:focus-visible {
-    outline: 3px solid var(--pxt-focus-border);
+    outline: 3px solid var(--pxt-focus-border) !important;
     outline-offset: 3px;
 }
 
@@ -303,4 +303,27 @@
 
 .sound-gallery-preview-wave {
     stroke: var(--pxt-primary-background);
+}
+
+.hc {
+    .sound-gallery-item-label-inner:focus {
+        outline: 3px solid @highContrastHighlightColor !important;
+    }
+
+    .common-button.sound-effect-play-button {
+        .fas.fa-play, .fas.fa-stop {
+            margin: 0 0 0 0.25rem;
+            color: @highContrastTextColor;
+        }
+        &:focus,:focus-visible {
+            outline: 3px solid var(--pxt-focus-border) !important;
+            &:after {
+                border: none;
+                outline: none;
+            }
+        }
+    }
+    #waveform-select .common-radio-choice.selected i {
+        color: @highContrastHighlightColor;
+    }
 }


### PR DESCRIPTION
Live demo: https://high-contrast-sfx-fixes.review-pxt.pages.dev/

Addresses visual issues in high contrast mode, primarily around the Sound Effect editor and EditorToggles.

I have not reviewed other parts of Makecode, it's likely there will be other field editors with theme-related issues in high contrast mode.

To test, enable high contrast mode and open a Sound Effect editor. These changes should not impact the default theme.

# Changed visuals

### Sound effect editor:

Before:

https://github.com/user-attachments/assets/304f209b-5b2c-4217-be21-a0c5f005d0ae

After:

https://github.com/user-attachments/assets/cb2b9a67-918e-4a48-9c54-d3e70247496a

### Share EditorToggle

Before:

https://github.com/user-attachments/assets/fe4c08dc-9d9b-4426-9b12-e18924fb4ce5

After:

https://github.com/user-attachments/assets/9d082d20-6383-486f-b527-8dace62bb415

### Serial logger EditorToggle

Before:

https://github.com/user-attachments/assets/673dd481-8d0e-48b1-a06e-b1fad7fdd727

After: 

https://github.com/user-attachments/assets/64d04362-1675-45c2-b2bb-e3ad207e8912