### PR TITLE
prevent debugger toolbox from scrolling horizontally

### DIFF
--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -12,7 +12,11 @@
 *******************************/
 
 /* Debugger toolbox */
-.debuggerToolbox.elements {
+#debuggerToolbox {
+    max-width: 100%;
+}
+
+#debuggerToolbox.elements {
     height: 100%;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7460

for projects with long variable names, the debugger toolbox was overflowing so that you couldn't see any of the variable values without scrolling. this just prevents it from scrolling horizontally at all