### PR TITLE
High Contrast Fixes

### DIFF
--- a/react-common/components/theming/themeManager.ts
+++ b/react-common/components/theming/themeManager.ts
@@ -26,6 +26,11 @@ export class ThemeManager {
         return ThemeManager.instances.get(doc);
     }
 
+    public static isCurrentThemeHighContrast(doc: Document = document): boolean {
+        const themeManager = ThemeManager.getInstance(doc);
+        return themeManager.isHighContrast(themeManager.getCurrentColorTheme()?.id);
+    }
+
     public getCurrentColorTheme(): Readonly<pxt.ColorThemeInfo> {
         return this.currentTheme;
     }

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -38,6 +38,13 @@ div.field .ui.toggle.checkbox input:checked~label:before {
     border: 3px solid var(--pxt-colors-yellow-background) !important;
 }
 
+/*
+ * Toolbox
+ */
+.blocklyTreeRow:hover {
+    outline: 3px solid var(--pxt-colors-yellow-background) !important;
+}
+
 /* 
  * Inverted image colors
  */

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -45,20 +45,20 @@
 @HCaccessibleMenuColor: white;
 
 .hc {
-
-    /* Focus */
-
-    *[tabindex='0'],
+    /*
+    * Generic Focus Highlights
+    */
+    *[tabindex='0']:not(.blocklyWorkspace, .blocklyPassiveFocus, .blocklyTreeInner),
     *[tabindex*='d1'],
     *[tabindex*='d2'], /* Takes items with a defined tabIndex from 0 to 29. */
-    *[role='menuitem'],
+    *[role='menuitem']:not(.editor-menuitem),
     a:not([tabindex='-1']),
     input:not([tabindex='-1']),
     button:not([tabindex='-1']),
     #monacoEditor .blocklyTreeRow,
     #monacoEditor .monacoDraggableBlock {
         &:focus, &:hover {
-            outline: @editorFocusBorderSize solid @selected !important;
+            outline: 3px solid var(--pxt-colors-yellow-background) !important;
         }
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3904,7 +3904,7 @@ export class ProjectView
         const autoRun = this.state.autoRun && !clickTrigger; // if user pressed stop, don't restart
 
         // Only fire setState if something changed
-        const setStatePromise = this.state.simState !== SimState.Stopped || !!this.state.autoRun !== !!autoRun ? 
+        const setStatePromise = this.state.simState !== SimState.Stopped || !!this.state.autoRun !== !!autoRun ?
             this.setStateAsync({ simState: SimState.Stopped, autoRun: autoRun }) :
             Promise.resolve();
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -171,13 +171,6 @@ export class ProjectView
 
     private themeManager: ThemeManager;
 
-    private highContrastSubscriber: data.DataSubscriber = {
-        subscriptions: [],
-        onDataChanged: () => {
-            this.onHighContrastChanged();
-        }
-    };
-
     private cloudStatusSubscriber: data.DataSubscriber = {
         subscriptions: [],
         onDataChanged: (path) => this.onCloudStatusChanged(path)
@@ -197,9 +190,7 @@ export class ProjectView
         this.reload = false; //set to true in case of reset of the project where we are going to reload the page.
         this.settings = JSON.parse(pxt.storage.getLocal("editorSettings") || "{}")
         const shouldShowHomeScreen = this.shouldShowHomeScreen();
-        const isHighContrast = /hc=(\w+)/.test(window.location.href) || (window.matchMedia?.('(forced-colors: active)')?.matches);
         this.themeManager = ThemeManager.getInstance(document);
-        if (isHighContrast) core.setHighContrast(true);
 
         const simcfg = pxt.appTarget.simulator;
         this.state = {
@@ -243,11 +234,16 @@ export class ProjectView
         this.initSimulatorMessageHandlers();
         this.showThemePicker = this.showThemePicker.bind(this);
         this.hideThemePicker = this.hideThemePicker.bind(this);
+        this.onThemeChanged = this.onThemeChanged.bind(this);
         this.setColorThemeById = this.setColorThemeById.bind(this);
         this.showLoginDialog = this.showLoginDialog.bind(this);
 
         // add user hint IDs and callback to hint manager
         if (pxt.BrowserUtils.useOldTutorialLayout()) this.hintManager.addHint(ProjectView.tutorialCardId, this.tutorialCardHintCallback.bind(this));
+
+        this.themeManager.subscribe("mainWebapp", this.onThemeChanged);
+        const isHighContrast = /hc=(\w+)/.test(window.location.href) || (window.matchMedia?.('(forced-colors: active)')?.matches);
+        if (isHighContrast) this.setColorThemeById(pxt.appTarget.appTheme.highContrastColorTheme, true);
     }
 
     private autoRunOnStart(): boolean {
@@ -1195,15 +1191,14 @@ export class ProjectView
         this.loadBlocklyAsync();
 
         // subscribe to user preference changes (for simulator or non-render subscriptions)
-        data.subscribe(this.highContrastSubscriber, auth.HIGHCONTRAST);
         data.subscribe(this.cloudStatusSubscriber, `${cloud.HEADER_CLOUDSTATE}:*`);
         data.subscribe(this.headerChangeSubscriber, "header:*");
     }
 
     public componentWillUnmount() {
-        data.unsubscribe(this.highContrastSubscriber);
         data.unsubscribe(this.cloudStatusSubscriber);
         data.unsubscribe(this.headerChangeSubscriber);
+        this.themeManager?.unsubscribe("mainWebapp");
     }
 
     // Add an error guard for the entire application
@@ -1275,8 +1270,8 @@ export class ProjectView
                 return previousEditor ? previousEditor.unloadFileAsync() : Promise.resolve();
             })
             .then(() => {
-                let hc = this.getData<boolean>(auth.HIGHCONTRAST)
-                return this.editor.loadFileAsync(this.editorFile, hc)
+                let hc = this.themeManager.isHighContrast(this.themeManager.getCurrentColorTheme()?.id);
+                return this.editor.loadFileAsync(this.editorFile, hc);
             })
             .then(() => {
                 this.saveFileAsync(); // make sure state is up to date
@@ -3892,7 +3887,7 @@ export class ProjectView
         return (!!debugging != simulator.driver.isDebug()) || (!!tracing != simulator.driver.isTracing())
     }
 
-    stopSimulator(unload?: boolean, opts?: pxt.editor.SimulatorStartOptions) {
+    stopSimulator(unload?: boolean, opts?: pxt.editor.SimulatorStartOptions): Promise<void> {
         pxt.perf.measureStart(Measurements.StopSimulator)
         pxt.tickEvent('simulator.stop')
         const clickTrigger = opts && opts.clickTrigger;
@@ -3909,11 +3904,12 @@ export class ProjectView
         const autoRun = this.state.autoRun && !clickTrigger; // if user pressed stop, don't restart
 
         // Only fire setState if something changed
-        if (this.state.simState !== SimState.Stopped || !!this.state.autoRun !== !!autoRun) {
-            this.setState({ simState: SimState.Stopped, autoRun: autoRun });
-        }
+        const setStatePromise = this.state.simState !== SimState.Stopped || !!this.state.autoRun !== !!autoRun ? 
+            this.setStateAsync({ simState: SimState.Stopped, autoRun: autoRun }) :
+            Promise.resolve();
 
         pxt.perf.measureEnd(Measurements.StopSimulator)
+        return setStatePromise;
     }
 
     suspendSimulator() {
@@ -3929,16 +3925,16 @@ export class ProjectView
         this.setState({ showMiniSim: visible });
     }
 
-    onHighContrastChanged() {
+    async onThemeChanged() {
         this.clearSerial();
         // Not this.restartSimulator; need full restart to consistently update visuals,
         // and don't want to steal focus.
         if (this.isSimulatorRunning()) {
-            this.stopSimulator();
+            await this.stopSimulator();
             this.startSimulator();
         }
 
-        const highContrast = this.getData<boolean>(auth.HIGHCONTRAST);
+        const highContrast = this.themeManager.isHighContrast(this.themeManager.getCurrentColorTheme()?.id);
         const bodyIsHighContrast = document.body.classList.contains("high-contrast");
         if (highContrast) {
             if (!bodyIsHighContrast) document.body.classList.add("high-contrast");
@@ -4040,7 +4036,7 @@ export class ProjectView
                         if (!cancellationToken.isCancelled()) {
                             pxt.debug(`sim: run`)
 
-                            const hc = data.getData<boolean>(auth.HIGHCONTRAST)
+                            const hc = this.themeManager.isHighContrast(this.themeManager.getCurrentColorTheme()?.id);
                             if (!pxt.react.isFieldEditorViewVisible?.()) {
                                 simulator.run(pkg.mainPkg, opts.debug, resp, {
                                     mute: this.state.mute === pxt.editor.MuteState.Muted,
@@ -5462,7 +5458,7 @@ export class ProjectView
         const isMultiplayerGame = this.state.isMultiplayerGame;
         const collapseIconTooltip = this.state.collapseEditorTools ? lf("Show the simulator") : lf("Hide the simulator");
         const isApp = cmds.isNativeHost() || pxt.BrowserUtils.isElectron();
-        const hc = this.getData<boolean>(auth.HIGHCONTRAST)
+        const hc = this.themeManager.isHighContrast(this.themeManager.getCurrentColorTheme()?.id);
 
         let rootClassList = [
             "ui",

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -323,7 +323,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
     renderCore() {
         const hasIdentity = pxt.auth.hasIdentity();
-        const highContrast = ThemeManager.isCurrentThemeHighContrast(document);
+        const highContrast = ThemeManager.isCurrentThemeHighContrast();
         const { greenScreen } = this.state;
         const accessibleBlocks = this.getData<boolean>(auth.ACCESSIBLE_BLOCKS);
         const targetTheme = pxt.appTarget.appTheme;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -16,6 +16,7 @@ import SimState = pxt.editor.SimState;
 import { sendUpdateFeedbackTheme } from "../../react-common/components/controls/Feedback/FeedbackEventListener";
 import KeyboardControlsHelp from "./components/KeyboardControlsHelp";
 import { CheckboxIcon } from "../../react-common/components/controls/Checkbox";
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 // common menu items -- do not remove
 // lf("About")
@@ -322,7 +323,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
     renderCore() {
         const hasIdentity = pxt.auth.hasIdentity();
-        const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
+        const highContrast = ThemeManager.isCurrentThemeHighContrast(document);
         const { greenScreen } = this.state;
         const accessibleBlocks = this.getData<boolean>(auth.ACCESSIBLE_BLOCKS);
         const targetTheme = pxt.appTarget.appTheme;

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -340,14 +340,7 @@ export const ENTER_KEY = 13;
 export const SPACE_KEY = 32;
 
 export function getHighContrastOnce(): boolean {
-    // User preference gets priority over theme setting.
-    if (data.getData<boolean>(auth.HIGHCONTRAST)) {
-        return true;
-    }
-
-    const themeManager = ThemeManager.getInstance(document);
-    const currentTheme = themeManager.getCurrentColorTheme();
-    return themeManager.isHighContrast(currentTheme?.id);
+    return ThemeManager.isCurrentThemeHighContrast();
 }
 export function toggleHighContrast() {
     setHighContrast(!getHighContrastOnce())

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -13,6 +13,7 @@ import * as projects from "./projects";
 import * as tutorial from "./tutorial";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 type HeaderBarView = "home" | "editor" | "tutorial" | "tutorial-tab" | "debugging" | "sandbox" | "time-machine";
 const LONGPRESS_DURATION = 750;
@@ -240,7 +241,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
 
     renderCore() {
         const targetTheme = pxt.appTarget.appTheme;
-        const highContrast = this.getData<boolean>(auth.HIGHCONTRAST);
+        const highContrast = ThemeManager.isCurrentThemeHighContrast();
         const view = this.getView();
 
         const { home, header, tutorialOptions } = this.props.parent.state;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -371,13 +371,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private errors: ErrorDisplayInfo[] = [];
     private callLocations: pxtc.LocationInfo[];
 
-    private userPreferencesSubscriber: data.DataSubscriber = {
-        subscriptions: [],
-        onDataChanged: () => {
-            this.onUserPreferencesChanged();
-        }
-    };
-
     private handleFlyoutWheel = (e: WheelEvent) => e.stopPropagation();
     private handleFlyoutScroll = (e: WheelEvent) => e.stopPropagation();
 
@@ -392,14 +385,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.getDisplayInfoForError = this.getDisplayInfoForError.bind(this);
         this.getErrorHelp = this.getErrorHelp.bind(this);
 
-        data.subscribe(this.userPreferencesSubscriber, auth.HIGHCONTRAST);
-
         ThemeManager.getInstance(document)?.subscribe("monaco", () => this.onUserPreferencesChanged());
     }
 
     onUserPreferencesChanged() {
-        const hc = data.getData<boolean>(auth.HIGHCONTRAST);
-
+        const hc = ThemeManager.isCurrentThemeHighContrast();
         if (this.loadMonacoPromise) this.defineEditorTheme(hc, true);
     }
 

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -4,10 +4,10 @@ import * as core from "./core";
 import * as toolbox from "./toolbox";
 import * as workspace from "./workspace";
 import * as data from "./data";
-import * as auth from "./auth";
 import * as pxtblockly from "../../pxtblocks";
 import { HELP_IMAGE_URI } from "../../pxteditor";
 import { getBlockAsText } from "./toolboxHelpers";
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -240,7 +240,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
     }
 
     protected getBlockStyle = (color: string) => {
-        const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
+        const highContrast = ThemeManager.isCurrentThemeHighContrast();
         return {
             backgroundColor: color,
             border: highContrast ? `2px solid ${color}` : "none",

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -5,18 +5,17 @@ import * as ReactDOM from "react-dom";
 import * as data from "./data";
 import * as sui from "./sui";
 import * as core from "./core";
-import * as cloudsync from "./cloudsync";
 import * as auth from "./auth";
-import * as identity from "./identity";
 import * as codecard from "./codecard"
 import * as carousel from "./carousel";
 import { showAboutDialogAsync } from "./dialogs";
 import { fireClickOnEnter } from "./util";
+import { sendUpdateFeedbackTheme } from "../../react-common/components/controls/Feedback/FeedbackEventListener";
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 import IProjectView = pxt.editor.IProjectView;
 import ISettingsProps = pxt.editor.ISettingsProps;
 import UserInfo = pxt.editor.UserInfo;
-import { sendUpdateFeedbackTheme } from "../../react-common/components/controls/Feedback/FeedbackEventListener";
 
 
 // This Component overrides shouldComponentUpdate, be sure to update that if the state is updated
@@ -301,7 +300,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
 
     renderCore() {
         const hasIdentity = pxt.auth.hasIdentity();
-        const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
+        const highContrast = ThemeManager.isCurrentThemeHighContrast()
         const targetTheme = pxt.appTarget.appTheme;
         // Targets with identity show github user on the profile screen.
         const githubUser = !hasIdentity && this.getData("github:user") as UserInfo;
@@ -1066,7 +1065,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
         const { name, description, largeImageUrl, videoUrl,
             youTubeId, youTubePlaylistId, buttonLabel, actionIcon, cardType, tags, otherActions } = this.props;
 
-        const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
+        const highContrast = ThemeManager.isCurrentThemeHighContrast();
         const tagColors: pxt.Map<string> = pxt.appTarget.appTheme.tagColors || {};
         const descriptions = description && description.split("\n");
         const image = !highContrast && (largeImageUrl || (youTubeId && `https://img.youtube.com/vi/${youTubeId}/0.jpg`));

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -5,9 +5,9 @@ import * as ReactTooltip from 'react-tooltip';
 
 import * as data from "./data";
 import * as core from "./core";
-import * as auth from "./auth";
 import { fireClickOnEnter } from "./util";
 import { focusLastActive } from "../../react-common/components/util";
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 export const appElement = document.getElementById('content');
 
@@ -1311,7 +1311,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
             'modal transition visible active',
             className
         ]);
-        const hc = this.getData<boolean>(auth.HIGHCONTRAST);
+        const hc = ThemeManager.isCurrentThemeHighContrast();
         const portalClassName = cx([
             hc ? 'hc' : '',
             mountClasses

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -632,6 +632,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                 }
                 <div className="blocklyTreeRoot">
                     <div
+                        className="blocklyTreeInner"
                         role="tree"
                         tabIndex={0}
                         ref="categoryTree"


### PR DESCRIPTION
This primarily updates areas in pxt where we were checking the old true/false high contrast setting (which is no longer used) instead of the using the new theme manager. It was just an oversight in the theming work. I've created a little static helper function in the theme manager to save some repetitive lines of code.

Separately, it fixes a few places where we were seeing superfluous yellow outlines in hc mode. We have some generic highlighting css logic which, in general, is convenient. But it does seem to be causing some issues too, highlighting things we don't want highlighted. I've special-cased those out for now, but if it becomes a more common occurrence, we may need to rework it more completely.

This fixes one of the issues brought up in https://github.com/microsoft/pxt-microbit/issues/6366 (inconsistent settings), but it does not remove the white background (which was by design). We can decide what we want to do for that separately and follow up in a different change, if needed.