### PR TITLE
Remove experiment card resize on tablet screens

### DIFF
--- a/theme/scriptsearch.less
+++ b/theme/scriptsearch.less
@@ -60,23 +60,6 @@
     }
 }
 
-// reduce all card sizes
-@media only screen and (max-width: @largestMobileScreen) {
-    .ui.searchdialog {
-        .ui.card, .ui.cards>.card {
-            width: 9rem;
-            height: 9rem;
-
-            .ui.cardimage {
-                height: 5rem;
-                &.upload {
-                    margin: auto;
-                }
-            }
-        }
-    }
-}
-
 /*******************************
     Script manager dialog
 *******************************/

--- a/theme/themes/pxt/modules/modal.overrides
+++ b/theme/themes/pxt/modules/modal.overrides
@@ -239,6 +239,13 @@
     }
 }
 
+@media only screen and (max-width: @largestMobileScreen) {
+    .ui.modal .content>.description {
+        // Overriding some default semantic ui styling
+        margin: 0.5rem 0 0 0 !important;
+        padding: 0 !important;
+    }
+}
 
 /*******************************
         Modal Close Icon

--- a/theme/themes/pxt/modules/modal.overrides
+++ b/theme/themes/pxt/modules/modal.overrides
@@ -239,14 +239,6 @@
     }
 }
 
-@media only screen and (max-width: @largestMobileScreen) {
-    .ui.modal .content>.description {
-        // Overriding some default semantic ui styling
-        margin: 0.5rem 0 0 0 !important;
-        padding: 0 !important;
-    }
-}
-
 /*******************************
         Modal Close Icon
 *******************************/

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -301,9 +301,6 @@ a.ui.card:focus,
     }
 
     .ui.card, .ui.cards>.card {
-        .content .description {
-            display: none;
-        }
         .content .header {
             font-size: 80%;
             font-weight: normal;

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -301,6 +301,12 @@ a.ui.card:focus,
     }
 
     .ui.card, .ui.cards>.card {
+        .content>.description {
+            // Overriding some default semantic ui styling
+            margin: 0.5rem 0 0 0 !important;
+            padding: 0 !important;
+        }
+
         .content .header {
             font-size: 80%;
             font-weight: normal;


### PR DESCRIPTION
When they're as small as this removed CSS specifies, you can't really read any of the titles. I think it's better to leave them legible but in a one-column vertical list (especially since we usually only have a handfull). This is what we already do for extensions.

Fixes https://github.com/microsoft/pxt-minecraft/issues/2870

Before (note: I added a bunch of random experiments for testing):
<img width="505" height="584" alt="image" src="https://github.com/user-attachments/assets/38acc518-bc2e-461a-90e1-3de94c68f1f0" />


After (you have to scroll, but at least you can read them):
<img width="531" height="698" alt="image" src="https://github.com/user-attachments/assets/72336ce6-deec-4c84-938c-e9bf06339d96" />
