### PR TITLE
Reset the focus manager when loading a header

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1855,6 +1855,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         // note that we don't need to clear the flyout SVG cache since those
         // will regenerate themselves more precisely based on the hash of the
         // input blocks xml.
+
+        // Avoid the focus manager remembering prior workspace node selections.
+        Blockly.getFocusManager().unregisterTree(this.editor);
+        Blockly.getFocusManager().registerTree(this.editor, true);
     }
 
     clearFlyoutCaches() {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1857,8 +1857,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         // input blocks xml.
 
         // Avoid the focus manager remembering prior workspace node selections.
-        Blockly.getFocusManager().unregisterTree(this.editor);
-        Blockly.getFocusManager().registerTree(this.editor, true);
+        const focusManager = Blockly.getFocusManager();
+        if (focusManager.isRegistered(this.editor)) {
+            focusManager.unregisterTree(this.editor);
+            focusManager.registerTree(this.editor, true);
+        }
     }
 
     clearFlyoutCaches() {


### PR DESCRIPTION
This avoids us remembering workspace selections (via 'w') for new projects.

This fixes this scenario: https://github.com/microsoft/pxt-microbit/issues/6421#issuecomment-3023424575

The remaining scenarios on that ticket will be fixed by the next blockly/plugin upgrade next week.

Demo: https://blockly-ws-focus-reset.review-pxt.pages.dev/ (once built)

