### PR TITLE
PXT High Contrast Fixes

### DIFF
--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -176,3 +176,21 @@ div.field .ui.toggle.checkbox input:checked~label:before {
 #sidedocsbar a:focus span {
     color: var(--pxt-link-hover) !important;
 }
+
+/*
+ * Editor Toggle
+ */
+#editortoggle .selected.item {
+    transition: none;
+    &:focus {
+        box-shadow: inset 0 0 0 6px #000000 !important;
+    }
+    >.icon {
+        color: #000000 !important;
+    }
+}
+
+#editordropdown.ui.button.active > .icon {
+    color: #000000 !important;
+}
+

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -9,12 +9,19 @@
     z-index: 1;
 }
 
+/*
+Override default button background for the area menu, which requires transparency,
+but still use a fairly opaque one to keep focus/visibility on the main buttons.
+*/
 .area-menu-container .area-button {
-    /*
-    Override default button background for the area menu, which requires transparency,
-    but still use a fairly opaque one to keep focus/visibility on the main buttons.
-    */
     background-color: var(--pxt-neutral-alpha80) !important;
+}
+
+/* 
+ * "User-provided content" header in the import modal.
+ */
+.ui.violet.message .header {
+    color: var(--pxt-colors-purple-background) !important;
 }
 
 /* 

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -91,16 +91,6 @@
         }
     }
 
-    #editortoggle .active.item {
-        transition: none;
-        &:focus {
-            box-shadow: inset 0 0 0 6px @HCbackground !important;
-        }
-        >.icon {
-            color: @HCbackground !important;
-        }
-    }
-
     @media all and (pointer:coarse) { /* If touch screen */
         *[tabindex='0'],
         *[tabindex*='d1'],

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -304,7 +304,7 @@ div.blocklyTreeIcon span {
         color: var(--pxt-primary-foreground);
     }
 
-    div.blocklyTreeRow .blocklyTreeIcon {
+    div.blocklyTreeRow .blocklyTreeIcon:not(.blocklyTreeIconsearch) {
         color: var(--block-meta-color);
     }
 


### PR DESCRIPTION
1. Fix the search toolbox category colors in high contrast (fixes https://github.com/microsoft/pxt-minecraft/issues/2760)
2. Fix the editor toggle buttons in high contrast (in conjunction with https://github.com/microsoft/pxt-minecraft/pull/2788)
3. Fix the "user provided content" header in high contrast (fixes https://github.com/microsoft/pxt-minecraft/issues/2762)