### PR TITLE
workaround chrome bug that allows block text to be selected

### DIFF
--- a/pxtblocks/plugins/renderer/constants.ts
+++ b/pxtblocks/plugins/renderer/constants.ts
@@ -118,7 +118,25 @@ export class ConstantProvider extends Blockly.zelos.ConstantProvider {
             // Flyout heading.
             selector + ' .blocklyFlyoutHeading .blocklyFlyoutLabelText {' +
             'font-size: 1.5rem;',
-            '}'
+            '}',
+
+            // The rules below are all to work around a chrome bug where the browser isn't respecting
+            // the user-select: none css style on blockly SVG text: https://github.com/microsoft/pxt-arcade/issues/6838
+            `${selector} .blocklyText::selection {`,
+            `fill: #fff;`,
+            `}`,
+            `${selector} .blocklyNonEditableField>text::selection,`,
+            `${selector} .blocklyEditableField>text::selection,`,
+            `${selector} .blocklyNonEditableField>g>text::selection,`,
+            `${selector} .blocklyEditableField>g>text::selection {`,
+            `fill: #575E75;`,
+            `}`,
+
+            // Dropdown field.
+            `${selector} .blocklyDropdownText::selection {`,
+            `fill: #fff !important;`,
+            `}`,
+
         ])
     }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6838

this "fixes" the bug where all the block text sometimes turns black. i put that in quotes because as far as i can tell, that bug is a browser bug where chrome won't respect the `user-select: none` css that is placed on all the blockly blocks. to workaround that behavior, i'm adding styling that makes it so that the selected text color is the same as the unselected text color so that you can't see the difference