### PR TITLE
Add single letter shortcuts to toggle sim and download code

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -959,7 +959,7 @@ declare namespace pxt.editor {
         saveAndCompile(): void;
         updateHeaderName(name: string): void;
         updateHeaderNameAsync(name: string): Promise<void>;
-        compile(): void;
+        compile(): Promise<void>;
 
         setFile(fn: IFile, line?: number): void;
         setSideFile(fn: IFile, line?: number): void;
@@ -986,6 +986,7 @@ declare namespace pxt.editor {
         clearUserPoke(): void;
         setHintSeen(step: number): void;
         setEditorOffset(): void;
+        ariaAnnounce(msg: string): void;
 
         anonymousPublishHeaderByIdAsync(headerId: string, projectName?: string): Promise<ShareData>;
         publishCurrentHeaderAsync(persistent: boolean, screenshotUri?: string): Promise<string>;
@@ -1099,6 +1100,7 @@ declare namespace pxt.editor {
         showBoardDialogAsync(features?: string[], closeIcon?: boolean): Promise<void>;
         checkForHwVariant(): boolean;
         pairAsync(): Promise<boolean>;
+        shouldShowPairingDialogOnDownload(): boolean;
 
         createModalClasses(classes?: string): string;
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -33,6 +33,7 @@
 </head>
 
 <body class="main pxt-theme-root">
+    <div id="aria-announce" class="sr-only" aria-live="polite" aria-atomic="true"></div>
     <div id='loading' class="ui active dimmer">
         <div class="ui large main loader msft"></div>
     </div>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3345,6 +3345,13 @@ export class ProjectView
         return cmds.pairAsync();
     }
 
+    shouldShowPairingDialogOnDownload = () => {
+        return pxt.appTarget.appTheme.preferWebUSBDownload
+            && pxt.appTarget?.compile?.webUSB
+            && pxt.usb.isEnabled
+            && !webusb.userPrefersDownloadFlagSet();
+    }
+
     ///////////////////////////////////////////////////////////
     ////////////             Compile              /////////////
     ///////////////////////////////////////////////////////////
@@ -5263,6 +5270,13 @@ export class ProjectView
         });
 
         setTimeout(() => this.clearUserPoke(), 10000);
+    }
+
+    ariaAnnounce(msg: string) {
+        const el = document.getElementById("aria-announce");
+        if (el) {
+            el.textContent = msg;
+        }
     }
 
     ///////////////////////////////////////////////////////////

--- a/webapp/src/components/KeyboardControlsHelp.tsx
+++ b/webapp/src/components/KeyboardControlsHelp.tsx
@@ -33,6 +33,8 @@ const KeyboardControlsHelp = () => {
                     <Row name={lf("Copy / paste")} shortcuts={[ShortcutNames.COPY, ShortcutNames.PASTE]} joiner="/" />
                     {cleanUpRow}
                     {contextMenuRow}
+                    <Row name={lf("Start / stop simulator")} shortcuts={[["S"]]} />
+                    <Row name={lf("Download your code to the {0}", pxt.appTarget.appTheme.boardName)} shortcuts={[["L"]]} />
                 </tbody>
             </table>
             <h3>{lf("Editor Overview")}</h3>

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -189,7 +189,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     protected onDownloadButtonClick = async () => {
         pxt.tickEvent("editortools.downloadbutton", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
-        if (this.shouldShowPairingDialogOnDownload()
+        if (this.props.parent.shouldShowPairingDialogOnDownload()
             && !pxt.packetio.isConnected()
             && !pxt.packetio.isConnecting()
         ) {
@@ -256,13 +256,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         window.open(pxt.appTarget.appTheme.downloadDialogTheme?.downloadMenuHelpURL);
     }
 
-    protected shouldShowPairingDialogOnDownload = () => {
-        return pxt.appTarget.appTheme.preferWebUSBDownload
-            && pxt.appTarget?.compile?.webUSB
-            && pxt.usb.isEnabled
-            && !userPrefersDownloadFlagSet();
-    }
-
     protected getCompileButton(view: View): JSX.Element[] {
         const collapsed = true; // TODO: Cleanup this
         const targetTheme = pxt.appTarget.appTheme;
@@ -292,7 +285,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         const packetioConnected = !!this.getData("packetio:connected");
         const packetioConnecting = !!this.getData("packetio:connecting");
         const packetioIcon = this.getData("packetio:icon") as string;
-        const hideFileDownloadIcon = view === View.Computer && this.shouldShowPairingDialogOnDownload();
+        const hideFileDownloadIcon = view === View.Computer && this.props.parent.shouldShowPairingDialogOnDownload();
         const fileDownloadIcon = targetTheme.downloadIcon || "xicon file-download";
 
         const successIcon = (packetioConnected && pxt.appTarget.appTheme.downloadDialogTheme?.deviceSuccessIcon)


### PR DESCRIPTION
These only work within the Blockly workspace.

Keeping a draft PR open for notes.

The aria live region to announce that the download has finished is not read out on VO. It also doesn't work if we change it to being assertive. The screen reader is busy announcing the focus change from the downloading dialog to the workspace. Perhaps this focus change is enough? Test this on different screen readers and then decide on an approach for UT.