### PR TITLE
Theme Fixes for Minecraft

### DIFF
--- a/pxtblocks/fields/field_gridpicker.ts
+++ b/pxtblocks/fields/field_gridpicker.ts
@@ -756,7 +756,7 @@ Blockly.Css.register(`
 }
 
 .blocklyGridPickerTooltip {
-    z-index: 955;
+    z-index: 995;
 }
 
 .blocklyGridPickerSelectedBar {

--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -360,7 +360,8 @@ text.blocklyCheckbox {
     }
 }
 
-.blocklyWidgetDiv .blocklyContextMenu .blocklyMenuItem.blocklyMenuItemHighlight, .blocklyWidgetDiv .blocklyContextMenu .goog-menuitem-hover {
+.blocklyWidgetDiv .blocklyContextMenu .blocklyMenuItem.blocklyMenuItemHighlight,
+.blocklyWidgetDiv .blocklyContextMenu .gridpicker-menuitem-hover {
     border: none !important;
     padding: .92857143em 1.14285714em !important;
     background: var(--pxt-neutral-background1-hover) !important;

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -440,7 +440,7 @@ div.blocklyTreeIcon span {
     div.blocklyTreeRow {
         border-left-width: 12px !important;
     }
-    div.blocklyTreeRoot div div div div div.blocklyTreeRow {
+    div.blocklyTreeRoot div div:not(#advanced) div div div.blocklyTreeRow {
         border-left-width: 18px !important;
     }
 }

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -299,12 +299,22 @@ div.blocklyTreeIcon span {
     Inverted Toolbox
 *******************************/
 #root.hc .invertedToolbox {
+    div.blocklyTreeRow {
+        background-color: var(--pxt-primary-background);
+        color: var(--pxt-primary-foreground);
+    }
+
     div.blocklyTreeRow .blocklyTreeIcon {
         color: var(--block-meta-color);
     }
 
-    div.blocklyTreeRow.blocklyTreeSelected .blocklyTreeIcon {
-        color: var(--pxt-target-background3);
+    div.blocklyTreeRow.blocklyTreeSelected {
+        background-color: var(--block-meta-color);
+        color: var(--pxt-primary-foreground);
+
+        .blocklyTreeIcon, .blocklyTreeLabel {
+            color: var(--pxt-primary-foreground);
+        }
     }
 }
 

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -821,13 +821,8 @@
         }
     }
 
-    .tutorial-hint .tutorial-callout-button.ui.button {
-        color: @white;
-        background: @tutorialPrimaryColor;
-
-        &.disabled {
-            display: none;
-        }
+    .tutorial-hint .tutorial-callout-button.ui.button.disabled {
+        display: none;
     }
 
     // Overrides


### PR DESCRIPTION
Fixes some theme bugs for minecraft. Specifically:
1. Update old grid picker css class name
2. Fixes for the inverted toolbox in high contrast
3. Fixing the left-side border in the advanced category (so it isn't indented, like a nested category would be)
4. Removing some unnecessary styling for the tutorial hint button

Each fix is more-or-less contained within an individual commit, if that makes it easier to review.

Try it: https://minecraft.makecode.com/app/288596656e511d83e5edbaf5ad42971705affaa7-b70643ab5b