### PR TITLE
fix null pointer check again

### DIFF
--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -236,7 +236,7 @@ export class FieldAnimationEditor extends FieldAssetEditor<FieldAnimationOptions
     onDispose() {
         super.onDispose();
 
-        const root = (this.sourceBlock_ as Blockly.BlockSvg)?.getSvgRoot();
+        const root = (this.sourceBlock_ as Blockly.BlockSvg)?.getSvgRoot?.();
         if (root) {
             root.removeEventListener("mouseenter", this.onMouseEnter);
             root.removeEventListener("mouseleave", this.cancelAnimation);


### PR DESCRIPTION
not sure how i missed this when testing locally, but here we are. if the sourceblock is not a blocksvg, it will be defined but won't have the getSVGRoot function