### PR TITLE
Update CodeQL to ignore Monaco in tutorial tool

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,7 @@ on:
     branches: [ 'master', 'stable*', 'v[0-9]*' ]
     paths-ignore:
       - webapp/public/vs/language/typescript/tsWorker.js
+      - docs/static/tutorial-tool/vs
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]


### PR DESCRIPTION
CodeQL is currently broken after the addition of the Monaco editor in `docs/static` to be used in the tutorial tool. The builds take hours before failing. I've added `docs/static/tutorial-tool/vs` to the list of ignored paths.