### PR TITLE
Prevent the LED matrix from firing no-op change events

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -310,7 +310,8 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     }
 
     setValue(newValue: string | number, restoreState = true) {
-        super.setValue(String(newValue));
+        const shouldFireChangeEvent = newValue !== this.value_;
+        super.setValue(String(newValue), shouldFireChangeEvent);
         if (this.matrixSvg) {
             if (restoreState) this.restoreStateFromString();
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6248

The LED matrix was firing multiple redundant change events when the user interacted with it. Particularly bad was when the mousemove event fired multiple times over the same LED, triggering change events. This fix tests for an actual change in state and guards against firing additional events.

**Before**

https://github.com/user-attachments/assets/25310d7a-45b0-4444-b277-cec863df52ba

**After**

https://github.com/user-attachments/assets/580a9102-19ee-4295-95d3-78fdb91222df