### PR TITLE
fix extension button filtering logic

### DIFF
--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -59,6 +59,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
 
     protected shouldShowCustomCategory(ns: string) {
         let filters = this.parent.state.editorState && this.parent.state.editorState.filters;
+        const hasTutorialFilters = !!(filters);
 
         const projectFilter = getProjectToolboxFilters();
 
@@ -86,7 +87,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
                 filters.blocks["procedures_callnoreturn"]) &&
                 (!filters.namespaces || !shouldHideCategory("functions", filters.namespaces))) {
                 return true;
-            } else {
+            } else if (hasTutorialFilters) {
                 return false;
             }
         }


### PR DESCRIPTION
my hotfix from yesterday caused the filtering logic for namespaces to start filtering out the "extensions" button outside of tutorials. this PR fixes it, and should be hotfixed ASAP