### PR TITLE
indicate which provider last successfully signed in

### DIFF
--- a/react-common/components/profile/SignInModal.tsx
+++ b/react-common/components/profile/SignInModal.tsx
@@ -17,10 +17,11 @@ export interface SignInModalProps {
     }
     resolvePath?: (path: string) => string
     mode?: "signin" | "signup"
+    lastUsedIdentityProvider?: pxt.IdentityProviderId
 }
 
 export const SignInModal = (props: SignInModalProps) => {
-    const { onSignIn, onClose, appMessage, dialogMessages, hideDismissButton } = props
+    const { onSignIn, onClose, appMessage, dialogMessages, hideDismissButton, lastUsedIdentityProvider } = props
     const { signInMessage, signUpMessage } = dialogMessages || {
         signInMessage: lf("Sign in to save your progress and access your work anytime, anywhere."),
         signUpMessage: lf("Join now to save your progress and access your work anytime, anywhere.")
@@ -70,19 +71,24 @@ export const SignInModal = (props: SignInModalProps) => {
                 <div className='signin-body'>
                     <div className='providers'>
                         {pxt.auth.identityProviders().map((provider, index) => {
+                            const isLastUsedProvider = provider.id === lastUsedIdentityProvider
                             const title =
                                 mode === "signin"
                                     ? lf("Continue with {0}", provider.name)
                                     : lf("Sign up with {0}", provider.name)
+                            const ariaLabel = isLastUsedProvider
+                                ? lf("{0}. You last used this option.", title)
+                                : title
                             return (
                                 <Button
                                     key={index}
                                     className='provider'
                                     onClick={() => onSignIn(provider, rememberMe)}
                                     title={title}
-                                    ariaLabel={title}
+                                    ariaLabel={ariaLabel}
                                     label={
                                         <div className='label'>
+                                            {isLastUsedProvider && <div className='ui orange right ribbon label last-used-ribbon' aria-hidden="true">{lf("Last used")}</div>}
                                             <div>
                                                 <img className='logo' src={resolvePath(provider.icon)} />
                                             </div>

--- a/react-common/styles/profile/profile.less
+++ b/react-common/styles/profile/profile.less
@@ -400,18 +400,31 @@
                 background-color: var(--pxt-neutral-background1);
                 color: var(--pxt-neutral-foreground1);
                 border: solid 1px var(--pxt-neutral-foreground1);
+                position: relative;
+                overflow: visible;
 
                 .label {
                     display: flex;
                     flex-direction: row;
                     gap: 1rem;
+                    align-items: center;
+
+                    .last-used-ribbon {
+                        position: absolute;
+                        top: -1rem;
+                        right: -1rem;
+                        left: auto;
+                        transform: none;
+                        margin-right: 0;
+                        z-index: 1;
+                    }
 
                     .logo {
                         width: 1.25rem;
                     }
 
                     .title {
-                        align-self: center;
+                        text-align: left;
                     }
                 }
             }

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -26,6 +26,7 @@ export const COLOR_THEME_IDS = `${USER_PREF_MODULE}:${FIELD_COLOR_THEME_IDS}`
 export const LANGUAGE = `${USER_PREF_MODULE}:${FIELD_LANGUAGE}`
 export const READER = `${USER_PREF_MODULE}:${FIELD_READER}`
 export const HAS_USED_CLOUD = "has-used-cloud"; // Key into local storage to see if this computer has logged in before
+export const LAST_IDENTITY_PROVIDER = "last-identity-provider";
 
 export class Component<TProps, TState> extends data.Component<TProps, TState> {
     public getUserProfile(): pxt.auth.UserProfile {
@@ -46,6 +47,11 @@ class AuthClient extends pxt.auth.AuthClient {
         if (!!workspace.getWorkspaceType())
             await cloud.syncAsync();
         pxt.storage.setLocal(HAS_USED_CLOUD, "true");
+
+        const providerId = pxt.auth.identityProviderId(state.profile);
+        if (providerId) {
+            pxt.storage.setLocal(LAST_IDENTITY_PROVIDER, providerId);
+        }
     }
     protected onSignedOut(): Promise<void> {
         core.infoNotification(lf("Signed out"));
@@ -193,6 +199,11 @@ export function userProfile(): pxt.auth.UserProfile {
 
 export function userPreferences(): pxt.auth.UserPreferences {
     return data.getData<pxt.auth.UserPreferences>(USER_PREFERENCES);
+}
+
+export function lastUsedIdentityProviderId(): pxt.IdentityProviderId | undefined {
+    const providerId = pxt.storage.getLocal(LAST_IDENTITY_PROVIDER) as pxt.IdentityProviderId;
+    return pxt.auth.identityProvider(providerId) ? providerId : undefined;
 }
 
 export async function authCheckAsync(): Promise<pxt.auth.UserProfile | undefined> {

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -53,9 +53,15 @@ export class LoginDialog extends auth.Component<LoginDialogProps, LoginDialogSta
 
     renderCore() {
         const { visible, dialogMessages } = this.state;
+        const lastUsedIdentityProvider = auth.lastUsedIdentityProviderId();
 
         return <>
-            {visible && <SignInModal onClose={this.hide} onSignIn={this.signInAsync} dialogMessages={dialogMessages} />}
+            {visible && <SignInModal
+                onClose={this.hide}
+                onSignIn={this.signInAsync}
+                dialogMessages={dialogMessages}
+                lastUsedIdentityProvider={lastUsedIdentityProvider}
+            />}
         </>;
     }
 }


### PR DESCRIPTION
We had a user that thought they lost all their projects, but they just signed in to microsoft with their gmail account instead of into gmail (or vice versa sounds like). Store a small bit so we can flag which one the user last used to nudge them in the right direction next time they try to sign in (not too attached to ui just mirrored from homescreen flags):

<img width="591" height="350" alt="image" src="https://github.com/user-attachments/assets/fe6bc755-45c5-4b3a-8e0e-03443fcffac4" />

<img width="571" height="327" alt="image" src="https://github.com/user-attachments/assets/e1228cfe-1737-4450-90cc-4ec51cd0c19f" />
