### PR TITLE
Debounce showing monaco error list

### DIFF
--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -56,7 +56,7 @@ export class ErrorList extends auth.Component<ErrorListProps, ErrorListState> {
         super(props);
 
         this.state = {
-            isCollapsed: true,
+            isCollapsed: !this.props.errors?.length,
             isLoadingHelp: false,
         };
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1545,6 +1545,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                         this.updateDiagnostics();
                         this.changeCallback();
                         this.updateFieldEditors();
+
+                        if (this.errorListDebounceActive) {
+                            // Delay showing the error list while user is typing
+                            this.revealErrorListDebounced();
+                        }
                     });
                 }
 


### PR DESCRIPTION
This adds some debounce logic before we display the error list in the monaco editor, which is reset by any additional incoming errors or by any user typing.

I don't think we want this for blocks, since those errors are more immediately relevant (no mid-word typing scenarios), hence keeping the changes confined to monaco.

Try it: https://makecode.microbit.org/app/1fbaa8c7c5d8f918df6b430ffa705a682fc15887-0c5fd79306

Fixes https://github.com/microsoft/pxt-microbit/issues/6517