### PR TITLE
if the tour steps are empty, don't try to load anything

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5315,7 +5315,11 @@ export class ProjectView
     }
 
     async showOnboarding() {
-        const tourSteps: pxt.tour.BubbleStep[] = await parseTourStepsAsync(pxt.appTarget.appTheme?.tours?.editor)
+        const tourSteps: pxt.tour.BubbleStep[] = await parseTourStepsAsync(pxt.appTarget.appTheme?.tours?.editor);
+        if (tourSteps.length === 0) {
+            pxt.debug("No tour steps found for onboarding");
+            return;
+        }
         const config: pxt.tour.TourConfig = {
             steps: tourSteps,
             showConfetti: true,

--- a/webapp/src/onboarding.ts
+++ b/webapp/src/onboarding.ts
@@ -49,8 +49,14 @@ function getTargetMap(target: string): querySelector {
 }
 
 export async function loadTourStepsAsync(name: string): Promise<pxt.MarkdownSection[]> {
-    const md = await pxt.Cloud.markdownAsync(name);
-    return pxt.getSectionsFromMarkdownMetadata(md);
+    try {
+        const md = await pxt.Cloud.markdownAsync(name);
+        const markdownSections = pxt.getSectionsFromMarkdownMetadata(md);
+        return markdownSections;
+    } catch (error) {
+        pxt.log(`Error fetching the tour steps: ${error}`);
+        return [];
+    }
 }
 
 export async function parseTourStepsAsync(name: string): Promise<pxt.tour.BubbleStep[]> {


### PR DESCRIPTION
It sounds like the error that we were getting for this bug (https://github.com/microsoft/pxt-microbit/issues/6532) has more to do with electron package updates than with the actual tour handling, but I figured that it wouldn't hurt to add some more error handling.