### PR TITLE
Fix Minecraft Tutorial Layout with Experiments Banner

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -554,6 +554,10 @@
     }
 }
 
+#root.headless.tabTutorial.notificationBannerVisible #simulator .editor-sidebar {
+    top: calc(@mainMenuHeight + @bannerHeight);
+}
+
 #root.headless.tabTutorial.hideMenuBar {
     #simulator .editor-sidebar {
         top: 0;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2763

The `#headless` styling just above this change was overriding the typical `.notificationBannerVisible` styling. One option would be to add `!important` to the existing `.notificationBannerVisible` style, but that risks issues in other layouts, so I've added a new case taking `#headless` into account instead.