### PR TITLE
add arm builds below existing builds

### DIFF
--- a/docfiles/offline-app-body.html
+++ b/docfiles/offline-app-body.html
@@ -203,19 +203,40 @@
             <div id="download-segment" class="ui center aligned segment hidden">
                 <div class="ui grid">
                     <div class="eight wide column">
-                        <h3 class="ui">Windows</h3>
-                        <a id="download-win64" class="ui icon button" onclick="downloadWin64()">
-                            <i class="download icon"></i>
-                            makecode-@targetid@-setup-win64.exe
-                        </a>
+                        <h2 class="ui header">Windows</h2>
+                        <div class="ui segment">
+                            <h4 class="ui">Intel/AMD</h4>
+                            <a id="download-win64" class="ui icon button" onclick="downloadWin64()">
+                                <i class="download icon"></i>
+                                makecode-@targetid@-setup-win64.exe
+                            </a>
+                        </div>
+                        <div class="ui segment hidden" id="winarm64-section">
+                            <h4 class="ui">ARM</h4>
+                            <a id="download-winarm64" class="ui icon button" onclick="downloadWinArm64()">
+                                <i class="download icon"></i>
+                                makecode-@targetid@-setup-winarm64.exe
+                            </a>
+                        </div>
                     </div>
                     <div class="eight wide column">
-                        <h3 class="ui">Mac OS</h3>
-                        <a id="download-mac64" class="ui icon button" onclick="downloadMac64()">
-                            <i class="download icon"></i>
-                            makecode-@targetid@-mac64.zip
-                        </a>
+                        <h2 class="ui header">Mac OS</h2>
+                        <div class="ui segment">
+                            <h4 class="ui">Intel</h4>
+                            <a id="download-mac64" class="ui icon button" onclick="downloadMac64()">
+                                <i class="download icon"></i>
+                                makecode-@targetid@-mac64.zip
+                            </a>
+                        </div>
+                        <div class="ui segment">
+                            <h4 class="ui">Apple Silicon</h4>
+                            <a id="download-macarm64" class="ui icon button" onclick="downloadMacArm64()">
+                                <i class="download icon"></i>
+                                makecode-@targetid@-macarm64.zip
+                            </a>
+                        </div>
                     </div>
+
                 </div>
             </div>
         </div>

--- a/docfiles/offline-app-head.html
+++ b/docfiles/offline-app-head.html
@@ -87,6 +87,46 @@
             text-transform: uppercase;
         }
 
+        /* Download section styling */
+        #download-segment .ui.segment {
+            min-height: 140px;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.5em 0.8em;
+            margin: 0.2em 0;
+        }
+
+        #download-segment .ui.button {
+            margin-top: auto;
+            white-space: normal;
+            text-align: center;
+            height: 4.5em;
+            width: 90%;
+            line-height: 1.1;
+            padding: 0.5em 0.8em;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+        }
+
+        #download-segment .ui.button .download.icon {
+            margin-bottom: 0.5em !important;
+        }
+
+        #download-segment h4.ui {
+            margin-bottom: 0;
+            margin-top: 0;
+            flex-shrink: 0;
+        }
+
+        #download-segment h2.ui.header {
+            margin-top: 0;
+            margin-bottom: 0.3em;
+        }
+
         @media only screen and (max-width: 800px) {
             .flex-wrapper img {
                 display: none;
@@ -440,13 +480,24 @@
 
         function updateDownloadLinks(electronVersion) {
             $("#download-win64").attr("href", "https://makecode.com/api/release/@targetid@/" + electronVersion + "/win64");
+            $("#download-winarm64").attr("href", "https://makecode.com/api/release/@targetid@/" + electronVersion + "/winarm64");
             $("#download-mac64").attr("href", "https://makecode.com/api/release/@targetid@/" + electronVersion + "/mac64");
+            $("#download-macarm64").attr("href", "https://makecode.com/api/release/@targetid@/" + electronVersion + "/macarm64");
+            
+            // Show Windows ARM section if needed (currently hidden by default)
+            // $("#winarm64-section").removeClass("hidden");
         }
         function downloadWin64() {
             window.pxtTickEvent("offlineapp.download", { "target": "@targetid@", "platform": "win64" });
         }
+        function downloadWinArm64() {
+            window.pxtTickEvent("offlineapp.download", { "target": "@targetid@", "platform": "winarm64" });
+        }
         function downloadMac64() {
             window.pxtTickEvent("offlineapp.download", { "target": "@targetid@", "platform": "mac64" });
+        }
+        function downloadMacArm64() {
+            window.pxtTickEvent("offlineapp.download", { "target": "@targetid@", "platform": "macarm64" });
         }
         $(function () {
             try {


### PR DESCRIPTION
<img width="917" height="902" alt="image" src="https://github.com/user-attachments/assets/2ff2cb60-7d7e-4812-81f7-da0d759ce526" />

Also threw in a windows arm build button but currently hidden -- i have a pr up to generate them but don't think we have a machine to test.

re: https://github.com/microsoft/pxt-microbit/issues/6543