### PR TITLE
fix history file size issues

### DIFF
--- a/pxteditor/history.ts
+++ b/pxteditor/history.ts
@@ -245,11 +245,6 @@ export function createSnapshot(text: ScriptText) {
             }
         }
 
-        if (result[pxt.HISTORY_FILE]) {
-            // don't include the history file in the snapshot
-            delete result[pxt.HISTORY_FILE];
-        }
-
         return result;
     }
     catch(e) {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -1348,6 +1348,8 @@ namespace pxt {
                     cfg.dependencies[k] = v
                 }
             })
+
+            cfg.files = cfg.files.filter(fn => fn !== HISTORY_FILE);
             return cfg;
         }
 
@@ -1361,7 +1363,7 @@ namespace pxt {
                     files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
                     for (let f of this.getFiles()) {
                         // already stored
-                        if (f == pxt.CONFIG_NAME) continue;
+                        if (f === pxt.CONFIG_NAME || f === HISTORY_FILE) continue;
                         let str = this.readFile(f)
                         if (str == null)
                             U.userError("referenced file missing: " + f)

--- a/tests/pxt-editor-test/editorrunner.ts
+++ b/tests/pxt-editor-test/editorrunner.ts
@@ -5,7 +5,8 @@ import "mocha";
 import * as chai from "chai";
 import * as dmp from "diff-match-patch";
 import * as pxteditor from "../../pxteditor";
-import { getTextAtTime, HistoryFile, updateHistory } from "../../pxteditor/history";
+import { getTextAtTime, HistoryFile, parseHistoryFile, updateHistory } from "../../pxteditor/history";
+import { parse } from "path";
 
 pxt.appTarget = {
     versions: {
@@ -39,7 +40,20 @@ const versions = [
 
 function checkTimestamp(e: pxteditor.history.HistoryEntry, value: number) {
     chai.expect(e.timestamp).to.equal(value);
-    chai.expect(e.editorVersion).to.equal(value + "");
+}
+
+function checkCollapsedHistory(collapsedProject: pxt.workspace.ScriptText, originalProject: pxt.workspace.ScriptText) {
+    const collapsedHistory = parseHistoryFile(collapsedProject[pxt.HISTORY_FILE]);
+    const originalHistory = parseHistoryFile(originalProject[pxt.HISTORY_FILE]);
+
+    for (const entry of collapsedHistory.entries) {
+        const { files } = getTextAtTime(collapsedProject, collapsedHistory, entry.timestamp, patchText);
+        const { files: originalFiles } = getTextAtTime(originalProject, originalHistory, entry.timestamp, patchText);
+
+        chai.expect(files[pxt.MAIN_TS]).equals(originalFiles[pxt.MAIN_TS]);
+        chai.expect(files[pxt.MAIN_BLOCKS]).equals(originalFiles[pxt.MAIN_BLOCKS]);
+        chai.expect(files[pxt.CONFIG_NAME]).equals(originalFiles[pxt.CONFIG_NAME]);
+    }
 }
 
 function testDiff(textA: string, textB: string) {
@@ -110,90 +124,6 @@ describe("history", () => {
         chai.expect(text[filename]).to.equal(versions[0]);
     });
 
-    it("should collapse entries at a given interval", () => {
-        let { text, history } = createTestHistory();
-
-        const collapsed = pxteditor.history.collapseHistory([...history], {...text}, { interval: 250 }, diffText, patchText);
-
-        chai.expect(collapsed.length).to.equal(3);
-
-        for (let i = 0; collapsed.length > 0; i++) {
-            const entry = collapsed.pop();
-            text = pxteditor.history.applyDiff(text, entry, patchText);
-            if (collapsed.length) {
-                chai.expect(text[filename]).to.equal(versions[collapsed[collapsed.length - 1].timestamp / 100]);
-            }
-        }
-        chai.expect(text[filename]).to.equal(versions[0]);
-    });
-
-    it("should respect a min timestamp when collapsing", () => {
-        let { text, history } = createTestHistory();
-
-        const collapsed = pxteditor.history.collapseHistory([...history], {...text}, { interval: 250, minTime: 300 }, diffText, patchText);
-
-        chai.expect(collapsed.length).to.equal(4);
-        checkTimestamp(collapsed[0], 100);
-        checkTimestamp(collapsed[1], 200);
-        checkTimestamp(collapsed[2], 500);
-        checkTimestamp(collapsed[3], 800);
-
-        for (let i = 0; collapsed.length > 0; i++) {
-            const entry = collapsed.pop();
-            text = pxteditor.history.applyDiff(text, entry, patchText);
-            if (collapsed.length) {
-                chai.expect(text[filename]).to.equal(versions[collapsed[collapsed.length - 1].timestamp / 100]);
-            }
-        }
-        chai.expect(text[filename]).to.equal(versions[0]);
-    });
-
-    it("should respect a max timestamp when collapsing", () => {
-        let { text, history } = createTestHistory();
-
-        const collapsed = pxteditor.history.collapseHistory([...history], {...text}, { interval: 250, maxTime: 500 }, diffText, patchText);
-
-        chai.expect(collapsed.length).to.equal(5);
-        checkTimestamp(collapsed[0], 200);
-        checkTimestamp(collapsed[1], 500);
-        checkTimestamp(collapsed[2], 600);
-        checkTimestamp(collapsed[3], 700);
-        checkTimestamp(collapsed[4], 800);
-
-        for (let i = 0; collapsed.length > 0; i++) {
-            const entry = collapsed.pop();
-            text = pxteditor.history.applyDiff(text, entry, patchText);
-            if (collapsed.length) {
-                chai.expect(text[filename]).to.equal(versions[collapsed[collapsed.length - 1].timestamp / 100]);
-            }
-        }
-        chai.expect(text[filename]).to.equal(versions[0]);
-    });
-
-    it("should respect a min + max timestamp when collapsing", () => {
-        let { text, history } = createTestHistory();
-
-        const collapsed = pxteditor.history.collapseHistory([...history], {...text}, { interval: 250, minTime: 400, maxTime: 500 }, diffText, patchText);
-
-        chai.expect(collapsed.length).to.equal(7);
-        checkTimestamp(collapsed[0], 100);
-        checkTimestamp(collapsed[1], 200);
-        checkTimestamp(collapsed[2], 300);
-        checkTimestamp(collapsed[3], 500);
-        checkTimestamp(collapsed[4], 600);
-        checkTimestamp(collapsed[5], 700);
-        checkTimestamp(collapsed[6], 800);
-
-        for (let i = 0; collapsed.length > 0; i++) {
-            const entry = collapsed.pop();
-            text = pxteditor.history.applyDiff(text, entry, patchText);
-            if (collapsed.length) {
-                chai.expect(text[filename]).to.equal(versions[collapsed[collapsed.length - 1].timestamp / 100]);
-            }
-        }
-        chai.expect(text[filename]).to.equal(versions[0]);
-    });
-
     it("should handle adding and removing files", () => {
         const v1 = { "main.ts": versions[0] };
         const v2 = { "main.ts": versions[1], "custom.blocks": versions[2] };
@@ -214,21 +144,28 @@ describe("history", () => {
 })
 
 function createTestHistory() {
-    const history: pxteditor.history.HistoryEntry[] = [];
+    let previous: pxt.workspace.ScriptText = { [filename]: versions[0] };
 
-    let previous = { [filename]: versions[0] };
+    let oldTheme = pxt.appTarget.appTheme;
 
-    for (let i = 1; i < versions.length; i++) {
-        let current = { [filename]: versions[i] };
-        history.push(pxteditor.history.diffScriptText(previous, current, Date.now(), diffText));
-        history[history.length - 1].timestamp = 100 * i;
-        history[history.length - 1].editorVersion = "" + (100 * i);
-        previous = {...current};
+    pxt.appTarget.appTheme = {
+        timeMachineDiffInterval: 1
     }
+
+    for (let i = 0; i < versions.length; i++) {
+        let current = { ...previous, [filename]: versions[i] };
+
+        updateHistory(previous, current, 100 * i, [], diffText, patchText);
+
+        previous = current;
+    }
+
+    // console.log(JSON.stringify(parseHistoryFile(previous[pxt.HISTORY_FILE]).entries, null, 4));
+    pxt.appTarget.appTheme = oldTheme;
 
     return {
         text: previous as pxt.workspace.ScriptText,
-        history
+        history: parseHistoryFile(previous[pxt.HISTORY_FILE]).entries
     };
 }
 
@@ -290,6 +227,11 @@ for (let i = 0; i < 20; i++) {
 
 const ONE_MINUTE = 1000 * 60;
 const ONE_HOUR = ONE_MINUTE * 60;
+const ONE_DAY = ONE_HOUR * 24;
+
+const testProject = createProjectText();
+
+console.log((JSON.parse(testProject[pxt.HISTORY_FILE]) as HistoryFile).entries.map(e => new Date(e.timestamp).toLocaleString()).join("\n"));
 
 
 describe("updateHistory", () => {
@@ -406,7 +348,7 @@ describe("updateHistory", () => {
     });
 
     it("should restore to the version on the timestamp", () => {
-        const project = createProjectText();
+        const project = { ...testProject };
         const history = JSON.parse(project[pxt.HISTORY_FILE]) as HistoryFile;
 
         for (const entry of history.entries) {
@@ -414,6 +356,114 @@ describe("updateHistory", () => {
 
             chai.expect(files[pxt.MAIN_TS]).equals(entry.timestamp.toString());
         }
+    });
+});
+
+describe("collapseHistory", () => {
+    it("should collapse history entries", () => {
+        const project = { ...testProject };
+        const collapsed = { ...project };
+        const history = JSON.parse(project[pxt.HISTORY_FILE]) as HistoryFile;
+
+        pxteditor.history.collapseHistory(
+            collapsed,
+            { interval: ONE_DAY },
+            diffText,
+            patchText
+        );
+
+        // taken from createProjectText below
+        const expectedTimes = [
+            // first entry
+            new Date(2024, 8, 12, 8, 0, 0, 0),
+            // end of each day
+            new Date(2024, 8, 12, 8, 24, 0, 0),
+            new Date(2024, 8, 13, 10, 7, 0, 0),
+            new Date(2024, 8, 15, 8, 30, 45, 0),
+        ]
+
+        const newHistory = parseHistoryFile(collapsed[pxt.HISTORY_FILE]);
+
+        chai.expect(newHistory.entries.length).to.equal(4);
+
+
+        for (let i = 1; i < newHistory.entries.length; i++) {
+            const entry = newHistory.entries[i];
+
+            chai.expect(entry.timestamp).to.equal(expectedTimes[i].getTime());
+
+            const { files } = getTextAtTime(project, newHistory, entry.timestamp, patchText);
+            const { files: originalFiles } = getTextAtTime(project, history, entry.timestamp, patchText);
+
+            chai.expect(files[pxt.MAIN_TS]).equals(originalFiles[pxt.MAIN_TS]);
+        }
+    });
+
+    it("should collapse entries at a given interval", () => {
+        let { text } = createTestHistory();
+
+        const collapsed = { ...text };
+
+        pxteditor.history.collapseHistory(collapsed, { interval: 250 }, diffText, patchText);
+        checkCollapsedHistory(collapsed, text);
+        const entries = parseHistoryFile(collapsed[pxt.HISTORY_FILE]).entries;
+
+        chai.expect(entries.length).to.equal(3);
+        checkTimestamp(entries[0], 0);
+        checkTimestamp(entries[1], 200);
+        checkTimestamp(entries[2], 500);
+    });
+
+    it("should respect a min timestamp when collapsing", () => {
+        let { text } = createTestHistory();
+
+        const collapsed = { ...text };
+
+        pxteditor.history.collapseHistory(collapsed, { interval: 250, minTime: 300  }, diffText, patchText);
+        checkCollapsedHistory(collapsed, text);
+
+        const entries = parseHistoryFile(collapsed[pxt.HISTORY_FILE]).entries;
+
+        chai.expect(entries.length).to.equal(4);
+        checkTimestamp(entries[0], 0);
+        checkTimestamp(entries[1], 100);
+        checkTimestamp(entries[2], 200);
+        checkTimestamp(entries[3], 500);
+    });
+
+    it("should respect a max timestamp when collapsing", () => {
+        let { text } = createTestHistory();
+
+        const collapsed = { ...text };
+
+        pxteditor.history.collapseHistory(collapsed, { interval: 250, maxTime: 500 }, diffText, patchText);
+        checkCollapsedHistory(collapsed, text);
+
+        const entries = parseHistoryFile(collapsed[pxt.HISTORY_FILE]).entries;
+
+        chai.expect(entries.length).to.equal(4);
+        checkTimestamp(entries[0], 0);
+        checkTimestamp(entries[1], 300);
+        checkTimestamp(entries[2], 600);
+        checkTimestamp(entries[3], 700);
+    });
+
+    it("should respect a min + max timestamp when collapsing", () => {
+        let { text } = createTestHistory();
+
+        const collapsed = { ...text };
+
+        pxteditor.history.collapseHistory(collapsed, { interval: 250, minTime: 300, maxTime: 600 }, diffText, patchText);
+        checkCollapsedHistory(collapsed, text);
+
+        const entries = parseHistoryFile(collapsed[pxt.HISTORY_FILE]).entries;
+
+        chai.expect(entries.length).to.equal(5);
+        checkTimestamp(entries[0], 0);
+        checkTimestamp(entries[1], 100);
+        checkTimestamp(entries[2], 200);
+        checkTimestamp(entries[3], 400);
+        checkTimestamp(entries[4], 700);
     });
 });
 
@@ -447,11 +497,12 @@ describe("pxt.github.normalizeTutorialPath", () => {
 function createProjectText(): pxt.workspace.ScriptText {
     // A realistic timeline of project edits
     const dates = [
-        new Date(2024, 8, 13, 8, 0, 0, 0),
-        new Date(2024, 8, 13, 8, 15, 0, 0),
-        new Date(2024, 8, 13, 8, 17, 0, 0),
-        new Date(2024, 8, 13, 8, 23, 0, 0),
-        new Date(2024, 8, 13, 8, 24, 0, 0),
+        new Date(2024, 8, 12, 8, 0, 0, 0),
+        new Date(2024, 8, 12, 8, 15, 0, 0),
+        new Date(2024, 8, 12, 8, 17, 0, 0),
+        new Date(2024, 8, 12, 8, 23, 0, 0),
+        new Date(2024, 8, 12, 8, 24, 0, 0),
+
         new Date(2024, 8, 13, 8, 25, 0, 0),
         new Date(2024, 8, 13, 8, 45, 0, 0),
         new Date(2024, 8, 13, 8, 47, 0, 0),
@@ -463,6 +514,7 @@ function createProjectText(): pxt.workspace.ScriptText {
         new Date(2024, 8, 13, 9, 56, 0, 0),
         new Date(2024, 8, 13, 10, 5, 0, 0),
         new Date(2024, 8, 13, 10, 7, 0, 0),
+
         new Date(2024, 8, 15, 8, 0, 0, 0),
         new Date(2024, 8, 15, 8, 15, 0, 0),
         new Date(2024, 8, 15, 8, 15, 20, 0),
@@ -512,6 +564,7 @@ function createProjectText(): pxt.workspace.ScriptText {
         new Date(2024, 8, 15, 8, 30, 0, 0),
         new Date(2024, 8, 15, 8, 30, 20, 0),
         new Date(2024, 8, 15, 8, 30, 45, 0),
+
         new Date(2024, 8, 18, 8, 45, 0, 0),
     ];
 

--- a/tests/pxt-editor-test/editorrunner.ts
+++ b/tests/pxt-editor-test/editorrunner.ts
@@ -6,7 +6,6 @@ import * as chai from "chai";
 import * as dmp from "diff-match-patch";
 import * as pxteditor from "../../pxteditor";
 import { getTextAtTime, HistoryFile, parseHistoryFile, updateHistory } from "../../pxteditor/history";
-import { parse } from "path";
 
 pxt.appTarget = {
     versions: {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -385,16 +385,23 @@ export class EditorPackage {
         })
     }
 
-    setContentAsync(n: string, v: string): Promise<void> {
+    async setContentAsync(n: string, v: string): Promise<void> {
         Util.assert(!!n, "missing file name");
         let f = this.files[n];
-        let p = Promise.resolve();
         if (!f) {
             f = new File(this, n, '')
             this.files[n] = f
-            p = p.then(() => this.updateConfigAsync(cfg => cfg.files.indexOf(n) < 0 ? cfg.files.push(n) : 0))
+
+            // if this is a new file, add it to the config but skip the history file and pxt.json
+            if (n !== pxt.CONFIG_NAME && n !== pxt.HISTORY_FILE) {
+                await this.updateConfigAsync(cfg => {
+                    if (cfg.files.indexOf(n) < 0) {
+                        cfg.files.push(n);
+                    }
+                });
+            }
         }
-        return p.then(() => f.setContentAsync(v));
+        return f.setContentAsync(v);
     }
 
     updateGitJsonCache() {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -19,7 +19,7 @@ import U = pxt.Util;
 import Cloud = pxt.Cloud;
 
 import * as pxtblockly from "../../pxtblocks";
-import { getTextAtTime, HistoryFile } from "../../pxteditor/history";
+import { getTextAtTime, HistoryFile, parseHistoryFile } from "../../pxteditor/history";
 import { Milestones } from "./constants";
 
 
@@ -39,6 +39,9 @@ let headerQ = new U.PromiseQueue();
 
 let impl: WorkspaceProvider;
 let implType: string;
+
+const ONE_DAY = 1000 * 60 * 60 * 24;
+const TWO_HOURS = 1000 * 60 * 60 * 2;
 
 export function getWorkspaceType(): string {
     return implType
@@ -663,7 +666,7 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
                     }
 
                     if (toWrite) {
-                        pxteditor.history.updateHistory(previous.text, toWrite, Date.now(), h.pubVersions || [], diffText, patchText);
+                        pxteditor.history.updateHistory(previous.text, toWrite, Date.now(), h.pubVersions || [], diffText, patchText, true);
                     }
                 }
             }

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -19,7 +19,7 @@ import U = pxt.Util;
 import Cloud = pxt.Cloud;
 
 import * as pxtblockly from "../../pxtblocks";
-import { getTextAtTime, HistoryFile, parseHistoryFile } from "../../pxteditor/history";
+import { getTextAtTime, HistoryFile } from "../../pxteditor/history";
 import { Milestones } from "./constants";
 
 
@@ -39,9 +39,6 @@ let headerQ = new U.PromiseQueue();
 
 let impl: WorkspaceProvider;
 let implType: string;
-
-const ONE_DAY = 1000 * 60 * 60 * 24;
-const TWO_HOURS = 1000 * 60 * 60 * 2;
 
 export function getWorkspaceType(): string {
     return implType


### PR DESCRIPTION
this fixes an issue that was reported on the forum where a project's history file was growing huge and making the editor super slow and preventing sharing from working. the underlying issue was that `_history` was being added to the `files` list in `pxt.json`. i'm still not sure how that happened exactly, but this PR fixes that and also adds some fixes to control the file size.

changes include:
* prevents `_history` from being added to `pxt.json` (or at least prevents it on the code path that i think is most likely the culprit)
* prevents `_history` from being included in the result of `filesToBePublishedAsync`, which decides which files are included in downloaded and share projects
* prunes existing history snapshots to remove `_history` if it's present in case any projects ran into this bug
* adds some logic to collapse the diff entries stored in `_history` once per day. all entries that are older than one day are squashed in an interval of 2 hours