### PR TITLE
add focus outline to tutorial controls

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -214,6 +214,11 @@
                 opacity: 1;
             }
         }
+
+        &:focus-visible {
+            outline-offset: 2px;
+            outline: 4px solid var(--pxt-focus-border);
+        }
     }
 
     > .common-button.square-button {
@@ -267,6 +272,11 @@
     .ui.button:hover, .ui.button:focus {
         background: var(--pxt-colors-blue-hover);
         color: var(--pxt-colors-blue-foreground);
+    }
+
+    .ui.button:focus-visible {
+        outline-offset: 2px;
+        outline: 4px solid var(--pxt-focus-border);
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6345

![focus-outline](https://github.com/user-attachments/assets/329015d9-5f55-40da-a87a-0de800dffd12)
