### PR TITLE
add velocity editor and asset controls to piano roll

### DIFF
--- a/localtypings/pxtmusic.d.ts
+++ b/localtypings/pxtmusic.d.ts
@@ -45,6 +45,7 @@ declare namespace pxt.assets.music {
         notes: Note[];
         startTick: number;
         endTick: number;
+        velocity?: number;
     }
 
     export interface Note {

--- a/pxtlib/music.ts
+++ b/pxtlib/music.ts
@@ -32,6 +32,7 @@ namespace pxt.assets.music {
      *     5 measures
      *     6 number of tracks
      *     ...tracks
+     *     ...track velocities
      *
      * track(6 + instrument length + note length bytes)
      *     0 id
@@ -83,13 +84,24 @@ namespace pxt.assets.music {
      *          0 = normal
      *          1 = flat
      *          2 = sharp
+     *
+     * track velocity
+     *     0 track id
+     *     1...velocities
+     *
+     * velocty
+     *     1 byte
      */
 
     function encodeSong(song: Song) {
         const encodedTracks = song.tracks
             .filter((track) => track.notes.length > 0)
             .map(encodeTrack);
-        const trackLength = encodedTracks.reduce((d, c) => c.length + d, 0);
+        const encodedTrackVelocities = song.tracks
+            .map(encodeTrackVelocity)
+            .filter((v): v is Uint8Array => !!v);
+
+        const trackLength = (encodedTracks.concat(encodedTrackVelocities)).reduce((d, c) => c.length + d, 0);
 
         const out = new Uint8Array(7 + trackLength);
         out[0] = 0; // encoding version
@@ -105,6 +117,10 @@ namespace pxt.assets.music {
             current += track.length;
         }
 
+        for (const trackVelocity of encodedTrackVelocities) {
+            out.set(trackVelocity, current);
+            current += trackVelocity.length;
+        }
         return out;
     }
 
@@ -181,6 +197,17 @@ namespace pxt.assets.music {
         return encodeMelodicTrack(track);
     }
 
+    function encodeTrackVelocity(track: Track) {
+        if (!track.notes.some(note => note.velocity !== undefined && note.velocity < 128)) return undefined;
+
+        const out = new Uint8Array(1 + track.notes.length);
+        out[0] = track.id;
+        for (let i = 0; i < track.notes.length; i++) {
+            out[1 + i] = track.notes[i].velocity || 0;
+        }
+        return out;
+    }
+
     function encodeMelodicTrack(track: Track) {
         const encodedInstrument = encodeInstrument(track.instrument);
         const encodedNotes = track.notes.map(note => encodeNoteEvent(note, track.instrument.octave, false));
@@ -248,12 +275,17 @@ namespace pxt.assets.music {
             tracks: []
         };
 
+        const numTracks = buf[6];
         let current = 7;
 
-        while (current < buf.length) {
+        for (let i = 0; i < numTracks; i++) {
             const [track, pointer] = decodeTrack(buf, current);
             current = pointer;
             res.tracks.push(track);
+        }
+
+        while (current < buf.length) {
+            current = decodeTrackVelocity(buf, res.tracks, current);
         }
 
         return res;
@@ -294,6 +326,16 @@ namespace pxt.assets.music {
         }
 
         return decodeMelodicTrack(buf, offset);
+    }
+
+    function decodeTrackVelocity(buf: Uint8Array, tracks: Track[], offset: number): number {
+        const trackId = buf[offset];
+        const track = tracks.find(t => t.id === trackId);
+        if (!track) throw new Error(`Track with id ${trackId} not found`);
+        for (let i = 0; i < track.notes.length; i++) {
+            track.notes[i].velocity = buf[offset + i + 1];
+        }
+        return offset + track.notes.length + 1;
     }
 
     function decodeDrumInstrument(buf: Uint8Array, offset: number): DrumInstrument {

--- a/pxtsim/sound/sequencer.ts
+++ b/pxtsim/sound/sequencer.ts
@@ -160,17 +160,17 @@ namespace pxsim.music {
             this.spatialAudioPlayer = player;
         }
 
-        protected getMelodicTrackVolume(trackIndex: number) {
+        protected getMelodicTrackVolume(trackIndex: number, velocity: number) {
             let trackVolume = 1024;
             if (trackIndex < this.trackVolumes.length) {
                 trackVolume = this.trackVolumes[trackIndex];
             }
 
-            return this.globalVolume * (trackVolume / 1024);
+            return this.globalVolume * (trackVolume / 1024) * (velocity / 128);
         }
 
-        protected getDrumTrackVolume(trackIndex: number, drumIndex: number) {
-            const trackVolume = this.getMelodicTrackVolume(trackIndex);
+        protected getDrumTrackVolume(trackIndex: number, drumIndex: number, velocity: number) {
+            const trackVolume = this.getMelodicTrackVolume(trackIndex, velocity);
             let drumVolume = 1024;
 
             if (trackIndex < this.drumTrackVolumes.length && drumIndex < this.drumTrackVolumes[trackIndex].length) {
@@ -200,12 +200,14 @@ namespace pxsim.music {
                 for (const noteEvent of track.notes) {
                     if (noteEvent.startTick === this._currentTick) {
                         for (const note of noteEvent.notes) {
+                            const velocity = noteEvent.velocity ?? 128;
+
                             if (this.spatialAudioPlayer) {
                                 if (track.drums) {
                                     playDrumAtSpatialAudioPlayerAsync(
                                         this.spatialAudioPlayer,
                                         track.drums[note.note],
-                                        this.getDrumTrackVolume(i, note.note)
+                                        this.getDrumTrackVolume(i, note.note, velocity)
                                     );
                                 }
                                 else {
@@ -214,16 +216,16 @@ namespace pxsim.music {
                                         note.note,
                                         track.instrument,
                                         tickToMs(this.currentlyPlaying.beatsPerMinute, this.currentlyPlaying.ticksPerBeat, noteEvent.endTick - noteEvent.startTick),
-                                        this.getMelodicTrackVolume(i)
+                                        this.getMelodicTrackVolume(i, velocity)
                                     );
                                 }
                             }
                             else {
                                 if (track.drums) {
-                                    playDrumAsync(track.drums[note.note], () => currentToken.cancelled, this.getDrumTrackVolume(i, note.note));
+                                    playDrumAsync(track.drums[note.note], () => currentToken.cancelled, this.getDrumTrackVolume(i, note.note, velocity));
                                 }
                                 else {
-                                    playNoteAsync(note.note, track.instrument, tickToMs(this.currentlyPlaying.beatsPerMinute, this.currentlyPlaying.ticksPerBeat, noteEvent.endTick - noteEvent.startTick), () => currentToken.cancelled, this.getMelodicTrackVolume(i));
+                                    playNoteAsync(note.note, track.instrument, tickToMs(this.currentlyPlaying.beatsPerMinute, this.currentlyPlaying.ticksPerBeat, noteEvent.endTick - noteEvent.startTick), () => currentToken.cancelled, this.getMelodicTrackVolume(i, velocity));
                                 }
                             }
                         }

--- a/pxtsim/sound/song.ts
+++ b/pxtsim/sound/song.ts
@@ -272,12 +272,17 @@ namespace pxsim.music {
             tracks: []
         };
 
+        const numTracks = buf[6];
         let current = 7;
 
-        while (current < buf.length) {
+        for (let i = 0; i < numTracks; i++) {
             const [track, pointer] = decodeTrack(buf, current);
             current = pointer;
             res.tracks.push(track);
+        }
+
+        while (current < buf.length) {
+            current = decodeTrackVelocity(buf, res.tracks, current);
         }
 
         return res;
@@ -318,6 +323,17 @@ namespace pxsim.music {
         }
 
         return decodeMelodicTrack(buf, offset);
+    }
+
+    function decodeTrackVelocity(buf: Uint8Array, tracks: pxt.assets.music.Track[], offset: number): number {
+        const trackId = buf[offset];
+        const track = tracks.find(t => t.id === trackId);
+        if (!track) return buf.length;
+
+        for (let i = 0; i < track.notes.length; i++) {
+            track.notes[i].velocity = buf[offset + i + 1];
+        }
+        return offset + track.notes.length + 1;
     }
 
     function decodeDrumInstrument(buf: Uint8Array, offset: number): pxt.assets.music.DrumInstrument {

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -1,9 +1,9 @@
 .piano-roll-root {
     --key-border: 1px solid black;
 
-    --note-event-color: #a3f0c5;
-    --note-event-border: 2px solid #21905c;
-    --note-event-text-color: #21905c;
+    --note-event-color: #03adfc;
+    --note-event-border: 2px solid darken(#03adfc, 20%);
+    --note-event-text-color: darken(#03adfc, 30%);
 
     --note-event-text-color-hover: #ffffff;
     --note-event-border-hover: 2px solid #ffffff;
@@ -14,9 +14,9 @@
     --black-key-color: black;
     --key-text-color: black;
 
-    --workspace-white-key-color: #36535f;
-    --workspace-black-key-color: #2e4c58;
-    --workspace-grid-line-color: #1e343d;
+    --workspace-white-key-color: #405470;
+    --workspace-black-key-color: #36475f;
+    --workspace-grid-line-color: #283547;
 
     --measure-header-text-color: white;
 
@@ -223,9 +223,11 @@
     cursor: pointer;
 }
 
-.piano-roll .workspace .note-event:hover {
-    border: var(--note-event-border-hover);
-    color: var(--note-event-text-color-hover);
+.piano-roll .workspace {
+    .note-event:hover, .note-event.highlighted {
+        border: var(--note-event-border-hover);
+        color: var(--note-event-text-color-hover);
+    }
 }
 
 .piano-roll .scroll-container {
@@ -277,6 +279,7 @@
         height: var(--velocity-editor-height);
         width: var(--grid-cell-width);
         position: absolute;
+        cursor: grab;
 
         .velocity-slider-inner {
             position: relative;
@@ -306,7 +309,7 @@
             background-color: var(--note-event-color);
         }
 
-        &:focus-within {
+        &:focus-within, &:hover, &.highlighted {
             .velocity-slider-view {
                 border: var(--note-event-border-hover);
             }

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -5,6 +5,11 @@
     --note-event-border: 2px solid #21905c;
     --note-event-text-color: #21905c;
 
+    --note-event-text-color-hover: #ffffff;
+    --note-event-border-hover: 2px solid #ffffff;
+
+    --header-text-color: black;
+
     --white-key-color: white;
     --black-key-color: black;
     --key-text-color: black;
@@ -12,6 +17,12 @@
     --workspace-white-key-color: #36535f;
     --workspace-black-key-color: #2e4c58;
     --workspace-grid-line-color: #1e343d;
+
+    --measure-header-text-color: white;
+
+    --playhead-color: #ff0000;
+
+    --velocity-slider-color: var(--note-event-color);
 
     --header-background: #f0f0f0;
 }
@@ -30,9 +41,12 @@
 
     --header-height: 2.5rem;
     --timeline-height: 1.5rem;
+    --velocity-editor-height: 130px;
 
     max-height: 100%;
     height: 100%;
+    overflow-x: hidden;
+    overflow-y: hidden;
 }
 
 .piano-roll-root {
@@ -46,7 +60,8 @@
     flex-shrink: 0;
 }
 
-.piano-roll .header, .piano-roll .footer {
+.piano-roll .header,
+.piano-roll .footer {
     height: var(--header-height);
     display: flex;
     flex-direction: row;
@@ -57,6 +72,7 @@
 
 .piano-roll .footer {
     flex-shrink: 0;
+    color: var(--header-text-color);
 
     .music-playback-controls {
         .common-button {
@@ -64,7 +80,7 @@
         }
 
         .music-undo-redo .common-button {
-            color: black;
+            color: var(--header-text-color);
             background: none;
             border: none;
 
@@ -75,13 +91,18 @@
     }
 }
 
-.piano-roll .header .octave-controls {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+.piano-roll .header {
+    user-select: none;
+    color: var(--header-text-color);
 
-    & > .common-input-wrapper > .common-input-group {
-        max-width: 2rem;
+    .octave-controls {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        &>.common-input-wrapper>.common-input-group {
+            max-width: 2rem;
+        }
     }
 }
 
@@ -97,7 +118,7 @@
     max-width: 100%;
 
     background: var(--workspace-grid-line-color);
-    color: white;
+    color: var(--measure-header-text-color);
 
     &.hidden {
         display: none;
@@ -134,7 +155,8 @@
         align-items: flex-end;
         justify-content: flex-end;
 
-        &.active, &.playing {
+        &.active,
+        &.playing {
             background-color: var(--note-event-color);
         }
     }
@@ -148,7 +170,8 @@
         position: absolute;
         margin-top: calc(var(--black-key-height) * -0.5);
 
-        &.active, &.playing {
+        &.active,
+        &.playing {
             background-color: var(--note-event-color);
         }
     }
@@ -164,7 +187,8 @@
         background-color: var(--white-key-color);
         color: var(--key-text-color);
 
-        &.active, &.playing {
+        &.active,
+        &.playing {
             background-color: var(--note-event-color);
         }
     }
@@ -200,8 +224,8 @@
 }
 
 .piano-roll .workspace .note-event:hover {
-    border-color: white;
-    color: white;
+    border: var(--note-event-border-hover);
+    color: var(--note-event-text-color-hover);
 }
 
 .piano-roll .scroll-container {
@@ -217,5 +241,75 @@
     left: 0;
     width: 2px;
     height: 100%;
-    background-color: red;
+    background-color: var(--playhead-color);
+}
+
+.velocity-editor {
+    position: relative;
+    display: flex;
+
+    width: 100%;
+    height: var(--velocity-editor-height);
+    background-color: var(--workspace-grid-line-color);
+    flex-shrink: 0;
+    border-top: var(--note-event-border-hover);
+    overflow-x: hidden;
+    overflow-y: hidden;
+
+    .velocity-editor-sidebar {
+        position: sticky;
+        left: 0;
+        top: 0;
+        width: var(--sidebar-width);
+        height: var(--velocity-editor-height);
+        background-color: var(--workspace-grid-line-color);
+        flex-shrink: 0;
+        z-index: 1;
+    }
+
+    .velocity-sliders {
+        height: var(--velocity-editor-height);
+        position: relative;
+        flex-shrink: 0;
+    }
+
+    .velocity-slider {
+        height: var(--velocity-editor-height);
+        width: var(--grid-cell-width);
+        position: absolute;
+
+        .velocity-slider-inner {
+            position: relative;
+            height: var(--velocity-editor-height);
+            width: var(--grid-cell-width);
+        }
+
+        input[type="range"] {
+            position: absolute;
+            left: 0;
+            top: 0;
+
+            writing-mode: vertical-rl;
+            direction: rtl;
+            height: 100%;
+            width: 100%;
+            opacity: 0;
+        }
+
+        .velocity-slider-view {
+            position: absolute;
+            left: 0;
+            bottom: 0;
+
+            width: 100%;
+            border: var(--note-event-border);
+            background-color: var(--note-event-color);
+        }
+
+        &:focus-within {
+            .velocity-slider-view {
+                border: var(--note-event-border-hover);
+            }
+        }
+    }
 }

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -68,6 +68,8 @@
     gap: 0.5rem;
     background-color: var(--header-background);
     align-items: center;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
 }
 
 .piano-roll .footer {
@@ -75,6 +77,7 @@
     color: var(--header-text-color);
 
     .music-playback-controls {
+        padding: 0;
         .common-button {
             height: calc(var(--header-height) - 0.3rem)
         }

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -1,3 +1,21 @@
+.piano-roll-root {
+    --key-border: 1px solid black;
+
+    --note-event-color: #a3f0c5;
+    --note-event-border: 2px solid #21905c;
+    --note-event-text-color: #21905c;
+
+    --white-key-color: white;
+    --black-key-color: black;
+    --key-text-color: black;
+
+    --workspace-white-key-color: #36535f;
+    --workspace-black-key-color: #2e4c58;
+    --workspace-grid-line-color: #1e343d;
+
+    --header-background: #f0f0f0;
+}
+
 .piano-roll {
     display: flex;
     flex-direction: column;
@@ -10,19 +28,8 @@
     --grid-cell-height: calc(var(--octave-height) / 12);
     --grid-cell-width: calc(var(--octave-width) / 16);
 
-    --key-border: 1px solid black;
-
-    --note-event-color: #a3f0c5;
-    --note-event-border: 2px solid #21905c;
-    --note-event-text-color: #21905c;
-
-    --white-key-color: white;
-    --black-key-color: black;
-    --key-text-color: black;
-
-    --header-background: #f0f0f0;
-
     --header-height: 2.5rem;
+    --timeline-height: 1.5rem;
 
     max-height: 100%;
     height: 100%;
@@ -31,7 +38,7 @@
 .piano-roll-root {
     height: 100%;
     overflow-y: hidden;
-    background: var(--pxt-neutral-background1)
+    background: var(--workspace-grid-line-color)
 }
 
 .piano-roll .header-container {
@@ -75,6 +82,32 @@
 
     & > .common-input-wrapper > .common-input-group {
         max-width: 2rem;
+    }
+}
+
+.measure-header {
+    height: var(--timeline-height);
+    display: flex;
+    flex-direction: row;
+    margin-left: var(--sidebar-width);
+    height: var(--timeline-height);
+    overflow-x: hidden;
+    overflow-y: hidden;
+    flex-shrink: 0;
+    max-width: 100%;
+
+    background: var(--workspace-grid-line-color);
+    color: white;
+
+    &.hidden {
+        display: none;
+    }
+
+    .measure {
+        width: var(--octave-width);
+        flex-shrink: 0;
+        padding-left: 0.25rem;
+        user-select: none;
     }
 }
 
@@ -140,6 +173,7 @@
 .piano-roll .workspace-container {
     flex: 1;
     overflow-x: hidden;
+    overflow-y: hidden;
 }
 
 .piano-roll .workspace {

--- a/webapp/src/assetEditor.tsx
+++ b/webapp/src/assetEditor.tsx
@@ -164,10 +164,11 @@ export class AssetEditor extends React.Component<{}, AssetEditorState> {
 
     render() {
         if (this.state.editing) {
+            const editorType = this.state.editing.type === "song" ? "music" : "image";
             return <ImageFieldEditor
                 ref={this.refHandler}
                 singleFrame={this.state.editing.type !== "animation"}
-                isMusicEditor={this.state.editing.type === "song"}
+                editorType={editorType}
                 doneButtonCallback={this.sendSaveRequest}
                 hideDoneButton={true}
                 includeSpecialTagsInFilter={true}

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -242,14 +242,14 @@ export function init() {
 
         switch (fieldEditorId) {
             case "image-editor":
-                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} />);
+                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} editorType="image" />);
                 break;
             case "animation-editor":
-                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={false} />);
+                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={false} editorType="image"  />);
                 break;
 
             case "tilemap-editor":
-                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} />);
+                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} editorType="image"  />);
                 break;
             case "soundeffect-editor":
                 current.injectElement(
@@ -265,13 +265,13 @@ export function init() {
                 )
                 break;
             case "music-editor":
-                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} isMusicEditor={true} />);
+                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} editorType="music" />);
                 break;
             case "file-picker":
                 current.injectElement(<AssetFilePicker ref={ refHandler } />);
                 break;
             case "piano-roll-editor":
-                current.injectElement(<PianoRollFieldEditor handleRef={ refHandler } />);
+                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} editorType="piano-roll" />);
                 break;
 
         }

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -6,7 +6,7 @@ import * as ReactDOM from "react-dom";
 import { ImageFieldEditor } from "./components/ImageFieldEditor";
 import { SoundEffectEditor } from "./components/soundEffectEditor/SoundEffectEditor";
 import { AssetFilePicker } from "./components/AssetFilePicker";
-import { PianoRollFieldEditor } from "./components/pianoRoll/fieldEditor";
+import { PianoRollFieldEditor } from "./components/pianoRoll/FieldEditor";
 
 export interface EditorBounds {
     top: number;

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -12,10 +12,11 @@ import { EditorToggle } from "../../../react-common/components/controls/EditorTo
 import { MusicFieldEditor } from "./MusicFieldEditor";
 import { classList } from "../../../react-common/components/util";
 import { FocusTrap, FocusTrapRegion } from "../../../react-common/components/controls/FocusTrap";
+import { PianoRollAssetEditor } from "./PianoRollFieldEditor";
 
 export interface ImageFieldEditorProps {
     singleFrame: boolean;
-    isMusicEditor?: boolean;
+    editorType: "image" | "music" | "piano-roll";
     doneButtonCallback?: () => void;
     hideDoneButton?: boolean;
     includeSpecialTagsInFilter?: boolean;
@@ -80,7 +81,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
 
         let showHeader = headerVisible;
         // If there is no asset, show the gallery to prevent changing shape when it's added
-        let showGallery = !this.props.isMusicEditor || !this.asset || editingTile;
+        let showGallery = !this.isSongEditor() || !this.asset || editingTile;
         const showMyAssets = !hideMyAssets && !editingTile;
 
         if (this.asset && !this.galleryAssets && showGallery) {
@@ -142,7 +143,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
         }
 
         return (
-            <FocusTrap onEscape={this.onDoneClick} className={classList("image-editor-wrapper", this.props.isMusicEditor && "music-asset-editor")}>
+            <FocusTrap onEscape={this.onDoneClick} className={classList("image-editor-wrapper", this.isSongEditor() && "music-asset-editor")}>
                 {showHeader && <div className="gallery-editor-header">
                     <div className="image-editor-header-left" />
                     <div className="image-editor-header-center">
@@ -172,8 +173,13 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                             className="image-editor-region"
                             enabled={currentView === "editor"}
                         >
-                            {this.props.isMusicEditor ?
+                            {this.props.editorType === "music" ?
                                 <MusicFieldEditor
+                                    ref="image-editor"
+                                    onDoneClicked={this.onDoneClick}
+                                    hideDoneButton={this.props.hideDoneButton} /> :
+                            (this.props.editorType === "piano-roll" ?
+                                <PianoRollAssetEditor
                                     ref="image-editor"
                                     onDoneClicked={this.onDoneClick}
                                     hideDoneButton={this.props.hideDoneButton} /> :
@@ -186,7 +192,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                                     hideDoneButton={this.props.hideDoneButton}
                                     hideAssetName={!pxt.appTarget?.appTheme?.assetEditor}
                                 />
-                            }
+                            )}
                         </FocusTrapRegion>
                         <ImageEditorGallery
                             items={filteredAssets}
@@ -650,6 +656,10 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                 this.imageEditorRegion.focus();
             }
         })
+    }
+
+    protected isSongEditor(): boolean {
+        return this.props.editorType === "music" || this.props.editorType === "piano-roll";
     }
 }
 

--- a/webapp/src/components/PianoRollFieldEditor.tsx
+++ b/webapp/src/components/PianoRollFieldEditor.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+
+import { FieldEditorComponent } from '../blocklyFieldView';
+import { AssetEditorCore } from "./ImageFieldEditor";
+import { PianoRollFieldEditor } from "./pianoRoll/FieldEditor";
+
+interface PianoRollAssetEditorProps {
+    onDoneClicked: () => void;
+    hideDoneButton?: boolean;
+}
+
+export class PianoRollAssetEditor extends React.Component<PianoRollAssetEditorProps, {}> implements AssetEditorCore {
+    protected pianoRollFieldEditorRef: FieldEditorComponent<any>;
+    protected openedAsset: pxt.Song;
+
+    constructor(props: PianoRollAssetEditorProps) {
+        super(props);
+        this.state = {
+            editRef: 0
+        }
+    }
+
+    render() {
+        return (
+            <PianoRollFieldEditor
+                handleRef={this.handlePianoFieldEditorRef}
+            />
+        )
+    }
+
+    getAsset(): pxt.Song {
+        return this.pianoRollFieldEditorRef?.getValue();
+    }
+
+    openAsset(value: pxt.Song) {
+        if (this.pianoRollFieldEditorRef) {
+            this.pianoRollFieldEditorRef.init(value, this.props.onDoneClicked);
+        }
+        else {
+            this.openedAsset = value;
+        }
+    }
+
+    openGalleryAsset(asset: pxt.Asset): void {
+        // TODO
+    }
+
+    getJres(): string {
+        return "";
+    }
+
+    loadJres(value: string): void {
+
+    }
+
+    disableResize(): void {
+
+    }
+
+    onResize(): void {
+
+    }
+
+    getPersistentData(): any {
+        return this.pianoRollFieldEditorRef?.getPersistentData();
+    }
+
+    restorePersistentData(value: any): void {
+        this.pianoRollFieldEditorRef?.restorePersistentData(value);
+    }
+
+    protected handlePianoFieldEditorRef = (ref: FieldEditorComponent<any>) => {
+        this.pianoRollFieldEditorRef = ref;
+        if (this.openedAsset) {
+            this.pianoRollFieldEditorRef?.init(this.openedAsset, this.props.onDoneClicked);
+            this.openedAsset = undefined;
+        }
+    }
+}

--- a/webapp/src/components/pianoRoll/FieldEditor.tsx
+++ b/webapp/src/components/pianoRoll/FieldEditor.tsx
@@ -12,6 +12,8 @@ export const PianoRollFieldEditor = (props: Props) => {
     const [asset, setAsset] = useState<pxt.Song>();
     const [undoStack, setUndoStack] = useState<PianoRollState["undoStack"]>([]);
     const [redoStack, setRedoStack] = useState<PianoRollState["redoStack"]>([]);
+    const [velocityEditorVisible, setVelocityEditorVisible] = useState<PianoRollState["velocityEditorVisible"]>(undefined);
+    const [selectedTrack, setSelectedTrack] = useState<PianoRollState["selectedTrack"]>(undefined);
 
     const resultRef = useRef<PianoRollState>();
 
@@ -30,13 +32,17 @@ export const PianoRollFieldEditor = (props: Props) => {
                 getPersistentData: () => {
                     return {
                         undoStack: resultRef.current?.undoStack,
-                        redoStack: resultRef.current?.redoStack
+                        redoStack: resultRef.current?.redoStack,
+                        velocityEditorVisible: resultRef.current?.velocityEditorVisible,
+                        selectedTrack: resultRef.current?.selectedTrack
                     }
                 },
                 restorePersistentData: (value: any) => {
                     if (value) {
                         setUndoStack(value.undoStack || []);
                         setRedoStack(value.redoStack || []);
+                        setVelocityEditorVisible(value.velocityEditorVisible);
+                        setSelectedTrack(value.selectedTrack);
                     }
                 }
             })
@@ -53,6 +59,8 @@ export const PianoRollFieldEditor = (props: Props) => {
             undoStack={undoStack}
             redoStack={redoStack}
             onStateChanged={onStateChange}
+            selectedTrack={selectedTrack}
+            velocityEditorVisible={velocityEditorVisible}
         />
     )
 }

--- a/webapp/src/components/pianoRoll/FieldEditor.tsx
+++ b/webapp/src/components/pianoRoll/FieldEditor.tsx
@@ -19,10 +19,8 @@ export const PianoRollFieldEditor = (props: Props) => {
 
     useEffect(() => {
         if (handleRef) {
-            let asset: pxt.Song | undefined;
             handleRef({
                 init: (value: pxt.Song, close: () => void) => {
-                    asset = value;
                     setAsset(value);
                 },
                 getValue: () => ({
@@ -47,7 +45,7 @@ export const PianoRollFieldEditor = (props: Props) => {
                 }
             })
         }
-    }, [handleRef])
+    }, [handleRef, asset])
 
     const onStateChange = useCallback((state: PianoRollState) => {
         resultRef.current = state;

--- a/webapp/src/components/pianoRoll/FieldEditor.tsx
+++ b/webapp/src/components/pianoRoll/FieldEditor.tsx
@@ -6,10 +6,15 @@ interface Props {
     handleRef: (e: FieldEditorComponent<any>) => void;
 }
 
+interface DoneCallback {
+    onDoneClicked: () => void;
+}
+
 export const PianoRollFieldEditor = (props: Props) => {
     const { handleRef } = props;
 
     const [asset, setAsset] = useState<pxt.Song>();
+    const [onDoneClicked, setOnDoneClicked] = useState<DoneCallback>(undefined);
     const [undoStack, setUndoStack] = useState<PianoRollState["undoStack"]>([]);
     const [redoStack, setRedoStack] = useState<PianoRollState["redoStack"]>([]);
     const [velocityEditorVisible, setVelocityEditorVisible] = useState<PianoRollState["velocityEditorVisible"]>(undefined);
@@ -22,11 +27,23 @@ export const PianoRollFieldEditor = (props: Props) => {
             handleRef({
                 init: (value: pxt.Song, close: () => void) => {
                     setAsset(value);
+                    setOnDoneClicked({ onDoneClicked: close });
                 },
-                getValue: () => ({
-                    ...asset,
-                    song: resultRef.current.asset
-                }),
+                getValue: () => {
+                    const result = {
+                        ...asset,
+                        song: resultRef.current?.asset
+                    };
+
+                    if (resultRef.current?.name) {
+                        result.meta = {
+                            ...(asset.meta || result.meta || {}),
+                            displayName: resultRef.current.name
+                        }
+                    }
+
+                    return result;
+                },
                 getPersistentData: () => {
                     return {
                         undoStack: resultRef.current?.undoStack,
@@ -59,6 +76,9 @@ export const PianoRollFieldEditor = (props: Props) => {
             onStateChanged={onStateChange}
             selectedTrack={selectedTrack}
             velocityEditorVisible={velocityEditorVisible}
+            showEditControls={true}
+            onDoneClicked={onDoneClicked?.onDoneClicked}
+            name={asset?.meta?.displayName}
         />
     )
 }

--- a/webapp/src/components/pianoRoll/Header.tsx
+++ b/webapp/src/components/pianoRoll/Header.tsx
@@ -1,19 +1,22 @@
+import { Checkbox } from "../../../../react-common/components/controls/Checkbox";
 import { Dropdown, DropdownItem } from "../../../../react-common/components/controls/Dropdown";
 import { Song, lf, isDrumInstrument, NOTE_RANGES } from "./types";
 
 interface Props {
     song: Song;
     selectedTrack: number;
+    velocityEditorVisible: boolean;
 
     onTrackSelected(trackId: number): void;
     onTrackCreated(): void;
     onTrackDeleted(trackId: number): void;
     onInstrumentSelected(trackId: number, instrumentId: number): void;
     onOctavesChanged(minOctave: number, maxOctave: number): void;
+    onVelocityEditorToggle(): void;
 }
 
 export const Header = (props: Props) => {
-    const { song, selectedTrack, onTrackSelected, onInstrumentSelected, onTrackCreated, onTrackDeleted, onOctavesChanged } = props;
+    const { song, selectedTrack, velocityEditorVisible, onVelocityEditorToggle, onTrackSelected, onInstrumentSelected, onTrackCreated, onTrackDeleted, onOctavesChanged } = props;
 
     const onTrackDropdownChange = (id: string) => {
         if (id === "new-track") {
@@ -118,6 +121,12 @@ export const Header = (props: Props) => {
                     />
                 </div>
             }
+            <Checkbox
+                id="velocity-editor-toggle"
+                label={lf("Show Velocity Editor")}
+                isChecked={velocityEditorVisible}
+                onChange={onVelocityEditorToggle}
+            />
         </div>
     );
 }

--- a/webapp/src/components/pianoRoll/MeasureHeader.tsx
+++ b/webapp/src/components/pianoRoll/MeasureHeader.tsx
@@ -1,0 +1,17 @@
+import { range } from "./utils";
+
+interface Props {
+    measures: number;
+}
+
+export const MeasureHeader = (props: Props) => {
+    const { measures } = props;
+
+    return (
+        <div className="measure-header" id="measure-header">
+            {range(0, measures).map(m =>
+                <div key={m + 1} className="measure">{m + 1}</div>
+            )}
+        </div>
+    );
+}

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -1,7 +1,7 @@
 import { PianoRollThemeProvider, usePianoRollThemeContext } from "./context"
 import { Workspace } from "./Workspace"
 import { Sidebar } from "./Sidebar"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { changeMeasures, changeOctaves, changeTrackInstrument, fromPXTSong, getEmptySong, isDrumInstrument, newTrack, NoteEvent, Song, toPXTSong, Track, updateNoteEvent, updateNoteEvents, updateTrack } from "./types"
 import { Header } from "./Header"
 import { DeleteTrackModal } from "./DeleteTrackModal"
@@ -11,12 +11,15 @@ import { isPlaying, startPlaybackAsync, stopPlayback, updatePlaybackSongAsync } 
 import { PlaybackControls } from "../musicEditor/PlaybackControls"
 import { MeasureHeader } from "./MeasureHeader"
 import { VelocityEditor } from "./VelocityEditor"
+import { fire } from "blockly/core/events/utils"
 
 interface PianoRollProps {
     onStateChanged?: (state: PianoRollState) => void;
     asset?: pxt.assets.music.Song;
     undoStack?: StateSnapshot[];
     redoStack?: StateSnapshot[];
+    selectedTrack?: number;
+    velocityEditorVisible?: boolean;
 }
 
 type modalType = "delete-track" | "delete-error" | "drum-warning";
@@ -39,6 +42,8 @@ export interface PianoRollState {
     undoStack: StateSnapshot[];
     redoStack: StateSnapshot[];
     asset: pxt.assets.music.Song;
+    selectedTrack: number;
+    velocityEditorVisible: boolean;
 }
 
 interface StateSnapshot {
@@ -48,8 +53,17 @@ interface StateSnapshot {
 
 
 const PianoRollInternal = (props: PianoRollProps) => {
-    const { onStateChanged, asset, undoStack: initialUndoStack, redoStack: initialRedoStack } = props;
+    const {
+        onStateChanged,
+        asset,
+        selectedTrack: initialSelectedTrack,
+        velocityEditorVisible: initialVelocityEditorVisible,
+        undoStack: initialUndoStack,
+        redoStack: initialRedoStack
+    } = props;
     const { state: theme, dispatch: updateTheme, } = usePianoRollThemeContext();
+
+    const lastFiredState = useRef<PianoRollState | null>(null);
 
     const [song, setSong] = useState<Song>(asset ? fromPXTSong(asset) : getEmptySong());
     const [selectedTrack, setSelectedTrack] = useState(song.tracks[0].id);
@@ -58,7 +72,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
     const [undoStack, setUndoStack] = useState<StateSnapshot[]>(initialUndoStack || []);
     const [redoStack, setRedoStack] = useState<StateSnapshot[]>(initialRedoStack || []);
 
-    const [velocityEditorVisible, setVelocityEditorVisible] = useState(false);
+    const [velocityEditorVisible, setVelocityEditorVisible] = useState(initialVelocityEditorVisible || false);
 
     useEffect(() => {
         if (asset) {
@@ -66,12 +80,17 @@ const PianoRollInternal = (props: PianoRollProps) => {
             setSong(song);
             setSelectedTrack(song.tracks[0].id);
             setModal(null);
-            setUndoStack(props.undoStack || []);
-            setRedoStack(props.redoStack || []);
+            setUndoStack(initialUndoStack || []);
+            setRedoStack(initialRedoStack || []);
+            setSelectedTrack(initialSelectedTrack || song.tracks[0].id);
+            setVelocityEditorVisible(initialVelocityEditorVisible || false);
             stopPlayback();
         }
     }, [asset])
 
+    // these props might be passed in after the initial mounting of the component,
+    // so this use effect ensures that we override the internal state whenever
+    // these props change
     useEffect(() => {
         if (initialUndoStack) {
             setUndoStack(initialUndoStack);
@@ -79,15 +98,32 @@ const PianoRollInternal = (props: PianoRollProps) => {
         if (initialRedoStack) {
             setRedoStack(initialRedoStack);
         }
-    }, [initialUndoStack, initialRedoStack]);
+        if (initialSelectedTrack !== undefined) {
+            setSelectedTrack(initialSelectedTrack);
+        }
+        if (initialVelocityEditorVisible !== undefined) {
+            setVelocityEditorVisible(initialVelocityEditorVisible);
+        }
+    }, [initialUndoStack, initialRedoStack, initialSelectedTrack, initialVelocityEditorVisible]);
 
-    const fireStateChange = (song: Song, undoStack: StateSnapshot[], redoStack: StateSnapshot[]) => {
+    const fireStateChange = (newState: Partial<PianoRollState>) => {
         if (onStateChanged) {
-            onStateChanged({
-                asset: toPXTSong(song),
-                undoStack,
-                redoStack
-            })
+            if (!lastFiredState.current) {
+                lastFiredState.current = {
+                    asset: toPXTSong(song),
+                    undoStack,
+                    redoStack,
+                    selectedTrack,
+                    velocityEditorVisible
+                };
+            }
+            const stateToFire = {
+                ...lastFiredState.current,
+                ...newState
+            };
+
+            onStateChanged(stateToFire);
+            lastFiredState.current = stateToFire;
         }
     }
 
@@ -96,7 +132,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
         setRedoStack([])
 
         setSong(newSong);
-        fireStateChange(newSong, [...undoStack, { song, selectedTrack }], [])
+        fireStateChange({ asset: toPXTSong(newSong), undoStack: [...undoStack, { song, selectedTrack }], redoStack: [] })
 
         if (isPlaying()) {
             updatePlaybackSongAsync(toPXTSong(newSong));
@@ -109,13 +145,16 @@ const PianoRollInternal = (props: PianoRollProps) => {
 
     const onTrackSelected = (trackId: number) => {
         setSelectedTrack(trackId);
+        fireStateChange({ selectedTrack: trackId });
     }
 
     const onTrackCreated = () => {
         const newSong = newTrack(song.instruments[0].id, song);
         updateSong(newSong);
 
-        setSelectedTrack(newSong.tracks[newSong.tracks.length - 1].id);
+        const newTrackId = newSong.tracks[newSong.tracks.length - 1].id;
+        setSelectedTrack(newTrackId);
+        fireStateChange({ selectedTrack: newTrackId });
     }
 
     const onTrackDeleted = (trackId: number) => {
@@ -218,6 +257,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
 
     const onVelocityEditorToggle = () => {
         setVelocityEditorVisible(!velocityEditorVisible);
+        fireStateChange({ velocityEditorVisible: !velocityEditorVisible });
     }
 
     const undo = () => {
@@ -232,7 +272,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
         setSong(lastState.song);
         setSelectedTrack(lastState.selectedTrack);
 
-        fireStateChange(lastState.song, [...undoStack], [...redoStack])
+        fireStateChange({ asset: toPXTSong(lastState.song), undoStack: [...undoStack], redoStack: [...redoStack] });
 
         if (lastState.song.measures !== song.measures) {
             updateTheme({ measures: lastState.song.measures });
@@ -255,7 +295,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
         setSong(nextState.song);
         setSelectedTrack(nextState.selectedTrack);
 
-        fireStateChange(nextState.song, [...undoStack], [...redoStack])
+        fireStateChange({ asset: toPXTSong(nextState.song), undoStack: [...undoStack], redoStack: [...redoStack] });
 
         if (nextState.song.measures !== song.measures) {
             updateTheme({ measures: nextState.song.measures });
@@ -326,7 +366,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     </div>
                 </div>
             </div>
-            { velocityEditorVisible &&
+            {velocityEditorVisible &&
                 <VelocityEditor notes={track.events} onNotesChange={onVelocityChange} />
             }
             <div className="footer">

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -85,8 +85,9 @@ const PianoRollInternal = (props: PianoRollProps) => {
             setSelectedTrack(initialSelectedTrack || song.tracks[0].id);
             setVelocityEditorVisible(initialVelocityEditorVisible || false);
             stopPlayback();
+            fireStateChange({ asset, undoStack: initialUndoStack || [], redoStack: initialRedoStack || [], selectedTrack: initialSelectedTrack || song.tracks[0].id, velocityEditorVisible: initialVelocityEditorVisible || false })
         }
-    }, [asset])
+    }, [asset, onStateChanged])
 
     // these props might be passed in after the initial mounting of the component,
     // so this use effect ensures that we override the internal state whenever
@@ -105,6 +106,12 @@ const PianoRollInternal = (props: PianoRollProps) => {
             setVelocityEditorVisible(initialVelocityEditorVisible);
         }
     }, [initialUndoStack, initialRedoStack, initialSelectedTrack, initialVelocityEditorVisible]);
+
+    useEffect(() => {
+        if (onStateChanged) {
+            fireStateChange({});
+        }
+    }, [onStateChanged])
 
     const fireStateChange = (newState: Partial<PianoRollState>) => {
         if (onStateChanged) {

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -2,7 +2,7 @@ import { PianoRollThemeProvider, usePianoRollThemeContext } from "./context"
 import { Workspace } from "./Workspace"
 import { Sidebar } from "./Sidebar"
 import { useEffect, useState } from "react"
-import { changeMeasures, changeOctaves, changeTrackInstrument, fromPXTSong, getEmptySong, isDrumInstrument, newTrack, Song, toPXTSong, Track, updateTrack } from "./types"
+import { changeMeasures, changeOctaves, changeTrackInstrument, fromPXTSong, getEmptySong, isDrumInstrument, newTrack, NoteEvent, Song, toPXTSong, Track, updateNoteEvent, updateNoteEvents, updateTrack } from "./types"
 import { Header } from "./Header"
 import { DeleteTrackModal } from "./DeleteTrackModal"
 import { DeleteErrorModal } from "./DeleteErrorModal"
@@ -10,6 +10,7 @@ import { DrumWarningModal } from "./DrumWarningModal"
 import { isPlaying, startPlaybackAsync, stopPlayback, updatePlaybackSongAsync } from "../musicEditor/playback"
 import { PlaybackControls } from "../musicEditor/PlaybackControls"
 import { MeasureHeader } from "./MeasureHeader"
+import { VelocityEditor } from "./VelocityEditor"
 
 interface PianoRollProps {
     onStateChanged?: (state: PianoRollState) => void;
@@ -56,6 +57,8 @@ const PianoRollInternal = (props: PianoRollProps) => {
 
     const [undoStack, setUndoStack] = useState<StateSnapshot[]>(initialUndoStack || []);
     const [redoStack, setRedoStack] = useState<StateSnapshot[]>(initialRedoStack || []);
+
+    const [velocityEditorVisible, setVelocityEditorVisible] = useState(false);
 
     useEffect(() => {
         if (asset) {
@@ -209,6 +212,14 @@ const PianoRollInternal = (props: PianoRollProps) => {
         updateSong(changeOctaves(selectedTrack, minOctave, maxOctave, song));
     }
 
+    const onVelocityChange = (notes: NoteEvent[]) => {
+        updateSong(updateNoteEvents(song, selectedTrack, notes));
+    }
+
+    const onVelocityEditorToggle = () => {
+        setVelocityEditorVisible(!velocityEditorVisible);
+    }
+
     const undo = () => {
         if (!undoStack.length) return;
 
@@ -284,6 +295,8 @@ const PianoRollInternal = (props: PianoRollProps) => {
                 <Header
                     song={song}
                     selectedTrack={selectedTrack}
+                    velocityEditorVisible={velocityEditorVisible}
+                    onVelocityEditorToggle={onVelocityEditorToggle}
                     onTrackSelected={onTrackSelected}
                     onInstrumentSelected={onInstrumentSelected}
                     onTrackCreated={onTrackCreated}
@@ -313,6 +326,9 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     </div>
                 </div>
             </div>
+            { velocityEditorVisible &&
+                <VelocityEditor notes={track.events} onNotesChange={onVelocityChange} />
+            }
             <div className="footer">
                 <PlaybackControls
                     beatsPerMinute={song.tempo}

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -9,6 +9,7 @@ import { DeleteErrorModal } from "./DeleteErrorModal"
 import { DrumWarningModal } from "./DrumWarningModal"
 import { isPlaying, startPlaybackAsync, stopPlayback, updatePlaybackSongAsync } from "../musicEditor/playback"
 import { PlaybackControls } from "../musicEditor/PlaybackControls"
+import { MeasureHeader } from "./MeasureHeader"
 
 interface PianoRollProps {
     onStateChanged?: (state: PianoRollState) => void;
@@ -20,6 +21,12 @@ interface PianoRollProps {
 type modalType = "delete-track" | "delete-error" | "drum-warning";
 
 export const PianoRoll = (props: PianoRollProps) => {
+    useEffect(() => {
+        return () => {
+            stopPlayback();
+        }
+    }, [])
+
     return (
         <PianoRollThemeProvider>
             <PianoRollInternal {...props} />
@@ -284,6 +291,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     onOctavesChanged={onOctavesChanged}
                 />
             </div>
+            <MeasureHeader measures={song.measures} />
             <div className="scroll-container">
                 <div className="content-container">
                     <div className="sidebar-container">

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -11,7 +11,7 @@ import { isPlaying, startPlaybackAsync, stopPlayback, updatePlaybackSongAsync } 
 import { PlaybackControls } from "../musicEditor/PlaybackControls"
 import { MeasureHeader } from "./MeasureHeader"
 import { VelocityEditor } from "./VelocityEditor"
-import { fire } from "blockly/core/events/utils"
+import { EditControls } from "../musicEditor/EditControls"
 
 interface PianoRollProps {
     onStateChanged?: (state: PianoRollState) => void;
@@ -20,6 +20,9 @@ interface PianoRollProps {
     redoStack?: StateSnapshot[];
     selectedTrack?: number;
     velocityEditorVisible?: boolean;
+    showEditControls?: boolean;
+    name?: string;
+    onDoneClicked?: () => void;
 }
 
 type modalType = "delete-track" | "delete-error" | "drum-warning";
@@ -44,6 +47,7 @@ export interface PianoRollState {
     asset: pxt.assets.music.Song;
     selectedTrack: number;
     velocityEditorVisible: boolean;
+    name?: string;
 }
 
 interface StateSnapshot {
@@ -59,7 +63,10 @@ const PianoRollInternal = (props: PianoRollProps) => {
         selectedTrack: initialSelectedTrack,
         velocityEditorVisible: initialVelocityEditorVisible,
         undoStack: initialUndoStack,
-        redoStack: initialRedoStack
+        redoStack: initialRedoStack,
+        name: initialName,
+        showEditControls,
+        onDoneClicked
     } = props;
     const { state: theme, dispatch: updateTheme, } = usePianoRollThemeContext();
 
@@ -71,6 +78,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
 
     const [undoStack, setUndoStack] = useState<StateSnapshot[]>(initialUndoStack || []);
     const [redoStack, setRedoStack] = useState<StateSnapshot[]>(initialRedoStack || []);
+    const [name, setName] = useState(props.name || undefined);
 
     const [velocityEditorVisible, setVelocityEditorVisible] = useState(initialVelocityEditorVisible || false);
 
@@ -105,7 +113,8 @@ const PianoRollInternal = (props: PianoRollProps) => {
         if (initialVelocityEditorVisible !== undefined) {
             setVelocityEditorVisible(initialVelocityEditorVisible);
         }
-    }, [initialUndoStack, initialRedoStack, initialSelectedTrack, initialVelocityEditorVisible]);
+        setName(initialName);
+    }, [initialUndoStack, initialRedoStack, initialSelectedTrack, initialVelocityEditorVisible, initialName]);
 
     useEffect(() => {
         if (onStateChanged) {
@@ -121,7 +130,8 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     undoStack,
                     redoStack,
                     selectedTrack,
-                    velocityEditorVisible
+                    velocityEditorVisible,
+                    name
                 };
             }
             const stateToFire = {
@@ -313,6 +323,11 @@ const PianoRollInternal = (props: PianoRollProps) => {
         }
     }
 
+    const onNameChange = (newName: string) => {
+        setName(newName);
+        fireStateChange({ name: newName });
+    }
+
     const closeModal = () => setModal(null);
 
     const track = song.tracks.find(t => t.id === selectedTrack)!;
@@ -390,6 +405,15 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     hideBassClefOption={true}
                     singlePlayButton={true}
                 />
+                <div className="spacer" />
+                { showEditControls &&
+                    <EditControls
+                        assetName={name}
+                        onAssetNameChanged={onNameChange}
+                        hideDoneButton={!onDoneClicked}
+                        onDoneClicked={onDoneClicked}
+                    />
+                }
             </div>
         </div>
     )

--- a/webapp/src/components/pianoRoll/VelocityEditor.tsx
+++ b/webapp/src/components/pianoRoll/VelocityEditor.tsx
@@ -1,0 +1,89 @@
+import { usePianoRollTheme } from "./context";
+import { NoteEvent } from "./types";
+import { noteLeft } from "./utils";
+
+interface Props {
+    notes: NoteEvent[];
+    onNotesChange: (note: NoteEvent[]) => void;
+}
+
+interface NoteOffset {
+    events: NoteEvent[];
+    velocity: number;
+    start: number;
+}
+
+export const VelocityEditor = (props: Props) => {
+    const { notes, onNotesChange } = props;
+    const theme = usePianoRollTheme();
+    const { octaveWidth, measures } = theme;
+
+    const width = octaveWidth * measures;
+
+    const offsets: NoteOffset[] = [];
+
+    for (const note of notes) {
+        const offset = offsets.find(o => o.start === note.start);
+        if (offset) {
+            offset.events.push(note);
+        }
+        else {
+            offsets.push({ start: note.start, events: [note], velocity: note.velocity ?? 128 });
+        }
+    }
+
+    return (
+        <div id="velocity-editor" className="velocity-editor">
+            <div className="velocity-editor-sidebar" />
+            <div className="velocity-sliders" style={{ width: `${width}px` }}>
+                {offsets.map((note, i) => (
+                    <VelocitySlider
+                        key={note.start}
+                        velocity={note.velocity}
+                        tick={note.start}
+                        onChange={(velocity) => {
+                            onNotesChange(note.events.map(e => ({ ...e, velocity })));
+                        }}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+interface VelocitySliderProps {
+    velocity: number;
+    tick: number;
+    onChange: (velocity: number) => void;
+}
+
+
+const VelocitySlider = (props: VelocitySliderProps) => {
+    const { velocity, onChange, tick } = props;
+
+    const theme = usePianoRollTheme();
+
+    const description = lf("Change velocity for notes at tick {0}", tick);
+    const fill = (velocity / 128) * 100 + "%";
+
+    return (
+        <div className="velocity-slider" style={{ left: noteLeft(theme, tick) }}>
+            <div className="velocity-slider-inner">
+                <div
+                    className="velocity-slider-view"
+                    style={{ height: fill }}
+                />
+                <input
+                    type="range"
+                    aria-orientation="vertical"
+                    aria-label={description}
+                    min={0}
+                    step={8}
+                    max={128}
+                    value={velocity}
+                    onChange={(e) => onChange(parseInt(e.target.value))}
+                />
+            </div>
+        </div>
+    );
+}

--- a/webapp/src/components/pianoRoll/VelocityEditor.tsx
+++ b/webapp/src/components/pianoRoll/VelocityEditor.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from "react";
+import { classList } from "../../../../react-common/components/util";
 import { usePianoRollTheme } from "./context";
 import { NoteEvent } from "./types";
 import { noteLeft } from "./utils";
@@ -18,6 +20,8 @@ export const VelocityEditor = (props: Props) => {
     const theme = usePianoRollTheme();
     const { octaveWidth, measures } = theme;
 
+    const [highlightedTick, setHighlightedTick] = useState<Number>(undefined);
+
     const width = octaveWidth * measures;
 
     const offsets: NoteOffset[] = [];
@@ -32,17 +36,61 @@ export const VelocityEditor = (props: Props) => {
         }
     }
 
+    const highlightTick = (tick: number) => {
+        if (tick !== highlightedTick) {
+            if (highlightedTick) {
+                const previousEvents = offsets.find(n => n.start === highlightedTick);
+                if (previousEvents) {
+                    for (const note of previousEvents.events) {
+                        const el = document.getElementById(`note-${note.id}`);
+                        if (el) {
+                            el.classList.remove("highlighted");
+                        }
+                    }
+                }
+            }
+            setHighlightedTick(tick);
+            const currentEvents = offsets.find(n => n.start === tick);
+            if (currentEvents) {
+                for (const note of currentEvents.events) {
+                    const el = document.getElementById(`note-${note.id}`);
+                    if (el) {
+                        el.classList.add("highlighted");
+                    }
+                }
+            }
+        }
+    }
+
+    const onHighlightEnd = (tick: number) => {
+        if (highlightedTick === tick) {
+            const currentEvents = offsets.find(n => n.start === tick);
+            if (currentEvents) {
+                for (const note of currentEvents.events) {
+                    const el = document.getElementById(`note-${note.id}`);
+                    if (el) {
+                        el.classList.remove("highlighted");
+                    }
+                }
+            }
+            setHighlightedTick(undefined);
+        }
+    }
+
     return (
         <div id="velocity-editor" className="velocity-editor">
             <div className="velocity-editor-sidebar" />
             <div className="velocity-sliders" style={{ width: `${width}px` }}>
-                {offsets.map((note, i) => (
+                {offsets.map((notes, i) => (
                     <VelocitySlider
-                        key={note.start}
-                        velocity={note.velocity}
-                        tick={note.start}
+                        key={notes.start}
+                        velocity={notes.velocity}
+                        tick={notes.start}
+                        highlighted={highlightedTick === notes.start}
+                        onHighlight={highlightTick}
+                        onHighlightEnd={onHighlightEnd}
                         onChange={(velocity) => {
-                            onNotesChange(note.events.map(e => ({ ...e, velocity })));
+                            onNotesChange(notes.events.map(e => ({ ...e, velocity })));
                         }}
                     />
                 ))}
@@ -54,20 +102,47 @@ export const VelocityEditor = (props: Props) => {
 interface VelocitySliderProps {
     velocity: number;
     tick: number;
+    highlighted: boolean;
     onChange: (velocity: number) => void;
+    onHighlight: (tick: number) => void;
+    onHighlightEnd: (tick: number) => void;
 }
 
 
 const VelocitySlider = (props: VelocitySliderProps) => {
-    const { velocity, onChange, tick } = props;
+    const { velocity, onChange, tick, onHighlight, onHighlightEnd, highlighted } = props;
 
     const theme = usePianoRollTheme();
 
     const description = lf("Change velocity for notes at tick {0}", tick);
     const fill = (velocity / 128) * 100 + "%";
 
+    const sliderRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const onHover = (e: MouseEvent) => {
+            onHighlight(tick);
+        }
+
+        const onHoverEnd = (e: MouseEvent) => {
+            onHighlightEnd(tick);
+        }
+        sliderRef.current?.addEventListener("pointerenter", onHover);
+        sliderRef.current?.addEventListener("pointerleave", onHoverEnd);
+
+        return () => {
+            sliderRef.current?.removeEventListener("pointerenter", onHover);
+            sliderRef.current?.removeEventListener("pointerleave", onHoverEnd);
+        }
+    }, [onHighlight, onHighlightEnd, tick])
+
     return (
-        <div className="velocity-slider" style={{ left: noteLeft(theme, tick) }}>
+        <div
+            id={`velocity-slider-${tick}`}
+            className={classList("velocity-slider", highlighted && "highlighted")}
+            style={{ left: noteLeft(theme, tick) }}
+            ref={sliderRef}
+        >
             <div className="velocity-slider-inner">
                 <div
                     className="velocity-slider-view"

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -38,6 +38,27 @@ export const Workspace = (props: Props) => {
         const horizontalScroller = workspaceRef.current?.parentElement;
         const verticalScroller = horizontalScroller?.parentElement?.parentElement;
         const measureScroller = document.getElementById("measure-header");
+        const velocityEditor = document.getElementById("velocity-editor");
+
+        const changeHorizontalScroll = (delta: number) => {
+            const scroll = gestureState.current.startScrollX - delta;
+            if (horizontalScroller) {
+                horizontalScroller.scrollLeft = scroll;
+            }
+            if (measureScroller) {
+                measureScroller.scrollLeft = scroll;
+            }
+            if (velocityEditor) {
+                velocityEditor.scrollLeft = scroll;
+            }
+        }
+
+        const changeVerticalScroll = (delta: number) => {
+            const scroll = gestureState.current.startScrollY - delta;
+            if (verticalScroller) {
+                verticalScroller.scrollTop = scroll;
+            }
+        }
 
         const clientToNoteCoordinates = (clientX: number, clientY: number) => {
             const bounds = workspaceRef.current?.getBoundingClientRect();
@@ -82,15 +103,8 @@ export const Workspace = (props: Props) => {
 
             if (gestureState.current.isScrolling) {
                 if (!gestureState.current.noteEvent || isDrumTrack) {
-                    if (horizontalScroller) {
-                        horizontalScroller.scrollLeft = gestureState.current.startScrollX - deltaX;
-                    }
-                    if (measureScroller) {
-                        measureScroller.scrollLeft = gestureState.current.startScrollX - deltaX;
-                    }
-                    if (verticalScroller) {
-                        verticalScroller.scrollTop = gestureState.current.startScrollY - deltaY;
-                    }
+                    changeHorizontalScroll(deltaX);
+                    changeVerticalScroll(deltaY);
                 }
                 else {
                     const editing = gestureState.current.noteEvent;

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -3,7 +3,7 @@ import { addPlaybackStateListener, addTickListener, removePlaybackStateListener,
 import { usePianoRollTheme } from "./context";
 import { NoteEventView } from "./NoteEvent"
 import { changeNoteEventDuration, getMaxDuration, newNoteEvent, NoteEvent, Track } from "./types";
-import { noteWidth, workspaceHeight, workspaceWidth, xToTick, yToNote } from "./utils";
+import { noteWidth, range, workspaceHeight, workspaceWidth, xToTick, yToNote } from "./utils";
 import { useWorkspaceBackground } from "./workspaceBackground";
 
 interface Props {
@@ -37,6 +37,7 @@ export const Workspace = (props: Props) => {
     useEffect(() => {
         const horizontalScroller = workspaceRef.current?.parentElement;
         const verticalScroller = horizontalScroller?.parentElement?.parentElement;
+        const measureScroller = document.getElementById("measure-header");
 
         const clientToNoteCoordinates = (clientX: number, clientY: number) => {
             const bounds = workspaceRef.current?.getBoundingClientRect();
@@ -83,6 +84,9 @@ export const Workspace = (props: Props) => {
                 if (!gestureState.current.noteEvent || isDrumTrack) {
                     if (horizontalScroller) {
                         horizontalScroller.scrollLeft = gestureState.current.startScrollX - deltaX;
+                    }
+                    if (measureScroller) {
+                        measureScroller.scrollLeft = gestureState.current.startScrollX - deltaX;
                     }
                     if (verticalScroller) {
                         verticalScroller.scrollTop = gestureState.current.startScrollY - deltaY;

--- a/webapp/src/components/pianoRoll/context.tsx
+++ b/webapp/src/components/pianoRoll/context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useReducer } from "react";
+import { createContext, useContext, useEffect, useReducer, useRef } from "react";
 
 export interface PianoRollTheme {
     octaveWidth: number;
@@ -6,6 +6,9 @@ export interface PianoRollTheme {
     measures: number;
     minOctave: number;
     maxOctave: number;
+    gridLineColor: string;
+    whiteKeyWorkspaceColor: string;
+    blackKeyWorkspaceColor: string;
 }
 
 const defaultTheme: PianoRollTheme = {
@@ -13,7 +16,10 @@ const defaultTheme: PianoRollTheme = {
     whiteKeyHeight: 40,
     measures: 4,
     minOctave: 3,
-    maxOctave: 5
+    maxOctave: 5,
+    gridLineColor: "#283547",
+    whiteKeyWorkspaceColor: "#405470",
+    blackKeyWorkspaceColor: "#36475f"
 };
 
 interface ThemeAndUpdate {
@@ -36,18 +42,34 @@ export function PianoRollThemeProvider(
     const [state, dispatch] = useReducer(reducer, defaultTheme);
 
     const value = { state, dispatch };
+    const rootRef = useRef<HTMLDivElement | null>(null);
 
-    const handleRootRef = (el: HTMLDivElement | null) => {
-        if (el) {
-            el.setAttribute("style", `--octave-width: ${value.state.octaveWidth}px; --white-key-height: ${value.state.whiteKeyHeight}px;`);
+    useEffect(() => {
+        rootRef.current!.setAttribute("style", `--octave-width: ${value.state.octaveWidth}px; --white-key-height: ${value.state.whiteKeyHeight}px;`);
+        const style = getComputedStyle(rootRef.current!);
+
+        const gridLineColor = style.getPropertyValue("--workspace-grid-line-color");
+        const whiteKeyWorkspaceColor = style.getPropertyValue("--workspace-white-key-color");
+        const blackKeyWorkspaceColor = style.getPropertyValue("--workspace-black-key-color");
+
+        if (
+            gridLineColor !== value.state.gridLineColor ||
+            whiteKeyWorkspaceColor !== value.state.whiteKeyWorkspaceColor ||
+            blackKeyWorkspaceColor !== value.state.blackKeyWorkspaceColor
+        ) {
+            dispatch({
+                gridLineColor,
+                whiteKeyWorkspaceColor,
+                blackKeyWorkspaceColor
+            });
         }
-    }
+    }, [])
 
     return (
         <PianoRollContext.Provider
             value={value}
         >
-            <div className="piano-roll-root" ref={handleRootRef}>
+            <div className="piano-roll-root" ref={rootRef}>
                 {props.children}
             </div>
         </PianoRollContext.Provider>

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -3,6 +3,7 @@ export interface NoteEvent {
     start: number;
     duration: number;
     note: number;
+    velocity: number;
 }
 
 export interface Track {
@@ -119,7 +120,8 @@ export function newNoteEvent(note: number, start: number, track: Track, isDrumTr
         id: track.nextId++,
         note,
         start,
-        duration: isDrumTrack ? 1 : Math.min(4, getMaxDuration(note, start, track, measures))
+        duration: isDrumTrack ? 1 : Math.min(4, getMaxDuration(note, start, track, measures)),
+        velocity: 128
     };
 
     return insertNoteEvent(newEvent, track);
@@ -198,6 +200,43 @@ export function updateTrack(updatedTrack: Track, song: Song): Song {
     };
 }
 
+export function updateNoteEvent(song: Song, trackId: number, updatedEvent: NoteEvent): Song {
+    const trackIndex = song.tracks.findIndex(t => t.id === trackId);
+    if (trackIndex === -1) return song;
+
+    const track = song.tracks[trackIndex];
+    const eventIndex = track.events.findIndex(e => e.id === updatedEvent.id);
+    if (eventIndex === -1) return song;
+
+    const updatedTrack = {
+        ...track,
+        events: [
+            ...track.events.slice(0, eventIndex),
+            updatedEvent,
+            ...track.events.slice(eventIndex + 1)
+        ]
+    };
+
+    return updateTrack(updatedTrack, song);
+}
+
+export function updateNoteEvents(song: Song, trackId: number, updatedEvents: NoteEvent[]): Song {
+    const trackIndex = song.tracks.findIndex(t => t.id === trackId);
+    if (trackIndex === -1) return song;
+
+    const track = song.tracks[trackIndex];
+
+    const updatedTrack = {
+        ...track,
+        events: track.events.map(e => {
+            const updatedEvent = updatedEvents.find(ue => ue.id === e.id);
+            return updatedEvent ? updatedEvent : e;
+        })
+    };
+
+    return updateTrack(updatedTrack, song);
+}
+
 export function changeTrackInstrument(trackId: number, instrumentId: number, song: Song): Song {
     const trackIndex = song.tracks.findIndex(t => t.id === trackId);
     const track = { ...song.tracks[trackIndex] };
@@ -273,7 +312,8 @@ export function toPXTSong(song: Song): pxt.assets.music.Song {
                     notes: [{
                         note: e.note,
                         enharmonicSpelling: "normal"
-                    }]
+                    }],
+                    velocity: e.velocity
                 })),
                 instrument: isDrumInstrument(instrument) ? undefined : (instrument as MelodicInstrument).instrument,
                 drums: isDrumInstrument(instrument) ? (instrument as DrumInstrument).drums : undefined
@@ -303,12 +343,13 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
             maxOctave: 0
         }
 
-        const newNoteEvent = (note: number, startTick: number, endTick: number): void => {
+        const newNoteEvent = (note: number, startTick: number, endTick: number, velocity: number): void => {
             const newEvent: NoteEvent = {
                 id: newTrack.nextId++,
                 note,
                 start: Math.round(startTick / ticksPerSixteenth),
-                duration: Math.round((endTick - startTick) / ticksPerSixteenth)
+                duration: Math.round((endTick - startTick) / ticksPerSixteenth),
+                velocity: velocity ?? 128
             };
 
             newTrack.events.push(newEvent);
@@ -338,7 +379,7 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
 
         for (const event of track.notes) {
             for (const note of event.notes) {
-                newNoteEvent(note.note, event.startTick, event.endTick);
+                newNoteEvent(note.note, event.startTick, event.endTick, event.velocity);
             }
         }
 

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -326,9 +326,10 @@ export function toPXTSong(song: Song): pxt.assets.music.Song {
 
 export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
     const result = getEmptySong();
+    result.measures = pxtSong.measures;
 
     result.tracks = [];
-    result.nextId += 100;
+    result.nextId += 1000;
 
     const ticksPerSixteenth = pxtSong.ticksPerBeat / 4;
 
@@ -348,7 +349,7 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
                 id: newTrack.nextId++,
                 note,
                 start: Math.round(startTick / ticksPerSixteenth),
-                duration: Math.round((endTick - startTick) / ticksPerSixteenth),
+                duration: Math.max(1, Math.round((endTick - startTick) / ticksPerSixteenth)),
                 velocity: velocity ?? 128
             };
 

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -168,13 +168,14 @@ function insertNoteEvent(newEvent: NoteEvent, track: Track): Track {
 }
 
 export function newTrack(instrumentId: number, song: Song): Song {
+    const range = NOTE_RANGES.find(r => r.id === "treble")!;
     const newTrack: Track = {
         instrumentId,
         events: [],
         id: song.nextId++,
         nextId: 0,
-        minOctave: 3,
-        maxOctave: 5
+        minOctave: range.minOctave,
+        maxOctave: range.maxOctave
     };
 
     return {
@@ -298,8 +299,8 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
             instrumentId: 0,
             events: [],
             nextId: 0,
-            minOctave: 3,
-            maxOctave: 5
+            minOctave: 7,
+            maxOctave: 0
         }
 
         const newNoteEvent = (note: number, startTick: number, endTick: number): void => {
@@ -347,7 +348,7 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
             newTrack.maxOctave = range.maxOctave;
         }
 
-        if (newTrack.events.length > 0) {
+        if (newTrack.events.length > 0 || result.tracks.length === 0) {
             result.tracks.push(newTrack);
         }
     }

--- a/webapp/src/components/pianoRoll/workspaceBackground.tsx
+++ b/webapp/src/components/pianoRoll/workspaceBackground.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { usePianoRollTheme } from "./context"
+import { PianoRollTheme, usePianoRollTheme } from "./context"
 
 function createWorkspaceBackground(
     octaveWidth: number,
@@ -28,17 +28,25 @@ function createWorkspaceBackground(
 `.trim().replace(/\s+/g, " ")
 }
 
-function getBackgroundCss(octaveWidth: number, whiteKeyHeight: number) {
-    return `url("data:image/svg+xml,${encodeURIComponent(createWorkspaceBackground(octaveWidth, 7 * whiteKeyHeight))}")`;
+function getBackgroundCss(theme: PianoRollTheme) {
+    return `url("data:image/svg+xml,${encodeURIComponent(
+        createWorkspaceBackground(
+            theme.octaveWidth,
+            7 * theme.whiteKeyHeight,
+            theme.gridLineColor,
+            theme.blackKeyWorkspaceColor,
+            theme.whiteKeyWorkspaceColor
+        )
+    )}")`;
 }
 
 export function useWorkspaceBackground() {
     const theme = usePianoRollTheme();
-    const [bg, setBg] = useState(getBackgroundCss(theme.octaveWidth, theme.whiteKeyHeight));
+    const [bg, setBg] = useState(getBackgroundCss(theme));
 
     useEffect(() => {
-        setBg(getBackgroundCss(theme.octaveWidth, theme.whiteKeyHeight));
-    }, [theme.octaveWidth, theme.whiteKeyHeight])
+        setBg(getBackgroundCss(theme));
+    }, [theme.octaveWidth, theme.whiteKeyHeight, theme.gridLineColor, theme.blackKeyWorkspaceColor, theme.whiteKeyWorkspaceColor])
 
     return bg;
 }


### PR DESCRIPTION
more work on the piano roll editor!

<img width="1200" height="785" alt="image" src="https://github.com/user-attachments/assets/4493d37a-052b-4fcb-8b83-25b0d2644862" />


changes:
* added the usual asset editor chrome (name, done button, editor/my assets toggle)
* added velocity support for songs (more on this below)
* added a velocity editor to the piano roll
* cleaned up a lot of css
* made it blue
* fixed parsing of PXT songs

velocity support involves a change to the song format, but it's backwards compatible. the new data is simply tacked on to the end of the song buffer after all of the track data (and is completely optional). this new format will also work just fine with the old player code; the velocity values will just get ignored.

it should be completely safe to open a song from the old song editor in the piano roll editor, but going the other direction might cause you to lose velocity data so it's not recommended. i might add a warning dialog at some point to prevent this from accidentally happening.


i will eventually have another PR in common-packages that adds velocity support to the hardware sequencer implementation. again, it'll be 100% backwards compatible with existing songs.

