### PR TITLE
fix dropdown size for blockly fields in skillmap flyouts

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -956,6 +956,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 if (entry.intersectionRatio > 0) {
                     this.intersectionObserver.unobserve(entry.target);
                     this.editor.refreshTheme();
+                    const flyoutWorkspace = this.editor.getFlyout()?.getWorkspace();
+                    if (flyoutWorkspace) {
+                        flyoutWorkspace.refreshTheme();
+                    }
                 }
             })
         });


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7164

the issue here was that in blockly, the height of the border rect is determined based on the height of the font contained within it which blockly measures ahead of time before rendering. that code for measuring the font doesn't work, however, when the blockly workspace is rendered off screen like we do in skillmaps (we load the editor iframe in the background off screen). we already had a fix for this that calls refreshTheme on the main workspace to force the text height to be recalculated when we detect that it has appeared onscreen; this PR adds the flyout workspace to that previous fix.