### PR TITLE
clean up accessibility tick events and add missing ticks

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -1043,7 +1043,7 @@ declare namespace pxt.editor {
         toggleHighContrast(): void;
         setHighContrast(on: boolean): void;
         toggleGreenScreen(): void;
-        toggleAccessibleBlocks(): void;
+        toggleAccessibleBlocks(eventSource: string): void;
         launchFullEditor(): void;
         resetWorkspace(): void;
 

--- a/webapp/src/accessibility.tsx
+++ b/webapp/src/accessibility.tsx
@@ -63,16 +63,7 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
     }
 
     toggleAccessibleBlocks() {
-        pxt.tickEvent(
-            "accmenu.editor.toggleAccessibleBlocks",
-            {
-                enabling: !this.getData<boolean>(auth.ACCESSIBLE_BLOCKS) ? "true" : "false"
-            },
-            {
-                interactiveConsent: true,
-            }
-        );
-        this.props.parent.toggleAccessibleBlocks();
+        this.props.parent.toggleAccessibleBlocks("accmenu");
     }
 
     UNSAFE_componentWillReceiveProps(nextProps: EditorAccessibilityMenuProps) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2853,7 +2853,11 @@ export class ProjectView
     }
 
     private editorLoaded() {
-        pxt.tickEvent('app.editor', { projectHeaderId: this.state.header?.id });
+        pxt.tickEvent('app.editor', {
+            projectHeaderId: this.state.header?.id,
+            fileType: this.editorFile?.getExtension(),
+            accessibleBlocks: this.getData<boolean>(auth.ACCESSIBLE_BLOCKS) ? "true" : "false"
+        });
     }
 
     unloadProjectAsync(home?: boolean) {
@@ -5229,12 +5233,12 @@ export class ProjectView
         this.setState({ greenScreen: greenScreenOn });
     }
 
-    async toggleAccessibleBlocks() {
+    async toggleAccessibleBlocks(eventSource: string) {
         const nextEnabled = !this.getData<boolean>(auth.ACCESSIBLE_BLOCKS);
         if (nextEnabled) {
             pxt.storage.setLocal("onboardAccessibleBlocks", "1")
         }
-        await core.toggleAccessibleBlocks()
+        await core.toggleAccessibleBlocks(eventSource)
         this.reloadEditor();
     }
 
@@ -5324,10 +5328,12 @@ export class ProjectView
     ///////////////////////////////////////////////////////////
 
     hideNavigateRegions() {
+        pxt.tickEvent("app.hideNavigateRegions");
         this.setState({ navigateRegions: false });
     }
 
     showNavigateRegions() {
+        pxt.tickEvent("app.showNavigateRegions");
         const dialog = Array.from(document.querySelectorAll("[role=dialog]")).find(dialog => (dialog as any).checkVisibility());
         if (!dialog) {
             this.setState(state => state.home ? state : { navigateRegions: true })

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2855,8 +2855,7 @@ export class ProjectView
     private editorLoaded() {
         pxt.tickEvent('app.editor', {
             projectHeaderId: this.state.header?.id,
-            fileType: this.editorFile?.getExtension(),
-            accessibleBlocks: this.getData<boolean>(auth.ACCESSIBLE_BLOCKS) ? "true" : "false"
+            fileType: this.editorFile?.getExtension()
         });
     }
 
@@ -6393,6 +6392,12 @@ document.addEventListener("DOMContentLoaded", async () => {
             initHashchange();
             socketbridge.tryInit();
             electron.initElectron(theEditor);
+            pxt.tickEvent(
+                "accessibilty.accessibleBlocksEnabledForSession",
+                {
+                    enabled: data.getData<boolean>(auth.ACCESSIBLE_BLOCKS) ? "true" : "false",
+                }
+            );
         })
         .then(() => {
             const showHome = theEditor.shouldShowHomeScreen();

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -243,8 +243,18 @@ export async function setHighContrastPrefAsync(highContrast: boolean): Promise<v
     }
 }
 
-export async function setAccessibleBlocksPrefAsync(accessibleBlocks: boolean): Promise<void> {
+export async function setAccessibleBlocksPrefAsync(accessibleBlocks: boolean, eventSource: string): Promise<void> {
     const cli = await clientAsync();
+
+    pxt.tickEvent(
+        "auth.setAccessibleBlocks",
+        {
+            enabling: accessibleBlocks ? "true" : "false",
+            eventSource: eventSource,
+            local: !cli ? "true" : "false"
+        }
+    );
+
     if (cli) {
         await cli.patchUserPreferencesAsync({
             op: 'replace',

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -252,8 +252,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
     }
 
     toggleAccessibleBlocks() {
-        pxt.tickEvent("menu.toggleaccessibleblocks", undefined, { interactiveConsent: true });
-        this.props.parent.toggleAccessibleBlocks();
+        this.props.parent.toggleAccessibleBlocks("settings");
     }
 
     showResetDialog() {
@@ -655,7 +654,18 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
 
     toggleBuiltInHelp(help: pxt.editor.BuiltInHelp, focusIfVisible: boolean) {
         const url = `${builtInPrefix}${help}`;
-        if (this.state.docsUrl === url && !this.state.sideDocsCollapsed && !focusIfVisible) {
+        const shouldCollapse = this.state.docsUrl === url && !this.state.sideDocsCollapsed && !focusIfVisible;
+
+        pxt.tickEvent(
+            `sidedocs.builtin`,
+            {
+                path: url,
+                focusIfVisible: focusIfVisible ? "true" : "false",
+                collapsing: shouldCollapse ? "true" : "false"
+            },
+        );
+
+        if (shouldCollapse) {
             const wasEditorFocused = Blockly.getFocusManager().getFocusedTree();
             this.props.parent.setState({ sideDocsCollapsed: true });
 

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -357,11 +357,12 @@ export async function setHighContrast(on: boolean) {
     await auth.setHighContrastPrefAsync(on);
 }
 
-export async function toggleAccessibleBlocks() {
-    await setAccessibleBlocks(!data.getData<boolean>(auth.ACCESSIBLE_BLOCKS));
+export async function toggleAccessibleBlocks(eventSource: string) {
+    await setAccessibleBlocks(!data.getData<boolean>(auth.ACCESSIBLE_BLOCKS), eventSource);
 }
-export async function setAccessibleBlocks(on: boolean) {
-    await auth.setAccessibleBlocksPrefAsync(on);
+
+export async function setAccessibleBlocks(on: boolean, eventSource: string) {
+    await auth.setAccessibleBlocksPrefAsync(on, eventSource);
 }
 
 export async function setLanguage(lang: string) {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -266,8 +266,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
     }
 
     toggleAccessibleBlocks() {
-        pxt.tickEvent("home.toggleaccessibleblocks", undefined, { interactiveConsent: true });
-        this.props.parent.toggleAccessibleBlocks();
+        this.props.parent.toggleAccessibleBlocks("homesettings");
     }
 
     showResetDialog() {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6396

this pr makes a few tweaks to our accessibility tick events:
* combines all of the toggleAccessibleBlocks ticks into a single tick. the source of the tick (settings, homesettings, or accmenu) is now a custom dimension.
* adds tick events for showing/hiding the navigation regions
* adds tick events for showing the keyboard control sidedocs
* adds a custom dimensions to our `app.editor` tick which indicates what file type is loaded for the editor and whether accessible blocks are enabled

@abchatra @microbit-matt-hillsdon @microbit-lucy are there any other scenarios you'd like to collect data on? any keyboard shortcuts you want me to instrument? 