### PR TITLE
add dropdown options to block search fields

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1133,9 +1133,51 @@ namespace ts.pxtc.service {
             const computeParameterString = (symbol: SymbolInfo): string => {
                 const paramHelp = symbol.attributes?.paramHelp;
                 if (paramHelp) {
-                    Object.keys(paramHelp).map(p => paramHelp[p]).join(" ");
+                    return Object.keys(paramHelp).map(p => paramHelp[p]).join(" ");
                 }
                 return "";
+            }
+
+            // Extract dropdown options from parameters for search indexing
+            const computeDropdownOptionsString = (symbol: SymbolInfo): string => {
+                let options: string[] = [];
+
+                if (symbol.parameters) {
+                    symbol.parameters.forEach(param => {
+                        // Check for fieldEditorOptions that contain dropdown values
+                        if (param.options && param.options.fieldEditorOptions) {
+                            const editorOptions = param.options.fieldEditorOptions.value;
+                            if (editorOptions && Array.isArray(editorOptions)) {
+                                editorOptions.forEach(option => {
+                                    if (Array.isArray(option) && option.length >= 2) {
+                                        // option[0] is display text, option[1] is value
+                                        if (typeof option[0] === 'string') {
+                                            options.push(option[0]);
+                                        }
+                                    }
+                                });
+                            }
+                        }
+
+                        // Check if parameter is an enum and extract enum member names
+                        if (param.isEnum && param.type) {
+                            // Look up enum members in the API info
+                            const enumInfo = blockInfo.apis.byQName[param.type];
+                            if (enumInfo && enumInfo.kind === ts.pxtc.SymbolKind.Enum) {
+                                // Find enum members
+                                Object.keys(blockInfo.apis.byQName).forEach(qName => {
+                                    const member = blockInfo.apis.byQName[qName];
+                                    if (member.kind === ts.pxtc.SymbolKind.EnumMember &&
+                                        member.namespace === enumInfo.name) {
+                                        options.push(member.name);
+                                    }
+                                });
+                            }
+                        }
+                    });
+                }
+
+                return options.join(" ");
             }
 
             if (!builtinItems) {
@@ -1208,6 +1250,7 @@ namespace ts.pxtc.service {
                         jsdoc: s.attributes.jsDoc,
                         localizedCategory: tbSubset && typeof tbSubset[s.attributes.blockId] === "string"
                             ? tbSubset[s.attributes.blockId] as string : undefined,
+                        dropdownOptions: computeDropdownOptionsString(s),
                     };
                     return mappedSi;
                 });
@@ -1230,18 +1273,19 @@ namespace ts.pxtc.service {
                     shouldSort: true,
                     threshold: 0.6,
                     location: 0,
-                    distance: 100,
+                    distance: 1000,
                     maxPatternLength: 16,
                     minMatchCharLength: 2,
                     findAllMatches: false,
                     caseSensitive: false,
                     keys: [
                         { name: 'name', weight: 0.3 },
+                        { name: "dropdownOptions", weight: 0.15 },
                         { name: 'namespace', weight: 0.1 },
                         { name: 'localizedCategory', weight: 0.1 },
                         { name: 'block', weight: 0.4375 },
                         { name: 'params', weight: 0.0625 },
-                        { name: 'jsdoc', weight: 0.0625 }
+                        { name: 'jsdoc', weight: 0.0625 },
                     ],
                     sortFn: function (a: any, b: any): number {
                         const wa = a.qName ? 1 - weights[a.item.qName] / mw : 1;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -1775,6 +1775,7 @@ namespace ts.pxtc.service {
         localizedCategory?: string;
         builtinBlock?: boolean;
         params?: string;
+        dropdownOptions?: string;
     }
 
     export interface ProjectSearchOptions {


### PR DESCRIPTION
<img width="742" height="364" alt="image" src="https://github.com/user-attachments/assets/06efeaf5-7682-4b98-b4a0-ec6870376c72" />
When searching take into account dropdowns for search results (& also parameter help strings, that was implemented but just forgot return looks like)

left extracting the options to copilot & it did a decent job