### PR TITLE
use anchor elements for social buttons

### DIFF
--- a/react-common/components/share/SocialButton.tsx
+++ b/react-common/components/share/SocialButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button } from "../controls/Button";
+import { ButtonBody, ButtonProps, inflateButtonProps } from "../controls/Button";
 import { classList } from "../util";
 
 interface SocialButtonProps {
@@ -12,51 +12,50 @@ interface SocialButtonProps {
 export const SocialButton = (props: SocialButtonProps) => {
     const { className, url, type, heading } = props;
 
-    const classes = classList(className, "social-button", "type")
+    const classes = classList(className, "social-button", "type");
+    const socialOptions = pxt.appTarget.appTheme.socialOptions;
+    let socialUrl = "";
+
+    switch (type) {
+        case "facebook": {
+            socialUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
+            break;
+        }
+        case "twitter": {
+            let twitterText = lf("Check out what I made!");
+            if (socialOptions.twitterHandle && socialOptions.orgTwitterHandle) {
+                twitterText = lf("Check out what I made with @{0} and @{1}!", socialOptions.twitterHandle, socialOptions.orgTwitterHandle);
+            } else if (socialOptions.twitterHandle) {
+                twitterText = lf("Check out what I made with @{0}!", socialOptions.twitterHandle);
+            } else if (socialOptions.orgTwitterHandle) {
+                twitterText = lf("Check out what I made with @{0}!", socialOptions.orgTwitterHandle);
+            }
+            socialUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}` +
+                `&text=${encodeURIComponent(twitterText)}` +
+                (socialOptions.hashtags ? `&hashtags=${encodeURIComponent(socialOptions.hashtags)}` : '') +
+                (socialOptions.related ? `&related=${encodeURIComponent(socialOptions.related)}` : '');
+            break;
+        }
+        case "discourse": {
+            // https://meta.discourse.org/t/compose-a-new-pre-filled-topic-via-url/28074
+            socialUrl = `${socialOptions.discourse || "https://forum.makecode.com/"}new-topic?title=${encodeURIComponent(url)}`;
+            if (socialOptions.discourseCategory)
+            socialUrl += `&category=${encodeURIComponent(socialOptions.discourseCategory)}`;
+            break;
+        }
+        case "google-classroom":
+            socialUrl = `https://classroom.google.com/share?url=${encodeURIComponent(url)}`;
+            break;
+        case "microsoft-teams":
+            socialUrl = `https://teams.microsoft.com/share?href=${encodeURIComponent(url)}`;
+            break;
+        case "whatsapp":
+            socialUrl = `https://api.whatsapp.com/send?text=${encodeURIComponent(url)}`;
+            break;
+    }
 
     const handleClick = () => {
-        const socialOptions = pxt.appTarget.appTheme.socialOptions;
-        let socialUrl = '';
-
         pxt.tickEvent(`share.social.${type}`);
-        switch (type) {
-            case "facebook": {
-                socialUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
-                break;
-            }
-            case "twitter": {
-                let twitterText = lf("Check out what I made!");
-                if (socialOptions.twitterHandle && socialOptions.orgTwitterHandle) {
-                    twitterText = lf("Check out what I made with @{0} and @{1}!", socialOptions.twitterHandle, socialOptions.orgTwitterHandle);
-                } else if (socialOptions.twitterHandle) {
-                    twitterText = lf("Check out what I made with @{0}!", socialOptions.twitterHandle);
-                } else if (socialOptions.orgTwitterHandle) {
-                    twitterText = lf("Check out what I made with @{0}!", socialOptions.orgTwitterHandle);
-                }
-                socialUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}` +
-                    `&text=${encodeURIComponent(twitterText)}` +
-                    (socialOptions.hashtags ? `&hashtags=${encodeURIComponent(socialOptions.hashtags)}` : '') +
-                    (socialOptions.related ? `&related=${encodeURIComponent(socialOptions.related)}` : '');
-                break;
-            }
-            case "discourse": {
-                // https://meta.discourse.org/t/compose-a-new-pre-filled-topic-via-url/28074
-                socialUrl = `${socialOptions.discourse || "https://forum.makecode.com/"}new-topic?title=${encodeURIComponent(url)}`;
-                if (socialOptions.discourseCategory)
-                socialUrl += `&category=${encodeURIComponent(socialOptions.discourseCategory)}`;
-                break;
-            }
-            case "google-classroom":
-                socialUrl = `https://classroom.google.com/share?url=${encodeURIComponent(url)}`;
-                break;
-            case "microsoft-teams":
-                socialUrl = `https://teams.microsoft.com/share?href=${encodeURIComponent(url)}`;
-                break;
-            case "whatsapp":
-                socialUrl = `https://api.whatsapp.com/send?text=${encodeURIComponent(url)}`;
-                break;
-        }
-        pxt.BrowserUtils.popupWindow(socialUrl, heading, 600, 600);
     }
 
     switch (type) {
@@ -65,21 +64,68 @@ export const SocialButton = (props: SocialButtonProps) => {
         case "twitter":
         case "discourse":
         case "whatsapp":
-            return <Button className={classes}
-                ariaLabel={type}
-                title={heading}
-                leftIcon={`icon ${type}`}
-                onClick={handleClick} />
+            return (
+                <LinkButton
+                    className={classList(classes, "social-icon")}
+                    ariaLabel={type}
+                    title={heading}
+                    href={socialUrl}
+                    leftIcon={`icon ${type}`}
+                    heading={heading}
+                    onClick={handleClick}
+                />
+            );
 
         // Image buttons
         case "google-classroom":
         case "microsoft-teams":
-            return <Button className={classes}
-                ariaLabel={type}
-                title={heading}
-                label={<img src={`/static/logo/social-buttons/${type}.png`} alt={heading || pxt.U.rlf(type)} />}
-                onClick={handleClick} />
+            return (
+                <LinkButton
+                    className={classes}
+                    ariaLabel={type}
+                    title={heading}
+                    href={socialUrl}
+                    label={
+                        <img
+                            src={`/static/logo/social-buttons/${type}.png`}
+                            alt={heading || pxt.U.rlf(type)}
+                        />
+                    }
+                    heading={heading}
+                    onClick={handleClick}
+                />
+            );
+    }
+}
+
+const LinkButton = (props: ButtonProps & { heading: string }) => {
+    const inflatedProps = inflateButtonProps(props);
+
+    const onClick = (ev: React.MouseEvent) => {
+        if (props.onClick) {
+            props.onClick();
+        }
+
+        ev.stopPropagation();
+
+        // if we are in game, don't call preventDefault so that the default browser
+        // navigation behavior occurs
+        if (!pxt.BrowserUtils.isInGame()) {
+            ev.preventDefault();
+            pxt.BrowserUtils.popupWindow(props.href, props.heading, 600, 600);
+        }
     }
 
-
+    return (
+        <a
+            className={inflatedProps.className}
+            title={inflatedProps.title}
+            href={props.href}
+            target="_blank"
+            rel="noopener,noreferrer"
+            onClick={onClick}
+        >
+            <ButtonBody {...props} />
+        </a>
+    );
 }

--- a/react-common/styles/share/share.less
+++ b/react-common/styles/share/share.less
@@ -168,6 +168,12 @@
     .common-button.neutral {
         border: 1px solid var(--pxt-neutral-alpha20) !important;
     }
+
+    a.common-button.social-icon {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
 }
 
 .project-share-text {


### PR DESCRIPTION
this is a redo of https://github.com/microsoft/pxt/pull/10277

replaces the button elements for the social buttons with anchor elements. also changes the minecraft in game behavior so that we use the default browser navigation instead of window.open (which is unsupported in their embedded webview).