### PR TITLE
fix toolbox filter for tutorials with empty py->ts snippets

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -436,7 +436,7 @@ export function decompilePySnippetstoXmlAsync(code: string[]): Promise<string[]>
             // strip the namespace declaration out of the converted snippets and concat to convert to blocks
             const tsCode = [];
             for (let file of files) {
-                let match = res.outfiles[file + ".ts"].match(namespaceRegex);
+                let match = res.outfiles[file + ".ts"]?.match(namespaceRegex);
                 if (match && match[1]) {
                     const noNamespace = match[1];
                     // strip out 'export let' and 'export function'. This won't hit custom kinds since those are always const


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7328

when converting snippets from python to ts for a tutorial we create a separate source file for each snippet and convert them each individually. if one of those files happens to convert to an empty ts file, we leave it out of the language service response. this was triggering an exception that caused the toolbox filtering to fail.