### PR TITLE
Fix contrast for search icon in high contrast theme

### DIFF
--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -70,6 +70,11 @@ div.field .ui.toggle.checkbox input:checked~label:before {
     outline: 3px solid var(--pxt-colors-yellow-background) !important;
 }
 
+#blocklySearchInput i {
+    color: var(--pxt-neutral-foreground1);
+    opacity: 1;
+}
+
 /* 
  * Inverted image colors
  */


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2803

This is arguably only needed for Minecraft (where some minecraft-specific css affects it and need to be overridden), but the opacity increase is helpful for better contrast regardless, so I figured I'd just keep it in the general hc overrides file.

With fix:
<img width="273" height="165" alt="image" src="https://github.com/user-attachments/assets/1951086f-8045-462c-9149-a095c6c24bd4" />
