### PR TITLE
add blocks compiler error for missing for-of list

### DIFF
--- a/pxtblocks/compiler/compiler.ts
+++ b/pxtblocks/compiler/compiler.ts
@@ -642,11 +642,20 @@ function compileControlsForOf(e: Environment, b: Blockly.Block, comments: string
     let bOf = getInputTargetBlock(e, b, "LIST");
     let bDo = getInputTargetBlock(e, b, "DO");
 
+    let listExpression: pxt.blocks.JsNode;
+
+    if (!bOf || bOf.type === "placeholder") {
+        listExpression = pxt.blocks.mkText("null");
+    }
+    else {
+        listExpression = compileExpression(e, bOf, comments);
+    }
+
     let binding = lookup(e, b, getLoopVariableField(e, b).getField("VAR").getText());
 
     return [
         pxt.blocks.mkText("for (let " + binding.escapedName + " of "),
-        compileExpression(e, bOf, comments),
+        listExpression,
         pxt.blocks.mkText(")"),
         compileStatements(e, bDo)
     ]

--- a/pxtblocks/compiler/compiler.ts
+++ b/pxtblocks/compiler/compiler.ts
@@ -645,7 +645,7 @@ function compileControlsForOf(e: Environment, b: Blockly.Block, comments: string
     let listExpression: pxt.blocks.JsNode;
 
     if (!bOf || bOf.type === "placeholder") {
-        listExpression = pxt.blocks.mkText("null");
+        listExpression = pxt.blocks.mkText("[0]");
     }
     else {
         listExpression = compileExpression(e, bOf, comments);

--- a/pxtblocks/compiler/typeChecker.ts
+++ b/pxtblocks/compiler/typeChecker.ts
@@ -78,9 +78,18 @@ export function infer(allBlocks: Blockly.Block[], e: Environment, w: Blockly.Wor
                     break;
                 case "pxt_controls_for_of":
                 case "controls_for_of":
-                    const listTp = returnType(e, getInputTargetBlock(e, b, "LIST"));
-                    const elementTp = lookup(e, b, getLoopVariableField(e, b).getField("VAR").getText()).type;
-                    genericLink(listTp, elementTp);
+                    const listArgument = getInputTargetBlock(e, b, "LIST");
+                    if (listArgument && listArgument.type !== "placeholder") {
+                        const listTp = returnType(e, listArgument);
+                        const elementTp = lookup(e, b, getLoopVariableField(e, b).getField("VAR").getText()).type;
+                        genericLink(listTp, elementTp);
+                    }
+                    else {
+                        e.diagnostics.push({
+                            blockId: b.id,
+                            message: lf("The 'for of' block must have a list input")
+                        });
+                    }
                     break;
                 case "variables_set":
                 case "variables_change":


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6255

![image](https://github.com/user-attachments/assets/b9f325a8-d570-4047-8908-4202cfd384fe)

adds a descriptive error for for-of loops that are missing the list input. this error does appear in the error pane as well

i emit `[0]` here as that is consistent with how we handle emitting unknown arrays in other places in the blocks compiler.