### PR TITLE
add targetconfig flag for hiding extensions from search results

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -58,6 +58,8 @@ declare namespace pxt {
         upgrades?: string[];
         // This repo's simulator extension configuration
         simx?: SimulatorExtensionConfig;
+        // if true, this repo will not be shown in extension search results
+        hidden?: boolean;
     }
 
     interface SimulatorExtensionConfig {

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -997,6 +997,21 @@ namespace pxt.github {
                 : GitRepoStatus.Unknown;
     }
 
+    export function isRepoHidden(repo: ParsedRepo, config: pxt.PackagesConfig): boolean {
+        if (!repo || !config) return true;
+
+        const repoFull = repo.fullName?.toLowerCase();
+        const repoSlug = repo.slug?.toLowerCase();
+
+        const entry = config.approvedRepoLib[repoFull] || config.approvedRepoLib[repoSlug];
+
+        if (!entry || entry.hidden) {
+            return true;
+        }
+
+        return false;
+    }
+
     function isOrgBanned(repo: ParsedRepo, config: pxt.PackagesConfig): boolean {
         if (!config) return false; // don't know
         if (!repo || !repo.owner) return true;

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -78,7 +78,11 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         setSelectedTag("")
         setSearchComplete(false)
         setExtensionsToShow([emptyCard, emptyCard, emptyCard, emptyCard])
-        const exts = await fetchGithubDataAsync([searchFor])
+
+        const config = await pxt.packagesConfigAsync();
+
+        let exts = await fetchGithubDataAsync([searchFor])
+        exts = exts?.filter(e => !pxt.github.isRepoHidden(e, config));
         const parsedExt = exts?.map(repo => parseGithubRepo(repo)) ?? [];
         //Search bundled extensions as well
         fetchBundled().forEach(e => {


### PR DESCRIPTION
this is the feature work for https://github.com/microsoft/pxt-microbit/issues/6011

i'll open a separate pr on pxt-microbit to actually hide the extension.

this PR adds a new flag to the targetconfig that allows extensions to be hidden from search results. originally i wanted to use the "hidden" flag that we have in pxt.json, but we don't actually have access to that when doing a search since it would require us to clone the repo