### PR TITLE
Fix Static Package InitRegion Failure

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -312,27 +312,32 @@ namespace pxt.Cloud {
     }
 
     export async function initRegionAsync(): Promise<void> {
+        if (region !== undefined) {
+            // Already initialized
+            return;
+        }
+
         if (BrowserUtils.isLocalHost()) {
             region = cloud.DEV_REGION;
             return;
         }
 
-        if (region !== undefined || !pxt.webConfig?.cdnUrl) {
+        if (!pxt.webConfig?.cdnUrl) {
+            region = "unknown";
             return;
         }
 
-        const url = new URL("geo", pxt.webConfig.cdnUrl).toString();
-        const options: Util.HttpRequestOptions = { url };
-
         try {
+            const url = new URL("geo", pxt.webConfig.cdnUrl).toString();
+            const options: Util.HttpRequestOptions = { url };
             const response = await Util.requestAsync(options);
             if (response.statusCode !== 200) {
                 pxt.error(`Failed to get region: ${response.statusCode}`);
             }
             region = response.text.trim();
         } catch (e) {
-            handleNetworkError(options, e);
-            region = "error"; // Set to a default value to differentiate from uninitialized
+            pxt.error("Unable to determine region", e);
+            region = "unknown";
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6339

This fixes the static package scenario by making `initRegionAsync` more resilient to network & URL format failures. I couldn't find a reliable way to detect if we were in "static package" mode (and adding one seemed out of scope for this fix). But I think it can be fixed more simply: instead of throwing an exception when we can't get the region, just log the error to console, set a default, and move on. There's no particularly good reason to fail noisily in this case, so I think the simple log is sufficient.

Confirmed `pxt staticpkg` works again after this change.
