### PR TITLE
[pxt-cli] bump version to v12.2.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "12.2.23",
+  "version": "12.2.24",
   "description": "Microsoft MakeCode provides Blocks / JavaScript / Python tools and editors",
   "keywords": [
     "TypeScript",


### PR DESCRIPTION
__Do not edit the PR title.__
It was automatically generated by `pxt bump` and must follow a specific pattern.
GitHub workflows rely on it to trigger version tagging and publishing to npm.