### PR TITLE
Fix flyoutOnly (and unifiedToolbox) bugs

### DIFF
--- a/pxtblocks/plugins/duplicateOnDrag/duplicateOnDrag.ts
+++ b/pxtblocks/plugins/duplicateOnDrag/duplicateOnDrag.ts
@@ -65,7 +65,7 @@ export function shouldDuplicateOnDrag(block: Blockly.Block) {
                 if (ref && (!ref.childBlockType || ref.childBlockType === block.type)) {
                     if (ref.inputName) {
                         const targetConnection = block.outputConnection.targetConnection;
-                        if (targetConnection.getParentInput().name === ref.inputName) {
+                        if (targetConnection.getParentInput()?.name === ref.inputName) {
                             return true;
                         }
                     }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -223,7 +223,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.loadingXml = true;
 
             const flyout = this.editor.getFlyout() as pxtblockly.CachingFlyout;
-            flyout?.clearBlockCache();
+            if (flyout && typeof flyout.clearBlockCache === 'function') {
+                flyout.clearBlockCache();
+            }
 
             const loadingDimmer = document.createElement("div");
             loadingDimmer.className = "ui active dimmer";

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -548,7 +548,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
          */
         const that = this;
         Blockly.Toolbox.prototype.getFocusableElement = function() {
-            return that.getToolboxDiv().querySelector(".blocklyTreeRoot [role=tree]") as HTMLElement;
+            return that.getToolboxDiv()?.querySelector(".blocklyTreeRoot [role=tree]") as HTMLElement ?? that.getBlocksAreaDiv();
         };
         Blockly.Toolbox.prototype.getRestoredFocusableNode = function() {
             return null;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -61,6 +61,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     compilationResult: pxtblockly.BlockCompilationResult;
     shouldFocusWorkspace = false;
     functionsDialog: CreateFunctionDialog = null;
+    registeredKeyboardNavigationStyles = false;
 
     showCategories: boolean = true;
     breakpointsByBlock: pxt.Map<number>; // Map block id --> breakpoint ID
@@ -784,7 +785,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         // Increase the Blockly connection radius
         Blockly.config.snapRadius = 48;
         Blockly.config.connectingSnapRadius = 96;
-        if (accessibleBlocksEnabled) {
+        if (accessibleBlocksEnabled && !this.registeredKeyboardNavigationStyles) {
+            this.registeredKeyboardNavigationStyles = true;
             KeyboardNavigation.registerKeyboardNavigationStyles();
         }
         this.editor = Blockly.inject(blocklyDiv, this.getBlocklyOptions(forceHasCategories)) as Blockly.WorkspaceSvg;


### PR DESCRIPTION
A few bug fixes:

1. Fix a null ref in duplicateOnDrag, which seemed to happen when the block was created for the flyout
2. Ensures we have an actual CachingFlyout before calling clearBlockCache
3. If the toolbox isn't in the DOM and `getFocusableElement()` is called (can happen when transitioning from flyoutOnly -> regular mode), then return the blocksArea (next closest parent) instead. Returning null here causes a crash and the blockly injection fails.
4. Prevent duplicate calls to `KeyboardNavigation.registerKeyboardNavigationStyles()`, which cause an exception.

Fixes https://github.com/microsoft/pxt-minecraft/issues/2859.