### PR TITLE
Popout link support for keyboard nav docs

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -611,7 +611,20 @@ export interface SideDocsState {
     sideDocsCollapsed?: boolean;
 }
 
-export const builtInPrefix = "/builtin/";
+
+interface BuiltInHelpDetails {
+    component: () => JSX.Element;
+    popOutHref: string;
+}
+
+const builtIns: Record<pxt.editor.BuiltInHelp, BuiltInHelpDetails> = {
+    "keyboardControls": {
+        component: KeyboardControlsHelp,
+        popOutHref: "https://makecode.com/accessibility"
+    }
+}
+
+export const builtInPrefix = "/builtin/"
 
 export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
     private openingSideDoc = false;
@@ -622,11 +635,18 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
         }
 
         this.toggleVisibility = this.toggleVisibility.bind(this);
-        this.popOut = this.popOut.bind(this);
+        this.notifyPopOut = this.notifyPopOut.bind(this);
+        this.close = this.close.bind(this);
     }
 
     private rootDocsUrl(): string {
         return (pxt.webConfig.docsUrl || '/--docs') + "#";
+    }
+
+    private notifyPopOut() {
+        SideDocs.notify({
+            type: "popout"
+        })
     }
 
     public static notify(message: pxsim.SimulatorMessage) {
@@ -693,14 +713,13 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
         this.props.parent.editor.focusWorkspace();
     }
 
-    isCollapsed() {
-        return !!this.state.sideDocsCollapsed;
+    close() {
+        this.props.parent.setState({ sideDocsCollapsed: true, sideDocsLoadUrl: '' });
+        this.props.parent.editor.focusWorkspace();
     }
 
-    popOut() {
-        SideDocs.notify({
-            type: "popout"
-        })
+    isCollapsed() {
+        return !!this.state.sideDocsCollapsed;
     }
 
     toggleVisibility() {
@@ -751,7 +770,20 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
         if (!docsUrl) return null;
 
         const url = sideDocsCollapsed ? this.rootDocsUrl() : docsUrl;
-        const isBuiltIn = url.startsWith(`${builtInPrefix}`);
+        const builtIn = url.startsWith(`${builtInPrefix}`)
+            ? builtIns[url.slice(builtInPrefix.length) as pxt.editor.BuiltInHelp]
+            : undefined;
+        const openInNewTabLinkProps: React.ComponentProps<'a'> = builtIn ? {
+            target: "_blank",
+            href: builtIn.popOutHref,
+            rel: "noopener",
+            onClick: this.close,
+        } : {
+            onClick: this.notifyPopOut,
+            onKeyDown: fireClickOnEnter,
+            role: "button",
+            tabIndex: 0,
+        };
 
         /* eslint-disable @microsoft/sdl/react-iframe-missing-sandbox */
         return <div>
@@ -759,29 +791,22 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
                 <sui.Icon icon={`icon inverted chevron ${showLeftChevron ? 'left' : 'right'}`} />
             </button>
             <div id="sidedocs" onKeyDown={this.handleKeyDown}>
-                {!lockedEditor && !isBuiltIn && <div className="ui app hide" id="sidedocsbar">
-                    <a className="ui icon link" role="button" tabIndex={0} data-content={lf("Open documentation in new tab")} aria-label={lf("Open documentation in new tab")} onClick={this.popOut} onKeyDown={fireClickOnEnter} >
+                {!lockedEditor && <div className="ui app hide" id="sidedocsbar">
+                    <a className="ui icon link" aria-label={lf("Open documentation in new tab")} {...openInNewTabLinkProps}>
                         <sui.Icon icon="external" />
                     </a>
                 </div>}
                 <div id="sidedocsframe-wrapper">
-                    {this.renderContent(url, isBuiltIn, lockedEditor)}
+                    {this.renderContent(url, builtIn, lockedEditor)}
                 </div>
             </div>
         </div>
         /* eslint-enable @microsoft/sdl/react-iframe-missing-sandbox */
     }
 
-    renderContent(url: string, isBuiltin: boolean, lockedEditor: boolean) {
-        if (isBuiltin) {
-            const component = url.slice(builtInPrefix.length) as pxt.editor.BuiltInHelp;
-            switch (component) {
-                case "keyboardControls": {
-                    return <KeyboardControlsHelp />
-                }
-            }
-        }
-        return (
+    renderContent(url: string, builtIn: BuiltInHelpDetails | undefined, lockedEditor: boolean) {
+        const BuiltInComponent =  builtIn?.component;
+        return BuiltInComponent ? <BuiltInComponent /> : (
             <iframe id="sidedocsframe" src={url} title={lf("Documentation")} aria-atomic="true" aria-live="assertive"
                 sandbox={`allow-scripts allow-same-origin allow-forms ${lockedEditor ? "" : "allow-popups"}`} />
         )


### PR DESCRIPTION
These link to the accessibility page, which will be updated for the release to document the keyboard controls in more detail and show shortcuts for all platforms. In time they'll hopefully also link to or embed the video content that the Foundation is preparing for onboarding.

Lucy and Jaqueline have been discussing this by email and Lucy confirmed this is the UX they have agreed.

Depending on future content updates a fragment link specific to keyboard nav might be more suitable in future but this is fine for now and there's not much content before keyboard nav on the revised version on https://github.com/microsoft/pxt/pull/10697