### PR TITLE
don't directly ref monaco sources in playground either

### DIFF
--- a/docs/playground.html
+++ b/docs/playground.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
     <link rel="stylesheet" href="https://cdn.makecode.com/blob/2163189fd5e35c0981ed55318415582a7c9aeb12/doccdn/semantic.css" type="text/css">
     <link data-name="vs/editor/editor.main" rel="stylesheet"
-        href="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/editor/editor.main.css">
+        href="/static/tutorial-tool/vs/editor/editor.main.css">
     <link rel="stylesheet" href="/static/shared/iframeeditor.css">
     <link rel="stylesheet" href="/static/playground/playground.css">
     <title>MakeCode Blocks Playground</title>
@@ -52,12 +52,10 @@
     <!-- @include tracking.html -->
     <!-- @include thin-footer.html -->
 
-    <script>var require = { paths: { 'vs': 'https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs' } };</script>
-    <script src="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/loader.js"></script>
+    <script>var require = { paths: { 'vs': '/static/tutorial-tool/vs' } };</script>
+    <script src="/static/tutorial-tool/vs/loader.js"></script>
     <script
-        src="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/editor/editor.main.nls.js"></script>
-    <script
-        src="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/editor/editor.main.js"></script>
+        src="/static/tutorial-tool/vs/editor/editor.main.js"></script>
     <script src="/static/playground/samples/all.js"></script>
     <script src="/static/playground/playground.js"></script>
 


### PR DESCRIPTION
re: https://github.com/microsoft/pxt/pull/10866

i suppose could have (or could still) move to docs/static/monaco/vs/..., didn't realize playground was in the same boat. can still do that but would need to dupe them then remove in a few days once tutorial-tool cache clears, or just leave as is and ref like it currently is