### PR TITLE
trigger on change for dropdown & warn on empty ask ai prompt

### DIFF
--- a/teachertool/src/components/CriteriaInstanceDisplay.tsx
+++ b/teachertool/src/components/CriteriaInstanceDisplay.tsx
@@ -53,6 +53,11 @@ const InlineInputSegment: React.FC<InlineInputSegmentProps> = ({
             return;
         }
 
+        if (!initialValue) {
+            setErrorMessage(Strings.ValueRequired);
+            return;
+        }
+
         // We still allow some invalid values to be set on the parameter so the user can see what they typed
         // and the associated error.
         // Without this, we risk erroring too soon (i.e. typing in first digit of number with min > 10),
@@ -88,6 +93,7 @@ const InlineInputSegment: React.FC<InlineInputSegmentProps> = ({
                 icon={errorMessage ? "fas fa-exclamation-triangle" : undefined}
                 initialValue={initialValue}
                 onChange={onChange}
+                onOptionSelected={onChange}
                 preserveValueOnBlur={true}
                 placeholder={numeric ? "0" : param.name}
                 title={tooltip}


### PR DESCRIPTION
re: teams thread

trigger the on change when dropdown changed so that it applies without editing (i think i had this locally and it dropped off, change was already there), and do warning on empty prompt (same as when you put in a block question

<img width="756" height="507" alt="image" src="https://github.com/user-attachments/assets/e5529ee9-fc3e-4e59-8327-11cdd2272e63" />
