### PR TITLE
[Stable11.3] use stable dist tag when publishing

### DIFF
--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -114,6 +114,16 @@ export function runNpmAsync(...args: string[]) {
     return runNpmAsyncWithCwd(".", ...args);
 }
 
+export async function npmLatestVersionAsync(packageName: string) {
+    const output = await spawnWithPipeAsync({
+        cmd: addCmd("npm"),
+        args: ["view", packageName, "dist-tags.latest"],
+        cwd: ".",
+    });
+
+    return output.toString("utf8").trim()
+}
+
 export interface NpmRegistry {
     _id: string;
     _name: string;


### PR DESCRIPTION
seems like npm now actually checks to see if the tag you are publishing is less than whatever is in latest and errors out. all publishes require a dist tag, so this change basically checks to see what latest currently points to and if the version to be published is less than latest, publishes to a dist tag called `stable[major].[minor]` instead

untested! just gonna run the github action and see what happens