### PR TITLE
Ensure that extension card button and links work with screen reader

### DIFF
--- a/react-common/components/controls/Card.tsx
+++ b/react-common/components/controls/Card.tsx
@@ -25,38 +25,22 @@ export const Card = (props: CardProps) => {
         tabIndex
     } = props;
 
-    
-    const handleLinkOrTriggerClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-        if (e.target && (e.target as HTMLElement).tagName == "A") {
-            return;
-        }
-        e.preventDefault();
-        onClick();
-    }
-
-    const handleClick = (e: React.MouseEvent) => {
-        handleLinkOrTriggerClick(e);
-    }
-
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        const charCode = (typeof e.which == "number") ? e.which : e.keyCode;
-        if (charCode === /*enter*/13 || charCode === /*space*/32) {
-            handleLinkOrTriggerClick(e);
-        }
-    }
-
     return <div
         id={id}
         className={classList("common-card", className)}
-        role={role || (onClick ? "button" : undefined)}
-        aria-describedby={ariaDescribedBy}
-        aria-labelledby={ariaLabelledBy}
+        role={role}
         aria-hidden={ariaHidden}
-        aria-label={ariaLabel}
-        onClick={handleClick}
-        tabIndex={tabIndex}
-        onKeyDown={handleKeyDown}>
+        aria-label={ariaLabel}>
             <div className="common-card-body">
+                {onClick &&
+                    <button
+                        className="common-card-action"
+                        tabIndex={tabIndex}
+                        aria-describedby={ariaDescribedBy}
+                        aria-labelledby={ariaLabelledBy}
+                        onClick={onClick}
+                    />
+                }
                 {children}
             </div>
             {label &&

--- a/react-common/components/theming/ThemeCard.tsx
+++ b/react-common/components/theming/ThemeCard.tsx
@@ -15,14 +15,14 @@ export const ThemeCard = (props: ThemeCardProps) => {
         <Card
             className="theme-card"
             role="listitem"
-            aria-label={theme.name}
+            ariaLabelledBy={theme.id + "-title"}
             key={theme.id}
             onClick={() => onClick(theme)}
             tabIndex={onClick && 0}
         >
             <div className="theme-info-box">
                 <ThemePreview theme={theme} />
-                <div className="theme-picker-item-name">{themeName}</div>
+                <div id={theme.id + "-title"} className="theme-picker-item-name">{themeName}</div>
             </div>
         </Card>
     );

--- a/react-common/styles/controls/Card.less
+++ b/react-common/styles/controls/Card.less
@@ -5,14 +5,34 @@
     border: 1px solid var(--pxt-neutral-stencil1);
     transition: border 0.1s ease;
     position: relative;
+    overflow: hidden;
 
     .common-card-body {
-        overflow: hidden;
         border-radius: 0.5rem;
+    }
+
+    .common-card-action {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 0;
+        border: none;
+        padding: 0;
+        margin: 0;
+        background: transparent;
+        color: transparent;
+        cursor: pointer;
+
+        &:focus-visible {
+            outline: 2px solid var(--pxt-focus-border, Highlight);
+            outline-offset: -2px;
+            border-radius: 0.5rem;
+        }
     }
 }
 
-.common-card[role="button"] {
+.common-card:has(.common-card-action) {
     cursor: pointer;
 
     &:hover {

--- a/react-common/styles/controls/Card.less
+++ b/react-common/styles/controls/Card.less
@@ -16,7 +16,7 @@
         inset: 0;
         width: 100%;
         height: 100%;
-        z-index: 0;
+        z-index: 1;
         border: none;
         padding: 0;
         margin: 0;

--- a/react-common/styles/extensions/ExtensionCard.less
+++ b/react-common/styles/extensions/ExtensionCard.less
@@ -60,6 +60,8 @@
 
     a.link-button {
         float: right;
+        position: relative;
+        z-index: 1;
     }
 
     .common-extension-card-contents {


### PR DESCRIPTION
When pressing Enter or Space on the "learn more" link of an extension card while running NVDA, the card itself as a button is triggered. This adds the extension to the project and makes it impossible for screen reader users to navigate to the extension documentation.

The theme card has been tweaked slightly in response to the card change to maintain current screen reader behaviour.

This PR restructures the card so that both the button and link can be triggered independently. No changes for mouse users or keyboard users without a screen reader are expected.