### PR TITLE
fix exception when accessing bubble position before rendered

### DIFF
--- a/pxtblocks/plugins/comments/blockComment.ts
+++ b/pxtblocks/plugins/comments/blockComment.ts
@@ -235,7 +235,7 @@ export class CommentIcon extends Blockly.icons.Icon implements Blockly.IHasBubbl
     // to use setBubbleLocation and getBubbleLocation instead
     getBubbleLocation(): Blockly.utils.Coordinate | undefined {
         if (this.bubbleIsVisible()) {
-            return this.textInputBubble.getRelativeToSurfaceXY();
+            return this.textInputBubble?.getRelativeToSurfaceXY();
         }
         return undefined
     }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6391

i made the setBubbleVisible method async a while ago to fix an issue with comment rendering. as a result, it's possible for the bubble to not have been created when getBubbleLocation is called even though bubbleIsVisible returns true.