### PR TITLE
make sure icons are included in the built semantic.css for pxt-core docs

### DIFF
--- a/theme/theme.config
+++ b/theme/theme.config
@@ -29,7 +29,7 @@
 @divider    : 'pxt';
 @flag       : 'pxt';
 @header     : 'pxt';
-@icon       : 'pxt';
+@icon       : 'default';
 @image      : 'pxt';
 @input      : 'pxt';
 @label      : 'pxt';


### PR DESCRIPTION
part of the fix for https://github.com/microsoft/pxt-microbit/issues/6457

for some reason, icons weren't being included in the built css for the makecode docs. this fixes that, but the semantic file in doccdn still needs to be updated (which i'll do in a separate PR)