### PR TITLE
don't disable cloud sync for skillmap

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -6260,7 +6260,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     let theme = pxt.appTarget.appTheme;
     const isControllerIFrame = theme.allowParentController || pxt.shell.isControllerMode()
     // disable auth in iframe scenarios
-    if (isControllerIFrame)
+    if (isControllerIFrame && !pxt.BrowserUtils.isSkillmapEditor())
         pxt.auth.enableAuth(false);
     enableAnalytics()
 


### PR DESCRIPTION
this was regressed by https://github.com/microsoft/pxt/pull/9546. I believe that change went out in arcade in march, so it's been broken for most of this year.

fixes cloud syncing of skillmap projects.