### PR TITLE
Port to stable: Do not hide extensions that are not specified in the target config (#10764)

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -1005,7 +1005,7 @@ namespace pxt.github {
 
         const entry = config.approvedRepoLib[repoFull] || config.approvedRepoLib[repoSlug];
 
-        if (!entry || entry.hidden) {
+        if (entry && entry.hidden) {
             return true;
         }
 


### PR DESCRIPTION
Port of https://github.com/microsoft/pxt/commit/279e0f08bfc5dfa4b64dac1d8102422f15bd1be4 (https://github.com/microsoft/pxt/pull/10764)