### PR TITLE
Editor context in described in 'extensions' page

### DIFF
--- a/common-docs/extensions.md
+++ b/common-docs/extensions.md
@@ -4,7 +4,7 @@
 
 ## Using Extensions #using
 
-In the web editor, click on the **Settings** (the ⚙️ symbol) menu and then choose **Extensions** to search and add extensions to the project.
+In the code editor, click on the **Settings** (the ⚙️ symbol) menu and then choose **Extensions** to search and add extensions to the project.
 The Blocks and any other JavaScript definitions from the extension are automatically loaded in the editor.
 
 ### ~ reminder


### PR DESCRIPTION
The "editor" isn't always in a web browser context. Change "web" to "code" as suggested.

Closes https://github.com/microsoft/pxt-minecraft/issues/2897#event-19708019824