### PR TITLE
Prevent file explorer from opening in Minecraft tutorials

### DIFF
--- a/react-common/styles/controls/Button.less
+++ b/react-common/styles/controls/Button.less
@@ -29,7 +29,7 @@
     filter: grayscale(.15) brightness(.85) contrast(1.3);
 }
 
-.common-button .right {
+.common-button .right:not(.icon.toggle.right) {
     margin-left: 0.5rem;
 }
 

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -691,7 +691,7 @@
         #simulator .editor-sidebar {
             display: block !important;
             height: @defaultTutorialHeight;
-            width: 100%;
+            width: 100% !important;
         }
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1844,6 +1844,9 @@ export class ProjectView
                 pxt.storage.setLocal("onboardAccessibleBlocks", "0")
             }
 
+            // Force editor tools to collapse in headless tutorials and blocks mode (essentially hiding file explorer)
+            const forceEditorToolsCollapse = pxt.appTarget.simulator.headless && (!!h.tutorial || h.editor === pxt.BLOCKS_PROJECT_NAME);
+
             this.setState({
                 home: false,
                 showFiles: h.githubId ? true : false,
@@ -1854,7 +1857,8 @@ export class ProjectView
                 currFile: file,
                 sideDocsLoadUrl: sideDocsLoadUrl,
                 debugging: false,
-                isMultiplayerGame: false
+                isMultiplayerGame: false,
+                collapseEditorTools: forceEditorToolsCollapse || this.state.collapseEditorTools,
             });
 
             pkg.getEditorPkg(pkg.mainPkg).onupdate = () => {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -148,6 +148,7 @@ export interface SettingsMenuProps extends ISettingsProps {
     accessibleBlocks: boolean;
     showShare?: boolean;
     inBlocks: boolean;
+    inTutorial: boolean;
 }
 
 // This Component overrides shouldComponentUpdate, be sure to update that if the state is updated
@@ -321,6 +322,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             || this.state.accessibleBlocks != nextState.accessibleBlocks
             || this.state.showShare != nextState.showShare
             || nextProps.inBlocks !== this.props.inBlocks
+            || nextProps.inTutorial !== this.props.inTutorial;
     }
 
     renderCore() {
@@ -345,7 +347,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             !readOnly &&
             !isController &&
             !!targetTheme.simCollapseInMenu &&
-            !(headless && (this.props.inBlocks || this.props.parent.isTutorial()));
+            !(headless && (this.props.inBlocks || this.props.inTutorial));
         const showGreenScreen = targetTheme.greenScreen || /greenscreen=1/i.test(window.location.href);
         const showPrint = targetTheme.print && !pxt.BrowserUtils.isIE();
         const showProjectSettings = targetTheme.showProjectSettings;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -341,7 +341,11 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         const showHome = !targetTheme.lockedEditor && !isController && auth.hasIdentity();
         const showShare = this.props.showShare && pxt.appTarget.cloud?.sharing && !isController;
         const showSave = !readOnly && !isController && !!targetTheme.saveInMenu && !disableFileAccessinMaciOs && !disableFileAccessinAndroid;
-        const showSimCollapse = !readOnly && !isController && !!targetTheme.simCollapseInMenu && !(headless && this.props.inBlocks);
+        const showSimCollapse =
+            !readOnly &&
+            !isController &&
+            !!targetTheme.simCollapseInMenu &&
+            !(headless && (this.props.inBlocks || this.props.parent.isTutorial()));
         const showGreenScreen = targetTheme.greenScreen || /greenscreen=1/i.test(window.location.href);
         const showPrint = targetTheme.print && !pxt.BrowserUtils.isIE();
         const showProjectSettings = targetTheme.showProjectSettings;

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -233,7 +233,16 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
                 return <projects.ProjectSettingsMenu parent={this.props.parent} />
             case "tutorial-tab":
             case "editor":
-                return <container.SettingsMenu parent={this.props.parent} greenScreen={greenScreen} accessibleBlocks={accessibleBlocks} showShare={!!header} inBlocks={this.props.parent.isBlocksActive()} />
+                return (
+                    <container.SettingsMenu
+                        parent={this.props.parent}
+                        greenScreen={greenScreen}
+                        accessibleBlocks={accessibleBlocks}
+                        showShare={!!header}
+                        inBlocks={this.props.parent.isBlocksActive()}
+                        inTutorial={this.props.parent.isTutorial()}
+                    />
+                );
             default:
                 return <div />
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2853

This makes a few changes related to this issue:

1. Fixes CSS styling for the width of the tutorials in tablet mode, so it won't be overridden by non-tablet styles that keep it to the left
2. Hides "show file explorer" from the settings menu when in tutorials
3. Forces the file explorer to close when opening a blocks or tutorial project in minecraft
4. Fixes styling on the menu button icon, so it doesn't have extra padding

Upload target: https://minecraft.makecode.com/app/d173665bb290e6ae3f7d05fd869a9fdde751b1a9-7f317c4fc0?ingame=1&ipc=1
