### PR TITLE
propagate opts through editor controller ticks

### DIFF
--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -361,9 +361,9 @@ export function enableControllerAnalytics() {
         return;
     }
 
-    const te = pxt.tickEvent;
-    pxt.tickEvent = function (id: string, data?: pxt.Map<string | number>): void {
-        if (te) te(id, data);
+    const analyticsTickEvent = pxt.tickEvent;
+    pxt.tickEvent = function (id: string, data?: pxt.Map<string | number>, opts?: pxt.TelemetryEventOptions): void {
+        if (analyticsTickEvent) analyticsTickEvent(id, data, opts);
         postHostMessageAsync(<pxt.editor.EditorMessageEventRequest>{
             type: 'pxthost',
             action: 'event',


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/3000

third parameter was getting dropped:
tick source 
<img width="566" height="252" alt="image" src="https://github.com/user-attachments/assets/d543a619-5ade-4ca2-a002-81e333ff65d3" />
-> this changed file
<img width="632" height="236" alt="image" src="https://github.com/user-attachments/assets/798bce5f-4d65-4f75-ac70-a100de3bc906" />
-> pxtlib/analytics where it's used
<img width="787" height="222" alt="image" src="https://github.com/user-attachments/assets/f7500af1-ea0e-42fd-b4a6-6ed51c4db4fd" />
