### PR TITLE
fix tab navigation in side docs

### DIFF
--- a/pxtblocks/layout.ts
+++ b/pxtblocks/layout.ts
@@ -346,6 +346,10 @@ export function cleanUpBlocklySvg(svg: SVGElement): SVGElement {
     pxt.U.toArray(svg.querySelectorAll('.blocklyBlockCanvas,.blocklyBubbleCanvas'))
         .forEach(el => el.removeAttribute('transform'));
 
+    svg.querySelectorAll("[tabindex]").forEach(el => {
+        el.removeAttribute("tabindex");
+    });
+
     // In order to get the Blockly comment's text area to serialize properly they have to have names
     const parser = new DOMParser();
     pxt.U.toArray(svg.querySelectorAll('.blocklyTextarea'))

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -185,14 +185,17 @@ function snippetBtn(label: string, icon: string): JQuery {
 }
 
 function addFireClickOnEnter(el: JQuery<HTMLElement>) {
-    el.keypress(e => {
-        const charCode = (typeof e.which == "number") ? e.which : e.keyCode;
-        if (charCode === 13 /* enter */ || charCode === 32 /* space */) {
-            e.preventDefault();
-            e.currentTarget.click();
-        }
-    });
+    el.keypress(fireClickOnEnter);
 }
+
+export function fireClickOnEnter(e: KeyboardEvent | JQuery.KeyPressEvent) {
+    const charCode = (typeof e.which == "number") ? e.which : e.keyCode;
+    if (charCode === 13 /* enter */ || charCode === 32 /* space */) {
+        e.preventDefault();
+        (e.currentTarget as HTMLElement).click();
+    }
+}
+
 
 let aspectRatioListenerInit = false;
 function initAspectRatioListener() {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -6,7 +6,7 @@
 
 import { BlocksRenderOptions, blocklyToSvgAsync, initializeAndInject, render } from "../pxtblocks";
 import { initEditorExtensionsAsync } from "../pxteditor/editor";
-import { defaultClientRenderOptions, renderAsync } from "./renderer";
+import { defaultClientRenderOptions, fireClickOnEnter, renderAsync } from "./renderer";
 
 import * as pxtblockly from "../pxtblocks";
 import * as Blockly from "blockly";
@@ -763,6 +763,7 @@ export function startDocsServer(loading: HTMLElement, content: HTMLElement, back
         backButton.addEventListener("click", () => {
             goBack();
         });
+        backButton.addEventListener("keydown", fireClickOnEnter);
         setElementDisabled(backButton, true);
     }
 

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -221,6 +221,12 @@
         margin-left: 1.25rem;
         cursor: pointer;
         user-select: none;
+        color: var(--pxt-page-foreground);
+        display: block;
+
+        &:hover {
+            text-decoration: none;
+        }
     }
 
     #sidedocs-back-button.disabled {

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -90,10 +90,10 @@
 </head>
 
 <body id="docs">
-    <div id="sidedocs-back-button" class="ui" style="display: none">
+    <a id="sidedocs-back-button" class="ui" style="display: none" tabindex="0">
         <i class="ui icon left arrow"></i>
         <span id="back-label"></span>
-    </div>
+    </a>
     <div id="sidedocs-back-button-divider" class="ui divider"></div>
     <div id='loading' class="ui active inverted dimmer">
         <div class="ui loader"></div>

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -748,14 +748,14 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
                 <sui.Icon icon={`icon inverted chevron ${showLeftChevron ? 'left' : 'right'}`} />
             </button>
             <div id="sidedocs" onKeyDown={this.handleKeyDown}>
-                <div id="sidedocsframe-wrapper">
-                    {this.renderContent(url, isBuiltIn, lockedEditor)}
-                </div>
                 {!lockedEditor && !isBuiltIn && <div className="ui app hide" id="sidedocsbar">
                     <a className="ui icon link" role="button" tabIndex={0} data-content={lf("Open documentation in new tab")} aria-label={lf("Open documentation in new tab")} onClick={this.popOut} onKeyDown={fireClickOnEnter} >
                         <sui.Icon icon="external" />
                     </a>
                 </div>}
+                <div id="sidedocsframe-wrapper">
+                    {this.renderContent(url, isBuiltIn, lockedEditor)}
+                </div>
             </div>
         </div>
         /* eslint-enable @microsoft/sdl/react-iframe-missing-sandbox */


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6330

this pr fixes a few side docs tab navigation bugs
* the "go back" button wasn't tab navigable. it now has a tabindex and was converted to an `<a>` element
* the pop-out button was at the end of the tab order in the side docs. it's now the first element in the order
* the rendered SVG blocks still had the tabindex attribute on some elements
