### PR TITLE
audio sim: lower the volume to be closer to that of the other audio blocks

### DIFF
--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -933,6 +933,8 @@ namespace pxsim {
             channel.generator = distortion;
             channel.generator.connect(channel.gain);
             source.connect(distortion);
+            // scaling the volume to be a multiplier of 0.1
+            // 0.1 is what sounded the best when testing audio recordings against other music blocks
             channel.gain.gain.value = volume * 0.1;
 
             return audioElement;

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -933,7 +933,7 @@ namespace pxsim {
             channel.generator = distortion;
             channel.generator.connect(channel.gain);
             source.connect(distortion);
-            channel.gain.gain.value = volume;
+            channel.gain.gain.value = volume * 0.1;
 
             return audioElement;
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6408

To test: https://makecode.microbit.org/app/39186a02f452020872fe9c95c14f43a1cefb8b66-476243682f#