### PR TITLE
Prevent selection when resizing tutorial instructions

### DIFF
--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -62,6 +62,8 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         const cleanupBodyEvents = () => {
             document.removeEventListener("pointermove", resize, false);
             document.removeEventListener("pointerup", onPointerUp, false);
+            document.removeEventListener("mousemove", preventSelection, false);
+            document.removeEventListener("mousedown", preventSelection, false);
             document.removeEventListener("touchmove", preventSelection, false);
             document.removeEventListener("touchstart", preventSelection, false);
             document.body.classList.remove("cursor-resize");

--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -54,9 +54,16 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
             e.stopPropagation();
         };
 
+        const preventSelection = (e: Event) => {
+            e.preventDefault();
+            e.stopPropagation();
+        };
+
         const cleanupBodyEvents = () => {
             document.removeEventListener("pointermove", resize, false);
             document.removeEventListener("pointerup", onPointerUp, false);
+            document.removeEventListener("mousemove", preventSelection, false);
+            document.removeEventListener("mousedown", preventSelection, false);
             document.body.classList.remove("cursor-resize");
         };
 
@@ -77,6 +84,11 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
                 document.body.classList.add("cursor-resize");
                 document.addEventListener("pointermove", resize, false);
                 document.addEventListener("pointerup", onPointerUp, false);
+
+                // We use pointer events for the resize, but mouse events can still fire and cause things to get selected.
+                // Just prevent it while dragging.
+                document.addEventListener("mousemove", preventSelection, false);
+                document.addEventListener("mousedown", preventSelection, false);
             }
         };
 

--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -62,8 +62,8 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
         const cleanupBodyEvents = () => {
             document.removeEventListener("pointermove", resize, false);
             document.removeEventListener("pointerup", onPointerUp, false);
-            document.removeEventListener("mousemove", preventSelection, false);
-            document.removeEventListener("mousedown", preventSelection, false);
+            document.removeEventListener("touchmove", preventSelection, false);
+            document.removeEventListener("touchstart", preventSelection, false);
             document.body.classList.remove("cursor-resize");
         };
 
@@ -89,6 +89,8 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
                 // Just prevent it while dragging.
                 document.addEventListener("mousemove", preventSelection, false);
                 document.addEventListener("mousedown", preventSelection, false);
+                document.addEventListener("touchmove", preventSelection, false);
+                document.addEventListener("touchstart", preventSelection, false);
             }
         };
 

--- a/react-common/components/controls/VerticalResizeContainer.tsx
+++ b/react-common/components/controls/VerticalResizeContainer.tsx
@@ -54,18 +54,9 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
             e.stopPropagation();
         };
 
-        const preventSelection = (e: Event) => {
-            e.preventDefault();
-            e.stopPropagation();
-        };
-
         const cleanupBodyEvents = () => {
             document.removeEventListener("pointermove", resize, false);
             document.removeEventListener("pointerup", onPointerUp, false);
-            document.removeEventListener("mousemove", preventSelection, false);
-            document.removeEventListener("mousedown", preventSelection, false);
-            document.removeEventListener("touchmove", preventSelection, false);
-            document.removeEventListener("touchstart", preventSelection, false);
             document.body.classList.remove("cursor-resize");
         };
 
@@ -87,12 +78,8 @@ export const VerticalResizeContainer = (props: VerticalResizeContainerProps) => 
                 document.addEventListener("pointermove", resize, false);
                 document.addEventListener("pointerup", onPointerUp, false);
 
-                // We use pointer events for the resize, but mouse events can still fire and cause things to get selected.
-                // Just prevent it while dragging.
-                document.addEventListener("mousemove", preventSelection, false);
-                document.addEventListener("mousedown", preventSelection, false);
-                document.addEventListener("touchmove", preventSelection, false);
-                document.addEventListener("touchstart", preventSelection, false);
+                e.preventDefault();
+                e.stopPropagation();
             }
         };
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2852

We were missing the call to prevent the pointer down event from propagating when entering resize mode, so dragging the cursor was still causing text to get selected.