### PR TITLE
Keyboard Controls help tweaks

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -821,7 +821,7 @@ declare namespace pxt.editor {
         extensionsVisible?: boolean;
         isMultiplayerGame?: boolean; // Arcade: Does the current project contain multiplayer blocks?
         activeTourConfig?: pxt.tour.TourConfig;
-        navigateRegions?: boolean;
+        areaMenuOpen?: boolean;
         feedback?: FeedbackState;
         themePickerOpen?: boolean;
         errorListNote?: string;

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -1064,8 +1064,7 @@ declare namespace pxt.editor {
         showOnboarding(): void;
         showTour(config: pxt.tour.TourConfig): void;
         closeTour(): void;
-        showNavigateRegions(): void;
-        hideNavigateRegions(): void;
+        toggleAreaMenu(): void;
         showKeymap(show: boolean): void;
         toggleKeymap(): void;
         signOutGithub(): void;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "11.4.32",
+  "version": "11.4.33",
   "description": "Microsoft MakeCode provides Blocks / JavaScript / Python tools and editors",
   "keywords": [
     "TypeScript",

--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -19,7 +19,7 @@ namespace pxsim.accessibility {
             return "togglekeyboardcontrolshelp";
         } else if (e.key === "b" && meta) {
             e.preventDefault();
-            return "navigateregions"
+            return "toggleareamenu"
         }
         return null
     }

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -75,7 +75,7 @@ namespace pxsim {
         url: string;
     }
 
-    export type GlobalAction = "escape" | "navigateregions" | "togglekeyboardcontrolshelp";
+    export type GlobalAction = "escape" | "toggleareamenu" | "togglekeyboardcontrolshelp";
 
     export interface SimulatorActionMessage extends SimulatorMessage {
         type: "action";

--- a/theme/areamenu.less
+++ b/theme/areamenu.less
@@ -5,7 +5,7 @@
 /* Reference import */
 @import (reference) "semantic.less";
 
-.navigate-regions-container {
+.area-menu-container {
     position: fixed;
     top: 0;
     left: 0;
@@ -16,14 +16,14 @@
     height: 100%;
     z-index: @modalDimmerZIndex;
 
-    .region-button {
+    .area-button {
         position: absolute;
         background-color: var(--pxt-neutral-alpha50);
         border-radius: 0;
         border: 3px solid var(--pxt-neutral-background1);
         padding: 0;
 
-        &.simulator-region {
+        &.simulator-area {
             // Must be more than the z-index of 1 that high contrast mode adds to all buttons.
             z-index: 2 !important;
         }

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -34,7 +34,7 @@
 @import 'accessibility';
 @import 'highcontrast';
 @import 'greenscreen';
-@import 'navigateregions';
+@import 'areamenu';
 
 @import 'extension';
 @import 'extensionErrors';

--- a/theme/sidedoc-keyboard-nav-help.less
+++ b/theme/sidedoc-keyboard-nav-help.less
@@ -31,6 +31,7 @@
     .hint {
         font-size: 85%;
         line-height: 1;
+        margin: 0.5rem 0 0 0;
     }
     table {
         width: 100%;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5326,12 +5326,12 @@ export class ProjectView
     toggleAreaMenu() {
         const dialog = Array.from(document.querySelectorAll("[role=dialog]")).find(dialog => (dialog as any).checkVisibility());
         this.setState((state) => {
-            const { navigateRegions } = state;
+            const { areaMenuOpen } = state;
             if (state.home || dialog) {
                 // Skip on home page or if a dialog is open.
                 return state;
             }
-            return { navigateRegions: !navigateRegions }
+            return { areaMenuOpen: !areaMenuOpen }
         });
     }
 
@@ -5594,7 +5594,7 @@ export class ProjectView
                 {hideMenuBar ? <div id="editorlogo"><a className="poweredbylogo"></a></div> : undefined}
                 {lightbox ? <sui.Dimmer isOpen={true} active={lightbox} portalClassName={'tutorial'} className={'ui modal'}
                     shouldFocusAfterRender={false} closable={true} onClose={this.hideLightbox} /> : undefined}
-                {this.state.navigateRegions && <AreaMenuOverlay parent={this}/>}
+                {this.state.areaMenuOpen && <AreaMenuOverlay parent={this}/>}
                 {this.state.activeTourConfig && <Tour config={this.state.activeTourConfig} onClose={this.closeTour} />}
                 {this.state.themePickerOpen && <ThemePickerModal themes={this.themeManager.getAllColorThemes()} onThemeClicked={theme => this.setColorThemeById(theme?.id, true)} onClose={this.hideThemePicker} />}
             </div>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -80,7 +80,7 @@ import Util = pxt.Util;
 import { HintManager } from "./hinttooltip";
 import { mergeProjectCode, appendTemporaryAssets } from "./mergeProjects";
 import { Tour } from "./components/onboarding/Tour";
-import { NavigateRegionsOverlay } from "./components/NavigateRegionsOverlay";
+import { AreaMenuOverlay } from "./components/AreaMenuOverlay";
 import { parseTourStepsAsync } from "./onboarding";
 import { initGitHubDb } from "./idbworkspace";
 import { BlockDefinition, CategoryNameID } from "./toolbox";
@@ -334,8 +334,8 @@ export class ProjectView
                 this.setSimulatorFullScreen(false);
                 return;
             }
-            case "navigateregions" : {
-                this.showNavigateRegions();
+            case "toggleareamenu" : {
+                this.toggleAreaMenu();
                 return
             }
             case "togglekeyboardcontrolshelp": {
@@ -5320,18 +5320,19 @@ export class ProjectView
     }
 
     ///////////////////////////////////////////////////////////
-    ////////////             Navigate regions     /////////////
+    ////////////            Area menu             /////////////
     ///////////////////////////////////////////////////////////
 
-    hideNavigateRegions() {
-        this.setState({ navigateRegions: false });
-    }
-
-    showNavigateRegions() {
+    toggleAreaMenu() {
         const dialog = Array.from(document.querySelectorAll("[role=dialog]")).find(dialog => (dialog as any).checkVisibility());
-        if (!dialog) {
-            this.setState(state => state.home ? state : { navigateRegions: true })
-        }
+        this.setState((state) => {
+            const { navigateRegions } = state;
+            if (state.home || dialog) {
+                // Skip on home page or if a dialog is open.
+                return state;
+            }
+            return { navigateRegions: !navigateRegions }
+        });
     }
 
     ///////////////////////////////////////////////////////////
@@ -5593,7 +5594,7 @@ export class ProjectView
                 {hideMenuBar ? <div id="editorlogo"><a className="poweredbylogo"></a></div> : undefined}
                 {lightbox ? <sui.Dimmer isOpen={true} active={lightbox} portalClassName={'tutorial'} className={'ui modal'}
                     shouldFocusAfterRender={false} closable={true} onClose={this.hideLightbox} /> : undefined}
-                {this.state.navigateRegions && <NavigateRegionsOverlay parent={this}/>}
+                {this.state.navigateRegions && <AreaMenuOverlay parent={this}/>}
                 {this.state.activeTourConfig && <Tour config={this.state.activeTourConfig} onClose={this.closeTour} />}
                 {this.state.themePickerOpen && <ThemePickerModal themes={this.themeManager.getAllColorThemes()} onThemeClicked={theme => this.setColorThemeById(theme?.id, true)} onClose={this.hideThemePicker} />}
             </div>

--- a/webapp/src/components/AreaMenuOverlay.tsx
+++ b/webapp/src/components/AreaMenuOverlay.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import * as Blockly from "blockly";
 import * as ReactDOM from "react-dom";
 import { Button, ButtonProps } from "../../../react-common/components/controls/Button";
 import { FocusTrap } from "../../../react-common/components/controls/FocusTrap";
@@ -200,6 +201,7 @@ export const AreaMenuOverlay = ({ parent }: AreaMenuOverlapProps) => {
     const [areaRects, setAreaRects] = useState(getRects());
 
     const moveFocusToArea = useCallback((area: Area) => {
+        Blockly.hideChaff();
         area.focus(parent);
         movedFocusToAreaRef.current = true;
         parent.toggleAreaMenu();

--- a/webapp/src/components/KeyboardControlsHelp.tsx
+++ b/webapp/src/components/KeyboardControlsHelp.tsx
@@ -1,14 +1,16 @@
 import * as React from "react";
 import { getActionShortcut, getActionShortcutsAsKeys, ShortcutNames } from "../shortcut_formatting";
 
+const isMacPlatform = pxt.BrowserUtils.isMac();
+
 const KeyboardControlsHelp = () => {
     const ref = React.useRef<HTMLElement>(null);
     React.useEffect(() => {
         ref.current?.focus()
     }, []);
     const ctrl = lf("Ctrl");
-    const cmd = pxt.BrowserUtils.isMac() ? "⌘" : ctrl;
-    const optionOrCtrl = pxt.BrowserUtils.isMac() ? "⌥" : ctrl;
+    const cmd = isMacPlatform ? "⌘" : ctrl;
+    const optionOrCtrl = isMacPlatform ? "⌥" : ctrl;
     const contextMenuRow = <Row name={lf("Open context menu")} shortcuts={[ShortcutNames.MENU]} />
     const cleanUpRow = <Row name={lf("Workspace: Format code")} shortcuts={[ShortcutNames.CLEAN_UP]} />
     const orAsJoiner = lf("or")
@@ -80,7 +82,7 @@ const KeyboardControlsHelp = () => {
 }
 
 const Shortcut = ({ keys }: { keys: string[] }) => {
-    const joiner = pxt.BrowserUtils.isMac() ? " " : " + "
+    const joiner = isMacPlatform ? " " : " + "
     return (
         <span className="shortcut">
             {keys.reduce((acc, key) => {

--- a/webapp/src/components/KeyboardControlsHelp.tsx
+++ b/webapp/src/components/KeyboardControlsHelp.tsx
@@ -20,13 +20,13 @@ const KeyboardControlsHelp = () => {
             <table>
                 <tbody>
                     <Row name={lf("Show/hide shortcut help")} shortcuts={[ShortcutNames.LIST_SHORTCUTS]} />
-                    <Row name={lf("Jump to region")} shortcuts={[[cmd, "B"]]} />
+                    <Row name={lf("Open/close area menu")} shortcuts={[[cmd, "B"]]} />
                     <Row name={lf("Block and toolbox navigation")} shortcuts={[ShortcutNames.UP, ShortcutNames.DOWN, ShortcutNames.LEFT, ShortcutNames.RIGHT]} />
                     <Row name={lf("Toolbox")} shortcuts={[ShortcutNames.TOOLBOX]} />
                     {editOrConfirmRow}
                     <Row name={lf("Move mode")} shortcuts={[ShortcutNames.MOVE]} >
-                        <br /><span className="hint">{lf("Move with arrow keys")}</span>
-                        <br /><span className="hint">{lf("Hold {0} for free movement", optionOrCtrl)}</span>
+                        <p className="hint">{lf("Press arrow keys to move to connections")}</p>
+                        <p className="hint">{lf("Hold {0} to move anywhere", optionOrCtrl)}</p>
                     </Row>
                     <Row name={lf("Copy / paste")} shortcuts={[ShortcutNames.COPY, ShortcutNames.PASTE]} joiner="/" />
                     {cleanUpRow}
@@ -37,7 +37,7 @@ const KeyboardControlsHelp = () => {
             <table>
                 <tbody>
                     <Row name={lf("Move between menus, simulator and the workspace")} shortcuts={[[lf("Tab")], [lf("Shift"), lf("Tab")]]} joiner="row"/>
-                    <Row name={lf("Jump to region")} shortcuts={[[cmd, "B"]]} />
+                    <Row name={lf("Open/close area menu")} shortcuts={[[cmd, "B"]]} />
                     <Row name={lf("Exit")} shortcuts={[ShortcutNames.EXIT]} />
                     <Row name={lf("Toolbox")} shortcuts={[ShortcutNames.TOOLBOX]} />
                     <Row name={lf("Toolbox: Move in and out of categories")} shortcuts={[ShortcutNames.LEFT, ShortcutNames.RIGHT]} />
@@ -66,8 +66,8 @@ const KeyboardControlsHelp = () => {
             <table>
                 <tbody>
                     <Row name={lf("Move mode")} shortcuts={[ShortcutNames.MOVE]} />
-                    <Row name={lf("Move mode: Move to new position")} shortcuts={[ShortcutNames.UP, ShortcutNames.DOWN, ShortcutNames.LEFT, ShortcutNames.RIGHT]} />
-                    <Row name={lf("Move mode: Free movement")}>
+                    <Row name={lf("Move mode: Move to connections")} shortcuts={[ShortcutNames.UP, ShortcutNames.DOWN, ShortcutNames.LEFT, ShortcutNames.RIGHT]} />
+                    <Row name={lf("Move mode: Move anywhere")}>
                         {lf("Hold {0} and press arrow keys", optionOrCtrl)}
                     </Row>
                     <Row name={lf("Move mode: Confirm")} {...enterOrSpace} />
@@ -136,7 +136,6 @@ const Row = ({ name, shortcuts = [], joiner, children}: RowProps) => {
                         : [...acc, joiner ? ` ${joiner} ` : " ", shortcut]
                 }, [])}
                 {children}
-                <br />
             </td>
         </tr>
     )

--- a/webapp/src/shortcut_formatting.ts
+++ b/webapp/src/shortcut_formatting.ts
@@ -78,6 +78,10 @@ export function getActionShortcutsAsKeys(
     return isMacShortcut === isMacPlatform;
   });
   currentPlatform = currentPlatform.length === 0 ? named : currentPlatform;
+  // Prefer simpler shortcuts. This promotes Ctrl+Y for redo.
+  currentPlatform.sort((a, b) => {
+    return a.length - b.length;
+  })
 
   // If there are modifiers return only one shortcut on the assumption they are
   // intended for different platforms. Otherwise assume they are alternatives.


### PR DESCRIPTION
Tweaks in response to feedback and discussions around terminology.

- "Jump to region" renamed to "Open area menu" and corresponding internal renames. This makes it clearer that you don't need to hold Cmd+B.
- Cmd+B now toggles the area menu rather than just opens it.
- Tweak text describing move mode.
- Tweak shortcut display to prefer Ctrl+Y on Windows for redo.
- Tweak the platform detection to make it easier to hack locally to try the other platform's scenario.

I've also opened a Blockly PR to sort out the weirdly ordered Shift+Cmd+Z.