### PR TITLE
keep the error list collapsed if collapsed by user

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -820,6 +820,7 @@ declare namespace pxt.editor {
         simSerialActive?: boolean;
         deviceSerialActive?: boolean;
         errorListState?: ErrorListState;
+        errorListCollapsedByUser?: boolean;
         screenshoting?: boolean;
         extensionsVisible?: boolean;
         isMultiplayerGame?: boolean; // Arcade: Does the current project contain multiplayer blocks?

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1092,6 +1092,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     <ErrorList
                         errors={this.errors}
                         onSizeChange={this.onErrorListResize}
+                        collapsedByUser={this.parent.state.errorListCollapsedByUser}
+                        onUserCollapse={this.setErrorListCollapsePreference}
                         getErrorHelp={this.getErrorHelp}
                         showLoginDialog={this.parent.showLoginDialog}
                         startDebugger={this.startDebugger}
@@ -1103,6 +1105,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     onErrorListResize() {
         this.parent.fireResize();
+    }
+
+    protected setErrorListCollapsePreference = (collapsed: boolean) => {
+        this.parent.setState({
+            errorListCollapsedByUser: collapsed
+        });
     }
 
     onExceptionDetected(exception: pxsim.DebuggerBreakpointMessage) {

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -44,6 +44,8 @@ export interface ErrorListProps {
         continuationHash?: string,
         dialogMessages?: { signInMessage?: string; signUpMessage?: string }
     ) => void;
+    collapsedByUser?: boolean;
+    onUserCollapse?: (collapsed: boolean) => void;
 }
 
 export interface ErrorListState {
@@ -64,6 +66,10 @@ export class ErrorList extends auth.Component<ErrorListProps, ErrorListState> {
     }
 
     componentDidUpdate(prevProps: Readonly<ErrorListProps>, prevState: Readonly<ErrorListState>, snapshot?: any): void {
+        if (this.props.collapsedByUser) {
+            return;
+        }
+
         // Auto-expand if there are new errors
         if (this.props.errors.length > 0 && this.state.isCollapsed) {
             let shouldExpand = this.props.errors.length > prevProps.errors.length;
@@ -190,6 +196,10 @@ export class ErrorList extends auth.Component<ErrorListProps, ErrorListState> {
             pxt.tickEvent('errorlist.expand', null, { interactiveConsent: true })
         } else {
             pxt.tickEvent('errorlist.collapse', null, { interactiveConsent: true })
+        }
+
+        if (this.props.onUserCollapse) {
+            this.props.onUserCollapse(!this.state.isCollapsed);
         }
 
         this.setState({

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -664,6 +664,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     {showErrorList && (
                         <ErrorList
                             onSizeChange={this.setErrorListState}
+                            collapsedByUser={this.parent.state.errorListCollapsedByUser}
+                            onUserCollapse={this.setErrorListCollapsePreference}
                             errors={this.errors}
                             startDebugger={this.startDebugger}
                             getErrorHelp={this.getErrorHelp}
@@ -957,6 +959,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 errorListState: newState
             });
         }
+    }
+
+    protected setErrorListCollapsePreference = (collapsed: boolean) => {
+        this.parent.setState({
+            errorListCollapsedByUser: collapsed
+        });
     }
 
     prepare() {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7461

as the title says, keep track of if the error list was explicitly collapsed by the user and, if so, don't automatically re-expand it when the errors change