### PR TITLE
Fix "on start" block in stack traces

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1089,7 +1089,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 return undefined;
             }
 
-            const blockId = this.compilationResult ? pxtblockly.findBlockIdByLine(this.compilationResult.sourceMap, { start: locInfo.line, length: locInfo.endLine - locInfo.line }) : undefined;
+            const blockId = locInfo.functionName === "<main>" /* Root JS function, therefore On Start block */ ?
+                this.editor.getBlocksByType(ts.pxtc.ON_START_TYPE)?.[0]?.id :
+                (this.compilationResult ? pxtblockly.findBlockIdByLine(this.compilationResult.sourceMap, { start: locInfo.line, length: locInfo.endLine - locInfo.line }) : undefined);
+
             if (!blockId) {
                 return undefined;
             }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6397

The JS code for anything in "on start" is just at the root level of the javascript, which leads to some confusion when we parse the locInfo associated with an "on start" stack frame.

In these cases, we can detect we're at the root level (therefore in "on start") by checking if the function name is the root function defined here: https://github.com/microsoft/pxt/blob/d15df7021d902c7e41f54a3e3d51c604b3097010/pxtcompiler/emitter/emitter.ts#L1056

# Before
![image](https://github.com/user-attachments/assets/bd65387e-048c-4602-9e7c-d29a09c37b47)
![image](https://github.com/user-attachments/assets/f13bddad-6ce9-4df9-828d-14e55de4b579)

# After
![image](https://github.com/user-attachments/assets/286a6bda-014a-42a8-8cc2-9b52fabdd1f6)
![image](https://github.com/user-attachments/assets/99229234-9861-45f5-9b39-cc23ceeb4156)

# Try it
Upload Target: https://makecode.microbit.org/app/9d047dac5da6b08a6c61a5d74a74ac4f59d78e98-b603a45996