### PR TITLE
Persist code eval project ID when signing in

### DIFF
--- a/teachertool/src/components/SignInModal.tsx
+++ b/teachertool/src/components/SignInModal.tsx
@@ -14,6 +14,15 @@ export const SignInModal: React.FC<IProps> = () => {
         params: pxt.Util.parseQueryString(window.location.href),
     }
 
+    // Projects loaded from urls get cleared after load, so check if we need to add that back.
+    if (teacherTool.projectMetadata?.persistId && !callbackState.params?.["project"]) {
+        if (!callbackState.params) {
+            callbackState.params = {};
+        }
+
+        callbackState.params["project"] = teacherTool.projectMetadata.persistId;
+    }
+
     return teacherTool.modalOptions?.modal === "sign-in" ? (
         <RCSignInModal
             onClose={hideModal}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6505

The project gets cleared from the URL [here](https://github.com/microsoft/pxt/blob/06dba324c2d357418a1b44ec29df10c297b7e3b5/teachertool/src/transforms/handleProjectOnLoadAsync.ts#L25). Because of that, it wasn't getting added to the `CallbackState` during sign-in.

To fix it, we can just check for the project directly and add it back.