### PR TITLE
only emit python annotated assigns when definition

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1882,7 +1882,7 @@ namespace pxt.py {
         }
 
         let lExp: B.JsNode | undefined = undefined;
-        if (annotation && annotAsType) {
+        if (annotation && annotAsType && target.kind === "Name" && (target as py.Name).isdef) {
             // if we have a type annotation, emit it in these cases if the r-value is:
             //  - null / undefined
             //  - empty list

--- a/tests/pyconverter-test/baselines/ann_assign.ts
+++ b/tests/pyconverter-test/baselines/ann_assign.ts
@@ -1,0 +1,21 @@
+class Foo {
+    l: Bar[]
+    constructor() {
+        this.l = []
+    }
+
+}
+
+class Bar {
+    constructor() {
+
+    }
+
+}
+
+let foo = 9
+foo = 8
+let bar : Bar = null
+bar = null
+let bop : number[] = []
+bop = []

--- a/tests/pyconverter-test/cases/ann_assign.py
+++ b/tests/pyconverter-test/cases/ann_assign.py
@@ -1,0 +1,16 @@
+class Foo:
+    def __init__(self):
+        self.l: List[Bar] = []
+
+class Bar:
+    def __init__(self):
+        pass
+
+foo: number = 9
+foo: number = 8
+
+bar: Bar = None
+bar: Bar = None
+
+bop: List[number] = []
+bop: List[number] = []


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6760

as the title says, only emit the type declaration of python annotated assignments when emitting the declaration of the variable. otherwise, just union the type and move on