### PR TITLE
Improved keyboard focus outlines for various screens

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -209,6 +209,9 @@ div.blocklyWidgetDiv {
     position: fixed;
     /* Lower Z index for BlocklyWidgetDiv and grid picker tooltips */
     z-index: @blocklyWidgetDivZIndex;
+    &:focus-visible {
+        outline: none;
+    }
 }
 
 div.blocklyWidgetDiv.functioneditor {
@@ -219,6 +222,9 @@ div.blocklyWidgetDiv.functioneditor {
 div.blocklyDropDownDiv {
     z-index: @blocklyDropdownDivZIndex;
     overflow: hidden;
+    &:focus-visible {
+        outline: none;
+    }
 }
 
 div.blocklyTooltipDiv {

--- a/theme/common.less
+++ b/theme/common.less
@@ -1074,7 +1074,7 @@ Field editors
                 border-radius: 500rem;
                 padding: 0.7rem 1rem;
 
-                & > i.fas.fa-search {
+                & i.fas.fa-search {
                     position: relative;
                     margin-top: 0.1rem;
                     right: 0;
@@ -1082,6 +1082,25 @@ Field editors
 
                     opacity: .5;
                     transition: opacity 0.3s ease;
+                }
+                & > button:focus-visible {
+                    outline: 3px solid var(--pxt-focus-border);
+                    border-radius: 20%;
+                    &::after {
+                        content: none;
+                    }
+                }
+                &:focus-within {
+                    outline: 3px solid var(--pxt-focus-border);
+                    &:has(button:focus-visible) {
+                        outline: none;
+                    }
+                }
+                &:focus-within::after {
+                    content: none;
+                }
+                & > input:focus {
+                    outline: none !important;
                 }
             }
 
@@ -1158,6 +1177,10 @@ Field editors
             background-color: var(--pxt-neutral-background1-hover) !important;
             color: var(--pxt-neutral-foreground1-hover) !important;
         }
+
+        &:focus-visible {
+            outline: 3px solid var(--pxt-focus-border);
+        }
     }
 
     .extension-grid {
@@ -1197,10 +1220,11 @@ Field editors
         color: @white
     }
 
-    .extension-tag:focus::after  {
-        border: .05rem;
-        border-color: var(--pxt-focus-border);
-        border-radius: 1.6rem;
+    .extension-tag:focus-visible {
+        outline: 3px solid var(--pxt-focus-border);
+        &::after {
+            content: none;
+        }
     }
 
     .tab-header {

--- a/theme/serial.less
+++ b/theme/serial.less
@@ -113,6 +113,11 @@
     transition: border-radius 1s ease-in-out;
 }
 
+#serialHeader .button:focus-visible {
+    outline: 3px solid var(--pxt-focus-border);
+    outline-offset: 1px;
+}
+
 #serialConsole,
 #serialCsv {
     margin-top: 0.5rem;


### PR DESCRIPTION
### Summary

- Removed keyboard focus outlines around Sound Effect and Melody editors
- Show data screen
- Extensions page

On the Extensions page, the css is using an `::after` pseudo-element to apparently implement focus outlines, and I don't understand why but it was causing issues with the high contrast outlines. I disabled the `::after`  specifically for the Extensions page, but I'd like to flag it here. The correct solution might be to fix the buttons and inputs at a higher level, or alternatively it is implemented this way for a good reason.

### Removed blue focus outlines around Sound Effect and Melody editors

When opened using the mouse.

**Before**

<img width="334" alt="image" src="https://github.com/user-attachments/assets/e17c4efc-9b13-4257-9be9-a189ae143b95" />

<img width="510" alt="image" src="https://github.com/user-attachments/assets/00eb9bc5-8630-4ea4-9b96-cf59f690149c" />

**After**

<img width="305" alt="image" src="https://github.com/user-attachments/assets/04dd39ab-2db4-46db-a8f7-535ac9993c6f" />

<img width="462" alt="image" src="https://github.com/user-attachments/assets/9c6a8e2c-f286-42fe-9428-d1c84a3987e8" />

### Show data screen

**Before**

https://github.com/user-attachments/assets/ee3810f7-d797-4c70-9e33-a0c08b8bff3f

**After**

https://github.com/user-attachments/assets/68ea266e-4ec1-4dd6-8d72-5103b8321098

### Extensions page

**Before**

https://github.com/user-attachments/assets/73782c0e-6d4f-43de-9349-130d46f97fb3

**After**

https://github.com/user-attachments/assets/e24407e4-4673-4bf2-87f9-7b8ed5261e8c

### Extensions page (high contrast)

**Before**

https://github.com/user-attachments/assets/23db2027-b83e-4058-b342-57ce72dea1a6

**After**

https://github.com/user-attachments/assets/3f261ac2-2ed5-44e0-a5cf-3f68b14f3687
