### PR TITLE
add forceStatement annotation and deprecate handlerStatement

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -939,6 +939,10 @@ declare namespace ts.pxtc {
         toolboxParentArgument?: string; // Used with toolboxParent. The name of the arg that this block should be inserted into as a shadow
         duplicateWithToolboxParent?: string; // The ID of an additional block that will be created, which wraps this block in the toolbox. The original (unwrapped) block will also remain in the toolbox.
         duplicateWithToolboxParentArgument?: string; // Used with duplicateWithToolboxParent. The name of the arg that this block should be inserted into as a shadow.
+        blockHandlerKey?: string; // optional field for explicitly declaring the handler key to use to compare duplicate events
+        afterOnStart?: boolean; // indicates an event that should be compiled after on start when converting to typescripts
+        handlerStatement?: boolean; // deprecated, use forceStatement instead
+        forceStatement?: boolean; // indicates that the block for this API should be a statement, regardless of the return value or if it has a handler param
 
         // On namepspace
         subcategories?: string[];
@@ -946,9 +950,6 @@ declare namespace ts.pxtc {
         groupIcons?: string[];
         groupHelp?: string[];
         labelLineWidth?: string;
-        handlerStatement?: boolean; // indicates a block with a callback that can be used as a statement
-        blockHandlerKey?: string; // optional field for explicitly declaring the handler key to use to compare duplicate events
-        afterOnStart?: boolean; // indicates an event that should be compiled after on start when converting to typescript
 
         // on interfaces
         indexerGet?: string;

--- a/pxtblocks/compiler/compiler.ts
+++ b/pxtblocks/compiler/compiler.ts
@@ -290,9 +290,9 @@ function updateDisabledBlocks(e: Environment, allBlocks: Blockly.Block[], topBlo
         // multiple calls allowed
         if (b.type == ts.pxtc.ON_START_TYPE)
             flagDuplicate(ts.pxtc.ON_START_TYPE, b);
-        else if (isFunctionDefinition(b) || call && call.attrs.blockAllowMultiple && !call.attrs.handlerStatement) return;
+        else if (isFunctionDefinition(b) || call && call.attrs.blockAllowMultiple && !(call.attrs.handlerStatement || call.attrs.forceStatement)) return;
         // is this an event?
-        else if (call && call.hasHandler && !call.attrs.handlerStatement) {
+        else if (call && call.hasHandler && !(call.attrs.handlerStatement || call.attrs.forceStatement)) {
             // compute key that identifies event call
             // detect if same event is registered already
             const key = call.attrs.blockHandlerKey || callKey(e, b);

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -343,12 +343,15 @@ function initBlock(block: Blockly.Block, info: pxtc.BlocksInfo, fn: pxtc.SymbolI
         block.setInputsInline(true);
     }
 
-    setOutputCheck(block, fn.retType, info);
-
-    // hook up/down if return value is void
     const hasHandlers = hasArrowFunction(fn);
-    block.setPreviousStatement(!(hasHandlers && !fn.attributes.handlerStatement) && fn.retType == "void");
-    block.setNextStatement(!(hasHandlers && !fn.attributes.handlerStatement) && fn.retType == "void");
+    const isStatement = !!fn.attributes.handlerStatement || !!fn.attributes.forceStatement || (fn.retType === "void" && !hasHandlers);
+
+    if (!isStatement) {
+        setOutputCheck(block, fn.retType, info);
+    }
+
+    block.setPreviousStatement(isStatement);
+    block.setNextStatement(isStatement);
 
     block.setTooltip(/^__/.test(fn.namespace) ? "" : fn.attributes.jsDoc);
     function buildBlockFromDef(def: pxtc.ParsedBlockDef, expanded = false) {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -890,6 +890,7 @@ namespace ts.pxtc {
     const booleanAttributes: (keyof CommentAttrs)[] = [
         "advanced",
         "handlerStatement",
+        "forceStatement",
         "afterOnStart",
         "optionalVariableArgs",
         "blockHidden",

--- a/tests/blocklycompiler-test/baselines/force_statement.ts
+++ b/tests/blocklycompiler-test/baselines/force_statement.ts
@@ -1,0 +1,4 @@
+testNamespace.forceStatement()
+testNamespace.handlerStatement(function () {
+
+})

--- a/tests/blocklycompiler-test/cases/force_statement.blocks
+++ b/tests/blocklycompiler-test/cases/force_statement.blocks
@@ -1,0 +1,14 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="forceStatement">
+<next>
+<block type="handlerStatement">
+<statement name="HANDLER">
+</statement>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/blocklycompiler-test/test-library/forceStatement.ts
+++ b/tests/blocklycompiler-test/test-library/forceStatement.ts
@@ -1,0 +1,16 @@
+namespace testNamespace {
+    //% forceStatement
+    //% blockId=forceStatement
+    //% block="force statement"
+    export function forceStatement(): boolean {
+        return true;
+    }
+
+    //% handlerStatement
+    //% blockId=handlerStatement
+    //% block="handler statement"
+    //% handlerStatement=true
+    export function handlerStatement(handler: () => void): boolean {
+        return true;
+    }
+}

--- a/tests/blocklycompiler-test/test-library/pxt.json
+++ b/tests/blocklycompiler-test/test-library/pxt.json
@@ -8,7 +8,8 @@
         "expandableBlocks.ts",
         "spritekind.ts",
         "toStringArgs.ts",
-        "blockAliasFor.ts"
+        "blockAliasFor.ts",
+        "forceStatement.ts"
     ],
     "public": true,
     "dependencies": {},

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -566,6 +566,10 @@ describe("blockly compiler", function () {
         it("should compile gridTemplate blocks to template strings", done => {
             blockTestAsync("grid_template_string").then(done, done);
         })
+
+        it ("should handle forceStatement blocks", done => {
+            blockTestAsync("force_statement").then(done, done);
+        })
     });
 
     describe("compiling expandable blocks", () => {

--- a/tests/decompile-test/baselines/force_statement.blocks
+++ b/tests/decompile-test/baselines/force_statement.blocks
@@ -1,0 +1,24 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="forceStatement">
+<next>
+<block type="typescript_statement">
+<mutation declaredvars="x" numlines="1" error="Function with forceStatement cannot be used as an expression." line0="let x &#61; testNamespace.forceStatement&#40;&#41;&#59;" />
+<next>
+<block type="handlerStatement">
+<statement name="HANDLER">
+</statement>
+<next>
+<block type="typescript_statement">
+<mutation declaredvars="y" numlines="2" error="Function with forceStatement cannot be used as an expression." line0="let y &#61; testNamespace.handlerStatement&#40;&#40;&#41; &#61;&#62; &#123;" line1="&#125;&#41;&#59;" />
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/force_statement.ts
+++ b/tests/decompile-test/cases/force_statement.ts
@@ -1,0 +1,8 @@
+testNamespace.forceStatement();
+let x = testNamespace.forceStatement();
+
+testNamespace.handlerStatement(() => {
+});
+
+let y = testNamespace.handlerStatement(() => {
+});

--- a/tests/decompile-test/cases/testBlocks/forceStatement.ts
+++ b/tests/decompile-test/cases/testBlocks/forceStatement.ts
@@ -1,0 +1,16 @@
+namespace testNamespace {
+    //% forceStatement
+    //% blockId=forceStatement
+    //% block="force statement"
+    export function forceStatement(): boolean {
+        return true;
+    }
+
+    //% handlerStatement
+    //% blockId=handlerStatement
+    //% block="handler statement"
+    //% handlerStatement=true
+    export function handlerStatement(handler: () => void): boolean {
+        return true;
+    }
+}

--- a/tests/decompile-test/cases/testBlocks/pxt.json
+++ b/tests/decompile-test/cases/testBlocks/pxt.json
@@ -16,7 +16,8 @@
         "globals.ts",
         "spritekind.ts",
         "decompilerShadowAlias.ts",
-        "blockAliasFor.ts"
+        "blockAliasFor.ts",
+        "forceStatement.ts"
     ],
     "public": true,
     "dependencies": {},


### PR DESCRIPTION
this PR adds a new comment annotation, `//% forceStatement`, which can be used to force a block to be a statement regardless of if it returns a value or has a function as an argument. `handlerStatement` should be considered deprecated in favor of `forceStatement`, which is the same except it also handles return values

i'm adding this mainly for minecraft where a lot of javascript APIs currently throw away return values so that the blocks can be statements. with this change we can have it both ways: return values in js and statements in blocks.

