### PR TITLE
reassign window location when loading beta in-game

### DIFF
--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -521,19 +521,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                                 description={lf("Open files from your computer")}
                                 onClick={this.importExtensionFile}
                             />}
-                            {showOpenBeta && <codecard.CodeCardView
-                                ariaLabel={lf("Open the next version of the editor")}
-                                role="link"
-                                key={'beta'}
-                                className="beta"
-                                icon="lab ui cardimage"
-                                iconColor="secondary"
-                                name={lf("Beta Editor")}
-                                label={lf("Beta")}
-                                labelClass="red right ribbon"
-                                description={lf("Open the next version of the editor")}
-                                url={betaUrl}
-                            />}
+                            {showOpenBeta && <BetaExperimentCard betaUrl={betaUrl} />}
                         </div>
                     }
                     {isEmpty() ?
@@ -576,4 +564,33 @@ class ScriptSearchCodeCard extends sui.StatelessUIElement<ScriptSearchCodeCardPr
         const { onCardClick, onClick, scr, ...rest } = this.props;
         return <codecard.CodeCardView {...rest} onClick={this.handleClick} />
     }
+}
+
+const BetaExperimentCard = (props: { betaUrl: string }) => {
+    const { betaUrl } = props;
+
+    let onClick: () => void = undefined;
+
+    if (pxt.BrowserUtils.isInGame()) {
+        onClick = () => {
+            window.location.assign(betaUrl);
+        };
+    }
+
+    return (
+        <codecard.CodeCardView
+            ariaLabel={lf("Open the next version of the editor")}
+            role="link"
+            key={'beta'}
+            className="beta"
+            icon="lab ui cardimage"
+            iconColor="secondary"
+            name={lf("Beta Editor")}
+            label={lf("Beta")}
+            labelClass="red right ribbon"
+            description={lf("Open the next version of the editor")}
+            url={!onClick ? betaUrl : undefined}
+            onClick={onClick}
+        />
+    );
 }


### PR DESCRIPTION
fixes the issue in minecraft where clicking the beta experiment card on mac causes a new window to pop up instead of loading beta.

seems like the minecraft client treats all link clicks as new windows. assigning the window location seems to work though! tested on mac