### PR TITLE
add monkey patch workaround for blockly focus issue when deleting block

### DIFF
--- a/pxtblocks/monkeyPatches/blockSvg.ts
+++ b/pxtblocks/monkeyPatches/blockSvg.ts
@@ -20,4 +20,57 @@ export function monkeyPatchBlockSvg() {
             }
         }
     }
+
+    // This is duplicated exactly from Blockly.BlockSvg.prototype.dispose,
+    // except the radius of the connection search is increased to make
+    // it more likely to focus a nearby block instead of the workspace
+    // when a block is deleted. See https://github.com/RaspberryPiFoundation/blockly/issues/9585
+    Blockly.BlockSvg.prototype.dispose = function (this: Blockly.BlockSvg, healStack: boolean, animate: boolean) {
+        this.disposing = true;
+
+        Blockly.Tooltip.dispose();
+        Blockly.ContextMenu.hide();
+
+        // If this block (or a descendant) was focused, focus its parent or
+        // workspace instead.
+        const focusManager = Blockly.getFocusManager();
+        if (
+            this.getSvgRoot().contains(
+                focusManager.getFocusedNode()?.getFocusableElement() ?? null,
+            )
+        ) {
+            let parent: Blockly.BlockSvg | undefined | null = this.getParent();
+            if (!parent) {
+                const connection = this.outputConnection ?? this.previousConnection;
+                if (connection) {
+                    // By default, Blockly searches for nearby connections within a radius of 0
+                    // to only get blocks that are touching. As a result, it usually returns nothing
+                    // and focuses the root of the workspace. Instead, we use the workspace dimensions
+                    // to try and find a block that's on screen
+                    const workspace = this.workspace;
+                    const viewMetrics = workspace?.getMetrics();
+                    const radius = viewMetrics ? Math.max(viewMetrics.viewWidth, viewMetrics.viewHeight) / 2: 0;
+
+                    const targetConnection = connection.closest(
+                        radius,
+                        new Blockly.utils.Coordinate(0, 0),
+                    ).connection;
+                    parent = targetConnection?.getSourceBlock();
+                }
+            }
+            if (parent) {
+                focusManager.focusNode(parent);
+            } else {
+                setTimeout(() => focusManager.focusTree(this.workspace), 0);
+            }
+        }
+
+        if (animate) {
+            this.unplug(healStack);
+            Blockly.blockAnimations.disposeUiEffect(this);
+        }
+
+        Blockly.Block.prototype.dispose.call(this, !!healStack);
+        Blockly.utils.dom.removeNode(this.getSvgRoot());
+    }
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7392

this adds a monkey patch workaround for the annoying blockly focus behavior when deleting a top-level block

the only changed lines from the core implementation are lines 50-58, which now calculate a radius based off of the workspace view width/height rather than only looking in a radius of 0.

...well, i also had to replace the `this.svgGroup` reference with a call to `this.getSvgRoot()` (which returns the same element) because `svgGroup` is private, but it's fundamentally unchanged

if you want to diff against blockly's version, it's [here](https://github.com/RaspberryPiFoundation/blockly/blob/1c280d10cc1dcad7d50a1678211871058d4e9cfb/core/block_svg.ts#L864)

@microbit-robert FYI