### PR TITLE
Rename type parameter in Generics example

### DIFF
--- a/common-docs/javascript/generics.md
+++ b/common-docs/javascript/generics.md
@@ -131,7 +131,7 @@ function identity<T>(arg: T): T {
     return arg;
 }
 
-let myIdentity: <U>(arg: U) => U = identity;
+let myIdentity: <V>(arg: V) => V = identity;
 ```
 
 We can also write the generic type as a call signature of an object literal type:


### PR DESCRIPTION
A quick fix to de-confuse html rendering when `<U>` is not escaped within the innerHTML of a `<pre>` element and certain browsers think this means "start underlining".

Closes https://github.com/microsoft/pxt-microbit/issues/6773