### PR TITLE
Even More High Contrast Fixes

### DIFF
--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -11,8 +11,8 @@
 
 .area-menu-container .area-button {
     /*
-    Override default button background for the area menu, which requires transparency
-    But still use a fairly opaque one to keep focus/visibility on the main buttons.
+    Override default button background for the area menu, which requires transparency,
+    but still use a fairly opaque one to keep focus/visibility on the main buttons.
     */
     background-color: var(--pxt-neutral-alpha80) !important;
 }

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -140,3 +140,28 @@ div.field .ui.toggle.checkbox input:checked~label:before {
 .teaching-bubble .teaching-bubble-steps {
     color: var(--pxt-neutral-foreground1) !important;
 }
+
+/*
+ * Side Docs
+ */
+
+#sidedocs {
+    background-color: var(--pxt-neutral-foreground1);
+}
+
+#sidedocsbar a i,
+#sidedocsbar a span {
+    color: var(--pxt-neutral-background1) !important;
+}
+
+#sidedocsbar a:hover,
+#sidedocsbar a:focus {
+    outline: 3px solid var(--pxt-neutral-background1) !important; /* Yellow does not contrast well against white background */
+}
+
+#sidedocsbar a:hover i,
+#sidedocsbar a:focus i,
+#sidedocsbar a:hover span,
+#sidedocsbar a:focus span {
+    color: var(--pxt-link-hover) !important;
+}

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -156,7 +156,8 @@ div.field .ui.toggle.checkbox input:checked~label:before {
 
 #sidedocsbar a:hover,
 #sidedocsbar a:focus {
-    outline: 3px solid var(--pxt-neutral-background1) !important; /* Yellow does not contrast well against white background */
+    /* Yellow does not contrast well against white background */
+    outline: 3px solid var(--pxt-neutral-background1) !important;
 }
 
 #sidedocsbar a:hover i,

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -9,6 +9,14 @@
     z-index: 1;
 }
 
+.area-menu-container .area-button {
+    /*
+    Override default button background for the area menu, which requires transparency
+    But still use a fairly opaque one to keep focus/visibility on the main buttons.
+    */
+    background-color: var(--pxt-neutral-alpha80) !important;
+}
+
 /* 
  * Checkbox styles
  * In HC the neutral and primary colors are the same, so we need to differentiate with

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -734,20 +734,6 @@
         text-decoration: underline !important;
     }
 
-    #sidedocsbar {
-        a {
-            color: @HCbackground !important;
-
-            &:focus {
-                color: @selected !important;
-
-                i, span {
-                    color: @selected !important;
-                }
-            }
-        }
-    }
-
     /* Dropdown */
     .ui.dropdown .menu,
     .ui.menu .ui.dropdown .menu {

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -597,10 +597,6 @@
         }
         .item:focus {
             border-color: @selected !important;
-
-            span {
-                color: @HCbackground !important;
-            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6439 but still uses a more-opaque-than-default color to keep focus on the main buttons
Fixes https://github.com/microsoft/pxt-microbit/issues/6434 by removing some unnecessary css
Fixes https://github.com/microsoft/pxt-microbit/issues/6435 with some new override styling, moved to overrides file