### PR TITLE
fix render of youtube links and images in docs pages

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -220,6 +220,29 @@
 			"outFiles": []
 		},
 		{
+			"name": "pxt serve (core)",
+			"type": "node",
+			"request": "launch",
+			"program": "${workspaceRoot}/built/pxt.js",
+			"stopOnEntry": false,
+			"args": [
+				"serve",
+				"--rebundle",
+				"--noauth"
+			],
+			"cwd": "${workspaceRoot}",
+			"runtimeExecutable": null,
+			"runtimeArgs": [
+				"--nolazy"
+			],
+			"env": {
+				"NODE_ENV": "development"
+			},
+			"console": "integratedTerminal",
+			"sourceMaps": false,
+			"outFiles": []
+		},
+		{
 			"name": "pxt serve (bedrock)",
 			"type": "node",
 			"request": "launch",

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -41,6 +41,7 @@ pxt.docs.requireDOMSanitizer = () => {
     const sanitizeHtml = require("sanitize-html");
     const defaults = sanitizeHtml.defaults || {};
     const baseAllowedAttrs = defaults.allowedAttributes || {};
+    const allowedTags = defaults.allowedTags || [];
 
     const mergeClassAttribute = (tag: string, ...otherAttributes: string[]) => {
         const existing: string[] = baseAllowedAttrs[tag] || [];
@@ -49,6 +50,7 @@ pxt.docs.requireDOMSanitizer = () => {
 
     const options = {
         ...defaults,
+        allowedTags: [...allowedTags, "img"],
         allowedAttributes: {
             ...baseAllowedAttrs,
             code: mergeClassAttribute("code"),

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -728,7 +728,7 @@ ${opts.repo.name.replace(/^pxt-/, '')}=github:${opts.repo.fullName}#${opts.repo.
             return r;
         }
 
-        html = html.replace(/<h(\d)[^>]+>\s*([~@])?\s*(.*?)<\/h\d>/g, (full: string, lvl: string, tp: string | undefined, body: string) => {
+        html = html.replace(/<h(\d)[^>]*>\s*([~@])?\s*(.*?)<\/h\d>/g, (full: string, lvl: string, tp: string | undefined, body: string) => {
             let m = /^(\w+)\s+(.*)/.exec(body)
             let cmd = m ? m[1] : body
             let args = m ? m[2] : ""


### PR DESCRIPTION
fixing a couple of regressions caused by the recent marked/sanitize-html upgrades

we embed youtube videos for youtube links that are alone on a line in a markdown page. the marked upgrade broke this behavior because it was generating slightly different html that tripped up our big macro regex that replaces the generated html with the thumbnail embed

sanitize-html was also stripping all images from the generated html because img isn't in the default list of allowed tags

@ganicke FYI!