### PR TITLE
don't cache used blocks when doing quick builds

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2563,7 +2563,7 @@ async function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
     const hexCachePath = path.resolve(process.cwd(), "built", "hexcache");
     nodeutil.mkdirP(hexCachePath);
 
-    pxt.log(`building target.json in ${process.cwd()}...`)
+    pxt.log(`building target.json in ${process.cwd()}...`);
 
     let builtInfo: pxt.Map<pxt.PackageApiInfo> = {};
 
@@ -2576,7 +2576,7 @@ async function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
 
     await buildWebStringsAsync();
     if (!options.quick) await internalGenDocsAsync(false, true)
-    if (pxt.appTarget.cacheusedblocksdirs) cfg.tutorialInfo = await internalCacheUsedBlocksAsync();
+    if (pxt.appTarget.cacheusedblocksdirs && !options.quick) cfg.tutorialInfo = await internalCacheUsedBlocksAsync();
 
     await forEachBundledPkgAsync(async (pkg, dirname) => {
         pxt.log(`building bundled ${dirname}`);


### PR DESCRIPTION
this tweaks the `quick` cli option when building targets so that we skip the step where we cache used blocks for tutorials. notably, the quick option is passed to the target build when using the `--rebundle` flag on `pxt serve`.

in pxt-minecraft, we cache a bunch of hour of code tutorial blocks which takes a very long to cache when doing a serve:
* without this change, `pxt serve --rb` takes about 59 seconds on my machine to actually start the local dev server.
* with this change, `pxt serve --rb` takes 17 seconds

just know that if you're testing tutorial perf locally, make sure to not use rebundle (this is globally true of all perf investigations)