### PR TITLE
Hide Error List in Version History & Debug

### DIFF
--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -175,6 +175,7 @@ export function all(): Experiment[] {
             id: "forceEnableAiErrorHelp",
             name: lf("AI Error Explainer"),
             description: lf("Get AI's help explaining errors in your code"),
+            feedbackUrl: "https://github.com/microsoft/pxt/issues/10694"
         },
     ];
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -514,6 +514,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     private initBlocklyToolbox() {
+        if (pxt.shell.isTimeMachineEmbed()) {
+            return;
+        }
+
         // Remove unwanted additional tab stop from the editor.
         // We add tabindex to the tree wrapping the toolbox categories (excluding search) instead.
         const toolboxDiv = this.getToolboxDiv();
@@ -595,7 +599,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const oldWorkspaceSvgOnTreeBlur = Blockly.WorkspaceSvg.prototype.onTreeBlur;
         (Blockly.WorkspaceSvg as any).prototype.onTreeBlur = function (nextTree: Blockly.IFocusableNode | null): void {
             // Keep the flyout open whe a variable is created.
-            if ((that.editor.getFlyout() as pxtblockly.CachingFlyout).forceOpen) {
+            if ((that.editor.getFlyout() as pxtblockly.CachingFlyout)?.forceOpen) {
                 that.setFlyoutForceOpen(false);
                 return;
             }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1009,7 +1009,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     display(): JSX.Element {
         let flyoutOnly = this.parent.state.editorState && this.parent.state.editorState.hasCategories === false;
-        let showErrorList = pxt.Util.isFeatureEnabled("blocksErrorList");
+        let showErrorList = pxt.Util.isFeatureEnabled("blocksErrorList") && !pxt.shell.isTimeMachineEmbed() && !this.parent.state.debugging;
         return (
             <div className="blocksAndErrorList">
                 <div className="blocksEditorOuter">

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -103,7 +103,13 @@ export class ErrorList extends auth.Component<ErrorListProps, ErrorListState> {
         const errorListContent = !isCollapsed ? groupedErrors.map((e, i) => <ErrorListItem errorGroup={e} index={i} key={`errorlist_error_${i}`}/> ) : undefined;
         const errorCount = errors.length;
 
-        const showErrorHelp = !!getErrorHelp && !!showLoginDialog && (pxt.appTarget.appTheme.forceEnableAiErrorHelp || pxt.Util.isFeatureEnabled("aiErrorHelp"));
+        const showDebuggerSuggestion = startDebugger && !pxt.shell.isReadOnly();
+
+        const showErrorHelp =
+            !!getErrorHelp &&
+            !!showLoginDialog &&
+            !pxt.shell.isReadOnly() &&
+            (pxt.appTarget.appTheme.forceEnableAiErrorHelp || pxt.Util.isFeatureEnabled("aiErrorHelp"));
 
         const helpLoader = (
             <div className="error-help-loader" onClick={(e) => e.stopPropagation()}>
@@ -133,7 +139,7 @@ export class ErrorList extends auth.Component<ErrorListProps, ErrorListState> {
                             {isLoadingHelp ? helpLoader : helpButton}
                         </div>
                     )}
-                    {startDebugger && (
+                    {showDebuggerSuggestion && (
                         <Button id="debug-button"
                             onClick={this.props.startDebugger}
                             title={lf("Debug this project")}

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -640,7 +640,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     display(): JSX.Element {
-        const showErrorList = pxt.appTarget.appTheme.errorList;
+        const showErrorList = pxt.appTarget.appTheme.errorList && !pxt.shell.isTimeMachineEmbed() && !this.parent.state.debugging;
 
         return (
             <div id="monacoEditorArea" className={`monacoEditorArea`} style={{ direction: 'ltr' }}>


### PR DESCRIPTION
This change does a few things.

1. First and foremost, it hides the error list when in the version history and debug views (fixes https://github.com/microsoft/pxt-microbit/issues/6377)
2. It also hides the "Explain with AI" and "Launch in Debugger" buttons when in readonly mode - for example, the share page. Both of these buttons can have unexpected behavior in those scenarios (like asking for log-in where it isn't supported, or getting stuck in debug mode)
3. Fixes unrelated focus issues and null references in readonly mode, caused by trying to manipulate the toolbox when it wasn't available.
4. Adds a feedback URL for the "AI Error Explainer" experiment (as requested in https://github.com/microsoft/pxt/pull/10692#discussion_r2164986818)

Upload target: https://makecode.microbit.org/app/358fa96db053a5c91fd5827a0cc871fbaf1d6be4-bf5998c599