### PR TITLE
Do not hide unapproved extensions when searching

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -1005,7 +1005,7 @@ namespace pxt.github {
 
         const entry = config.approvedRepoLib[repoFull] || config.approvedRepoLib[repoSlug];
 
-        if (!entry || entry.hidden) {
+        if (entry && entry.hidden) {
             return true;
         }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6494

Since unapproved extensions don't appear in targetconfig, they were getting filtered out by our `isRepoHidden` check. To fix, I think we can default to showing the extension rather than hiding it when we cannot find a targetconfig entry.

Now extensions like microbit-foundation/pxt-microbit-ml will still be hidden (as specified in target config) but unapproved extensions that are directly searched via URL (like the one mentioned in the bug above) will still go through.

Try it: https://makecode.microbit.org/app/40ceb5e8ccbbab04932a4b514501555031b35106-ecabc34326