### PR TITLE
remove "run simulator" context menu item in monaco and fix shortcut

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -994,6 +994,15 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 run: () => Promise.resolve(this.parent.typecheckNow())
             });
 
+            this.editor.addAction({
+                id: "runSimulator",
+                label: lf("Run Simulator"),
+                keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+                keybindingContext: "!editorReadonly",
+                precondition: "!editorReadonly",
+                run: () => Promise.resolve(this.parent.runSimulator())
+            });
+
             if (pxt.appTarget.compile && pxt.appTarget.compile.hasHex) {
                 this.editor.addAction({
                     id: "compileHex",

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -994,17 +994,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 run: () => Promise.resolve(this.parent.typecheckNow())
             });
 
-            this.editor.addAction({
-                id: "runSimulator",
-                label: lf("Run Simulator"),
-                keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
-                keybindingContext: "!editorReadonly",
-                precondition: "!editorReadonly",
-                contextMenuGroupId: "0_pxtnavigation",
-                contextMenuOrder: 0.21,
-                run: () => Promise.resolve(this.parent.runSimulator())
-            });
-
             if (pxt.appTarget.compile && pxt.appTarget.compile.hasHex) {
                 this.editor.addAction({
                     id: "compileHex",

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1000,7 +1000,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
                 keybindingContext: "!editorReadonly",
                 precondition: "!editorReadonly",
-                run: () => Promise.resolve(this.parent.runSimulator())
+                run: async () => this.parent.startStopSimulator({ clickTrigger: true })
             });
 
             if (pxt.appTarget.compile && pxt.appTarget.compile.hasHex) {


### PR DESCRIPTION
https://github.com/microsoft/pxt-minecraft/issues/2840

this removes the "run simulator" context menu item from the monaco editor but leaves the keyboard shortcut behind (ctrl+enter). it also tweaks the keyboard shortcut so that it behaves the same as clicking the run button; in other words it now toggles the run state rather than doing nothing if already running.

the "clickTrigger" param here indicates user interaction and is used in the mc editor to indicate that we should hide the code window