### PR TITLE
Add a "unified toolbox" option which works for blocks and text

### DIFF
--- a/docs/writing-docs/tutorials/control-options.md
+++ b/docs/writing-docs/tutorials/control-options.md
@@ -30,9 +30,17 @@ Typically, when a tutorial starts the default editor view, it's for editing code
 ### @preferredEditor asset
 ```
 
-### Flyout blocks
+### Unified toolbox
 
-To have all of the available blocks in a permanently visible flyout instead of the toolbox, use **@flyoutOnly**. The default setting is ``false``.
+To have all of the available blocks grouped in a permanently visible flyout (instead of the toolbox), use **@unifiedToolbox**. The default setting is ``false``.
+
+```
+### @unifiedToolbox true
+```
+
+### Flyout blocks (deprecated)
+
+This flag is deprecated. Use `unifiedToolbox` instead.
 
 ```
 ### @flyoutOnly true

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1237,7 +1237,8 @@ declare namespace pxt.tutorial {
     interface TutorialMetadata {
         activities?: boolean; // tutorial consists of activities, then steps. uses `###` for steps
         explicitHints?: boolean; // tutorial expects explicit hints in `#### ~ tutorialhint` format
-        flyoutOnly?: boolean; // no categories, display all blocks in flyout
+        flyoutOnly?: boolean; // Deprecated. Indicates unifiedToolbox (below) + some Minecraft-HOC-specific UI adjustments.
+        unifiedToolbox?: boolean; // No categories, display all blocks directly in an always-open flyout.
         hideToolbox?: boolean; // hide the toolbox in the tutorial
         hideIteration?: boolean; // hide step control in tutorial
         diffs?: boolean; // automatically diff snippets

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -49,6 +49,27 @@ span.blocklyTreeIcon {
 }
 
 /*******************************
+        Monaco Flyout Only
+*******************************/
+#root.flyoutOnly {
+    // Hide toolbox categories section & flyout header
+    .monacoToolboxDiv, .monacoFlyoutHeading {
+        display: none;
+    }
+
+    #monacoEditorInner {
+        display: flex;
+        flex-direction: row;
+
+        #monacoFlyoutWidget {
+            position: relative;
+            border-radius: 0;
+            border-right: 5px solid var(--pxt-neutral-alpha80);
+        }
+    }
+}
+
+/*******************************
         Toolbox root
 *******************************/
 

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -1089,7 +1089,8 @@
         min-width: 25rem;
     }
 
-    #simulator .editor-sidebar {
+    #simulator .editor-sidebar,
+    #root.headless.tabTutorial #simulator .editor-sidebar {
         top: @mobileMenuHeight;
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1967,8 +1967,11 @@ export class ProjectView
                 editorState.filters = {
                     blocks: tutorialBlocks.usedBlocks,
                     defaultState: pxt.editor.FilterState.Hidden
-                }
-                editorState.hasCategories = !(header.tutorial.metadata && header.tutorial.metadata.flyoutOnly);
+                };
+                editorState.hasCategories = !(
+                    header.tutorial.metadata &&
+                    (header.tutorial.metadata.flyoutOnly || header.tutorial.metadata.unifiedToolbox)
+                );
             }
             this.setState({ editorState: editorState });
             this.editor.filterToolbox(true);
@@ -5172,6 +5175,7 @@ export class ProjectView
                     const flyoutOnly =
                         this.state.editorState?.hasCategories === false
                         || this.state.tutorialOptions?.metadata?.flyoutOnly
+                        || this.state.tutorialOptions?.metadata?.unifiedToolbox
                         || this.state.tutorialOptions?.metadata?.hideToolbox;
 
                     let headerHeight = 0;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -2174,21 +2174,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     // For editors that have no toolbox
     showFlyoutOnlyToolbox() {
         // Show a Flyout only with all the blocks
-        const allCategories = this.getAllCategories();
-        let allBlocks: toolbox.BlockDefinition[] = [];
-        allCategories.forEach(category => {
-            const blocks = category.blocks;
-            allBlocks = allBlocks.concat(blocks);
-            if (category.subcategories) category.subcategories.forEach(subcategory => {
-                const subblocks = subcategory.blocks;
-                allBlocks = allBlocks.concat(subblocks);
-            })
-        });
+        this.injectCategoryStyles();
 
-        let container = document.createElement("div");
-        ReactDOM.render(<toolbox.ToolboxStyle categories={allCategories} />, container);
-        document.getElementById('editorcontent').appendChild(container);
-
+        let allBlocks = this.getAllBlocks();
         let xmlList: Element[] = [];
         allBlocks.forEach((block) => {
             const blockXmlList = this.getBlockXml(block);

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -377,7 +377,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         const isTimeMachineEmbed = pxt.shell.isTimeMachineEmbed();
         const readOnly = pxt.shell.isReadOnly();
         const tutorial = tutorialOptions ? tutorialOptions.tutorial : false;
-        const flyoutOnly = editorState && editorState.hasCategories === false;
+        const hideZoomAndUndo = tutorial && tutorialOptions.metadata?.flyoutOnly; // Legacy flag that indicates Minecraft HOC (where zoom & undo are a the top)
         const hideToolbox = tutorial && tutorialOptions.metadata?.hideToolbox;
 
         const disableFileAccessinMaciOs = targetTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
@@ -398,8 +398,8 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         const running = simState == SimState.Running;
         const starting = simState == SimState.Starting;
 
-        const showUndoRedo = !readOnly && !debugging && !flyoutOnly && !hideToolbox;
-        const showZoomControls = !flyoutOnly && !hideToolbox;
+        const showUndoRedo = !readOnly && !debugging && !hideZoomAndUndo && !hideToolbox;
+        const showZoomControls = !hideZoomAndUndo && !hideToolbox;
         const showGithub = !!pxt.appTarget.cloud
             && !!pxt.appTarget.cloud.githubPackages
             && targetTheme.githubEditor

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -385,7 +385,9 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
     // Renders inline blocks, such as "||controller: Controller||".
     private renderInlineBlocks(content: HTMLElement) {
         const { parent } = this.props;
-        const hasCategories = !parent.state.tutorialOptions?.metadata?.flyoutOnly && !parent.state.tutorialOptions?.metadata?.hideToolbox;
+        const hasCategories = !parent.state.tutorialOptions?.metadata?.flyoutOnly
+            && !parent.state.tutorialOptions?.metadata?.hideToolbox
+            && !parent.state.tutorialOptions?.metadata?.unifiedToolbox;
         const inlineBlocks = pxt.Util.toArray(content.querySelectorAll(`:not(pre) > code`))
             .map((inlineBlock: HTMLElement) => {
                 const text = inlineBlock.innerText;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1379,7 +1379,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.toolbox.hide();
         }
 
-        if (this.parent.isTutorial() && (this.parent.state.tutorialOptions?.metadata?.flyoutOnly || this.parent.state.tutorialOptions?.metadata?.unifiedToolbox)) {
+        if (this.parent.isTutorial() &&
+            (this.parent.state.tutorialOptions?.metadata?.flyoutOnly ||
+                this.parent.state.tutorialOptions?.metadata?.unifiedToolbox)) {
             this.showUnifiedToolbox();
         }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1390,21 +1390,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     // Merge all toolbox categories into one single, always-open flyout
     showUnifiedToolbox() {
-        const allCategories = this.getAllCategories();
-        let allBlocks: toolbox.BlockDefinition[] = [];
-        allCategories.forEach(category => {
-            const blocks = category.blocks;
-            allBlocks = allBlocks.concat(blocks);
-            if (category.subcategories) category.subcategories.forEach(subcategory => {
-                const subblocks = subcategory.blocks;
-                allBlocks = allBlocks.concat(subblocks);
-            })
-        });
+        this.injectCategoryStyles();
 
-        let container = document.createElement("div");
-        ReactDOM.render(<toolbox.ToolboxStyle categories={allCategories} />, container);
-        document.getElementById('editorcontent').appendChild(container);
-
+        let allBlocks = this.getAllBlocks();
         let combinedGroup: toolbox.GroupDefinition = {
             name: lf("Snippets"),
             blocks: allBlocks

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1379,7 +1379,40 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.toolbox.hide();
         }
 
+        if (this.parent.isTutorial() && (this.parent.state.tutorialOptions?.metadata?.flyoutOnly || this.parent.state.tutorialOptions?.metadata?.unifiedToolbox)) {
+            this.showUnifiedToolbox();
+        }
+
         this.updateDebuggerToolbox();
+    }
+
+    // Merge all toolbox categories into one single, always-open flyout
+    showUnifiedToolbox() {
+        const allCategories = this.getAllCategories();
+        let allBlocks: toolbox.BlockDefinition[] = [];
+        allCategories.forEach(category => {
+            const blocks = category.blocks;
+            allBlocks = allBlocks.concat(blocks);
+            if (category.subcategories) category.subcategories.forEach(subcategory => {
+                const subblocks = subcategory.blocks;
+                allBlocks = allBlocks.concat(subblocks);
+            })
+        });
+
+        let container = document.createElement("div");
+        ReactDOM.render(<toolbox.ToolboxStyle categories={allCategories} />, container);
+        document.getElementById('editorcontent').appendChild(container);
+
+        let combinedGroup: toolbox.GroupDefinition = {
+            name: lf("Snippets"),
+            blocks: allBlocks
+        }
+
+        this.flyout.setState( {
+            hide: false,
+            groups: [combinedGroup],
+            stayOpenOnDrag: true,
+        })
     }
 
     private updateDebuggerToolbox() {

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -39,6 +39,7 @@ export interface MonacoFlyoutState {
     selectedBlock?: string;
     hoverBlock?: string;
     hide?: boolean;
+    stayOpenOnDrag?: boolean;
 }
 
 export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyoutState> {
@@ -145,7 +146,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
             dragBlock.style.left = `${pxt.BrowserUtils.getClientX(e)}px`;
             // For devices without PointerEvents (iOS < 13.0) use state to
             // hide the flyout rather than focusing the editor
-            this.setState({ hide: true });
+            this.setState({ hide: !this.state.stayOpenOnDrag });
         }
     }
 

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -1,4 +1,5 @@
 
+import * as ReactDOM from "react-dom";
 import * as srceditor from "./srceditor";
 import * as toolbox from "./toolbox";
 import * as compiler from "./compiler";
@@ -134,6 +135,29 @@ export abstract class ToolboxEditor extends srceditor.Editor {
 
     public getAllCategories() {
         return this.getToolboxCategories(false).concat(this.getToolboxCategories(true));
+    }
+
+    protected getAllBlocks(): toolbox.BlockDefinition[] {
+        const allCategories = this.getAllCategories();
+        let allBlocks: toolbox.BlockDefinition[] = [];
+        allCategories.forEach(category => {
+            const blocks = category.blocks;
+            allBlocks = allBlocks.concat(blocks);
+            if (category.subcategories) category.subcategories.forEach(subcategory => {
+                const subblocks = subcategory.blocks;
+                allBlocks = allBlocks.concat(subblocks);
+            })
+        });
+        return allBlocks;
+    }
+
+    // Injects a style element that allows the tutorial engine to render blocks
+    // and associate them with their categories, even if the toolbox itself is not present.
+    protected injectCategoryStyles() {
+        const allCategories = this.getAllCategories();
+        let container = document.createElement("div");
+        ReactDOM.render(<toolbox.ToolboxStyle categories={allCategories} />, container);
+        document.getElementById('editorcontent').appendChild(container);
     }
 
     public getToolboxCategories(isAdvanced?: boolean) {


### PR DESCRIPTION
This adds a `unifiedToolbox` flag for tutorials, which groups all blocks into a single flyout that is always open. Basically, it's `flyoutOnly` without the side effects, and it works for blocks and text. I did not change `flyoutOnly` because some tutorials may rely on the side effects to work. (Minecraft HOC, for example, has zoom + undo buttons at the top, so `flyoutOnly` hides those buttons from the editor toolbar).

Also fixes a tiny layout bug I noticed where tutorial instructions weren't having their top set correctly when in tablet mode, which caused a little overlap between the instructions & the editor below.

Fixes https://github.com/microsoft/pxt-minecraft/issues/2720

Monaco:
<img width="1381" height="971" alt="image" src="https://github.com/user-attachments/assets/d584be31-cbd7-4d7c-a947-587e94d5364b" />

Blocks:
<img width="1383" height="975" alt="image" src="https://github.com/user-attachments/assets/d33c8aad-86a4-41c8-9cf8-748c618bd947" />
