### PR TITLE
Add editor controller message to enable keyboard controls

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -80,9 +80,11 @@ declare namespace pxt.editor {
         | "getblockastext"
 
         | "toggletrace" // EditorMessageToggleTraceRequest
+        | "showthemepicker"
         | "togglehighcontrast"
         | "sethighcontrast" // EditorMessageSetHighContrastRequest
         | "togglegreenscreen"
+        | "togglekeyboardcontrols"
         | "settracestate" //
         | "setsimulatorfullscreen" // EditorMessageSimulatorFullScreenRequest
 
@@ -422,6 +424,7 @@ declare namespace pxt.editor {
         versions: pxt.TargetVersions;
         locale: string;
         availableLocales?: string[];
+        keyboardControls: boolean;
     }
 
     export interface PackageExtensionData {
@@ -1045,6 +1048,7 @@ declare namespace pxt.editor {
         setHighContrast(on: boolean): void;
         toggleGreenScreen(): void;
         toggleAccessibleBlocks(eventSource: string): void;
+        isAccessibleBlocks(): boolean;
         launchFullEditor(): void;
         resetWorkspace(): void;
 

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -240,6 +240,10 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                 return Promise.resolve()
                                     .then(() => projectView.setSimulatorFullScreen(fsmsg.enabled));
                             }
+                            case "showthemepicker" : {
+                                return Promise.resolve()
+                                    .then(() => projectView.showThemePicker());
+                            }
                             case "togglehighcontrast": {
                                 return Promise.resolve()
                                     .then(() => projectView.toggleHighContrast());
@@ -252,6 +256,10 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                             case "togglegreenscreen": {
                                 return Promise.resolve()
                                     .then(() => projectView.toggleGreenScreen());
+                            }
+                            case "togglekeyboardcontrols": {
+                                return Promise.resolve()
+                                    .then(() => projectView.toggleAccessibleBlocks("editormessage"));
                             }
                             case "print": {
                                 return Promise.resolve()
@@ -266,7 +274,8 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                         resp = {
                                             versions: pxt.appTarget.versions,
                                             locale: ts.pxtc.Util.userLanguage(),
-                                            availableLocales: pxt.appTarget.appTheme.availableLocales
+                                            availableLocales: pxt.appTarget.appTheme.availableLocales,
+                                            keyboardControls: projectView.isAccessibleBlocks()
                                         } as pxt.editor.InfoMessage;
                                     });
                             }

--- a/pxtservices/editorDriver.ts
+++ b/pxtservices/editorDriver.ts
@@ -178,6 +178,15 @@ export class EditorDriver extends IframeDriver {
         );
     }
 
+    async showThemePicker() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "showthemepicker"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
     async toggleHighContrast() {
         await this.sendRequest(
             {
@@ -192,6 +201,15 @@ export class EditorDriver extends IframeDriver {
             {
                 type: "pxteditor",
                 action: "togglegreenscreen"
+            } as pxt.editor.EditorMessageRequest
+        );
+    }
+
+    async toggleAccessibleBlocks() {
+        await this.sendRequest(
+            {
+                type: "pxteditor",
+                action: "togglekeyboardcontrols"
             } as pxt.editor.EditorMessageRequest
         );
     }

--- a/webapp/public/controller.html
+++ b/webapp/public/controller.html
@@ -138,13 +138,20 @@
                 };
                 msg.response = true;
             }
+            else if (action == 'info') {
+                msg.response = true;
+            }
             if (msg.response)
                 pendingMsgs[msg.id] = msg;
             editor.postMessage(msg, "*")
         }
 
         function receiveMessage(ev) {
-            var editor = document.getElementById("iframe").contentWindow;
+            var editor = document.getElementById("iframe")?.contentWindow;
+            // Prevents messages from other sources being logged to the console.
+            if (!editor || editor !== ev.source) {
+                return;
+            }
             var msg = ev.data;
             console.log('received...')
             console.log(msg)
@@ -178,6 +185,7 @@
             }
             if (msg.type == "pxteditor") {
                 var req = pendingMsgs[msg.id];
+                if (!req) return;
                 if (req.action == "renderblocks") {
                     var img = document.createElement("img");
                     img.src = msg.resp;
@@ -241,8 +249,10 @@
         <button class="ui button" onclick="sendMessage('renderblocks')">renderblocks</button>
         <button class="ui button" onclick="sendMessage('closeflyout')">close flyout</button>
         <button class="ui button" onclick="sendMessage('setsimulatorfullscreen')">set sim full screen</button>
+        <button class="ui button" onclick="sendMessage('showthemepicker')">show theme picker</button>
         <button class="ui button" onclick="sendMessage('togglehighcontrast')">toggle high contrast</button>
         <button class="ui button" onclick="sendMessage('togglegreenscreen')">toggle green screen</button>
+        <button class="ui button" onclick="sendMessage('togglekeyboardcontrols')">toggle keyboard controls</button>
         <button class="ui button" onclick="sendMessage('print')">print</button>
         <button class="ui button" onclick="sendMessage('pair')">pair</button>
         <button class="ui button" onclick="sendMessage('info')">info</button>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -87,6 +87,7 @@ import { BlockDefinition, CategoryNameID } from "./toolbox";
 import { FeedbackModal } from "../../react-common/components/controls/Feedback/Feedback";
 import { ThemeManager } from "../../react-common/components/theming/themeManager";
 import { applyPolyfills } from "./polyfills";
+import { sendUpdateFeedbackTheme } from "../../react-common/components/controls/Feedback/FeedbackEventListener";
 
 pxt.blocks.requirePxtBlockly = () => pxtblockly as any;
 pxt.blocks.requireBlockly = () => Blockly;
@@ -5207,16 +5208,17 @@ export class ProjectView
     ////////////            Theming               /////////////
     ///////////////////////////////////////////////////////////
 
-    toggleHighContrast() {
-        core.toggleHighContrast();
-        pxt.tickEvent("app.highcontrast", { on: core.getHighContrastOnce() ? 1 : 0 });
-        if (this.isSimulatorRunning()) {  // if running, send updated high contrast state.
-            this.startSimulator()
-        }
+    toggleHighContrast(): void {
+        this.setHighContrast(!core.getHighContrastOnce());
     }
 
-    setHighContrast(on: boolean) {
-        return core.setHighContrast(on);
+    setHighContrast(on: boolean): void {
+        if (!pxt.appTarget.appTheme.highContrastColorTheme || !pxt.appTarget.appTheme.defaultColorTheme) {
+            return;
+        }
+        pxt.tickEvent("app.highcontrast", { on: on ? 1 : 0 });
+        sendUpdateFeedbackTheme(on);
+        this.setColorThemeById(on ? pxt.appTarget.appTheme.highContrastColorTheme : pxt.appTarget.appTheme.defaultColorTheme, true);
     }
 
     toggleGreenScreen() {
@@ -5238,6 +5240,10 @@ export class ProjectView
         }
         await core.toggleAccessibleBlocks(eventSource)
         this.reloadEditor();
+    }
+
+    isAccessibleBlocks(): boolean {
+        return this.getData<boolean>(auth.ACCESSIBLE_BLOCKS);
     }
 
     setBannerVisible(b: boolean) {

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -342,13 +342,6 @@ export const SPACE_KEY = 32;
 export function getHighContrastOnce(): boolean {
     return ThemeManager.isCurrentThemeHighContrast();
 }
-export function toggleHighContrast() {
-    setHighContrast(!getHighContrastOnce())
-}
-export async function setHighContrast(on: boolean) {
-    sendUpdateFeedbackTheme(on);
-    await auth.setHighContrastPrefAsync(on);
-}
 
 export async function toggleAccessibleBlocks(eventSource: string) {
     await setAccessibleBlocks(!data.getData<boolean>(auth.ACCESSIBLE_BLOCKS), eventSource);

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -251,7 +251,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
 
     toggleHighContrast() {
         pxt.tickEvent("home.togglecontrast", undefined, { interactiveConsent: true });
-        core.toggleHighContrast();
+        this.props.parent.toggleHighContrast();
     }
 
     showThemePicker() {


### PR DESCRIPTION
This PR also:
- returns the keyboard controls state in the `info` editor message
- fixes the iframe message for togglehighcontrast, at the moment, togglehighcontrast only takes effect once the editor is reloaded (see https://github.com/microsoft/pxt-microbit/issues/6499)
- adds an editor controller message to show the theme picker
- cleans up the console output for `controller.html` for clarity

Closes https://github.com/microsoft/pxt-microbit/issues/6499
Closes https://github.com/microsoft/pxt-microbit/issues/6500
