### PR TITLE
fix escaping of xml code snippets

### DIFF
--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -547,7 +547,7 @@ namespace pxt.docs {
             const rawLang = typeof token?.lang === "string" ? token.lang.trim() : "";
             const normalizedLang = htmlQuote(rawLang.toLowerCase());
             const text = typeof token?.text === "string" ? token.text : "";
-            const escaped = token?.escaped !== false;
+            const escaped = !!(token?.escaped) !== false;
             const code = escaped ? text : htmlQuote(text);
             const classAttr = normalizedLang ? ` class="lang-${normalizedLang}"` : "";
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt/issues/11243
fixes https://github.com/microsoft/pxt-arcade/issues/7549

fixes print. the root cause of this issue was that our markdown renderer wasn't properly escaping embedded xml snippets, which led to them being stripped from the generated XML when we ran the DOM sanitizer over the output