### PR TITLE
fix play tone clipping

### DIFF
--- a/pxtsim/sound/audioContextManager.ts
+++ b/pxtsim/sound/audioContextManager.ts
@@ -73,7 +73,7 @@ namespace pxsim.AudioContextManager {
     }
 
     function stopTone() {
-        AudioToneSource.dispose();
+        AudioToneSource.setCurrentToneGain(0, context().currentTime);
 
         if (audio) {
             audio.pause();

--- a/pxtsim/sound/audioToneSource.ts
+++ b/pxtsim/sound/audioToneSource.ts
@@ -38,6 +38,8 @@ namespace pxsim.AudioContextManager {
         protected constructor(context: AudioContext, destination: AudioNode) {
             super(context, destination);
 
+            this.vca.gain.value = 0;
+
             this.oscillator = context.createOscillator();
             this.oscillator.type = "triangle";
             this.oscillator.frequency.value = 0;


### PR DESCRIPTION
the recent audio refactor introduced some clipping when using play tone (or the melody block in microbit)

this pr fixes that by ramping to/from silence at the beginning and end of play tone