### PR TITLE
Do not show debug suggestion when a project can't compile

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1067,9 +1067,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.errors = errors;
     }
 
-    private getDisplayInfoForBlockError(blockId: string, message: string): ErrorDisplayInfo {
+    private getDisplayInfoForBlockError(blockId: string, message: string, preventsRunning: boolean): ErrorDisplayInfo {
         return {
             message: message,
+            preventsRunning: preventsRunning,
             onClick: () => {
                 this.clearHighlightedStatements();
                 this.editor.highlightBlock(blockId);
@@ -1513,7 +1514,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     let txt = ts.pxtc.flattenDiagnosticMessageText(diag.messageText, "\n");
                     b.setWarningText(txt, pxtblockly.PXT_WARNING_ID);
                     setHighlightWarningAsync(b, true);
-                    errorDisplayInfo.push(this.getDisplayInfoForBlockError(bid, txt));
+                    errorDisplayInfo.push(this.getDisplayInfoForBlockError(bid, txt, true));
                 }
             }
         })
@@ -1525,7 +1526,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 if (b) {
                     b.setWarningText(d.message, pxtblockly.PXT_WARNING_ID);
                     setHighlightWarningAsync(b, true);
-                    errorDisplayInfo.push(this.getDisplayInfoForBlockError(d.blockId, d.message));
+                    errorDisplayInfo.push(this.getDisplayInfoForBlockError(d.blockId, d.message, false));
                 }
             }
         })

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -30,6 +30,7 @@ export type ErrorDisplayInfo = {
     message: string;
     stackFrames?: StackFrameDisplayInfo[];
     metadata?: ErrorMetadata;
+    preventsRunning?: boolean;
     onClick?: () => void;
 };
 
@@ -103,7 +104,7 @@ export class ErrorList extends auth.Component<ErrorListProps, ErrorListState> {
         const errorListContent = !isCollapsed ? groupedErrors.map((e, i) => <ErrorListItem errorGroup={e} index={i} key={`errorlist_error_${i}`}/> ) : undefined;
         const errorCount = errors.length;
 
-        const showDebuggerSuggestion = startDebugger && !pxt.shell.isReadOnly();
+        const showDebuggerSuggestion = startDebugger && !pxt.shell.isReadOnly() && !errors.some(e => e.preventsRunning);
 
         const showErrorHelp =
             !!getErrorHelp &&

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -661,7 +661,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                         <ErrorList
                             onSizeChange={this.setErrorListState}
                             errors={this.errors}
-                            startDebugger={!!this.errors.find(a => a.stackFrames?.length) && this.startDebugger}
+                            startDebugger={this.startDebugger}
                             getErrorHelp={this.getErrorHelp}
                             note={
                                 this.parent.state.errorListNote && (
@@ -714,7 +714,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         return {
             message,
-            stackFrames
+            stackFrames,
+            preventsRunning: false
         };
     }
 
@@ -722,7 +723,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const message = lf("Line {0}: {1}", error.endLine ? error.endLine + 1 : error.line + 1, error.messageText);
         return {
             message,
-            onClick: () => this.goToError(error)
+            onClick: () => this.goToError(error),
+            preventsRunning: true
         };
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6372

For text errors, we were able to determine if an error was a compile or runtime error using the presence of a stack trace, but for block errors, there are some that do not prevent running the program but also do not have a stack, so the same method was not as reliable (hence, we just always showed the button).

However, looking more closely, I believe we can determine if it's a run-blocking error based on whether we detect the error in the typescript compile diagnostics or not. With that in mind, I've added a specific `preventsRunning` flag to errors, which we can now set and use for determining if we should show the debugger suggestion. When we detect a typescript compile error in blocks, we set this to true. If it's a runtime or blocks compilation error, we set it to false. I've switched the monaco errors to use this as well, though the actual behavior is unchanged.

Upload target: https://makecode.microbit.org/app/3b1b8b4f477f1fa3d985f34d8d1728b0a2e88ef2-82f12bc8d0