### PR TITLE
rephrase the reset dialog for minecraft, say delete instead of clear for other targets

### DIFF
--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -717,9 +717,13 @@ export function showReportAbuseAsync(pubId?: string) {
 }
 
 export function showResetDialogAsync() {
+    const isMinecraft = pxt.appTarget.id === "minecraft";
+    const dialogBody = isMinecraft
+        ? lf("You are about to delete all MakeCode projects from Minecraft. Are you sure? This operation cannot be undone.")
+        : lf("You are about to delete all projects. Are you sure? This operation cannot be undone.");
     return core.confirmAsync({
         header: lf("Reset"),
-        body: lf("You are about to clear all projects. Are you sure? This operation cannot be undone."),
+        body: dialogBody,
         agreeLbl: lf("Reset"),
         agreeClass: "red",
         agreeIcon: "sign out",


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2781

In Minecraft:
<img width="879" height="314" alt="image" src="https://github.com/user-attachments/assets/7902119e-35eb-48ac-af73-abc7950657e6" />

In microbit:
<img width="899" height="262" alt="image" src="https://github.com/user-attachments/assets/0e8438ba-e92c-4fe1-830a-e6b8adfd4172" />

