### PR TITLE
hoist hexliteral declarations in binaryjs

### DIFF
--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -177,6 +177,9 @@ namespace ts.pxtc {
             if (p.cachedJS) {
                 curr = p.cachedJS
                 cachedLen += curr.length
+                for (const hexlit of Object.keys(p.cachedJSHexLiterals)) {
+                    bin.hexlits[hexlit] = p.cachedJSHexLiterals[hexlit];
+                }
             } else {
                 curr = irToJS(bin, p)
                 newLen += curr.length
@@ -436,7 +439,9 @@ function ${id}(s) {
                     if (e.ptrlabel()) {
                         return e.ptrlabel().lblId + "";
                     } else if (e.hexlit() != null) {
-                        bin.hexlits[e.data] = `const ${e.data} = pxsim.BufferMethods.createBufferFromHex("${e.hexlit()}")\n`;
+                        const lit = `const ${e.data} = pxsim.BufferMethods.createBufferFromHex("${e.hexlit()}")\n`;
+                        proc.cachedJSHexLiterals[e.data] = lit;
+                        bin.hexlits[e.data] = lit;
                         return e.data;
                     } else if (typeof e.jsInfo == "string") {
                         return e.jsInfo;

--- a/pxtcompiler/emitter/ir.ts
+++ b/pxtcompiler/emitter/ir.ts
@@ -538,6 +538,7 @@ namespace ts.pxtc.ir {
         action: ts.FunctionLikeDeclaration = null;
         inlineBody: ir.Expr;
         cachedJS: string = null;
+        cachedJSHexLiterals: pxt.Map<string> = {}
         usingCtx: PxtNode = null;
 
         reset() {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6911

this PR fixes a bug wherein inlined functions that return an image or buffer would cause the generated binaryjs file for the simulator to have a syntaxerror. this bug only affects the simulator, not the native compiler, but it is possible to hit it from blocks:

https://makecode.com/_iAF4g8WUsFdh

the syntax error was because we were redeclaring the same hex literal constant each time the inlined function was emitted (so every time it was called). in order to fix it, i've hoisted the hexliteral declarations so that they are all declared at the top of binaryjs instead of next to the functions that use them, which allows me to deduplicate them.