### PR TITLE
lots of keyboard accessibility fixes for gridpicker

### DIFF
--- a/pxtblocks/fields/field_dropdown.ts
+++ b/pxtblocks/fields/field_dropdown.ts
@@ -11,6 +11,10 @@ export class FieldDropdown extends Blockly.FieldDropdown {
     override initView() {
         super.initView();
 
+        if (this.fieldGroup_) {
+            this.fieldGroup_.classList.add("pxtFieldDropdown");
+        }
+
         if (this.shouldAddBorderRect_()) {
             return;
         }
@@ -122,3 +126,9 @@ export class FieldDropdown extends Blockly.FieldDropdown {
         showEditorMixin.call(this, e);
     }
 }
+
+Blockly.Css.register(`
+.pxtFieldDropdown.blocklyActiveFocus > .blocklyFieldRect, .pxtFieldDropdown.blocklyPassiveFocus > .blocklyFieldRect {
+    stroke-opacity: 1;
+}
+`)

--- a/pxtblocks/fields/field_gridpicker.ts
+++ b/pxtblocks/fields/field_gridpicker.ts
@@ -86,6 +86,8 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
             this.gridTooltip_.style.top = `${rect.bottom + 5}px`;
             this.gridTooltip_.style.left = `${rect.left}px`;
         }
+
+        this.addKeyboardNavigableClass();
     }
 
     /**
@@ -373,6 +375,9 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
         const tableContainer = document.createElement("div");
         this.positionMenu_(tableContainer);
         tableContainer.focus();
+        if (!e) {
+            this.addKeyboardNavigableClass();
+        }
     }
 
     private positionMenu_(tableContainer: HTMLElement) {
@@ -524,7 +529,11 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
         });
 
         // Search on key change
-        searchBar.addEventListener("keyup", pxt.Util.debounce(() => {
+        searchBar.addEventListener("keyup", pxt.Util.debounce((e: KeyboardEvent) => {
+            if (e.code === "Tab") {
+                return;
+            }
+
             let text = searchBar.value;
             let re = new RegExp(text, "i");
             let filteredOptions = options.filter((block) => {
@@ -532,7 +541,7 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
                 const value = (block as any)[1]; // Language-neutral value.
                 return alt ? re.test(alt) : re.test(value);
             })
-            this.populateTableContainer.bind(this)(filteredOptions, tableContainer, scrollContainer);
+            this.populateTableContainer(filteredOptions, tableContainer, scrollContainer);
             if (text) {
                 this.highlightFirstItem(tableContainer)
             } else {
@@ -687,6 +696,7 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
     // Used for focus trap
     private handleTabKey(e: KeyboardEvent) {
         if (e.code === "Tab") {
+            this.addKeyboardNavigableClass();
             if (document.activeElement === this.lastFocusableElement && !e.shiftKey) {
                 this.firstFocusableElement.focus();
                 e.preventDefault();
@@ -694,6 +704,12 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
                 this.lastFocusableElement.focus();
                 e.preventDefault();
             }
+        }
+    }
+
+    private addKeyboardNavigableClass() {
+        if (this.scrollContainer) {
+            this.scrollContainer.classList.add("keyboardNavigable");
         }
     }
 }
@@ -724,6 +740,10 @@ Blockly.Css.register(`
     border-radius: 4px;
     position: relative;
     -webkit-overflow-scrolling: touch;
+}
+
+.blocklyGridPickerScroller.keyboardNavigable:has(:focus-visible) {
+    outline: 4px solid var(--pxt-focus-border);
 }
 
 .blocklyGridPickerPadder {
@@ -781,7 +801,7 @@ Blockly.Css.register(`
     display: none;
 }
 
-.blocklyWidgetDiv .blocklyGridPickerMenu .blocklyGridPickerRow .gridpicker-menuitem.gridpicker-option-focused {
+.blocklyWidgetDiv .blocklyGridPickerMenu:focus .blocklyGridPickerRow .gridpicker-menuitem.gridpicker-option-focused {
     outline: 3px solid var(--pxt-focus-border);
 }
 

--- a/pxtblocks/fields/field_gridpicker.ts
+++ b/pxtblocks/fields/field_gridpicker.ts
@@ -28,7 +28,6 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
     private firstItem_: HTMLElement;
 
     private hasSearchBar_: boolean;
-    private hideRect_: boolean;
 
     private observer: IntersectionObserver;
 
@@ -61,7 +60,6 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
 
         this.tooltipConfig_ = tooltipCfg;
         this.hasSearchBar_ = !!options.hasSearchBar || false;
-        this.hideRect_ = !!options.hideRect || false;
     }
 
     protected setFocusedItem_(_gridItemContainer: HTMLElement) {
@@ -287,15 +285,6 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
         this.closeModal_ = true;
         this.buttonClick_(value);
     };
-
-    /**
-     * Whether or not to show a box around the dropdown menu.
-     * @return {boolean} True if we should show a box (rect) around the dropdown menu. Otherwise false.
-     * @private
-     */
-    shouldShowRect_() {
-        return !this.hideRect_ ? !this.sourceBlock_.isShadow() : false;
-    }
 
     doClassValidation_(newValue: string) {
         return newValue;

--- a/pxtblocks/fields/field_gridpicker.ts
+++ b/pxtblocks/fields/field_gridpicker.ts
@@ -41,6 +41,8 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
     private selectedBarText_: HTMLElement;
     private selectedBarValue_: string;
 
+    protected scrollContainer: HTMLDivElement;
+
     private static DEFAULT_IMG = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
 
     constructor(text: string, options: FieldGridPickerOptions, validator?: Function) {
@@ -66,6 +68,18 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
         this.gridItems.forEach(button => button.classList.remove('gridpicker-option-focused', 'gridpicker-menuitem-highlight'));
         const activeItem = this.gridItems[this.activeDescendantIndex];
         activeItem.classList.add('gridpicker-option-focused');
+
+        Blockly.utils.style.scrollIntoContainerView(activeItem, this.scrollContainer);
+        const rect = activeItem.getBoundingClientRect();
+
+        const title = activeItem.title || (activeItem as any).alt;
+        this.gridTooltip_.textContent = title;
+        // Show the tooltip
+        this.gridTooltip_.style.visibility = title ? 'visible' : 'hidden';
+        this.gridTooltip_.style.display = title ? '' : 'none';
+
+        this.gridTooltip_.style.top = `${rect.bottom}px`;
+        this.gridTooltip_.style.left = `${rect.left}px`;
     }
 
     /**
@@ -365,6 +379,7 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
         const anchorBBox = this.getAnchorDimensions_();
 
         const { paddingContainer, scrollContainer } = this.createWidget_(tableContainer);
+        this.scrollContainer = scrollContainer;
 
         const containerSize = {
             width: paddingContainer.offsetWidth,
@@ -740,8 +755,9 @@ Blockly.Css.register(`
     display: none;
 }
 
-.blocklyWidgetDiv .blocklyGridPickerMenu .gridpicker-option.gridpicker-option-focused {
-    box-shadow: 0px 0px 0px 4px rgb(255, 255, 255);
+.blocklyWidgetDiv .blocklyGridPickerMenu .blocklyGridPickerRow .gridpicker-menuitem.gridpicker-option-focused {
+    outline: 3px solid var(--pxt-focus-border);
+    outline-offset: -5px;
 }
 
 .blocklyGridPickerTooltip {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3755,7 +3755,7 @@ export class ProjectView
     }
 
     setSimulatorFullScreen(enabled: boolean) {
-        if (this.state.collapseEditorTools) {
+        if (this.state.collapseEditorTools && !pxt.appTarget.simulator?.headless) {
             this.expandSimulator();
         }
         if (enabled) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2806

adds a bunch of fixes related to using the gridpicker with keyboard controls in minecraft:

* pressing escape when the field editor is expanded no longer opens the simulator
* fixes the focus indicator outline on shadow blocks with dropdown fields and labels, but no other editable inputs/fields (like the item block in the linked issue)
* focus is now trapped in the gridpicker when either the searchbar or selection bar is present
* the selected item is now actually visible when selecting using the keyboard arrows (uses the standard focus color)
* tabbing out of the searchbar no longer resets the selected item
* fixes keyboard nav when the items in the grid are filtered via the searchbar
* the tooltip is now displayed underneath the selected item when using keyboard navigation

![gridpicker-keyboard](https://github.com/user-attachments/assets/92cf45d2-ab00-48f1-8ac1-401ecb153ff0)
