### PR TITLE
fix html escape and unescape functions

### DIFF
--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -30,12 +30,12 @@ namespace ts.pxtc.Util {
 
     export function htmlEscape(_input: string) {
         if (!_input) return _input; // null, undefined, empty string test
-        return _input.replace(/([^\w .!?\-$])/g, c => "&#" + c.charCodeAt(0) + ";");
+        return _input.replace(/([^\w .!?\-$])/ug, c => "&#" + c.codePointAt(0) + ";");
     }
 
     export function htmlUnescape(_input: string) {
         if (!_input) return _input; // null, undefined, empty string test
-        return _input.replace(/(&#\d+;)/g, c => String.fromCharCode(Number(c.substr(2, c.length - 3))));
+        return _input.replace(/(&#\d+;)/g, c => String.fromCodePoint(Number(c.substr(2, c.length - 3))));
     }
 
     export function jsStringQuote(s: string) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6099

our html escaping code attempts to convert all non-ASCII characters to [HTML character references](https://en.wikipedia.org/wiki/Character_encodings_in_HTML#HTML_character_references). we did this by encoding each UTF8 character individually, but HTML character references support unicode code points. as a result, our html escaping code was improperly escaping unicode characters that use more than one UTF8 code point.

for example, the emoji 😒 is made up of two characters in UTF8, `\ud83d` and `\ude12`, but is actually only one unicode code point (in decimal: `128530`). the browser's DOMParser can't parse the two separate code points (`&#55357;&#56850;`) but it handles the proper unicode code point just fine (`&#128530;`)

the fix here was to add the `u` flag to our regex so that it treats the input as a stream of unicode characters rather than UTF8 and using `String.codePointAt` which handles multi-byte sequences instead of `String.charCodeAt` which does not.