### PR TITLE
Change debug selected styling 

### DIFF
--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -88,7 +88,7 @@ div.field .ui.toggle.checkbox input:checked~label:before {
 /* Sim toolbar */
 #simulator .editor-sidebar .simtoolbar .debug-button.active,
 #simulator .editor-sidebar .simtoolbar .debug-button.active:hover {
-    /* Make active state more apparent by inverting the colors */
+    /* Make active state more apparent with a yellow border */
     color: var(--pxt-neutral-foreground2) !important;
     background: var(--pxt-neutral-background2) !important;
     border: 3px solid var(--pxt-colors-yellow-background) !important;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/7096

Makes it so that the debug button keeps the dark background and light foreground and applies the bright yellow border like we do for other buttons.
<img width="1759" height="560" alt="image" src="https://github.com/user-attachments/assets/78925e31-3d5e-4d32-9792-48a62981ab75" />
