### PR TITLE
fix typechecking for unions of array types

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -657,6 +657,14 @@ namespace ts.pxtc {
     }
 
     function isArrayType(t: Type) {
+        if (t.flags & TypeFlags.Union && (t as UnionType).types) {
+            for (const subtype of (t as UnionType).types) {
+                if (!isArrayType(subtype)) {
+                    return false;
+                }
+            }
+            return true;
+        }
         if (!isObjectType(t)) {
             return false;
         }
@@ -701,7 +709,12 @@ namespace ts.pxtc {
 
     function arrayElementType(t: Type, idx = -1): Type {
         if (isArrayType(t))
-            return checkType((<TypeReference>t).typeArguments[0])
+            if (t.flags & TypeFlags.Union) {
+                return checkType(t.getNumberIndexType());
+            }
+            else {
+                return checkType((<TypeReference>t).typeArguments[0])
+            }
         return checker.getIndexTypeOfType(t, IndexKind.Number);
     }
 

--- a/tests/compile-test/lang-test0/53unionarraytypes.ts
+++ b/tests/compile-test/lang-test0/53unionarraytypes.ts
@@ -1,0 +1,6 @@
+let multidim = [[1, 3], ["one", "two"]]
+let a = multidim[0][0]
+let b = multidim[1][1]
+
+assert(a === 1)
+assert(b === "two");

--- a/tests/compile-test/lang-test0/pxt.json
+++ b/tests/compile-test/lang-test0/pxt.json
@@ -54,6 +54,8 @@
         "49unicode.ts",
         "50indexedtypes.ts",
         "51exceptions.ts",
+        "52parseint.ts",
+        "53unionarraytypes.ts",
         "99final.ts"
     ],
     "public": true,


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6113

when given a union type like `(number[] | string[])` our compiler was categorizing this as "not an array type" even though it's a union of two array types. as a result, the emitter would emit indexed access/assign operations using the generic map lookup functions rather than the array versions of those functions. our arrays are not addressable as maps, so you would end up getting an arcane runtime error when trying to index into an object of that type.

as i was adding a test for this, i also noticed that someone has added a test file for parseint but never actually added it to the pxt.json of our test project, so i added that as well.