### PR TITLE
compute used arguments and symbols in sim embed

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -509,6 +509,7 @@ export async function buildSimJsInfo(simOptions: SimulateOptions): Promise<pxtc.
     const currentTargetVersion = pxt.appTarget.versions.target;
     let compileResult = await compileAsync(false, opts => {
         opts.computeUsedParts = true;
+        opts.computeUsedSymbols = true;
 
         if (simOptions.debug)
             opts.breakpoints = true;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6275

when i fixed the aspect ratio of the sim embed, i swapped computeUsedSymbols for computeUsedParts. turns out we need both!