### PR TITLE
add the save only flag back to filedownload

### DIFF
--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -202,7 +202,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         // Matching the tick in the call to compile() above for historical reasons
         pxt.tickEvent("editortools.download", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
         pxt.tickEvent("editortools.downloadasfile", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
-        (this.props.parent as ProjectView).compile();
+        (this.props.parent as ProjectView).compile(true);
     }
 
     protected onPairClick = () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6545

The behavior was the same in arcade with or without the true flag. Wanted to clarify since the change was made (and then reverted incompletely) for arcade originally.