### PR TITLE
Do not show AI Error Help in offline app

### DIFF
--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -175,7 +175,8 @@ export function all(): Experiment[] {
             id: "forceEnableAiErrorHelp",
             name: lf("AI Error Explainer"),
             description: lf("Get AI's help explaining errors in your code"),
-            feedbackUrl: "https://github.com/microsoft/pxt/issues/10694"
+            feedbackUrl: "https://github.com/microsoft/pxt/issues/10694",
+            enableOnline: true
         },
     ];
 

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -110,6 +110,7 @@ export class ErrorList extends auth.Component<ErrorListProps, ErrorListState> {
             !!getErrorHelp &&
             !!showLoginDialog &&
             !pxt.shell.isReadOnly() &&
+            !pxt.BrowserUtils.isPxtElectron() &&
             (pxt.appTarget.appTheme.forceEnableAiErrorHelp || pxt.Util.isFeatureEnabled("aiErrorHelp"));
 
         const helpLoader = (


### PR DESCRIPTION
Since this feature requires login (and an internet connection), we don't want to show it in the offline app. With these changes, the experiment is hidden and the button is not shown in electron mode.

Fixes https://github.com/microsoft/pxt-microbit/issues/6529