### PR TITLE
reduce blockly snap radius to default value

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -795,7 +795,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         pxsim.U.clear(blocklyDiv);
 
         // Increase the Blockly connection radius
-        Blockly.config.snapRadius = 48;
+        Blockly.config.snapRadius = 28;
         Blockly.config.connectingSnapRadius = 96;
         this.editor = Blockly.inject(blocklyDiv, this.getBlocklyOptions(forceHasCategories)) as Blockly.WorkspaceSvg;
         pxtblockly.contextMenu.setupWorkspaceContextMenu(this.editor);


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6854

turns out that blockly's logic for bumping neighbor blocks is based off the of the snap radius. we increased this snap radius as part of the reindeer connector a long time ago, but now that blockly has a separate connecting snap radius we don't really have to modify that value to have the reindeer connectors still be effective. reducing the radius mean less random bumping of blocks when new blocks spawn in.

the linked issue is caused by bumping. when you paste blocks, the render was detecting that two blocks had their connections too close together and bumping them. as a result, the original blocks were appearing below the pasted ones and when you undo it looks like the original is deleted when it's actually the copy. the undo didn't restore the original's position because pasting temporarily disables blockly events while the new blocks are created.