### PR TITLE
Tab navigation improvement for the docs sidebar

### DIFF
--- a/theme/docs.less
+++ b/theme/docs.less
@@ -29,6 +29,7 @@
 
 @docsCardBorderColor: #e9eef2;
 @docsCardHoverBorderColor: #1dacf4;
+@docsCardFocusBorderColor: #0078D4; // --pxt-focus-border not available in iframed documentation
 
 #docs .footer,
 #docs .topbar,
@@ -219,6 +220,7 @@
     #sidedocs-back-button {
         margin-top: 1.25rem;
         margin-left: 1.25rem;
+        margin-right: 5rem; // Safety margin for the "open in new tab" button
         cursor: pointer;
         user-select: none;
         color: var(--pxt-page-foreground);
@@ -226,6 +228,11 @@
 
         &:hover {
             text-decoration: none;
+        }
+
+        &:focus-visible {
+            outline: 3px solid @docsCardFocusBorderColor;
+            outline-offset: 3px;
         }
     }
 
@@ -483,6 +490,10 @@
 
 .sideDocs #sidedocsbar a {
     color: @docsLinkColor;
+    &:focus-visible {
+        outline: 3px solid var(--pxt-focus-border);
+        outline-offset: 3px;
+    }
 }
 
 .replaceDocsAvatar() when not (@docsAvatarImage = none) {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -608,12 +608,14 @@ export interface SideDocsState {
 interface BuiltInHelpDetails {
     component: () => JSX.Element;
     popOutHref: string;
+    singleTabStop: boolean; // if the whole doc is only one tab stop, the "open in new tab" button placement becomes unintuitive.
 }
 
 const builtIns: Record<pxt.editor.BuiltInHelp, BuiltInHelpDetails> = {
     "keyboardControls": {
         component: KeyboardControlsHelp,
-        popOutHref: "https://makecode.com/accessibility"
+        popOutHref: "https://makecode.com/accessibility",
+        singleTabStop: true
     }
 }
 
@@ -778,20 +780,27 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
             tabIndex: 0,
         };
 
+        const openInNewTab = !lockedEditor && <div className="ui app hide" id="sidedocsbar">
+                    <a className="ui icon link" aria-label={lf("Open documentation in new tab")} {...openInNewTabLinkProps}>
+                        <sui.Icon icon="external" />
+                    </a>
+                </div>;
+
+        const content =  <div id="sidedocsframe-wrapper">
+                    {this.renderContent(url, builtIn, lockedEditor)}
+                </div>;
+
+        const flipNewTabLinkOrder = builtIn?.singleTabStop;
+
+        const contentParts = flipNewTabLinkOrder ? [content, openInNewTab] : [openInNewTab, content];
+
         /* eslint-disable @microsoft/sdl/react-iframe-missing-sandbox */
         return <div>
             <button id="sidedocstoggle" role="button" aria-label={sideDocsCollapsed ? lf("Expand the side documentation") : lf("Collapse the side documentation")} className="ui icon button large" onClick={this.toggleVisibility}>
                 <sui.Icon icon={`icon inverted chevron ${showLeftChevron ? 'left' : 'right'}`} />
             </button>
             <div id="sidedocs" onKeyDown={this.handleKeyDown}>
-                {!lockedEditor && <div className="ui app hide" id="sidedocsbar">
-                    <a className="ui icon link" aria-label={lf("Open documentation in new tab")} {...openInNewTabLinkProps}>
-                        <sui.Icon icon="external" />
-                    </a>
-                </div>}
-                <div id="sidedocsframe-wrapper">
-                    {this.renderContent(url, builtIn, lockedEditor)}
-                </div>
+                {contentParts}
             </div>
         </div>
         /* eslint-enable @microsoft/sdl/react-iframe-missing-sandbox */


### PR DESCRIPTION
A few usability boosts for the documents sidebar.
* Tidied up the CSS interaction between "Go back" and "open in new tab"
* Tidied up the "open in new tab" focus border
* Specifically for the keyboard navigation controls, move the tab order of "open in new tab" so that it obeys a more intuitive order of focusing the scrollable page on the first tab stop, and the "open in new tab" button on the second tab stop

This does not make sense to do for documentation that contains multiple tab stops, as it would put the "open in new tab" button after every tab stop in the page. This is because the documentation, including the go back button, is an iframe and injecting a tab stop for open in new tab would be a bigger piece of work. This approach does involve a little extra logic to re-sequence the DOM, I defer to your consideration whether it's clear enough and not overkill. I have however clarified the focus outlines for the `Go back` button in this case.

### Keyboard navigation help

**Before**

https://github.com/user-attachments/assets/c48aadc9-ffab-405a-a97e-d84895473dce

(pressing shift-tab to reach the button)

**After**

https://github.com/user-attachments/assets/ac0d4cec-98a1-46f6-b3f1-ce3c05e810d2

(pressing tab to reach the button)

### Block Reference help

**Before**

https://github.com/user-attachments/assets/c1fd0d00-7441-4c24-a3ad-04944b479d9d

**After**

https://github.com/user-attachments/assets/af79a828-94c7-4e22-b839-045c920329d0



