### PR TITLE
Fix not showing Keyboard Controls in help menu

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -82,24 +82,17 @@ function getKeyboardNavHelpItem(parent: IProjectView, cls: string = ""): JSX.Ele
 type DocsMenuEditorName = "Blocks" | "JavaScript" | "Python";
 interface DocsMenuProps extends ISettingsProps {
     editor: DocsMenuEditorName;
+    inBlocks: boolean;
 }
 
-function showKeyboardControls() {
-    const languageRestriction = pkg.mainPkg?.config?.languageRestriction;
-    const pyOnly = languageRestriction === pxt.editor.LanguageRestriction.PythonOnly;
-    const noBlocks = languageRestriction === pxt.editor.LanguageRestriction.NoBlocks;
-    const tsOnly = languageRestriction === pxt.editor.LanguageRestriction.JavaScriptOnly;
-    return !pyOnly && !tsOnly && !noBlocks && !!pkg.mainEditorPkg().files[pxt.MAIN_BLOCKS];
-}
-
-export class DocsMenu extends data.PureComponent<DocsMenuProps & { hasMainBlocksFile: boolean }, {}> {
+export class DocsMenu extends data.PureComponent<DocsMenuProps, {}> {
     renderCore() {
         const parent = this.props.parent;
         const targetTheme = pxt.appTarget.appTheme;
         const accessibleBlocksEnabled = data.getData<boolean>(auth.ACCESSIBLE_BLOCKS);
         return <sui.DropdownMenu role="menuitem" icon="help circle large"
             className="item mobile hide help-dropdown-menuitem" textClass={"landscape only"} title={lf("Help")} >
-            {this.props.hasMainBlocksFile && parent.isBlocksEditor() && showKeyboardControls() && accessibleBlocksEnabled && getKeyboardNavHelpItem(parent)}
+            {this.props.inBlocks && accessibleBlocksEnabled && getKeyboardNavHelpItem(parent)}
             {targetTheme.tours?.editor && getTourItem(parent)}
             {renderDocItems(parent, targetTheme.docMenu)}
             {getDocsLanguageItem(this.props.editor, parent)}
@@ -378,7 +371,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             <div className="ui divider"></div>
             {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
             <sui.Item role="menuitem" icon="paint brush" text={lf("Theme")} onClick={this.showThemePicker} />
-            {this.props.parent.isBlocksEditor() && showKeyboardControls() &&
+            {this.props.inBlocks &&
                 <CheckboxMenuItem
                     isChecked={accessibleBlocks}
                     label={lf("Keyboard Controls")}

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -275,7 +275,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
                 {this.getExitButtons(targetTheme, view, tutorialOptions)}
                 {showHomeButton && <sui.Item className={`icon openproject ${hasIdentity ? "mobile hide" : ""}`} role="menuitem" title={lf("Home")} icon="home large" ariaLabel={lf("Home screen")} onClick={this.goHome} />}
                 {showShareButton && <sui.Item className="icon shareproject mobile hide" role="menuitem" title={lf("Publish your game to create a shareable link")} icon="share alternate large" ariaLabel={lf("Share Project")} onClick={this.showShareDialog} />}
-                {showHelpButton && <container.DocsMenu parent={this.props.parent} editor={activeEditor} hasMainBlocksFile={!!pkg.mainEditorPkg().files[pxt.MAIN_BLOCKS]}/>}
+                {showHelpButton && <container.DocsMenu parent={this.props.parent} editor={activeEditor} inBlocks={this.props.parent.isBlocksActive()} />}
                 {this.getSettingsMenu(view)}
                 {hasIdentity && (view === "home" || view === "editor" || view === "tutorial-tab") && <identity.UserMenu parent={this.props.parent} />}
             </div>


### PR DESCRIPTION
It was missing on first load (with the setting enabled) because there isn't an editor at that point so isBlocksEditor returns false. Nothing causes the menu to re-render when an editor has been assigned. The settings component had a working inBlocks prop so we've switched to use that approach. I think that only really works because the parent component of the menus is not pure. So far as I can tell, there's no React state for the current editor.

Also simplify the conditions which had become over complicated since the decision was made to require the blocks editor to be active, not just the project to use blocks.

Fixes https://github.com/microsoft/pxt-microbit/issues/6447