### PR TITLE
fix area menu overlay for headless sim targets

### DIFF
--- a/webapp/src/components/AreaMenuOverlay.tsx
+++ b/webapp/src/components/AreaMenuOverlay.tsx
@@ -115,7 +115,11 @@ const areas: Area[] = [
             if (!bounds) {
                 return undefined;
             }
-            if (projectView.state.collapseEditorTools && !pxt.appTarget.simulator?.headless) {
+
+            const inTutorial = !!projectView.state.tutorialOptions?.tutorial;
+            const isHeadless = !!pxt.appTarget.simulator?.headless;
+
+            if (projectView.state.collapseEditorTools && !(isHeadless && inTutorial)) {
                 const isRtl = pxt.Util.isUserLanguageRtl();
                 // Shift over for a clearer area when the toolbox is collapsed
                 const copy = DOMRect.fromRect(bounds);

--- a/webapp/src/components/AreaMenuOverlay.tsx
+++ b/webapp/src/components/AreaMenuOverlay.tsx
@@ -60,6 +60,9 @@ const areas: Area[] = [
         ariaLabel: lf("Simulator"),
         shortcutKey: "2",
         getBounds(projectView: IProjectView) {
+            if (pxt.appTarget.simulator?.headless) {
+                return undefined;
+            }
             const element = isSimMini()
                 ? document.querySelector(".simPanel")
                 : projectView.state.collapseEditorTools ?
@@ -112,7 +115,7 @@ const areas: Area[] = [
             if (!bounds) {
                 return undefined;
             }
-            if (projectView.state.collapseEditorTools) {
+            if (projectView.state.collapseEditorTools && !pxt.appTarget.simulator?.headless) {
                 const isRtl = pxt.Util.isUserLanguageRtl();
                 // Shift over for a clearer area when the toolbox is collapsed
                 const copy = DOMRect.fromRect(bounds);
@@ -208,7 +211,7 @@ export const AreaMenuOverlay = ({ parent }: AreaMenuOverlapProps) => {
     }, [parent]);
     useEffect(() => {
         const listener = (e: KeyboardEvent) => {
-            const area = areas.find(area => area.shortcutKey === e.key);
+            const area = areas.find(area => area.shortcutKey === e.key && !!areaRects.get(area.id));
             if (area) {
                 e.preventDefault();
                 moveFocusToArea(area);


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2807

don't adjust the toolbox rect size when the simulator is collapsed and a tutorial is open as the sim sidebar causes the rect to be misplaced. this is only an issue in headless targets because the sim cannot be collapsed in a tutorial otherwise.

also makes it so that we don't render a shortcut for the simulator in headless targets since there is nothing to focus.