### PR TITLE
prevent drag+select when dragging from monaco flyout in safari

### DIFF
--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -102,6 +102,8 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
 
     protected getBlockDragStartHandler = (block: toolbox.BlockDefinition, snippet: string, color: string) => {
         return (e: any) => {
+            e.preventDefault();
+            e.stopPropagation();
             this.dragInfo = {
                 x: pxt.BrowserUtils.getClientX(e),
                 y: pxt.BrowserUtils.getClientY(e),


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2883

i don't foresee this causing any issues; i tested in edge and safari on my mac, but probably a good idea to try out on a touch screen for sanity's sake during this week's testing