### PR TITLE
Map category names to their respective icons for tutorial bullet points

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -535,7 +535,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     const iconNameString = iconNames.join(" ");
 
                     // Check if there's a category icon mapping first
-                    const categoryIcon = this.categoryIconMap[iconNameString];
+                    const categoryIcon = this.categoryIconMap[iconNameString.toLowerCase().trim()];
                     if (categoryIcon) {
                         // Use the mapped icon directly, split by spaces to handle multi-word icon names
                         icon.className = `ui icon ${categoryIcon}`;


### PR DESCRIPTION
Closes https://github.com/microsoft/pxt-arcade/issues/7373

Here's a preview:
<img width="296" height="915" alt="image" src="https://github.com/user-attachments/assets/df76dac5-45b8-4874-bc1f-53a1cc4794be" />
