### PR TITLE
use dropdown instead of select for language restriction

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -2853,6 +2853,10 @@ select.ui.dropdown {
     .expandable-menu {
         font-size: 12px !important;
     }
+
+    .language-restriction-dropdown > button {
+        min-width: 18rem;
+    }
 }
 
 .ui.modal.auto-save-disabled-warning {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -16,6 +16,7 @@ import { ThemeManager } from "../../react-common/components/theming/themeManager
 import IProjectView = pxt.editor.IProjectView;
 import ISettingsProps = pxt.editor.ISettingsProps;
 import UserInfo = pxt.editor.UserInfo;
+import { Dropdown, DropdownItem } from "../../react-common/components/controls/Dropdown";
 
 
 // This Component overrides shouldComponentUpdate, be sure to update that if the state is updated
@@ -1579,18 +1580,21 @@ export class NewProjectDialog extends data.Component<ISettingsProps, NewProjectD
         ];
 
         const mobile = pxt.BrowserUtils.isMobile();
-        const langOpts: sui.SelectItem[] = [
+        const langOpts: DropdownItem[] = [
             {
-                value: pxt.editor.LanguageRestriction.Standard,
-                display: python ? lf("Blocks, {0}, and {1}", "JavaScript", "Python") : lf("Blocks and {0}", "JavaScript")
+                id: pxt.editor.LanguageRestriction.Standard,
+                label: python ? lf("Blocks, {0}, and {1}", "JavaScript", "Python") : lf("Blocks and {0}", "JavaScript"),
+                title: python ? lf("Blocks, {0}, and {1}", "JavaScript", "Python") : lf("Blocks and {0}", "JavaScript")
             },
             python && {
-                value: pxt.editor.LanguageRestriction.PythonOnly,
-                display: lf("{0} Only", "Python")
+                id: pxt.editor.LanguageRestriction.PythonOnly,
+                label: lf("{0} Only", "Python"),
+                title: lf("{0} Only", "Python")
             },
             {
-                value: pxt.editor.LanguageRestriction.JavaScriptOnly,
-                display: lf("{0} Only", "JavaScript")
+                id: pxt.editor.LanguageRestriction.JavaScriptOnly,
+                label: lf("{0} Only", "JavaScript"),
+                title: lf("{0} Only", "JavaScript")
             }
         ];
         const classes = this.props.parent.createModalClasses("newproject");
@@ -1613,7 +1617,13 @@ export class NewProjectDialog extends data.Component<ISettingsProps, NewProjectD
             {chooseLanguageRestrictionOnNewProject && <div>
                 <br />
                 <sui.ExpandableMenu title={lf("Code options")} onShow={this.onExpandedMenuShow} onHide={this.onExpandedMenuHide}>
-                    <sui.Select options={langOpts} onChange={this.handleLanguageChange} aria-label={lf("Select Language")} />
+                    <Dropdown
+                        className="language-restriction-dropdown"
+                        id="language-restriction-dropdown"
+                        items={langOpts}
+                        selectedId={this.state.languageRestriction}
+                        onItemSelected={this.handleLanguageChange}
+                    />
                 </sui.ExpandableMenu>
             </div>}
         </sui.Modal>

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -436,60 +436,6 @@ export class ExpandableMenu extends UIElement<ExpandableMenuProps, ExpandableMen
     }
 }
 
-export interface SelectProps {
-    options: SelectItem[];
-    onChange?: (value: string) => void;
-    "aria-label"?: string;
-    label?: string;
-}
-
-export interface SelectState {
-    selected?: string;
-}
-
-export interface SelectItem {
-    value: string | number;
-    display?: string;
-}
-
-export class Select extends UIElement<SelectProps, SelectState> {
-    constructor(props: SelectProps) {
-        super(props);
-        const { options } = props;
-        this.state = {
-            selected: options[0] && (options[0].value + "")
-        };
-    }
-
-    handleOnChange = (ev: React.ChangeEvent<HTMLSelectElement>) => {
-        const { onChange } = this.props;
-        this.setState({
-            selected: ev.target.value
-        });
-
-        if (onChange) {
-            onChange(ev.target.value);
-        }
-    }
-
-    render() {
-        const { options, label, "aria-label": ariaLabel } = this.props;
-        const { selected } = this.state;
-
-        return (<div>
-            { label && `${label} ` }
-            <select value={selected} className="ui dropdown" onChange={this.handleOnChange} aria-label={ariaLabel} >
-                {options.map(opt =>
-                    opt && <option
-                        aria-selected={selected === opt.value}
-                        value={opt.value}
-                        key={opt.value}
-                    >{opt.display || opt.value}</option>
-                )}
-            </select>
-        </div>);
-    }
-}
 
 ///////////////////////////////////////////////////////////
 ////////////             Items                /////////////


### PR DESCRIPTION
seems like the minecraft client isn't a fan of `<select>` elements on ios. this works around that issue by replacing the one in the new project modal with our react-common dropdown. that was the only place actually using that sui component, so i removed it entirely.

added bonus is that this makes that dropdown more consistent with our other ones appearance wise.