### PR TITLE
fix onclick for checkbox menu items

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -835,7 +835,7 @@ const CheckboxMenuItem = (props: CheckboxMenuItemProps) => {
                 id={id}
                 className="menu-item-checkbox"
                 isChecked={isChecked}
-                onChange={onClick}
+                onChange={() => {}}
                 label={label}
                 tabIndex={-1}
             />


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6325

the onclick was double triggering. this removes the onclick from the inner element since clicking on that element also triggers the outer one anyway