### PR TITLE
add tutorial metadata flag for hiding from projects

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1247,6 +1247,7 @@ declare namespace pxt.tutorial {
         autoexpandOff?: boolean; // INTERNAL TESTING ONLY
         preferredEditor?: string; // preferred editor for opening the tutorial
         hideDone?: boolean; // Do not show a "Done" button at the end of the tutorial
+        hideFromProjects?: boolean; // hide this tutorial from the projects list
     }
 
     interface TutorialBlockConfigEntry {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -605,4 +605,9 @@ ${code}
 
         return hintCode;
     }
+
+    export function shouldFilterProject(metadata: pxt.tutorial.TutorialMetadata): boolean {
+        if (!metadata) return false;
+        return !!(metadata.hideFromProjects || metadata.hideIteration);
+    }
 }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -758,7 +758,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
             const showCloudProjectsCard = auth.hasIdentity() && !auth.loggedIn() && pxt.storage.getLocal(auth.HAS_USED_CLOUD);
 
             const headersToShow = headers
-                .filter(h => !h.tutorial?.metadata?.hideIteration)
+                .filter(h => !pxt.tutorial.shouldFilterProject(h.tutorial?.metadata))
                 .slice(0, ProjectsCarousel.NUM_PROJECTS_HOMESCREEN);
             const isFirstProject = (!headers || headers?.length == 0);
             return <carousel.Carousel tickId="myprojects" bleedPercent={20}>

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -450,7 +450,7 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
     private getSortedHeaders() {
         const { sortedBy, sortedAsc, searchFor } = this.state;
         const headers = (this.fetchLocalData() || [])
-            .filter(h => !h.tutorial?.metadata?.hideIteration);
+            .filter(h => !pxt.tutorial.shouldFilterProject(h.tutorial?.metadata));
 
         // Already sorted by relevance
         if (searchFor?.trim()) {


### PR DESCRIPTION
this is for minecraft. currently we only filter tutorials with the `hideIteration` flag from projects, but that flag has other side effects. this lets you have a regular-old multistep tutorial that doesn't go into your projects.