### PR TITLE
filter bad file entries when parsing pxt.json

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -572,6 +572,19 @@ namespace pxt {
             }
 
             const currentConfig = JSON.stringify(this.config);
+
+            if (this.config?.files) {
+                // clean up the files list. we had some issues in the past with
+                // invalid entries being added to pxt.json
+                this.config.files = this.config.files.filter(f =>
+                    f !== pxt.HISTORY_FILE &&
+                    f !== pxt.CONFIG_NAME &&
+                    f !== "undefined" &&
+                    f !== "null" &&
+                    !!f
+                );
+            }
+
             for (const dep in this.config.dependencies) {
                 const value = pxt.patching.upgradePackageReference(this.targetVersion(), dep, this.config.dependencies[dep]);
                 if (value != dep) {


### PR DESCRIPTION
a minor addendum to the fix in https://github.com/microsoft/pxt/pull/10676/files

that fix does remove the entries from the history file, but doesn't remove the offending entries from the files list in pxt.json. this PR adds some code to fix that list up and get rid of any invalid entries that might have found their way in.