### PR TITLE
Fix evalEnabled condition to check teachertool exists

### DIFF
--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -142,7 +142,7 @@
                             );
                         }
 
-                        var evalEnabled = targetConfig && targetConfig.teachertool.showSharePageEvalButton;
+                        var evalEnabled = targetConfig && targetConfig.teachertool && targetConfig.teachertool.showSharePageEvalButton;
                         if (!evalEnabled) {
                             var evalButton = document.querySelector("#eval-button");
                             if (evalButton) {


### PR DESCRIPTION
Looking at something else that's small in cli server that was bugging me for testing but i'll separate out this one line fix -- noticed while adding to arcade share page, should port to minecraft. condition fails if targetConfig has no teachertool section, exception prevents evaluate button from being removed (e.g. https://minecraft.makecode.com/93106-37679-73671-96611) @abchatra 