### PR TITLE
Context menu close on escape preserves flyout. Mini-sim from area menu fullscreens

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3741,10 +3741,10 @@ export class ProjectView
         if (enabled) {
             document.addEventListener('keydown', this.closeOnEscape);
             simulator.driver.focus();
+            this.closeFlyout();
         } else {
             document.removeEventListener('keydown', this.closeOnEscape);
         }
-        this.closeFlyout();
         this.setState({ fullscreen: enabled });
     }
 
@@ -5326,8 +5326,10 @@ export class ProjectView
     ///////////////////////////////////////////////////////////
 
     toggleAreaMenu() {
-        // Close the simulator if needed.
-        if (this.state.fullscreen) {
+        // Restore the simulator if needed. If the area menu is open, allow the simulator to
+        // stay fullscreened. The desired behaviour is that the mini sim can be fullscreened
+        // through the area menu, otherwise it has been restored already.
+        if (this.state.fullscreen && !this.state.areaMenuOpen) {
             this.setSimulatorFullScreen(false);
         }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6509
Fixes https://github.com/microsoft/pxt-microbit/issues/6510

Using escape to close the context menu for a block in the flyout should not close the flyout.

In the area menu, if the mini-simulator view is visible, selecting it should open it in fullscreen mode.

The first issue was manifested because escape fires `app.setSimulatorFullScreen(false)` which eagerly closes the flyout even though nothing is being fullscreened. I changed it to only fire if it is called with `true` which solves the problem.

It is not possible to solve this through managing event propagation, as the context menu key handlers are managed in Blockly and the simulator handlers are managed in Makecode.

While testing the other triggers for `app.setSimulatorFullscreen` to ensure they still worked, I uncovered an issue with the area menu. It is written such that, if the mini simulator is present and selected in the area menu, it should fullscreen. This was not happening either, also due to a similarly eager `setSimulatorFullScreen(false)` when `toggleAreaMenu` is used to dismiss the area menu. This is also fixed

### Context menus

**Before**

https://github.com/user-attachments/assets/8975e5cc-65ea-4cac-bfa1-9ea7ddd4b736

Escape once, closes both

**After**

https://github.com/user-attachments/assets/afe6fc99-053d-4f23-8241-b6e736f2fef2

Escape only closes one thing at a time

### Mini sim

**Before**

https://github.com/user-attachments/assets/327adefa-3c7f-4e35-8cef-06a7d2e38017

Mini sim stays mini when selected from area menu

**After

https://github.com/user-attachments/assets/a7093fb7-cd8d-48ba-a893-7a0379bcd11c

Mini sim gets fullscreened