### PR TITLE
Hide immersive reader full screen button in Minecraft

### DIFF
--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -232,7 +232,8 @@ export async function launchImmersiveReaderAsync(content: string, tutorialOption
         onPreferencesChanged: (pref: string) => {
             auth.setImmersiveReaderPrefAsync(pref)
         },
-        preferences: userReaderPref
+        preferences: userReaderPref,
+        allowFullscreen: !pxt.appTarget.simulator?.headless
     }
 
     try {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2882

Trying to go full screen causes some issues in Minecraft. Specifically, it'll only fill the Minecraft window (not the actual full screen), and it messes with the position of the MakeCode iframe when you exit. For now, just hide the button so users can't get into this state.