### PR TITLE
add button handler that focuses monaco flyout items on click

### DIFF
--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -10,6 +10,7 @@ import { getBlockAsText } from "./toolboxHelpers";
 import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
+import { classList } from "../../react-common/components/util";
 
 const DRAG_THRESHOLD = 5;
 const SELECTED_BORDER_WIDTH = 4;
@@ -374,11 +375,21 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
         const description = block.attributes.jsDoc.replace(/``/g, '"')
             .split("* @param", 1)[0] // drop any kind of parameter annotation
 
-        return <div className={`monacoBlock ${disabled ? "monacoDisabledBlock" : ""} ${selected ? "expand" : ""} ${hover ? "hover" : ""}`}
+        let buttonRef: HTMLDivElement;
+        const handleRef = (ref: HTMLDivElement) => {
+            if (ref) buttonRef = ref;
+        }
+
+        return <div
+            className={classList("monacoBlock", disabled && "monacoDisabledBlock", selected && "expand", hover && "hover")}
             style={this.getSelectedStyle()}
             title={block.attributes.jsDoc}
-            key={`block_${qName}_${index}`} tabIndex={!this.state.selectedBlock && index === 0 ? 0 : selected ? 0 : -1} role="listitem"
+            key={`block_${qName}_${index}`}
+            tabIndex={!this.state.selectedBlock && index === 0 ? 0 : selected ? 0 : -1}
+            role="listitem"
+            ref={handleRef}
             onFocus={() => this.handleFocus(qName)}
+            onClick={() => buttonRef && buttonRef.focus()}
             onBlur={() => this.handleBlur()}
             onMouseOver={this.getBlockMouseOver(qName)}
             onMouseOut={this.getBlockMouseOut(qName)}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2979

i cleaned up the formatting a little bit because it was bothering me; the relevant bit here is the `ref` and `onClick` handlers.

this was regressed by https://github.com/microsoft/pxt/pull/10642, which removed the on click handler in favor of managing the expand state of monaco flyout blocks based purely on whether they have focus or not. this PR adds a new click handler that calls focus so as to preserve the intent of that PR