### PR TITLE
[Stable11.3] fix instrument LFOs in simulator synth playback (#11061)

### DIFF
--- a/pxtsim/sound/song.ts
+++ b/pxtsim/sound/song.ts
@@ -302,11 +302,11 @@ namespace pxsim.music {
             },
             ampLFO: {
                 frequency: buf[offset + 21],
-                amplitude: get16BitNumber(buf, 22)
+                amplitude: get16BitNumber(buf, offset + 22)
             },
             pitchLFO: {
                 frequency: buf[offset + 24],
-                amplitude: get16BitNumber(buf, 25)
+                amplitude: get16BitNumber(buf, offset + 25)
             },
             octave: buf[offset + 27]
         }


### PR DESCRIPTION
Cherry picking my fix from https://github.com/microsoft/pxt/pull/11061 to arcade stable