### PR TITLE
High contrast dropdown menu fixes

### DIFF
--- a/react-common/components/controls/MenuDropdown.tsx
+++ b/react-common/components/controls/MenuDropdown.tsx
@@ -125,7 +125,7 @@ export const MenuDropdown = (props: MenuDropdownProps) => {
                 includeOutsideTabOrder={true}
                 dontTrapFocus={true}
                 dontRestoreFocus={true}
-                focusFirstItem={true}
+                focusFirstItem={false}
                 ariaLabelledby={id}
                 tagName="ul"
             >

--- a/react-common/styles/controls/MenuDropdown.less
+++ b/react-common/styles/controls/MenuDropdown.less
@@ -35,7 +35,6 @@
         display: flex;
         align-items: center;
         text-align: left;
-        position: relative;
 
         cursor: pointer;
         user-select: none;

--- a/react-common/styles/controls/MenuDropdown.less
+++ b/react-common/styles/controls/MenuDropdown.less
@@ -16,7 +16,7 @@
     margin: 0;
     background: var(--pxt-neutral-background1);
     border: 1px solid var(--pxt-neutral-stencil1);
-    overflow: visible;
+    overflow: visible; /* Allow focus borders to extend outside the pane */
 
     ul {
         list-style: none;

--- a/react-common/styles/controls/MenuDropdown.less
+++ b/react-common/styles/controls/MenuDropdown.less
@@ -16,7 +16,6 @@
     margin: 0;
     background: var(--pxt-neutral-background1);
     border: 1px solid var(--pxt-neutral-stencil1);
-    overflow: visible; /* Allow focus borders to extend outside the pane */
 
     ul {
         list-style: none;

--- a/react-common/styles/controls/MenuDropdown.less
+++ b/react-common/styles/controls/MenuDropdown.less
@@ -16,6 +16,7 @@
     margin: 0;
     background: var(--pxt-neutral-background1);
     border: 1px solid var(--pxt-neutral-stencil1);
+    overflow: visible;
 
     ul {
         list-style: none;
@@ -35,6 +36,7 @@
         display: flex;
         align-items: center;
         text-align: left;
+        position: relative;
 
         cursor: pointer;
         user-select: none;
@@ -53,6 +55,7 @@
 
         &:hover {
             text-decoration: none;
+            color: var(--pxt-neutral-foreground1);
         }
 
         &:hover:not(.disabled) {
@@ -77,25 +80,6 @@
     }
 }
 
-
 .common-menu-dropdown-item.common-button:focus::after {
-    outline: @buttonFocusOutlineLightBackground;
-}
-
-/****************************************************
- *                 High Contrast                    *
- ****************************************************/
-
-.high-contrast {
-    .common-menu-dropdown-pane {
-        color: @highContrastTextColor;
-        background-color: @highContrastBackgroundColor;
-        border: 1px solid @highContrastTextColor;
-    }
-
-    .common-menu-dropdown-item:hover,
-    .common-menu-dropdown > .menu-button.expanded {
-        outline: @highContrastFocusOutline;
-        z-index: @highContrastFocusZIndex;
-    }
+    outline: var(--pxt-focus-border) solid 3px !important;
 }

--- a/theme/color-themes/high-contrast.json
+++ b/theme/color-themes/high-contrast.json
@@ -76,7 +76,7 @@
         "pxt-neutral-alpha80": "rgba(255, 255, 255, 0.8)",
 
         "pxt-link": "#807FFF",
-        "pxt-link-hover": "#1b19ff",
+        "pxt-link-hover": "#BBBBFF",
         "pxt-focus-border": "#FFFF00",
 
         "pxt-success": "#00FF00",

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -209,11 +209,6 @@ div.field .ui.toggle.checkbox input:checked~label:before {
 /*
  * Dropdown Menu
  */
-/* .common-menu-dropdown-pane {
-    color: var(--pxt-neutral-foreground1);
-    background-color: var(--pxt-neutral-background1);
-    border: 1px solid var(--pxt-neutral-foreground1);
-} */
 .common-menu-dropdown-item:hover,
 .common-menu-dropdown > .menu-button.expanded {
     outline: var(--pxt-focus-border) solid 3px !important;

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -212,5 +212,6 @@ div.field .ui.toggle.checkbox input:checked~label:before {
 .common-menu-dropdown-item:hover,
 .common-menu-dropdown > .menu-button.expanded {
     outline: var(--pxt-focus-border) solid 3px !important;
+    outline-offset: -4px;
     z-index: 1;
 }

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -206,3 +206,16 @@ div.field .ui.toggle.checkbox input:checked~label:before {
     color: #000000 !important;
 }
 
+/*
+ * Dropdown Menu
+ */
+/* .common-menu-dropdown-pane {
+    color: var(--pxt-neutral-foreground1);
+    background-color: var(--pxt-neutral-background1);
+    border: 1px solid var(--pxt-neutral-foreground1);
+} */
+.common-menu-dropdown-item:hover,
+.common-menu-dropdown > .menu-button.expanded {
+    outline: var(--pxt-focus-border) solid 3px !important;
+    z-index: 1;
+}

--- a/theme/common.less
+++ b/theme/common.less
@@ -438,7 +438,6 @@ div.simframe > iframe {
     flex-shrink: 0;
 
     ul.common-menu-dropdown-pane {
-        overflow-y: auto;
         max-height: calc(100vh - @mainMenuHeight);
     }
 

--- a/theme/common.less
+++ b/theme/common.less
@@ -438,6 +438,7 @@ div.simframe > iframe {
     flex-shrink: 0;
 
     ul.common-menu-dropdown-pane {
+        overflow-y: auto;
         max-height: calc(100vh - @mainMenuHeight);
     }
 

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -11,7 +11,6 @@
 
 @selected: yellow;
 @disabled: #3ff23f;
-@hyperlink: #807FFF;
 
 /* Messages */
 #msg .hc {
@@ -716,12 +715,6 @@
         &:hover {
             border: 2px solid @selected;
         }
-    }
-
-    /* Hyperlinks */
-    a {
-        color: @hyperlink !important;
-        text-decoration: underline !important;
     }
 
     /* Dropdown */


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2890

This change ensures items in the menu dropdown:
1. Don't change foreground color on hover (even when they're links)
2. Do have the expected border on hover in high contrast mode

As a part of this, I also removed some redundant CSS and moved a few rules into the high contrast overrides file, making things more consistent with the new theming.

Lastly, I turned off the automatic focus on the first element in the list. This was causing double highlighting (keyboard focus on one, mouse hover on the other) which seemed confusing. It's also more consistent with our other dropdowns. I confirmed you can still use arrow keys to navigate into the menu once it's open.

With auto-focus, you get double highlights:
<img width="210" height="285" alt="image" src="https://github.com/user-attachments/assets/1c33414b-4a19-443a-99ee-f3bc8ac18f9a" />

Without, you can still navigate the menu with arrow keys, but you won't get the extra highlight until you start to do so, at which point it's much clearer what's happening:
<img width="213" height="290" alt="image" src="https://github.com/user-attachments/assets/3941ea04-bcef-45d5-ad20-627db1b67fea" />

Upload target: https://minecraft.makecode.com/app/d50b0bf765a03fb46e89b105df80bddc2f2cd59c-e7433d28d8