### PR TITLE
always open links in tutorial markdown in a new tab

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -668,13 +668,11 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         let renderer = new marked.Renderer()
         pxt.docs.setupRenderer(renderer);
 
-        // always popout external links
+        // always popout links
         const linkRenderer = renderer.link;
         renderer.link = function (href: string, title: string, text: string) {
-            const relative = /^[\/#]/.test(href);
-            const target = !relative ? '_blank' : '';
             const html = linkRenderer.call(renderer, href, title, text);
-            return html.replace(/^<a /, `<a ${target ? `target="${target}"` : ''} rel="nofollow noopener" `);
+            return html.replace(/^<a /, `<a target="_blank" rel="nofollow noopener" `);
         };
 
         // Set markdown options


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2986

this change removes the logic that we had for opening links in tutorials where the links would only open in a new tab only if it was an external page. now all links open in new tabs regardless of if they are relative or not.

this change makes me a little nervous because obviously that logic was written for _some_ reason but for the life of me i can't think of a scenario in which we'd want to navigate someone out of a tutorial. i looked at the git blame but didn't find any more context.