### PR TITLE
add a pxt.json flag for disabling version history

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -98,6 +98,7 @@ declare namespace pxt {
             namespaces: {[index: string]: "visible" | "hidden" | "disabled"},
             blocks: {[index: string]: "visible" | "hidden" | "disabled"},
         }
+        disableHistory?: boolean; // if set to true, project history will not be saved for this project. useful for giant projects where diffing on each edit can slow things down
     }
 
     interface PackageExtension {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -365,6 +365,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         const simCollapseText = headless ? lf("Toggle the File Explorer") : lf("Toggle the simulator");
         const extDownloadMenuItems = pxt.commands.getDownloadMenuItems?.() || [];
 
+        const pxtjson = pkg.mainEditorPkg()?.getKsPkg()?.config;
 
         const items: MenuItem[] = [];
         if (showHome) {
@@ -465,7 +466,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             });
         }
 
-        if (targetTheme.timeMachine) {
+        if (targetTheme.timeMachine && !(pxtjson?.disableHistory)) {
             items.push({
                 role: "menuitem",
                 leftIcon: "icon history",

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -633,16 +633,18 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
             .forEach(key => delete e.header[key as keyof Header]);
         h = e.header;
     }
-    if (text)
+    let pxtjson: pxt.PackageConfig | undefined;
+    if (text) {
         e.text = text
+        pxtjson = pxt.Package.parseAndValidConfig(text[pxt.CONFIG_NAME]);
+
+    }
     if (text || h.isDeleted) {
         h.saveId = null
     }
 
     // check if we have dynamic boards, store board info for home page rendering
-    if (text && pxt.appTarget.simulator && pxt.appTarget.simulator.dynamicBoardDefinition) {
-        const pxtjson = pxt.Package.parseAndValidConfig(text[pxt.CONFIG_NAME]);
-        if (pxtjson && pxtjson.dependencies)
+    if (pxtjson?.dependencies && pxt.appTarget.simulator && pxt.appTarget.simulator.dynamicBoardDefinition) {
             h.board = Object.keys(pxtjson.dependencies)
                 .filter(p => !!pxt.bundledSvg(p))[0];
     }
@@ -655,15 +657,22 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
 
         if (pxt.appTarget.appTheme.timeMachine) {
             try {
-                const previous = await impl.getAsync(h);
-
-                if (previous) {
-                    if (!toWrite && previous.header.pubVersions?.length !== h.pubVersions?.length) {
-                        toWrite = { ...previous.text };
+                if (pxtjson?.disableHistory) {
+                    if (toWrite?.[pxt.HISTORY_FILE]) {
+                        delete toWrite[pxt.HISTORY_FILE];
                     }
+                }
+                else {
+                    const previous = await impl.getAsync(h);
 
-                    if (toWrite) {
-                        pxteditor.history.updateHistory(previous.text, toWrite, Date.now(), h.pubVersions || [], diffText, patchText, true);
+                    if (previous) {
+                        if (!toWrite && previous.header.pubVersions?.length !== h.pubVersions?.length) {
+                            toWrite = { ...previous.text };
+                        }
+
+                        if (toWrite) {
+                            pxteditor.history.updateHistory(previous.text, toWrite, Date.now(), h.pubVersions || [], diffText, patchText, true);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
adds a secret pxt.json flag for disabling version history.

if you have a truly gigantic blocks project (like the zelda-like game that @jwunderl and I have been making on stream) then version history can cause the browser to have out of memory exceptions. clearly this is due to a memory leak we have somewhere; but since i don't have time to track that down at the moment this serves as a temporary stopgap.