### PR TITLE
Area overlay fixes

### DIFF
--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -2,6 +2,7 @@
 // Helpers designed to help to make a simulator accessible.
 namespace pxsim.accessibility {
     let liveRegion: HTMLDivElement;
+    let keydownListenerAdded = false;
 
     export function makeFocusable(elem: SVGElement): void {
         elem.setAttribute("focusable", "true");
@@ -25,6 +26,10 @@ namespace pxsim.accessibility {
     }
 
     export function postKeyboardEvent() {
+        if (keydownListenerAdded) {
+            return;
+        }
+        keydownListenerAdded = true;
         document.addEventListener("keydown", (e) => {
             const action = getGlobalAction(e)
             if (action) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5326,6 +5326,11 @@ export class ProjectView
     ///////////////////////////////////////////////////////////
 
     toggleAreaMenu() {
+        // Close the simulator if needed.
+        if (this.state.fullscreen) {
+            this.setSimulatorFullScreen(false);
+        }
+
         const dialog = Array.from(document.querySelectorAll("[role=dialog]")).find(dialog => (dialog as any).checkVisibility());
         this.setState((state) => {
             const { areaMenuOpen } = state;

--- a/webapp/src/components/AreaMenuOverlay.tsx
+++ b/webapp/src/components/AreaMenuOverlay.tsx
@@ -207,10 +207,6 @@ export const AreaMenuOverlay = ({ parent }: AreaMenuOverlapProps) => {
         parent.toggleAreaMenu();
     }, [parent]);
     useEffect(() => {
-        if (parent.state.fullscreen) {
-            parent.setSimulatorFullScreen(false);
-        }
-
         const listener = (e: KeyboardEvent) => {
             const area = areas.find(area => area.shortcutKey === e.key);
             if (area) {
@@ -236,16 +232,21 @@ export const AreaMenuOverlay = ({ parent }: AreaMenuOverlapProps) => {
         }
     }, [])
 
-    const handleEscape = () => {
+    const handleEscape = useCallback(() => {
         parent.toggleAreaMenu();
-    }
+    }, [parent]);
 
-    if (!areaRects.get("editor")) {
-        // Something is awry, bail out.
-        parent.toggleAreaMenu();
+    // Something is awry, bail out.
+    const bailOut = !areaRects.get("editor");
+    useEffect(() => {
+        if (bailOut) {
+            parent.toggleAreaMenu();
+        }
+    }, [bailOut, parent]);
+
+    if (bailOut) {
         return null;
     }
-
     return ReactDOM.createPortal(
         <FocusTrap dontRestoreFocus onEscape={handleEscape}>
             <div className="area-menu-container" >


### PR DESCRIPTION
- Ensure keydown listener cannot be registered multiple times in the sim. This fixes bad behaviour due to multiple listeners after sim re-run e.g. due to program changes, which combines unfortunately with the toggle behaviour for the area menu. 

- Correctly close the full screen sim before showing the area menu, switching to a simpler approach.

- Fix bail out logic as it logged a React warning. Perform the state change in an effect. So far as I know this can't be triggered as a user, but I tested it locally by removing "editor" from the area rects.

Fixes https://github.com/microsoft/pxt-microbit/issues/6462