### PR TITLE
fix instrument LFOs in simulator synth playback

### DIFF
--- a/pxtsim/sound/song.ts
+++ b/pxtsim/sound/song.ts
@@ -302,11 +302,11 @@ namespace pxsim.music {
             },
             ampLFO: {
                 frequency: buf[offset + 21],
-                amplitude: get16BitNumber(buf, 22)
+                amplitude: get16BitNumber(buf, offset + 22)
             },
             pitchLFO: {
                 frequency: buf[offset + 24],
-                amplitude: get16BitNumber(buf, 25)
+                amplitude: get16BitNumber(buf, offset + 25)
             },
             octave: buf[offset + 27]
         }


### PR DESCRIPTION
found this during stream today. seems like LFOs have been broken in the simulator song playback for a loooooong time. we should probably hotfix this!