### PR TITLE
Update label for card action buttons

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1359,7 +1359,7 @@ function codeCardUrl(props: Partial<ProjectsDetailProps>) {
 
 function cardActionButton(props: Partial<ProjectsDetailProps>, className: string, text: string, type: pxt.CodeCardType, onClick: any, autoFocus?: boolean, actionTitle?: string, linkRef?: React.RefObject<HTMLAnchorElement>) {
     const asLink = cardIsLink(props, type) && type != "forumExample";
-    const label = asLink ? lf("Open link in new window") : lf("Open in {0}", actionTitle || lf("Editor"));
+    const label = asLink ? lf("{0}, opens in new window", text) : lf("{0}, opens in {1}", text, actionTitle || lf("Editor"));
 
     return asLink ? // TODO (shakao)  migrate forumurl to otherAction json in md
         <sui.Link


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6752

The issue also mentions how the title is redundant, but I wanted to keep it since title sets the text for tooltips.