### PR TITLE
Actually Ignore Monaco in Code Scanning

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,10 +24,6 @@ on:
     - cron: '34 6 * * 0'
   workflow_call:
 
-# Ignore the monaco files in the scan
-paths-ignore:
-  - docs/static/tutorial-tool/vs
-
   # Permissions required by OpenID Connect to access Azure.
 permissions:
   security-events: write
@@ -58,6 +54,10 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        config: |
+          # Ignore the monaco files in the scan
+          paths-ignore:
+            - docs/static/tutorial-tool/vs
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
Turns out `paths-ignore` on the trigger only applies to when CodeQL runs, not what it scans. In order to ignore the Monaco editor files, we need to specify `paths-ignore` in the `config` property in the CodeQL setup. https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#specifying-directories-to-scan

> I also added `workflow_dispatch` to have the ability to do manual runs in the future. We can't iterate on the manual builds until they are in.