### PR TITLE
[Stable12.1] always open links in tutorial markdown in a new tab (#10918)

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -668,13 +668,11 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         let renderer = new marked.Renderer()
         pxt.docs.setupRenderer(renderer);
 
-        // always popout external links
+        // always popout links
         const linkRenderer = renderer.link;
         renderer.link = function (href: string, title: string, text: string) {
-            const relative = /^[\/#]/.test(href);
-            const target = !relative ? '_blank' : '';
             const html = linkRenderer.call(renderer, href, title, text);
-            return html.replace(/^<a /, `<a ${target ? `target="${target}"` : ''} rel="nofollow noopener" `);
+            return html.replace(/^<a /, `<a target="_blank" rel="nofollow noopener" `);
         };
 
         // Set markdown options


### PR DESCRIPTION
cherry picking the tutorial link fix to minecraft stable