### PR TITLE
Post users locale to simulator

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -851,6 +851,11 @@ namespace pxsim {
                 msg.breakOnStart = false;
             }
             this.postMessageCore(frame, msg);
+            const lang = this.options?.userLanguage;
+            if (lang) {
+                const langMsg: any = { type: 'pxt-set-language', lang: lang, source: MESSAGE_SOURCE };
+                this.postMessageCore(frame, langMsg);
+            }
             if (this.traceInterval) this.setTraceInterval(this.traceInterval);
             this.applyAspectRatioToFrame(frame);
             this.setFrameState(frame);


### PR DESCRIPTION
The jacdac simulator is introducing localization. The current draft is taking the language from browsers navigator: https://github.com/jacdac/jacdac-docs/pull/21

If pxt sent a message to the iframe, it would be possible to pick up the current language selection of the user inside the simulator and keep it in sync.

This pull request introduces a small enhancement to the simulator driver by ensuring the user's language preference is communicated to the simulator frame when initializing. This helps support localization and improves the user experience for non-English users.

Localization support:

* In `pxtsim/simdriver.ts`, the code now checks for a user language setting (`options.userLanguage`) and, if present, sends a `pxt-set-language` message to the simulator frame to set the appropriate language.
