### PR TITLE
Gave blocks rendered in docs a readable aria label

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -823,7 +823,7 @@ function renderInlineBlocksAsync(options: BlocksRenderOptions): Promise<void> {
                         if (symbolInfo && symbolInfo.attributes.help) {
                             // Create accessible label for the link using a human-readable name
                             const readableName = symbolInfo.name || symbolInfo.qName;
-                            const ariaLabel = lf("documentation for {0} block", readableName);
+                            const ariaLabel = lf("Documentation for {0} block", readableName);
                             $newel = $(`<a class="ui link"/>`).attr("href", `/reference/${symbolInfo.attributes.help}`).attr("aria-label", ariaLabel).append($newel);
                         }
                     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/7247

I don't know how to actually access the given docs page, but for those that do, here's an upload target:
https://arcade.makecode.com/app/53337314028ae219be261b6605c60ef19992c2f4-d2ca462b7b