### PR TITLE
add support for events that use blockAliasFor

### DIFF
--- a/pxtblocks/compiler/compiler.ts
+++ b/pxtblocks/compiler/compiler.ts
@@ -775,7 +775,20 @@ function compileEvent(e: Environment, b: Blockly.Block, stdfun: StdFunc, args: p
         argumentDeclaration = pxt.blocks.mkText(`function (${handlerArgs.join(", ")})`)
     }
 
-    return mkCallWithCallback(e, ns, stdfun.f, compiledArgs, body, argumentDeclaration, stdfun.isExtensionMethod);
+
+    let callNamespace = ns;
+    let callName = stdfun.f
+    if (stdfun.attrs.blockAliasFor) {
+        const aliased = e.blocksInfo.apis.byQName[stdfun.attrs.blockAliasFor];
+
+        if (aliased) {
+            callName = aliased.name;
+            callNamespace = aliased.namespace;
+        }
+    }
+
+
+    return mkCallWithCallback(e, callNamespace, callName, compiledArgs, body, argumentDeclaration, stdfun.isExtensionMethod);
 }
 
 function compileImage(e: Environment, b: Blockly.Block, frames: number, columns: number, rows: number, n: string, f: string, args?: pxt.blocks.JsNode[]): pxt.blocks.JsNode {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -575,8 +575,8 @@ ${output}</xml>`;
             };
         }
 
-        function compInfo(callInfo: pxtc.CallInfo): pxt.blocks.BlockCompileInfo {
-            const blockInfo = blocksInfo.apis.byQName[callInfo.qName];
+        function compInfo(callInfo: DecompilerCallInfo): pxt.blocks.BlockCompileInfo {
+            const blockInfo = blocksInfo.apis.byQName[callInfo.decompilerBlockAlias || callInfo.qName];
             if (blockInfo) {
                 return pxt.blocks.compileInfo(blockInfo);
             }
@@ -694,12 +694,18 @@ ${output}</xml>`;
         function isEventExpression(expr: ts.ExpressionStatement): boolean {
             if (expr.expression.kind == SK.CallExpression) {
                 const call = expr.expression as ts.CallExpression;
-                const callInfo = pxtInfo(call).callInfo;
+                const callInfo = pxtInfo(call).callInfo as DecompilerCallInfo;
                 if (!callInfo) {
                     error(expr)
                     return false;
                 }
-                const attributes = attrs(callInfo);
+                let attributes = attrs(callInfo);
+                if (!attributes.block) {
+                    if (env.aliasBlocks[callInfo.qName]) {
+                        callInfo.decompilerBlockAlias = env.aliasBlocks[callInfo.qName];
+                        attributes = attrs(callInfo);
+                    }
+                }
                 return attributes.blockId && !attributes.handlerStatement && !callInfo.isExpression && hasStatementInput(callInfo, attributes);
             }
             return false;
@@ -1290,11 +1296,8 @@ ${output}</xml>`;
                 const info = pxtInfo(call).callInfo;
                 const index = call.arguments.indexOf(n);
                 if (info && index !== -1) {
-                    const blockInfo = blocksInfo.apis.byQName[info.qName];
-                    if (blockInfo) {
-                        const comp = pxt.blocks.compileInfo(blockInfo);
-                        return comp && comp.parameters[index];
-                    }
+                    const comp = compInfo(info);
+                    return comp && comp.parameters[index];
                 }
             }
             return undefined;
@@ -2070,9 +2073,8 @@ ${output}</xml>`;
                 // }
             }
 
-            const args = paramList(info, env.blocks);
-            const api = env.blocks.apis.byQName[info.decompilerBlockAlias || info.qName];
-            const comp = pxt.blocks.compileInfo(api);
+            const args = paramList(info, env);
+            const comp = compInfo(info);
 
             const r = asExpression ? mkExpr(attributes.blockId, node)
                 : mkStmt(attributes.blockId, node);
@@ -2784,9 +2786,9 @@ ${output}</xml>`;
                 attributes.blockId = builtin.blockId;
             }
 
-            const args = paramList(info, env.blocks);
+            const args = paramList(info, env);
             const api = env.blocks.apis.byQName[info.qName];
-            const comp = pxt.blocks.compileInfo(api);
+            const comp = env.compInfo(info);
             const totalDecompilableArgs = comp.parameters.length + (comp.thisParameter ? 1 : 0);
 
             if (attributes.imageLiteral || attributes.gridLiteral) {
@@ -3591,14 +3593,13 @@ ${output}</xml>`;
         return node.kind === SK.ArrowFunction || node.kind === SK.FunctionExpression;
     }
 
-    function paramList(info: CallInfo, blocksInfo: BlocksInfo) {
+    function paramList(info: CallInfo, env: DecompilerEnv) {
         const res: DecompileArgument[] = [];
-        const sym = blocksInfo.apis.byQName[info.qName];
+        const sym = env.blocks.apis.byQName[info.qName];
 
         if (sym) {
-            const attributes = blocksInfo.apis.byQName[info.qName].attributes;
-            const comp = pxt.blocks.compileInfo(sym);
-            const builtin = pxt.blocks.builtinFunctionInfo[info.qName]
+            const attributes = env.blocks.apis.byQName[info.qName].attributes;
+            const comp = env.compInfo(info);
             let offset = attributes.imageLiteral ? 1 : 0;
 
             if (comp.thisParameter) {

--- a/tests/blocklycompiler-test/baselines/event_block_alias_for.ts
+++ b/tests/blocklycompiler-test/baselines/event_block_alias_for.ts
@@ -1,0 +1,6 @@
+testNamespace.testEvent2(function (num, bool) {
+
+})
+testNamespace.testEvent(function () {
+
+})

--- a/tests/blocklycompiler-test/cases/event_block_alias_for.blocks
+++ b/tests/blocklycompiler-test/cases/event_block_alias_for.blocks
@@ -1,0 +1,22 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="test_event_alias">
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="test_event_alias2">
+<value name="HANDLER_DRAG_PARAM_num">
+<block type="argument_reporter_number">
+<mutation duplicateondrag="true" />
+<field name="VALUE">num</field>
+</block>
+</value>
+<value name="HANDLER_DRAG_PARAM_bool">
+<block type="argument_reporter_boolean">
+<mutation duplicateondrag="true" />
+<field name="VALUE">bool</field>
+</block>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+</xml>

--- a/tests/blocklycompiler-test/test-library/blockAliasFor.ts
+++ b/tests/blocklycompiler-test/test-library/blockAliasFor.ts
@@ -1,0 +1,25 @@
+namespace testNamespace {
+    export function testEvent(handler: () => void): void {
+
+    }
+
+    //% blockId=test_event_alias
+    //% block="test"
+    //% blockAliasFor="testNamespace.testEvent"
+    //% draggableParameters=reporter
+    export function _testEvent(handler: () => void): void {
+        testEvent(handler);
+    }
+
+    export function testEvent2(handler: (num: number, bool: boolean) => void): void {
+
+    }
+
+    //% blockId=test_event_alias2
+    //% block="test $num and $bool"
+    //% blockAliasFor="testNamespace.testEvent2"
+    //% draggableParameters=reporter
+    export function _testEvent2(handler: (num: number, bool: boolean) => void): void {
+        testEvent2(handler);
+    }
+}

--- a/tests/blocklycompiler-test/test-library/pxt.json
+++ b/tests/blocklycompiler-test/test-library/pxt.json
@@ -7,7 +7,8 @@
         "mbit.ts",
         "expandableBlocks.ts",
         "spritekind.ts",
-        "toStringArgs.ts"
+        "toStringArgs.ts",
+        "blockAliasFor.ts"
     ],
     "public": true,
     "dependencies": {},

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -610,6 +610,10 @@ describe("blockly compiler", function () {
         it("should handle APIs where the handler's type uses the Action alias", done => {
             blockTestAsync("action_event").then(done, done);
         });
+
+        it("should handle events with blockAliasFor set", done => {
+            blockTestAsync("event_block_alias_for").then(done, done);
+        });
     })
 
     describe("compiling variable set", () => {

--- a/tests/decompile-test/baselines/event_block_alias_for.blocks
+++ b/tests/decompile-test/baselines/event_block_alias_for.blocks
@@ -1,0 +1,28 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="test_event_alias">
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="typescript_statement">
+<mutation numlines="1" error="Events must be top level" line0="testNamespace._testEvent&#40;&#40;&#41; &#61;&#62; &#123;&#125;&#41;&#59;" />
+</block>
+<block type="test_event_alias2">
+<value name="HANDLER_DRAG_PARAM_num">
+<block type="argument_reporter_number">
+<mutation duplicateondrag="true" />
+<field name="VALUE">num</field>
+</block>
+</value>
+<value name="HANDLER_DRAG_PARAM_bool">
+<block type="argument_reporter_boolean">
+<mutation duplicateondrag="true" />
+<field name="VALUE">bool</field>
+</block>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="typescript_statement">
+<mutation numlines="1" error="Events must be top level" line0="testNamespace._testEvent2&#40;&#40;num&#58; number&#44; bool&#58; boolean&#41; &#61;&#62; &#123;&#125;&#41;&#59;" />
+</block>
+</xml>

--- a/tests/decompile-test/cases/event_block_alias_for.ts
+++ b/tests/decompile-test/cases/event_block_alias_for.ts
@@ -1,0 +1,4 @@
+testNamespace.testEvent(() => {});
+testNamespace._testEvent(() => {});
+testNamespace.testEvent2((num: number, bool: boolean) => {});
+testNamespace._testEvent2((num: number, bool: boolean) => {});

--- a/tests/decompile-test/cases/testBlocks/blockAliasFor.ts
+++ b/tests/decompile-test/cases/testBlocks/blockAliasFor.ts
@@ -1,0 +1,25 @@
+namespace testNamespace {
+    export function testEvent(handler: () => void): void {
+
+    }
+
+    //% blockId=test_event_alias
+    //% block="test"
+    //% blockAliasFor="testNamespace.testEvent"
+    //% draggableParameters=reporter
+    export function _testEvent(handler: () => void): void {
+        testEvent(handler);
+    }
+
+    export function testEvent2(handler: (num: number, bool: boolean) => void): void {
+
+    }
+
+    //% blockId=test_event_alias2
+    //% block="test $num and $bool"
+    //% blockAliasFor="testNamespace.testEvent2"
+    //% draggableParameters=reporter
+    export function _testEvent2(handler: (num: number, bool: boolean) => void): void {
+        testEvent2(handler);
+    }
+}

--- a/tests/decompile-test/cases/testBlocks/pxt.json
+++ b/tests/decompile-test/cases/testBlocks/pxt.json
@@ -15,7 +15,8 @@
         "classHandlerParameter.ts",
         "globals.ts",
         "spritekind.ts",
-        "decompilerShadowAlias.ts"
+        "decompilerShadowAlias.ts",
+        "blockAliasFor.ts"
     ],
     "public": true,
     "dependencies": {},


### PR DESCRIPTION
allows events to use the `//% blockAliasFor=""` attribute. this PR affects both the blocks compiler and the ts decompiler.

i've also added tests for both directions