### PR TITLE
don't reload header after editing pxt.json when going home

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1604,12 +1604,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             });
     }
 
-    unloadFileAsync(): Promise<void> {
+    unloadFileAsync(unloadToHome?: boolean): Promise<void> {
         if (this.toolbox)
             this.toolbox.clearSearch();
         this.setErrors([]);
         this.parent.setState({errorListNote: undefined});
-        if (this.currFile && this.currFile.getName() == "this/" + pxt.CONFIG_NAME) {
+        if (this.currFile && this.currFile.getName() == "this/" + pxt.CONFIG_NAME && !unloadToHome) {
             // Reload the header if a change was made to the config file: pxt.json
             return this.parent.reloadHeaderAsync();
         }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6890

when you click home while editing pxt.json, the project gets reloaded. that reload interrupts the flow when going to the home screen, so adding a check to prevent us from reloading in that case.