### PR TITLE
add support for reporter parameters with the optionalVariableArgs annotation

### DIFF
--- a/pxtblocks/compiler/typeChecker.ts
+++ b/pxtblocks/compiler/typeChecker.ts
@@ -687,7 +687,7 @@ function getCBParameters(b: Blockly.Block, stdfun: StdFunc, e: Environment): Dec
                 varName = varBlock && varBlock.getField("VAR").getText();
             }
 
-            if (varName !== null) {
+            if (varName !== null && varName !== undefined) {
                 handlerArgs.push({
                     name: varName,
                     type: mkPoint(arg.type)

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -2174,9 +2174,18 @@ ${output}</xml>`;
                                     r.mutation = {
                                         "numargs": arrow.parameters.length.toString()
                                     };
-                                    arrow.parameters.forEach((parameter, i) => {
-                                        r.mutation["arg" + i] = (parameter.name as ts.Identifier).text;
-                                    });
+
+                                    if (attributes.draggableParameters === "reporter") {
+                                        arrow.parameters.forEach((parameter, i) => {
+                                            const arg = paramDesc.handlerParameters[i];
+                                            addDraggableInput(arg, (parameter.name as ts.Identifier).text);
+                                        });
+                                    }
+                                    else {
+                                        arrow.parameters.forEach((parameter, i) => {
+                                            r.mutation["arg" + i] = (parameter.name as ts.Identifier).text;
+                                        });
+                                    }
                                 }
                                 else {
                                     arrow.parameters.forEach((parameter, i) => {
@@ -2192,7 +2201,7 @@ ${output}</xml>`;
                                 }
                             }
                             if (attributes.draggableParameters) {
-                                if (arrow.parameters.length < paramDesc.handlerParameters.length) {
+                                if (arrow.parameters.length < paramDesc.handlerParameters.length && !attributes.optionalVariableArgs) {
                                     for (let i = arrow.parameters.length; i < paramDesc.handlerParameters.length; i++) {
                                         const arg = paramDesc.handlerParameters[i];
                                         addDraggableInput(arg, arg.name);

--- a/tests/blocklycompiler-test/baselines/variable_reporter_args.ts
+++ b/tests/blocklycompiler-test/baselines/variable_reporter_args.ts
@@ -1,0 +1,11 @@
+testNamespace.callbackWithVariableReporterArgs(function () {
+
+})
+
+testNamespace.callbackWithVariableReporterArgs(function (num1) {
+
+})
+
+testNamespace.callbackWithVariableReporterArgs(function (num1, class1) {
+
+})

--- a/tests/blocklycompiler-test/cases/variable_reporter_args.blocks
+++ b/tests/blocklycompiler-test/cases/variable_reporter_args.blocks
@@ -1,0 +1,34 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="test_handler_arguments5">
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="test_handler_arguments5">
+<mutation numargs="1" />
+<value name="HANDLER_DRAG_PARAM_c">
+<block type="argument_reporter_number">
+<mutation duplicateondrag="true" />
+<field name="VALUE">num1</field>
+</block>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="test_handler_arguments5">
+<mutation numargs="2" />
+<value name="HANDLER_DRAG_PARAM_c">
+<block type="argument_reporter_number">
+<mutation duplicateondrag="true" />
+<field name="VALUE">num1</field>
+</block>
+</value>
+<value name="HANDLER_DRAG_PARAM_d">
+<block type="argument_reporter_custom">
+<mutation typename="testNamespace.TestClass" duplicateondrag="true" />
+<field name="VALUE">class1</field>
+</block>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+</xml>

--- a/tests/blocklycompiler-test/test-library/actionEvent.ts
+++ b/tests/blocklycompiler-test/test-library/actionEvent.ts
@@ -119,3 +119,23 @@ namespace player {
     export function onChatCommand(command: string, argTypes: ChatArgument[], handler: (args: ChatCommandArguments) => void): void {
     }
 }
+
+namespace testNamespace {
+    //% blockId=test_handler_arguments5 optionalVariableArgs
+    //% block="Handler with optiional arguments"
+    //% draggableParameters="reporter"
+    //% blockAllowMultiple
+    export function callbackWithVariableReporterArgs(cb: (c: number, d: TestClass) => void) {}
+
+    //% blockId=test_create_class
+    //% block="Create test class with number %x"
+    export function createTestClass(x: number): TestClass { return new TestClass(x); }
+
+    export class TestClass {
+        constructor(x: number) {}
+
+        //% blockId=test_class_method
+        //% block="Some method|on %testClass|with number %x"
+        public testMethod(a: number) {}
+    }
+}

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -618,6 +618,10 @@ describe("blockly compiler", function () {
         it("should handle events with blockAliasFor set", done => {
             blockTestAsync("event_block_alias_for").then(done, done);
         });
+
+        it("should handle events with draggableParameters=reporter and optionalVariableArgs", done => {
+            blockTestAsync("variable_reporter_args").then(done, done);
+        });
     })
 
     describe("compiling variable set", () => {

--- a/tests/decompile-test/baselines/variable_reporter_args.blocks
+++ b/tests/decompile-test/baselines/variable_reporter_args.blocks
@@ -1,0 +1,34 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="test_handler_arguments5">
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="test_handler_arguments5">
+<mutation numargs="1" />
+<value name="HANDLER_DRAG_PARAM_c">
+<block type="argument_reporter_number">
+<mutation duplicateondrag="true" />
+<field name="VALUE">num1</field>
+</block>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="test_handler_arguments5">
+<mutation numargs="2" />
+<value name="HANDLER_DRAG_PARAM_c">
+<block type="argument_reporter_number">
+<mutation duplicateondrag="true" />
+<field name="VALUE">num1</field>
+</block>
+</value>
+<value name="HANDLER_DRAG_PARAM_d">
+<block type="argument_reporter_custom">
+<mutation typename="testNamespace.TestClass" duplicateondrag="true" />
+<field name="VALUE">class1</field>
+</block>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/testBlocks/basic.ts
+++ b/tests/decompile-test/cases/testBlocks/basic.ts
@@ -108,7 +108,7 @@ namespace testNamespace {
     export function callbackWithArguments(cb: (a: number, b: number) => void) {}
 
     //% blockId=test_handler_arguments2 optionalVariableArgs=true
-    //% block="Handler with optioinal arguments"
+    //% block="Handler with optional arguments"
     //% blockAllowMultiple
     export function callbackWithIgnoredArguments(cb: (c: number, d: number) => void) {}
 
@@ -121,6 +121,12 @@ namespace testNamespace {
     //% block="Handler with draggable reporters"
     //% blockAllowMultiple
     export function callbackWithDraggableParamsReporters(cb: (c: string, d: number, e: boolean, f: TestClass) => void) {}
+
+    //% blockId=test_handler_arguments5 optionalVariableArgs
+    //% block="Handler with optional arguments"
+    //% draggableParameters="reporter"
+    //% blockAllowMultiple
+    export function callbackWithVariableReporterArgs(cb: (c: number, d: TestClass) => void) {}
 
     /**
      * Enum value function

--- a/tests/decompile-test/cases/variable_reporter_args.ts
+++ b/tests/decompile-test/cases/variable_reporter_args.ts
@@ -1,0 +1,11 @@
+testNamespace.callbackWithVariableReporterArgs(function () {
+
+})
+
+testNamespace.callbackWithVariableReporterArgs(function (num1) {
+
+})
+
+testNamespace.callbackWithVariableReporterArgs(function (num1, class1) {
+
+})


### PR DESCRIPTION
this pr adds support for combining the `//% optionalVariableArgs` and `//% draggableParameters=reporter` annotations. 

the `optionalVariableArgs` annotation is what gives us the expandable callback parameters in the on chat blocks in minecraft. here's what those look like:

![optional-variable-args](https://github.com/user-attachments/assets/47772f19-8160-4015-9a86-dacf94e2994e)

with this pr, when you add the `draggableParameters=reporter` annotation you get the same behavior but with draggable blocks instead:

![optional-variable-args2](https://github.com/user-attachments/assets/5bdebe98-0ff2-4f84-8ab9-75e327170a19)
