### PR TITLE
[Stable11.3] fix workspace variable deleting bug

### DIFF
--- a/pxtblocks/plugins/flyout/verticalFlyout.ts
+++ b/pxtblocks/plugins/flyout/verticalFlyout.ts
@@ -1,7 +1,5 @@
 import * as Blockly from "blockly";
 
-const MAX_CACHED_FLYOUTS = 20;
-
 export class VerticalFlyout implements Blockly.IFlyout {
     horizontalLayout = false;
     RTL: boolean;
@@ -141,10 +139,6 @@ export class VerticalFlyout implements Blockly.IFlyout {
 
         this.activeFlyout = new CachedFlyout(this.options);
         this.cached.push(this.activeFlyout);
-
-        if (this.cached.length >= MAX_CACHED_FLYOUTS) {
-            this.cached.shift().dispose();
-        }
 
         this.element.appendChild(this.activeFlyout.createDom("g"));
         this.activeFlyout.init(this.targetWorkspace);


### PR DESCRIPTION
this is NOT a cherry pick!

this is a fix for https://github.com/microsoft/pxt-arcade/issues/6983

this does not need to be fixed in master, because i re-implemented how the flyout works for keyboard nav. however, we can't take those changes without taking all the blockly changes, so this is a targeted fix for this issue in arcade's stable branch. microbit and minecraft are not affected

the bug here was that for some reason disposing of the cached flyouts was also disposing the variable map of the main workspace. this fix removes that logic, which technically opens us up to a memory leak (though i think it's very unlikely to be a problem) but stops your project from being permanently ruined so i'd say that's a net win.

i'd like to hotfix this and https://github.com/microsoft/pxt/pull/10908 ASAP. the other PR will help restore projects that have previously experienced this bug