### PR TITLE
fix high contrast editor dropdown hover

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -507,7 +507,7 @@ div.simframe > iframe {
     float: right;
 }
 
-#root:not(.hc) #editordropdown {
+.main:not(.hc) #editordropdown {
     .menu {
         background-color: var(--pxt-neutral-background1) !important;
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6218

The `hc` class that used to get applied to the div with the root id is now getting applied to the div with the main class, so I updated the css here to reflect that, causing the css to be applied when we want it.

![image](https://github.com/user-attachments/assets/af5ca73a-0a44-4f16-a8fa-eaf2a3b5e09e)

![image](https://github.com/user-attachments/assets/74f86c0e-61e1-4655-959b-7522d318fa3b)

