### PR TITLE
switching menuitemcheckboxes to use icons rather than real checkboxes

### DIFF
--- a/react-common/components/controls/Checkbox.tsx
+++ b/react-common/components/controls/Checkbox.tsx
@@ -49,3 +49,17 @@ export const Checkbox = (props: CheckboxProps) => {
         </div>
     )
 }
+
+interface CheckboxIconProps {
+    isChecked: boolean;
+}
+
+export const CheckboxIcon = (props: CheckboxIconProps) => {
+    const { isChecked } = props;
+
+    return (
+        <span className={classList("common-checkbox-icon", isChecked && "checked")}>
+            {isChecked && <i className="fas fa-check" />}
+        </span>
+    );
+}

--- a/react-common/styles/controls/Checkbox.less
+++ b/react-common/styles/controls/Checkbox.less
@@ -11,18 +11,6 @@
     }
 }
 
-.common-checkbox.menu-item-checkbox {
-    padding: 0;
-
-    input {
-        margin-right: 0.75rem;
-
-        // This is matching the size of semantic ui icons
-        width: 18.875px;
-        height: 16px;
-    }
-}
-
 .common-checkbox.toggle {
     input {
         opacity: 0;
@@ -84,6 +72,41 @@
 
 #profile-email-checkbox {
     width: 2rem;
+}
+
+/****************************************************
+ *                 Checkbox Icon                    *
+ ****************************************************/
+
+ .common-checkbox-icon {
+    display: inline-block;
+    position: relative;
+
+    // This is matching the size of semantic ui icons
+    width: 16px;
+    height: 16px;
+
+    border: 1px solid var(--pxt-neutral-foreground1);
+    border-radius: 2px;
+
+    &.checked {
+        background-color: var(--pxt-primary-background);
+        border-color: var(--pxt-primary-accent);
+    }
+
+    i.fas.fa-check {
+        font-size: 11px;
+        position: absolute;
+        width: 14px;
+        height: 14px;
+        margin: 0;
+        color: var(--pxt-primary-foreground)
+    }
+}
+
+.menuitemcheckbox .common-checkbox-icon {
+    margin-left: .125rem;
+    margin-right: .875rem;
 }
 
 /****************************************************

--- a/theme/common.less
+++ b/theme/common.less
@@ -430,6 +430,10 @@ div.simframe > iframe {
     }
 }
 
+.ui.menu .ui.dropdown.item .menu .item.link.menuitemcheckbox {
+    display: flex;
+}
+
 
 
 /* toggle style */

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -14,9 +14,8 @@ import ISettingsProps = pxt.editor.ISettingsProps;
 import UserInfo = pxt.editor.UserInfo;
 import SimState = pxt.editor.SimState;
 import { sendUpdateFeedbackTheme } from "../../react-common/components/controls/Feedback/FeedbackEventListener";
-import { TabPane } from "./components/core/TabPane";
 import KeyboardControlsHelp from "./components/KeyboardControlsHelp";
-import { Checkbox, CheckboxIcon } from "../../react-common/components/controls/Checkbox";
+import { CheckboxIcon } from "../../react-common/components/controls/Checkbox";
 
 // common menu items -- do not remove
 // lf("About")

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -16,7 +16,7 @@ import SimState = pxt.editor.SimState;
 import { sendUpdateFeedbackTheme } from "../../react-common/components/controls/Feedback/FeedbackEventListener";
 import { TabPane } from "./components/core/TabPane";
 import KeyboardControlsHelp from "./components/KeyboardControlsHelp";
-import { Checkbox } from "../../react-common/components/controls/Checkbox";
+import { Checkbox, CheckboxIcon } from "../../react-common/components/controls/Checkbox";
 
 // common menu items -- do not remove
 // lf("About")
@@ -381,7 +381,6 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             <sui.Item role="menuitem" icon="paint brush" text={lf("Theme")} onClick={this.showThemePicker} />
             {showKeyboardControls() &&
                 <CheckboxMenuItem
-                    id="accessible-blocks-checkbox"
                     isChecked={accessibleBlocks}
                     label={lf("Keyboard Controls")}
                     onClick={this.toggleAccessibleBlocks}
@@ -389,7 +388,6 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             }
             {showGreenScreen &&
                 <CheckboxMenuItem
-                    id="green-screen-checkbox"
                     isChecked={greenScreen}
                     label={lf("Green Screen")}
                     onClick={this.toggleGreenScreen}
@@ -813,32 +811,29 @@ export class SandboxFooter extends data.PureComponent<SandboxFooterProps, {}> {
 }
 
 interface CheckboxMenuItemProps {
-    id: string;
     label: string;
     isChecked: boolean;
     onClick: () => void;
 }
 
 const CheckboxMenuItem = (props: CheckboxMenuItemProps) => {
-    const { id, label, isChecked, onClick } = props;
+    const { label, isChecked, onClick } = props;
 
     return (
         <div
             role="menuitemcheckbox"
             aria-checked={isChecked}
             tabIndex={0}
-            className="ui item link"
+            className="ui item link menuitemcheckbox"
             onClick={onClick}
             onKeyDown={fireClickOnEnter}
         >
-            <Checkbox
-                id={id}
-                className="menu-item-checkbox"
+            <CheckboxIcon
                 isChecked={isChecked}
-                onChange={() => {}}
-                label={label}
-                tabIndex={-1}
             />
+            <span>
+                {label}
+            </span>
         </div>
     );
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6325

![image](https://github.com/user-attachments/assets/2b9495b5-5954-49f9-bad9-9cbe74b96931)

swaps out the native checkboxes for a fake checkbox