### PR TITLE
don't lose description when opening thumbnail recorder

### DIFF
--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -386,7 +386,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
                             <Textarea
                                 ariaDescribedBy="share-description-title"
                                 ariaLabel={lf("Type a description for your project")}
-                                initialValue={projectDescription || ''}
+                                initialValue={description || projectDescription || ''}
                                 onChange={setDescription}
                                 id="projectDescriptionTextareaShare"
                                 maxLength={pxt.MAX_DESCRIPTION_LENGTH}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7427

when the input unrendered and then rendered again, the initial state was overwriting the description saved in state.