### PR TITLE
Fix Minecraft Workspace Background

### DIFF
--- a/pxtblocks/monkeyPatches/grid.ts
+++ b/pxtblocks/monkeyPatches/grid.ts
@@ -16,7 +16,12 @@ export function monkeyPatchGrid() {
 
     const gridPatternIds: string[] = [];
 
-    Blockly.Grid.createDom = function (rnd: string, gridOptions: Blockly.Options.GridOptions, defs: SVGElement) {
+    Blockly.Grid.createDom = function (
+        rnd: string,
+        gridOptions: Blockly.Options.GridOptions,
+        defs: SVGElement,
+        injectionDiv?: HTMLElement
+    ) {
         const id = "blocklyGridPattern" + rnd;
 
         const gridPattern = Blockly.utils.dom.createSvgElement(
@@ -43,6 +48,10 @@ export function monkeyPatchGrid() {
         );
 
         image.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", options.image.path)
+
+        if (injectionDiv) {
+            injectionDiv.style.setProperty('--blocklyGridPattern', `url(#${gridPattern.id})`);
+        }
 
         return gridPattern;
     }


### PR DESCRIPTION
We're using a patch to handle the custom minecraft background, but a (somewhat) recent Blockly update has changed how the pattern is referenced, so we now need to set the `--blocklyGridPattern` var. (Previously, it would just reference the id directly.)