### PR TITLE
take toolboxparent into account when generating block search string

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1074,14 +1074,17 @@ namespace ts.pxtc.service {
 
             // Fill default parameters in block string
             const computeBlockString = (symbol: SymbolInfo, skipParent = false, paramMap?: pxt.Map<string>): string => {
-                if (symbol.attributes?.toolboxParent && !skipParent) {
-                    const parentSymbol = blockInfo.blocksById[symbol.attributes.toolboxParent];
+                const toolboxParent = symbol.attributes?.toolboxParent || symbol.attributes?.duplicateWithToolboxParent;
+                const toolboxArgument = symbol.attributes?.toolboxParentArgument || symbol.attributes?.duplicateWithToolboxParentArgument;
+
+                if (toolboxParent && !skipParent) {
+                    const parentSymbol = blockInfo.blocksById[toolboxParent];
 
                     if (parentSymbol) {
                         const childString = computeBlockString(symbol, true);
 
                         const paramMap = {
-                            [symbol.attributes.toolboxParentArgument || "*"]: childString
+                            [toolboxArgument || "*"]: childString
                         };
 
                         return computeBlockString(parentSymbol, true, paramMap);

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1073,7 +1073,21 @@ namespace ts.pxtc.service {
             };
 
             // Fill default parameters in block string
-            const computeBlockString = (symbol: SymbolInfo): string => {
+            const computeBlockString = (symbol: SymbolInfo, skipParent = false, paramMap?: pxt.Map<string>): string => {
+                if (symbol.attributes?.toolboxParent && !skipParent) {
+                    const parentSymbol = blockInfo.blocksById[symbol.attributes.toolboxParent];
+
+                    if (parentSymbol) {
+                        const childString = computeBlockString(symbol, true);
+
+                        const paramMap = {
+                            [symbol.attributes.toolboxParentArgument || "*"]: childString
+                        };
+
+                        return computeBlockString(parentSymbol, true, paramMap);
+                    }
+                }
+
                 if (symbol.attributes?._def) {
                     let block = [];
                     const blockDef = symbol.attributes._def;
@@ -1088,10 +1102,21 @@ namespace ts.pxtc.service {
                             case "param":
                                 // In order, preference default value, var name, param name, blockdef param name
                                 let actualParam = compileInfo.definitionNameToParam[part.name];
-                                block.push(actualParam?.defaultValue
+
+                                let valueString = actualParam?.defaultValue
                                     || part.varName
                                     || actualParam?.actualName
-                                    || part.name);
+                                    || part.name;
+
+                                if (paramMap?.["*"]) {
+                                    valueString = paramMap["*"];
+                                    delete paramMap["*"];
+                                }
+                                else if (paramMap?.[actualParam.definitionName]) {
+                                    valueString = paramMap[actualParam.definitionName];
+                                }
+
+                                block.push(valueString);
                                 break;
                         }
                     }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6247

fixes the toolbox search to take the parent attributes into account when generating searchable strings for each block

before:

![image](https://github.com/user-attachments/assets/f71f8308-a086-4289-a0a1-5f72077e7d4f)

after: 

![image](https://github.com/user-attachments/assets/a0b68230-5440-430d-8254-265838b1ecac)
