### PR TITLE
put imported tiles into a custom tilemap gallery

### DIFF
--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1589,6 +1589,7 @@ namespace pxt {
                 }
                 if (entry.tilemapTile) {
                     tags.push("tile");
+                    tags.push("category-" + namespaceName)
                 }
             }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7300

Puts tiles imported from an asset pack in a custom category in the tile palette. That category is determined by the name of the project, invalid characters like space are replaced with underscores.