### PR TITLE
Focus toolbox when tutorial block opens toolbox category

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -483,7 +483,10 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
                             const toolboxSelector = `${editorSelector} .blocklyTreeRow[data-ns="${ns}"]`;
                             const toolboxRow = document.querySelector<HTMLDivElement>(toolboxSelector);
-                            toolboxRow?.click();
+                            if (toolboxRow) {
+                                toolboxRow.click();
+                                this.props.parent.editor.focusToolbox();
+                            }
                         });
                         inlineBlock.addEventListener("keydown", e => fireClickOnEnter(e as any))
                     }


### PR DESCRIPTION
When a tutorial inline block gets clicked on, the toolbox is focused. This allows the user to easily keyboard navigate from the toolbox with the appropriate category selected.

Fixes: https://github.com/microsoft/pxt-microbit/issues/6446

Preview: https://blockly-tutorial-focus.review-pxt.pages.dev/

cc: @microbit-matt-hillsdon 