### PR TITLE
fix tile cache when switching projects

### DIFF
--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -21,17 +21,24 @@ export class FieldTileset extends FieldImages implements FieldCustom {
     protected selectedOption_: TilesetDropdownOption;
 
     protected static referencedTiles: TilesetDropdownOption[];
-    protected static cachedRevision: number;
-    protected static cachedWorkspaceId: string;
+    protected static cachedPalette: string;
+    protected static cachedRevision = -1;
+    protected static bitmapCache: Map<string, string> = new Map();
 
     protected static getReferencedTiles(workspace: Blockly.Workspace) {
         const project = pxt.react.getTilemapProject();
+        const paletteKey = pxt.appTarget.runtime.palette ? pxt.appTarget.runtime.palette.join("") : undefined;
 
-        if (project.revision() !== FieldTileset.cachedRevision || workspace.id != FieldTileset.cachedWorkspaceId) {
+        if (paletteKey !== FieldTileset.cachedPalette) {
+            this.bitmapCache.clear();
+            this.cachedPalette = paletteKey;
+            this.cachedRevision = -1;
+        }
+
+        if (FieldTileset.cachedRevision !== project.revision()) {
             FieldTileset.cachedRevision = project.revision();
-            FieldTileset.cachedWorkspaceId = workspace.id;
-            const references = getAllReferencedTiles(workspace);
 
+            const references = getAllReferencedTiles(workspace);
             const supportedTileWidths = [16, 4, 8, 32];
 
             for (const width of supportedTileWidths) {
@@ -63,18 +70,29 @@ export class FieldTileset extends FieldImages implements FieldCustom {
                     (weights[b.id] || (weights[b.id] = tileWeight(b.id)))
             });
 
-            const getTileImage = (t: pxt.Tile) => tileWeight(t.id) <= 2 ?
-                mkTransparentTileImage(t.bitmap.width) :
-                bitmapToImageURI(pxt.sprite.Bitmap.fromData(t.bitmap), PREVIEW_SIDE_LENGTH, false);
-
             FieldTileset.referencedTiles = references.map(tile => [{
-                src: getTileImage(tile),
+                src: FieldTileset.getTileImage(tile),
                 width: PREVIEW_SIDE_LENGTH,
                 height: PREVIEW_SIDE_LENGTH,
                 alt: displayName(tile)
             }, tile.id, tile])
         }
+
         return FieldTileset.referencedTiles;
+    }
+
+
+    static getTileImage(t: pxt.Tile) {
+        const key = pxt.U.toHex(t.bitmap.data) + "-" + t.bitmap.width + "-" + t.bitmap.height;
+        if (!this.bitmapCache.has(key)) {
+            if (tileWeight(t.id) <= 2) {
+                this.bitmapCache.set(key, mkTransparentTileImage(t.bitmap.width));
+            }
+            else {
+                this.bitmapCache.set(key, bitmapToImageURI(pxt.sprite.Bitmap.fromData(t.bitmap), PREVIEW_SIDE_LENGTH, false))
+            }
+        }
+        return this.bitmapCache.get(key);
     }
 
     public isFieldCustom_ = true;
@@ -143,7 +161,6 @@ export class FieldTileset extends FieldImages implements FieldCustom {
         if (this.value_ && this.selectedOption_) {
             if (this.selectedOption_[1] !== this.value_) {
                 const tile = pxt.react.getTilemapProject().resolveTile(this.value_);
-                FieldTileset.cachedRevision = -1;
 
                 if (tile) {
                     this.selectedOption_ = [{

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -340,6 +340,8 @@ namespace pxt {
     export class TilemapProject {
         public needsRebuild = true;
 
+        protected static nextRevision = 0;
+
         protected extensionTileSets: TileSetCollection[];
         protected state: AssetSnapshot;
         protected committedState: AssetSnapshot;
@@ -354,7 +356,7 @@ namespace pxt {
 
         constructor() {
             this.committedState = {
-                revision: 0,
+                revision: TilemapProject.nextRevision++,
                 assets: {
                     [AssetType.Image]: new AssetCollection(AssetType.Image),
                     [AssetType.Tile]: new AssetCollection(AssetType.Tile),
@@ -365,7 +367,7 @@ namespace pxt {
                 }
             };
             this.state = {
-                revision: this.nextID++,
+                revision: TilemapProject.nextRevision++,
                 assets: {
                     [AssetType.Image]: new AssetCollection(AssetType.Image),
                     [AssetType.Tile]: new AssetCollection(AssetType.Tile),
@@ -1411,7 +1413,7 @@ namespace pxt {
 
         protected onChange() {
             this.needsRebuild = true;
-            this.state.revision = this.nextID++;
+            this.state.revision = TilemapProject.nextRevision++;
         }
 
         protected readImages(allJRes: Map<JRes>, isProjectFile = false) {

--- a/webapp/src/components/ImageEditor/store/imageReducer.ts
+++ b/webapp/src/components/ImageEditor/store/imageReducer.ts
@@ -157,6 +157,8 @@ const initialState: AnimationState = {
     interval: 200
 }
 
+let nextTilesetRevision = 1;
+
 const initialStore: ImageEditorStore = {
     store: {
         present: initialState,
@@ -257,7 +259,7 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
                     referencedTiles: toOpen.data.projectReferences,
                     previewAnimating: false,
                     onionSkinEnabled: false,
-                    tilesetRevision: 0,
+                    tilesetRevision: nextTilesetRevision++,
                     // Properties below this comment carry over if keep past is true
                     tool: action.keepPast ? state.editor.tool : initialStore.editor.tool,
                     cursorSize: action.keepPast ? state.editor.cursorSize : initialStore.editor.cursorSize,
@@ -266,7 +268,7 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
 
                 } : {
                     isTilemap: false,
-                    tilesetRevision: 0,
+                    tilesetRevision: nextTilesetRevision++,
 
                     // Properties below this comment carry over if keep past is true
                     selectedColor: action.keepPast ? state.editor.selectedColor : initialStore.editor.selectedColor,
@@ -318,7 +320,7 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
                 },
                 editor: {
                     ...state.editor,
-                    tilesetRevision: state.editor.tilesetRevision + 1
+                    tilesetRevision: nextTilesetRevision++
                 }
             };
         case actions.REDO_IMAGE_EDIT:
@@ -335,7 +337,7 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
                 },
                 editor: {
                     ...state.editor,
-                    tilesetRevision: state.editor.tilesetRevision + 1
+                    tilesetRevision: nextTilesetRevision++
                 }
             };
         default:
@@ -526,7 +528,7 @@ const editorReducer = (state: EditorState, action: any, store: EditorStore): Edi
                 deletedTiles: (state.deletedTiles || []).concat([action.id]),
                 selectedColor: action.index === state.selectedColor ? 0 : state.selectedColor,
                 backgroundColor: action.index === state.backgroundColor ? 0 : state.backgroundColor,
-                tilesetRevision: state.tilesetRevision + 1
+                tilesetRevision: nextTilesetRevision++
             };
         case actions.OPEN_TILE_EDITOR:
             const editType = action.index ? "edit" : "new";
@@ -549,7 +551,7 @@ const editorReducer = (state: EditorState, action: any, store: EditorStore): Edi
                 editedTiles,
                 selectedColor: action.index || (store.present as TilemapState).tileset.tiles.length,
                 editingTile: undefined,
-                tilesetRevision: state.tilesetRevision + 1
+                tilesetRevision: nextTilesetRevision++
             };
         case actions.SHOW_ALERT:
             tickEvent("show-alert");


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6945

this PR fixes two different caching issues. we cache tile bitmaps in two places: on the tileset field editor and in the image editor's ImageCanvas component.

both of those caches used a revision number as a means of detecting when the cache needs to be refreshed. however, those revision numbers were reset when switching projects which would cause the caches to fail to update. this PR changes both of them to be globally increasing numbers rather than being reset to 0 when switching projects.