### PR TITLE
fix context menu init and blockIdentity decompilation

### DIFF
--- a/pxtblocks/contextMenu/contextMenu.ts
+++ b/pxtblocks/contextMenu/contextMenu.ts
@@ -4,6 +4,7 @@ import { registerWorkspaceItems } from "./workspaceItems";
 import { onWorkspaceContextMenu } from "../external";
 import { registerBlockitems } from "./blockItems";
 
+let shortcutsInitialized = false;
 export function initContextMenu() {
     const msg = Blockly.Msg;
 
@@ -23,6 +24,8 @@ export function initContextMenu() {
     msg.DELETE_ALL_BLOCKS = lf("Delete All Blocks");
     msg.HELP = lf("Help");
 
+    if (shortcutsInitialized) return;
+    shortcutsInitialized = true;
     registerWorkspaceItems();
     registerBlockitems();
 }

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -3362,7 +3362,7 @@ ${output}</xml>`;
                 const pInfo = pxtInfo(n);
                 if (isUndefined(n)) {
                     return Util.lf("Undefined is not supported in blocks");
-                } else if (isDeclaredElsewhere(n as Identifier) && !(pInfo.commentAttrs && pInfo.commentAttrs.blockIdentity && pInfo.commentAttrs.enumIdentity)) {
+                } else if (isDeclaredElsewhere(n as Identifier) && !(pInfo.commentAttrs && pInfo.commentAttrs.blockIdentity && pInfo.commentAttrs.enumIdentity && env.blocks.apis.byQName[pInfo.commentAttrs.blockIdentity])) {
                     return Util.lf("Variable is declared in another file");
                 } else {
                     return undefined;
@@ -3396,7 +3396,7 @@ ${output}</xml>`;
             if (callInfo) {
                 const attributes = env.attrs(callInfo);
                 const blockInfo = env.compInfo(callInfo);
-                if (attributes.blockIdentity || attributes.blockId === "lists_length" || attributes.blockId === "text_length") {
+                if ((attributes.blockIdentity && env.blocks.apis.byQName[attributes.blockIdentity]) || attributes.blockId === "lists_length" || attributes.blockId === "text_length") {
                     return undefined;
                 }
                 else if (callInfo.decl.kind === SK.EnumMember) {
@@ -3474,7 +3474,7 @@ ${output}</xml>`;
 
         const attributes = env.attrs(callInfo);
 
-        if (!attributes.blockIdentity) {
+        if (!attributes.blockIdentity || !env.blocks.apis.byQName[attributes.blockIdentity]) {
             return Util.lf("Tagged template does not have blockIdentity set");
         }
 


### PR DESCRIPTION
this fixes two small unrelated bugs:

1. switching from text to blocks was broken by the change to the context menu init in https://github.com/microsoft/pxt/pull/10812 @microbit-grace FYI
2. when decompiling enums and constants with the `//% blockIdentity=""` annotation set, we didn't actually check to make sure the referenced API exists before deciding if this should be a grey block or not