### PR TITLE
Fix teaching bubble in high contrast

### DIFF
--- a/react-common/styles/onboarding/TeachingBubble.less
+++ b/react-common/styles/onboarding/TeachingBubble.less
@@ -164,29 +164,3 @@
         margin: 0;
     }
 }
-
-/****************************************************
- *                 High Contrast                    *
- ****************************************************/
-
-.high-contrast,
-.hc {
-    .teaching-bubble {
-        background: @highContrastBackgroundColor;
-        color: @highContrastTextColor;
-        border: solid @highContrastTextColor;
-
-        .teaching-bubble-navigation-buttons>.common-button {
-            color: @highContrastTextColor;
-            border: solid @highContrastTextColor;
-        }
-    }
-
-    .teaching-bubble-arrow {
-        color: @highContrastTextColor;
-    }
-
-    .teaching-bubble-cutout {
-        border: 0.25rem solid @highContrastHighlightColor;
-    }
-}

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -106,3 +106,29 @@ div.field .ui.toggle.checkbox input:checked~label:before {
 .blocksEditorOuter #blocklyTrashIcon {
     color: var(--pxt-primary-foreground);
 }
+
+/*
+ * Teaching Bubbles
+ */
+.teaching-bubble,
+.teaching-bubble .teaching-bubble-navigation-buttons > .common-button {
+    background: var(--pxt-neutral-background1) !important;
+    color: var(--pxt-neutral-foreground1) !important;
+    border: solid var(--pxt-neutral-foreground1) !important;
+}
+
+.teaching-bubble-cutout {
+    border: 0.25rem solid var(--pxt-neutral-alpha20);
+}
+
+.teaching-bubble .ai-footer {
+    opacity: 1 !important;
+}
+
+.teaching-bubble-arrow,
+.teaching-bubble .ai-footer-text,
+.teaching-bubble .feedback-button,
+.teaching-bubble .feedback-button.disabled,
+.teaching-bubble .teaching-bubble-steps {
+    color: var(--pxt-neutral-foreground1) !important;
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6419

This moves the teaching bubble high contrast css into our high-contrast-overrides file and updates it to account for some of the new error help elements.

Before:
![image](https://github.com/user-attachments/assets/9eb32ed2-7399-482d-985c-470229112aba)

After:
![image](https://github.com/user-attachments/assets/471e4b95-75fd-463f-af75-b24fdde3086e)
