### PR TITLE
set abs url rooted off current origin so worker requests work

### DIFF
--- a/docs/playground.html
+++ b/docs/playground.html
@@ -52,7 +52,7 @@
     <!-- @include tracking.html -->
     <!-- @include thin-footer.html -->
 
-    <script>var require = { paths: { 'vs': '/static/tutorial-tool/vs' } };</script>
+    <script>var require = { paths: { 'vs': location.origin + '/static/tutorial-tool/vs' } };</script>
     <script src="/static/tutorial-tool/vs/loader.js"></script>
     <script
         src="/static/tutorial-tool/vs/editor/editor.main.js"></script>

--- a/docs/tutorial-tool.html
+++ b/docs/tutorial-tool.html
@@ -53,7 +53,7 @@
     <!-- @include tracking.html -->
     <!-- @include thin-footer.html -->
 
-    <script>var require = { paths: { 'vs': '/static/tutorial-tool/vs' } };</script>
+    <script>var require = { paths: { 'vs': location.origin + '/static/tutorial-tool/vs' } };</script>
     <script src="/static/tutorial-tool/vs/loader.js"></script>
     <script
         src="/static/tutorial-tool/vs/editor/editor.main.js"></script>


### PR DESCRIPTION
re: https://github.com/microsoft/pxt/pull/10867, one more tweak -- root the path off current origin (`http://localhost:3232`, `http://makecode.com`) rather than relative. playground is back to mostly working but the ts language server fetching on playground is failing, because it requests the tsworker bundle from the worker itself:

```
editor.main.js:9  Uncaught Error: Failed to execute 'fetch' on 'WorkerGlobalScope': Failed to parse URL from /static/tutorial-tool/vs/language/typescript/tsWorker.js

TypeError: Failed to parse URL from /static/tutorial-tool/vs/language/typescript/tsWorker.js
    at A.load (https://makecode.com/static/tutorial-tool/vs/base/worker/workerMain.js:6:13847)
    at n.load (https://makecode.com/static/tutorial-tool/vs/base/worker/workerMain.js:6:11936)
    at r (https://makecode.com/static/tutorial-tool/vs/base/worker/workerMain.js:8:9341)
    at f._loadModule (https://makecode.com/static/tutorial-tool/vs/base/worker/workerMain.js:8:9469)
    at f._resolve (https://makecode.com/static/tutorial-tool/vs/base/worker/workerMain.js:9:452)
    at f.defineModule (https://makecode.com/static/tutorial-tool/vs/base/worker/workerMain.js:8:5564)
    at f._relativeRequire (https://makecode.com/static/tutorial-tool/vs/base/worker/workerMain.js:8:6188)
    at a (https://makecode.com/static/tutorial-tool/vs/base/worker/workerMain.js:8:8519)
    at https://makecode.com/static/tutorial-tool/vs/base/worker/workerMain.js:29:82407
    at new Promise (<anonymous>)
 ```
 
 weird tutorial-tool didn't have the issue but i guess default markdown is handled automatically there / doesn't require additional fetch