### PR TITLE
Support different tutorial instruction layouts per editor language

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -525,7 +525,8 @@ declare namespace pxt {
         tours?: {
             editor?: string // path to markdown file for the editor tour steps
         }
-        tutorialSimSidebarLayout?: boolean; // Enable tutorial layout with the sim in the sidebar (desktop only)
+        tutorialSimSidebarLayout?: boolean; // Enable tutorial layout with the sim in the sidebar (desktop only) for all languages.
+        tutorialSimSidebarLangs?: string[]; // List of languages that should use tutorialSimSidebarLayout.
         showOpenInVscode?: boolean; // show the open in VS Code button
         matchWebUSBDeviceInSim?: boolean; // if set, pass current device id as theme to sim when available.
         condenseProfile?: boolean; // if set, will make the profile dialog smaller

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -525,8 +525,7 @@ declare namespace pxt {
         tours?: {
             editor?: string // path to markdown file for the editor tour steps
         }
-        tutorialSimSidebarLayout?: boolean; // Enable tutorial layout with sim in sidebar (desktop only) for ALL code languages. When true, overrides tutorialSimSidebarLangs.
-        tutorialSimSidebarLangs?: string[]; // List of specific code languages that should use tutorial sim sidebar layout. Ignored if tutorialSimSidebarLayout is true.
+        tutorialSimSidebarLangs?: string[]; // Enable tutorial layout with sim in sidebar for specific editor languages (blocks, python, or javascript). Desktop only.
         showOpenInVscode?: boolean; // show the open in VS Code button
         matchWebUSBDeviceInSim?: boolean; // if set, pass current device id as theme to sim when available.
         condenseProfile?: boolean; // if set, will make the profile dialog smaller

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -525,8 +525,8 @@ declare namespace pxt {
         tours?: {
             editor?: string // path to markdown file for the editor tour steps
         }
-        tutorialSimSidebarLayout?: boolean; // Enable tutorial layout with the sim in the sidebar (desktop only) for all languages.
-        tutorialSimSidebarLangs?: string[]; // List of languages that should use tutorialSimSidebarLayout.
+        tutorialSimSidebarLayout?: boolean; // Enable tutorial layout with sim in sidebar (desktop only) for ALL code languages. When true, overrides tutorialSimSidebarLangs.
+        tutorialSimSidebarLangs?: string[]; // List of specific code languages that should use tutorial sim sidebar layout. Ignored if tutorialSimSidebarLayout is true.
         showOpenInVscode?: boolean; // show the open in VS Code button
         matchWebUSBDeviceInSim?: boolean; // if set, pass current device id as theme to sim when available.
         condenseProfile?: boolean; // if set, will make the profile dialog smaller

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -979,6 +979,7 @@ declare namespace pxt.editor {
         completeTutorialAsync(): Promise<void>;
         showTutorialHint(): void;
         isTutorial(): boolean;
+        useTutorialSimSidebarLayout(): boolean;
         onEditorContentLoaded(): void;
         pokeUserActivity(): void;
         stopPokeUserActivity(): void;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -535,10 +535,13 @@
         background: none transparent;
         min-width: inherit;
         max-width: inherit;
-        width: @simulatorWidth;
         top: @mainMenuHeight;
         bottom: 0;
         left: 0;
+
+        &:not(.topInstructions) {
+            width: @simulatorWidth;
+        }
 
         .simPanel {
             display: none;
@@ -549,7 +552,7 @@
         display: auto;
     }
 
-    #maineditor {
+    &:not(.tutorialSimSidebar) #maineditor {
         left: @simulatorWidth;
     }
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5112,14 +5112,6 @@ export class ProjectView
     }
 
     useTutorialSimSidebarLayout() {
-        if (!this.isTutorial() || pxt.BrowserUtils.isTabletSize()) {
-            return false;
-        }
-
-        if (pxt.appTarget.appTheme.tutorialSimSidebarLayout) {
-            return true;
-        }
-
         const lang = this.isBlocksActive() ? "blocks" : this.isPythonActive ? "python" : "javascript";
         return !!pxt.appTarget.appTheme.tutorialSimSidebarLangs?.includes(lang);
     }
@@ -5487,7 +5479,7 @@ export class ProjectView
         const isSidebarTutorial = pxt.appTarget.appTheme.sidebarTutorial;
         const isTabTutorial = inTutorial && !pxt.BrowserUtils.useOldTutorialLayout();
         const inTutorialExpanded = inTutorial && tutorialOptions.tutorialStepExpanded;
-        const tutorialSimSidebar = this.useTutorialSimSidebarLayout();
+        const tutorialSimSidebar = !pxt.BrowserUtils.isTabletSize() && this.useTutorialSimSidebarLayout();
         const inDebugMode = this.state.debugging;
         const inHome = this.state.home && !sandbox;
         const inEditor = !!this.state.header && !inHome;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -238,6 +238,7 @@ export class ProjectView
         this.onThemeChanged = this.onThemeChanged.bind(this);
         this.setColorThemeById = this.setColorThemeById.bind(this);
         this.showLoginDialog = this.showLoginDialog.bind(this);
+        this.useTutorialSimSidebarLayout = this.useTutorialSimSidebarLayout.bind(this);
 
         // add user hint IDs and callback to hint manager
         if (pxt.BrowserUtils.useOldTutorialLayout()) this.hintManager.addHint(ProjectView.tutorialCardId, this.tutorialCardHintCallback.bind(this));
@@ -5110,6 +5111,19 @@ export class ProjectView
         return this.state.tutorialOptions != undefined;
     }
 
+    useTutorialSimSidebarLayout() {
+        if (!this.isTutorial() || pxt.BrowserUtils.isTabletSize()) {
+            return false;
+        }
+
+        if (pxt.appTarget.appTheme.tutorialSimSidebarLayout) {
+            return true;
+        }
+
+        const lang = this.isBlocksActive() ? "blocks" : this.isPythonActive ? "python" : "javascript";
+        return pxt.appTarget.appTheme.tutorialSimSidebarLangs?.includes(lang);
+    }
+
     onEditorContentLoaded() {
         if (this.isTutorial()) {
             pxt.tickEvent("tutorial.editorLoaded")
@@ -5155,7 +5169,7 @@ export class ProjectView
             if (!pxt.BrowserUtils.useOldTutorialLayout()) {
                 const tutorialElements = document?.getElementsByClassName("tutorialWrapper");
                 const tutorialEl = tutorialElements?.length === 1 ? (tutorialElements[0] as HTMLElement) : undefined;
-                if (tutorialEl && (pxt.BrowserUtils.isTabletSize() || pxt.appTarget.appTheme.tutorialSimSidebarLayout)) {
+                if (tutorialEl && (pxt.BrowserUtils.isTabletSize() || this.useTutorialSimSidebarLayout())) {
                     this.setState({ editorOffset: tutorialEl.offsetHeight + "px" });
                 } else {
                     this.setState({ editorOffset: undefined });
@@ -5473,7 +5487,7 @@ export class ProjectView
         const isSidebarTutorial = pxt.appTarget.appTheme.sidebarTutorial;
         const isTabTutorial = inTutorial && !pxt.BrowserUtils.useOldTutorialLayout();
         const inTutorialExpanded = inTutorial && tutorialOptions.tutorialStepExpanded;
-        const tutorialSimSidebar = pxt.appTarget.appTheme.tutorialSimSidebarLayout && !pxt.BrowserUtils.isTabletSize();
+        const tutorialSimSidebar = this.useTutorialSimSidebarLayout();
         const inDebugMode = this.state.debugging;
         const inHome = this.state.home && !sandbox;
         const inEditor = !!this.state.header && !inHome;
@@ -6498,7 +6512,7 @@ document.addEventListener("DOMContentLoaded", async () => {
             }
 
             // Check to see if we should show the mini simulator (<= tablet size)
-            if (!theEditor.isTutorial() || pxt.appTarget.appTheme.tutorialSimSidebarLayout || pxt.BrowserUtils.useOldTutorialLayout()) {
+            if (!theEditor.isTutorial() || theEditor.useTutorialSimSidebarLayout() || pxt.BrowserUtils.useOldTutorialLayout()) {
                 if (pxt.BrowserUtils.isTabletSize()) {
                     theEditor.showMiniSim(true);
                 } else {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5121,7 +5121,7 @@ export class ProjectView
         }
 
         const lang = this.isBlocksActive() ? "blocks" : this.isPythonActive ? "python" : "javascript";
-        return pxt.appTarget.appTheme.tutorialSimSidebarLangs?.includes(lang);
+        return !!pxt.appTarget.appTheme.tutorialSimSidebarLangs?.includes(lang);
     }
 
     onEditorContentLoaded() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5112,7 +5112,7 @@ export class ProjectView
     }
 
     useTutorialSimSidebarLayout() {
-        const lang = this.isBlocksActive() ? "blocks" : this.isPythonActive ? "python" : "javascript";
+        const lang = this.isBlocksActive() ? "blocks" : this.isPythonActive() ? "python" : "javascript";
         return !!pxt.appTarget.appTheme.tutorialSimSidebarLangs?.includes(lang);
     }
 

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -154,7 +154,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
                 if (!hideIteration) return <tutorial.TutorialMenu parent={this.props.parent} />
                 break;
             case "tutorial-tab":
-                if (tutorialOptions && (pxt.appTarget?.appTheme?.tutorialSimSidebarLayout || pxt.BrowserUtils.isTabletSize())) {
+                if (tutorialOptions && (pxt.BrowserUtils.isTabletSize() || this.props.parent.useTutorialSimSidebarLayout())) {
                     const currentStep = tutorialOptions.tutorialStep ? tutorialOptions.tutorialStep + 1 : undefined;
                     const totalSteps = tutorialOptions.tutorialStepInfo ? tutorialOptions.tutorialStepInfo?.length : undefined;
                     return (


### PR DESCRIPTION
This change adds support for switching to the tutorial "sim sidebar" layout for specific editor languages (blocks, javascript, or python).

The name is confusing here. "Sim sidebar" means two things - the simulator is on the lefthand side *and* the instructions are at the top. It was made for Micro:bit, where it is used for all tutorials and having the sim on the side (vs minisim) is the more prominent difference. But in Minecraft (in-game), the simulator is hidden, so it just moves the instructions to the top, which is what we want. I considered renaming it to something like "top instruction layout", but that is overloaded with the layout for tablet-sized screens, so you could end up not enabling "top instructions" mode but still ending up with instructions at the top...which felt similarly confusing. So in the end, I just left it as-is.

I was a little worried about backwards compat when getting rid of the existing flag, but since pxtarget is versioned with the rest of the app, I think it's actually okay.

Once this is approved, I'll follow up with separate changes in pxt-minecraft, pxt-microbit, and pxt-calliope to add/update the flag.

Will fix https://github.com/microsoft/pxt-minecraft/issues/2743 once pxt-minecraft is also updated.

Try it: https://minecraft.makecode.com/app/0a4c40997c73033cbe3b20895572e677edcd6ae5-a9ffeb0a2d?gameVersion=1.21.91&inGame=1&ipc=1&lang=en-US&protocolVersion=17104896