### PR TITLE
Reload code eval iframe even when URL is the same

### DIFF
--- a/teachertool/src/components/MakecodeFrame.tsx
+++ b/teachertool/src/components/MakecodeFrame.tsx
@@ -18,8 +18,12 @@ export const MakeCodeFrame: React.FC<IProps> = () => {
 
     useEffect(() => {
         const newUrl = createIFrameUrl(teacherTool.projectMetadata?.id || "");
-        setFrameUrl(newUrl);
-    }, [frameId, teacherTool.projectMetadata?.id]);
+        if (frameUrl == newUrl) {
+            forceIFrameReload();
+        } else {
+            setFrameUrl(newUrl);
+        }
+    }, [frameId, teacherTool.projectMetadata?.id, teacherTool.projectReloadCounter]);
 
     function createIFrameUrl(shareId: string): string {
         const editorUrl: string = pxt.BrowserUtils.isLocalHost()

--- a/teachertool/src/components/ShareLinkInput.tsx
+++ b/teachertool/src/components/ShareLinkInput.tsx
@@ -44,7 +44,7 @@ export const ShareLinkInput: React.FC<IProps> = () => {
             return;
         }
 
-        const isReload: boolean = shareId !== projectMetadata?.shortid && shareId !== projectMetadata?.persistId;
+        const isReload: boolean = shareId === projectMetadata?.shortid || shareId === projectMetadata?.persistId;
         pxt.tickEvent(Ticks.LoadProjectFromInput, { checklistHash: getChecklistHash(teacherTool.checklist), isReload: isReload.toString() });
         loadProjectMetadataAsync(text, shareId, true);
     }, [text, projectMetadata?.shortid, projectMetadata?.persistId]);

--- a/teachertool/src/components/ShareLinkInput.tsx
+++ b/teachertool/src/components/ShareLinkInput.tsx
@@ -44,10 +44,9 @@ export const ShareLinkInput: React.FC<IProps> = () => {
             return;
         }
 
-        if (shareId !== projectMetadata?.shortid && shareId !== projectMetadata?.persistId) {
-            pxt.tickEvent(Ticks.LoadProjectFromInput, { checklistHash: getChecklistHash(teacherTool.checklist) });
-            loadProjectMetadataAsync(text, shareId);
-        }
+        const isReload: boolean = shareId !== projectMetadata?.shortid && shareId !== projectMetadata?.persistId;
+        pxt.tickEvent(Ticks.LoadProjectFromInput, { checklistHash: getChecklistHash(teacherTool.checklist), isReload: isReload.toString() });
+        loadProjectMetadataAsync(text, shareId, true);
     }, [text, projectMetadata?.shortid, projectMetadata?.persistId]);
 
     const icon = useMemo(() => {

--- a/teachertool/src/state/actions.ts
+++ b/teachertool/src/state/actions.ts
@@ -24,6 +24,7 @@ type DismissToast = ActionBase & {
 type SetProjectMetadata = ActionBase & {
     type: "SET_PROJECT_METADATA";
     metadata: ProjectData | undefined;
+    force?: boolean; // Optional flag to force reload even if metadata is the same
 };
 
 type SetEvalResult = ActionBase & {
@@ -162,9 +163,10 @@ const dismissToast = (toastId: string): DismissToast => ({
     toastId,
 });
 
-const setProjectMetadata = (metadata: ProjectData | undefined): SetProjectMetadata => ({
+const setProjectMetadata = (metadata: ProjectData | undefined, force?: boolean): SetProjectMetadata => ({
     type: "SET_PROJECT_METADATA",
     metadata,
+    force,
 });
 
 const setEvalResult = (criteriaInstanceId: string, result: CriteriaResult): SetEvalResult => ({

--- a/teachertool/src/state/reducer.ts
+++ b/teachertool/src/state/reducer.ts
@@ -29,6 +29,7 @@ export default function reducer(state: AppState, action: Action): AppState {
             return {
                 ...state,
                 projectMetadata: action.metadata,
+                projectReloadCounter: action.force ? state.projectReloadCounter + 1 : state.projectReloadCounter,
             };
         }
         case "SET_EVAL_RESULT": {

--- a/teachertool/src/state/state.ts
+++ b/teachertool/src/state/state.ts
@@ -20,6 +20,7 @@ export type AppState = {
     catalogOpen: boolean;
     screenReaderAnnouncement?: string;
     userProfile: pxt.auth.UserProfile | undefined;
+    projectReloadCounter: number; // Counter to force project reload
     flags: {
         testCatalog: boolean;
     };
@@ -40,6 +41,7 @@ export const initialAppState: AppState = {
     catalogOpen: false,
     screenReaderAnnouncement: undefined,
     userProfile: undefined,
+    projectReloadCounter: 0,
     flags: {
         testCatalog: false,
     },

--- a/teachertool/src/transforms/loadProjectMetadataAsync.ts
+++ b/teachertool/src/transforms/loadProjectMetadataAsync.ts
@@ -6,7 +6,7 @@ import { showToast } from "./showToast";
 import { makeToast } from "../utils";
 import { initNewProjectResults } from "./initNewProjectResults";
 
-export async function loadProjectMetadataAsync(inputText: string, shareLink: string) {
+export async function loadProjectMetadataAsync(inputText: string, shareLink: string, force?: boolean) {
     const { dispatch } = stateAndDispatch();
 
     const scriptId = pxt.Cloud.parseScriptId(shareLink);
@@ -32,7 +32,7 @@ export async function loadProjectMetadataAsync(inputText: string, shareLink: str
         ...projMeta,
         inputText,
     };
-    dispatch(Actions.setProjectMetadata(projectData));
+    dispatch(Actions.setProjectMetadata(projectData, force));
     initNewProjectResults();
     logDebug("Loaded project metadata", projMeta);
 }


### PR DESCRIPTION
This change is in response to https://github.com/microsoft/pxt-microbit/issues/6506. It doesn't fix the underlying issue (which is still a mystery), but it does provide a way for the user to trigger a reload of the project when it occurs.

Previously, if the `shareId` didn't change, the project wouldn't reload, even if you clicked enter in the input field. With this change, we force the reload even if `shareId` remains the same. This was a little weird to do, since we rely on the `shareId` state update to trigger the normal iframe reload, but by adding a simple counter to increment in addition to the URL, we can force that code to run even if `shareId` is the same.

Try it: https://makecode.microbit.org/app/9cc5d126301788ec0096f6b3cd3c050d73e691a7-0166509874--eval