### PR TITLE
Recover the duplicate shortcut in the blocks context menu

### DIFF
--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -20,7 +20,6 @@ import { createFieldEditor, initFieldEditors } from "./fields";
 import { promptTranslateBlock } from "./external";
 import { initVariables } from "./builtins/variables";
 import { initOnStart } from "./builtins/misc";
-import { initContextMenu } from "./contextMenu";
 import { renderCodeCard } from "./codecardRenderer";
 import { FieldDropdown } from "./fields/field_dropdown";
 import { setDraggableShadowBlocks, setDuplicateOnDrag, setDuplicateOnDragStrategy } from "./plugins/duplicateOnDrag";
@@ -608,7 +607,6 @@ function init(blockInfo: pxtc.BlocksInfo) {
     blocklyInitialized = true;
 
     initFieldEditors();
-    initContextMenu();
     initOnStart();
     initMath(blockInfo);
     initVariables();

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -20,6 +20,7 @@ import { createFieldEditor, initFieldEditors } from "./fields";
 import { promptTranslateBlock } from "./external";
 import { initVariables } from "./builtins/variables";
 import { initOnStart } from "./builtins/misc";
+import { initContextMenu } from "./contextMenu";
 import { renderCodeCard } from "./codecardRenderer";
 import { FieldDropdown } from "./fields/field_dropdown";
 import { setDraggableShadowBlocks, setDuplicateOnDrag, setDuplicateOnDragStrategy } from "./plugins/duplicateOnDrag";
@@ -588,6 +589,7 @@ export function cleanBlocks() {
  */
 export function initializeAndInject(blockInfo: pxtc.BlocksInfo) {
     init(blockInfo);
+    initContextMenu();
     initCopyPaste(false);
     injectBlocks(blockInfo);
 }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -37,6 +37,7 @@ import { DuplicateOnDragConnectionChecker, shouldDuplicateOnDrag } from "../../p
 import { PathObject } from "../../pxtblocks/plugins/renderer/pathObject";
 import { Measurements } from "./constants";
 import { flow, initCopyPaste } from "../../pxtblocks";
+import { initContextMenu } from "../../pxtblocks/contextMenu";
 import { HIDDEN_CLASS_NAME } from "../../pxtblocks/plugins/flyout/blockInflater";
 import { AIFooter } from "../../react-common/components/controls/AIFooter";
 import { CREATE_VAR_BTN_ID } from "../../pxtblocks/builtins/variables";
@@ -916,10 +917,14 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.initPrompts();
         this.initBlocklyToolbox();
         this.initWorkspaceSounds();
+        initContextMenu();
         initCopyPaste(accessibleBlocksEnabled);
-        // This must come after initCopyPaste which overrides the default cut, copy,
-        // paste shortcuts. The keyboard navigation plugin utilizes these cut, copy and paste
-        // shortcuts and wraps them with additional behaviours (e.g., toast notifications).
+        // This must come after initCopyPaste and initContextMenu.
+        // initCopyPaste overrides the default cut, copy, paste shortcuts.
+        // The keyboard navigation plugin utilizes these cut, copy and paste shortcuts 
+        // and wraps them with additional behaviours (e.g., toast notifications). 
+        // initContextMenu overrides the default context menu options. The plugin 
+        // decorates the duplicate block context menu item to display the shortcut.
         if (accessibleBlocksEnabled) {
             this.initAccessibleBlocks();
         }


### PR DESCRIPTION
This is done by initialising context menu before initialising accessible blocks.

**Before**

<img width="254" height="365" alt="Screenshot 2025-07-30 at 09 08 37" src="https://github.com/user-attachments/assets/4fbc84fa-70f8-418c-a763-07052ad96081" />

**After**

<img width="198" height="310" alt="Screenshot 2025-07-30 at 09 15 09" src="https://github.com/user-attachments/assets/e3277cbc-68a7-4fa1-a66d-9c08a4fb20c6" />
" />
