### PR TITLE
extend matrix field to support editing sprites

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -908,6 +908,9 @@ declare namespace ts.pxtc {
         iconURL?: string;
         imageLiteral?: number;
         gridLiteral?: number;
+        colorGridLiteral?: number;
+        gridLiteralPalette?: string;
+        gridLiteralPaletteNames?: string;
         gridLiteralOnColor?: string;
         gridLiteralOffColor?: string;
         imageLiteralColumns?: number; // optional number of columns

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -906,16 +906,7 @@ declare namespace ts.pxtc {
         icon?: string;
         jresURL?: string;
         iconURL?: string;
-        imageLiteral?: number;
-        gridLiteral?: number;
-        colorGridLiteral?: number;
-        gridLiteralPalette?: string;
-        gridLiteralPaletteNames?: string;
-        gridLiteralOnColor?: string;
-        gridLiteralOffColor?: string;
-        imageLiteralColumns?: number; // optional number of columns
-        imageLiteralRows?: number; // optional number of rows
-        imageLiteralScale?: number; // button sizing between 0.6 and 2, default is 1
+
         weight?: number;
         parts?: string;
         hiddenParts?: string; // allows an extesion to declaratively hide a part
@@ -991,6 +982,23 @@ declare namespace ts.pxtc {
         enumInitialMembers?: string[]; // The initial enum values which will be given the lowest values available
 
         /* end enum-only attributes */
+
+        /* led matrix field editor attributes */
+
+        imageLiteral?: number;
+        gridLiteral?: number;
+        colorGridLiteral?: number;
+        gridLiteralPalette?: string;
+        gridLiteralPaletteNames?: string;
+        gridLiteralUseProjectPalette?: boolean;
+        gridLiteralOnColor?: string;
+        gridLiteralOffColor?: string;
+        gridLiteralVerticalSpacing?: number; // optional spacing between pixels, default is 5
+        gridLiteralHorizontalSpacing?: number; // optional spacing between pixels, default is 7
+        gridLiteralBorderRadius?: number; // optional border radius for pixels, default is 5
+        imageLiteralColumns?: number; // optional number of columns
+        imageLiteralRows?: number; // optional number of rows
+        imageLiteralScale?: number; // button sizing between 0.6 and 2, default is 1
 
 
         isKind?: boolean; // annotation for built-in kinds in library code

--- a/pxtblocks/compiler/compiler.ts
+++ b/pxtblocks/compiler/compiler.ts
@@ -804,7 +804,7 @@ function compileImage(e: Environment, b: Blockly.Block, frames: number, columns:
         for (let j = 0; j < columns; ++j) {
             if (j > 0)
                 state += ' ';
-            state += (leds[(i * columns) + j] === '#') ? "#" : ".";
+            state += leds[(i * columns) + j];
         }
         state += '\n';
     }

--- a/pxtblocks/compiler/environment.ts
+++ b/pxtblocks/compiler/environment.ts
@@ -203,7 +203,7 @@ export function mkEnv(w: Blockly.Workspace, blockInfo?: pxtc.BlocksInfo, options
                     attrs: fn.attributes,
                     isExtensionMethod: instance,
                     isExpression: fn.retType && fn.retType !== "void",
-                    imageLiteral: fn.attributes.imageLiteral || fn.attributes.gridLiteral,
+                    imageLiteral: fn.attributes.imageLiteral || fn.attributes.gridLiteral || fn.attributes.colorGridLiteral,
                     imageLiteralColumns: fn.attributes.imageLiteralColumns,
                     imageLiteralRows: fn.attributes.imageLiteralRows,
                     hasHandler: pxt.blocks.hasHandler(fn),

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -2,6 +2,7 @@
 /// <reference path="../../built/pxtsim.d.ts" />
 
 import * as Blockly from "blockly";
+import { DEFAULT_LED_COLORS } from "./field_ledmatrix_colorPicker";
 import { FieldMatrix } from "./field_matrix";
 import { FieldCustom } from "./field_utils";
 
@@ -27,9 +28,12 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     public SERIALIZABLE = true;
 
     private params: any;
-    private onColor = "#FFFFFF";
-    private offColor: string;
+
+    private palette: string[];
+
     private static DEFAULT_OFF_COLOR = "#000000";
+    private static DEFAULT_ON_COLOR = "#FFFFFF";
+    private offOpacity = 0.2;
 
     private scale = 1;
 
@@ -39,12 +43,17 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     private yAxisLabel: LabelMode = LabelMode.None;
     private xAxisLabel: LabelMode = LabelMode.None;
 
-    private cellState: boolean[][] = [];
+    private cellState: number[][] = [];
 
     private currentDragState_: boolean;
 
     protected clearSelectionOnBlur = true;
     protected forceFocusVisible = true;
+
+    protected isColorMatrix = false;
+    protected colorNames: string[];
+
+    private activeColor = 1;
 
     constructor(text: string, params: any, validator?: Blockly.FieldValidator) {
         super(text, validator);
@@ -64,12 +73,37 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
             }
         }
 
-        if (this.params.onColor !== undefined) {
-            this.onColor = this.params.onColor;
+        this.isColorMatrix = !!this.params.isColorMatrix;
+
+        if (this.params.colors) {
+            this.palette = this.params.colors;
+        }
+        else {
+            this.palette = [
+                FieldLedMatrix.DEFAULT_OFF_COLOR,
+                ...DEFAULT_LED_COLORS
+            ];
         }
 
-        if (this.params.offColor !== undefined) {
-            this.offColor = this.params.offColor;
+        if (this.params.colorNames) {
+            this.colorNames = this.params.colorNames;
+        }
+        else {
+            this.colorNames = [
+                lf("off"),
+                ...DEFAULT_LED_COLORS
+            ];
+        }
+
+        if (this.params.hasOffColor) {
+            this.offOpacity = 1.0;
+        }
+
+        if (this.params.offOpacity) {
+            const val = parseFloat(this.params.offOpacity);
+            if (!isNaN(val) && val >= 0 && val <= 1) {
+                this.offOpacity = val;
+            }
         }
 
         if (this.params.scale !== undefined)
@@ -84,11 +118,17 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     }
 
     protected getCellToggled(x: number, y: number): boolean {
-        return this.cellState[x][y];
+        return !!this.cellState[x][y];
     }
 
     protected useTwoToneFocusIndicator(x: number, y: number): boolean {
         return this.getCellToggled(x, y);
+    }
+
+    setActiveColorIndex(index: number) {
+        if (index >= 0 && index < this.palette.length) {
+            this.activeColor = index;
+        }
     }
 
     /**
@@ -136,7 +176,7 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
             for (let i = 0; i < this.numMatrixCols; i++) {
                 this.cellState.push([])
                 for (let j = 0; j < this.numMatrixRows; j++) {
-                    this.cellState[i].push(false);
+                    this.cellState[i].push(0);
                 }
             }
 
@@ -149,7 +189,7 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
                 cellHorizontalMargin: FieldLedMatrix.CELL_HORIZONTAL_MARGIN,
                 cellVerticalMargin: FieldLedMatrix.CELL_VERTICAL_MARGIN,
                 cornerRadius: FieldLedMatrix.CELL_CORNER_RADIUS,
-                cellFill: this.offColor,
+                cellFill: this.palette[0],
                 padLeft: this.getYAxisWidth(),
                 scale: this.scale
             });
@@ -265,7 +305,7 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     }
 
     protected toggleCell = (x: number, y: number, value?: boolean) => {
-        this.cellState[x][y] = value ?? this.currentDragState_;
+        this.cellState[x][y] = (value ?? this.currentDragState_) ? this.activeColor : 0;
         this.updateValue();
     }
 
@@ -293,11 +333,11 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     }
 
     private getColor(x: number, y: number) {
-        return this.cellState[x][y] ? this.onColor : (this.offColor || FieldLedMatrix.DEFAULT_OFF_COLOR);
+        return this.palette[this.cellState[x][y]];
     }
 
     private getOpacity(x: number, y: number) {
-        const offOpacity = this.offColor ? '1.0': '0.2';
+        const offOpacity = this.offOpacity + "";
         return this.cellState[x][y] ? '1.0' : offOpacity;
     }
 
@@ -306,7 +346,10 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
         cellRect.setAttribute("fill", this.getColor(x, y));
         cellRect.setAttribute("fill-opacity", this.getOpacity(x, y));
         cellRect.setAttribute('class', `blocklyLed${this.cellState[x][y] ? 'On' : 'Off'}`);
-        cellRect.setAttribute("aria-checked", this.cellState[x][y].toString());
+        cellRect.setAttribute("aria-checked", (!!this.cellState[x][y]).toString());
+        if (this.isColorMatrix) {
+            cellRect.setAttribute("aria-label", this.colorNames[this.cellState[x][y]] || this.palette[this.cellState[x][y]] || lf("color {0}", this.cellState[x][y]));
+        }
     }
 
     setValue(newValue: string | number, restoreState = true) {
@@ -357,12 +400,10 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
                 const row = rows[y];
 
                 for (let j = 0; j < row.length && x < this.numMatrixCols; j++) {
-                    if (isNegativeCharacter(row[j])) {
-                        this.cellState[x][y] = false;
-                        x++;
-                    }
-                    else if (isPositiveCharacter(row[j])) {
-                        this.cellState[x][y] = true;
+                    const val = parseCharacter(row[j]);
+
+                    if (val !== -1) {
+                        this.cellState[x][y] = val;
                         x++;
                     }
                 }
@@ -372,12 +413,13 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
 
     // Composes the state into a string an updates the field's state
     private updateValue() {
+        const chars = ".#23456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         let res = "";
         for (let y = 0; y < this.numMatrixRows; y++) {
             for (let x = 0; x < this.numMatrixCols; x++) {
-                res += (this.cellState[x][y] ? "#" : ".") + " "
+                res += chars.charAt(this.cellState[x][y]) + " ";
             }
-            res += "\n" + FieldLedMatrix.TAB
+            res += "\n" + FieldLedMatrix.TAB;
         }
 
         // Blockly stores the state of the field as a string
@@ -393,12 +435,20 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     }
 }
 
-function isPositiveCharacter(c: string) {
-    return c === "#" || c === "*" || c === "1";
-}
-
-function isNegativeCharacter(c: string) {
-    return c === "." || c === "_" || c === "0";
+function parseCharacter(c: string): number {
+    const chars = ".#23456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    switch (c) {
+        case "#":
+        case "*":
+        case "1":
+            return 1;
+        case ".":
+        case "_":
+        case "0":
+            return 0;
+        default:
+            return chars.indexOf(c.toUpperCase());
+    }
 }
 
 

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -113,8 +113,11 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
         else if (Math.max(this.numMatrixCols, this.numMatrixRows) > 10)
             this.scale = 0.9;
 
-        this.size_.height = this.scale * Number(this.numMatrixRows) * (FieldLedMatrix.CELL_WIDTH + FieldLedMatrix.CELL_VERTICAL_MARGIN) + FieldLedMatrix.CELL_VERTICAL_MARGIN * 2 + FieldLedMatrix.BOTTOM_MARGIN + this.getXAxisHeight()
-        this.size_.width = this.scale * Number(this.numMatrixCols) * (FieldLedMatrix.CELL_WIDTH + FieldLedMatrix.CELL_HORIZONTAL_MARGIN) + FieldLedMatrix.CELL_HORIZONTAL_MARGIN + this.getYAxisWidth();
+        const verticalMargin = isNaN(this.params.verticalSpacing) ? FieldLedMatrix.CELL_VERTICAL_MARGIN : this.params.verticalSpacing;
+        const horizontalMargin = isNaN(this.params.horizontalSpacing) ? FieldLedMatrix.CELL_HORIZONTAL_MARGIN : this.params.horizontalSpacing;
+
+        this.size_.height = this.scale * Number(this.numMatrixRows) * (FieldLedMatrix.CELL_WIDTH + verticalMargin) + verticalMargin * 2 + FieldLedMatrix.BOTTOM_MARGIN + this.getXAxisHeight()
+        this.size_.width = this.scale * Number(this.numMatrixCols) * (FieldLedMatrix.CELL_WIDTH + horizontalMargin) + horizontalMargin + this.getYAxisWidth();
     }
 
     protected getCellToggled(x: number, y: number): boolean {
@@ -182,13 +185,16 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
 
             this.restoreStateFromString();
 
+            const verticalMargin = isNaN(this.params.verticalSpacing) ? FieldLedMatrix.CELL_VERTICAL_MARGIN : this.params.verticalSpacing;
+            const horizontalMargin = isNaN(this.params.horizontalSpacing) ? FieldLedMatrix.CELL_HORIZONTAL_MARGIN : this.params.horizontalSpacing;
+
             this.createMatrixDisplay({
                 cellWidth: FieldLedMatrix.CELL_WIDTH,
                 cellHeight: FieldLedMatrix.CELL_WIDTH,
                 cellLabel: lf("LED"),
-                cellHorizontalMargin: FieldLedMatrix.CELL_HORIZONTAL_MARGIN,
-                cellVerticalMargin: FieldLedMatrix.CELL_VERTICAL_MARGIN,
-                cornerRadius: FieldLedMatrix.CELL_CORNER_RADIUS,
+                cellHorizontalMargin: horizontalMargin,
+                cellVerticalMargin: verticalMargin,
+                cornerRadius: isNaN(this.params.borderRadius) ? FieldLedMatrix.CELL_CORNER_RADIUS : this.params.borderRadius,
                 cellFill: this.palette[0],
                 padLeft: this.getYAxisWidth(),
                 scale: this.scale
@@ -197,10 +203,10 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
             this.updateValue();
 
             if (this.xAxisLabel !== LabelMode.None) {
-                const y = this.scale * this.numMatrixRows * (FieldLedMatrix.CELL_WIDTH + FieldLedMatrix.CELL_VERTICAL_MARGIN) + FieldLedMatrix.CELL_VERTICAL_MARGIN * 2 + FieldLedMatrix.BOTTOM_MARGIN
+                const y = this.scale * this.numMatrixRows * (FieldLedMatrix.CELL_WIDTH + verticalMargin) + verticalMargin * 2 + FieldLedMatrix.BOTTOM_MARGIN
                 const xAxis = pxsim.svg.child(this.matrixSvg, "g", { transform: `translate(${0} ${y})` });
                 for (let i = 0; i < this.numMatrixCols; i++) {
-                    const x = this.getYAxisWidth() + this.scale * i * (FieldLedMatrix.CELL_WIDTH + FieldLedMatrix.CELL_HORIZONTAL_MARGIN) + FieldLedMatrix.CELL_WIDTH / 2 + FieldLedMatrix.CELL_HORIZONTAL_MARGIN / 2;
+                    const x = this.getYAxisWidth() + this.scale * i * (FieldLedMatrix.CELL_WIDTH + horizontalMargin) + FieldLedMatrix.CELL_WIDTH / 2 + horizontalMargin / 2;
                     const lbl = pxsim.svg.child(xAxis, "text", { x, class: "blocklyText" })
                     lbl.textContent = this.getLabel(i, this.xAxisLabel);
                 }
@@ -209,7 +215,7 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
             if (this.yAxisLabel !== LabelMode.None) {
                 const yAxis = pxsim.svg.child(this.matrixSvg, "g", {});
                 for (let i = 0; i < this.numMatrixRows; i++) {
-                    const y = this.scale * i * (FieldLedMatrix.CELL_WIDTH + FieldLedMatrix.CELL_VERTICAL_MARGIN) + FieldLedMatrix.CELL_WIDTH / 2 + FieldLedMatrix.CELL_VERTICAL_MARGIN * 2;
+                    const y = this.scale * i * (FieldLedMatrix.CELL_WIDTH + verticalMargin) + FieldLedMatrix.CELL_WIDTH / 2 + verticalMargin * 2;
                     const lbl = pxsim.svg.child(yAxis, "text", { x: 0, y, class: "blocklyText" })
                     lbl.textContent = this.getLabel(i, this.yAxisLabel);
                 }

--- a/pxtblocks/fields/field_ledmatrix_colorPicker.ts
+++ b/pxtblocks/fields/field_ledmatrix_colorPicker.ts
@@ -1,0 +1,81 @@
+import * as Blockly from "blockly";
+import { FieldImageDropdown } from "./field_imagedropdown";
+import { FieldLedMatrix } from "./field_ledmatrix";
+
+export const DEFAULT_LED_COLORS = [
+    "#FFFFFF",
+    "#ED1C23",
+    "#B97858",
+    "#FF7D27",
+    "#FFCA0C",
+    "#FFF200",
+    "#EEE5B2",
+    "#22B14D",
+    "#B4E61D",
+    "#00A2E8",
+    "#99D9EB",
+    "#3E47CB",
+    "#7092BE",
+    "#A249A4",
+    "#880014",
+    "#FFAEC9"
+]
+
+export function getDefaultColorNames() {
+    return [
+        lf("{id:color}white"),
+        lf("{id:color}red"),
+        lf("{id:color}brown"),
+        lf("{id:color}orange"),
+        lf("{id:color}yellow"),
+        lf("{id:color}light yellow"),
+        lf("{id:color}cream"),
+        lf("{id:color}green"),
+        lf("{id:color}light green"),
+        lf("{id:color}blue"),
+        lf("{id:color}light blue"),
+        lf("{id:color}dark blue"),
+        lf("{id:color}gray"),
+        lf("{id:color}purple"),
+        lf("{id:color}dark red"),
+        lf("{id:color}pink")
+    ]
+}
+
+export class FieldLEDMatrixColorPicker extends FieldImageDropdown {
+    constructor(blocksInfo: pxtc.BlocksInfo, colors?: string[], colorNames?: string[]) {
+        super((colors || DEFAULT_LED_COLORS)[0], {
+            blocksInfo,
+            columns: "4",
+            data: (colors || DEFAULT_LED_COLORS).map((color, index) => ([{
+                src: generateImageData(color),
+                width: 16,
+                height: 16,
+                alt: colorNames?.[index] || color
+            }, color])),
+        });
+    }
+
+    onColorSelected(index: number) {
+        if (!this.sourceBlock_) return;
+        const field = this.sourceBlock_.getField("LEDS") as FieldLedMatrix;
+
+        field.setActiveColorIndex(index + 1); // +1 to account for the off color at index 0
+    }
+
+    doValueUpdate_(newValue: string) {
+        super.doValueUpdate_(newValue);
+
+        this.onColorSelected(DEFAULT_LED_COLORS.indexOf(newValue));
+    }
+}
+
+function generateImageData(color: string) {
+    const canvas = document.createElement("canvas");
+    canvas.width = 16;
+    canvas.height = 16;
+    const ctx = canvas.getContext("2d")!;
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, 16, 16);
+    return canvas.toDataURL();
+}

--- a/pxtblocks/fields/field_ledmatrix_colorPicker.ts
+++ b/pxtblocks/fields/field_ledmatrix_colorPicker.ts
@@ -1,6 +1,9 @@
 import * as Blockly from "blockly";
 import { FieldImageDropdown } from "./field_imagedropdown";
 import { FieldLedMatrix } from "./field_ledmatrix";
+import { mkTransparentTileImage } from "./field_tileset";
+
+const TRANSPARENT_OPTION_KEY = "$transparent";
 
 export const DEFAULT_LED_COLORS = [
     "#FFFFFF",
@@ -43,16 +46,11 @@ export function getDefaultColorNames() {
 }
 
 export class FieldLEDMatrixColorPicker extends FieldImageDropdown {
-    constructor(blocksInfo: pxtc.BlocksInfo, colors?: string[], colorNames?: string[]) {
+    constructor(blocksInfo: pxtc.BlocksInfo, colors?: string[], colorNames?: string[], protected includeTransparency = false) {
         super((colors || DEFAULT_LED_COLORS)[0], {
             blocksInfo,
             columns: "4",
-            data: (colors || DEFAULT_LED_COLORS).map((color, index) => ([{
-                src: generateImageData(color),
-                width: 16,
-                height: 16,
-                alt: colorNames?.[index] || color
-            }, color])),
+            data: generateOptions(colors, colorNames, includeTransparency)
         });
     }
 
@@ -60,14 +58,50 @@ export class FieldLEDMatrixColorPicker extends FieldImageDropdown {
         if (!this.sourceBlock_) return;
         const field = this.sourceBlock_.getField("LEDS") as FieldLedMatrix;
 
-        field.setActiveColorIndex(index + 1); // +1 to account for the off color at index 0
+        field.setActiveColorIndex(index);
     }
 
     doValueUpdate_(newValue: string) {
         super.doValueUpdate_(newValue);
 
-        this.onColorSelected(DEFAULT_LED_COLORS.indexOf(newValue));
+        const options = this.getOptions();
+        const index = options.findIndex(([_, value]) => value === newValue);
+        if (index === -1) return;
+
+        if (this.includeTransparency) {
+            this.onColorSelected(index);
+        }
+        else {
+            this.onColorSelected(index + 1); // +1 to account for the off color at index 0
+        }
     }
+}
+
+function generateOptions(colors: string[], colorNames: string[], includeTransparency: boolean): [Blockly.ImageProperties, string][] {
+    if (!colors) colors = DEFAULT_LED_COLORS;
+    if (!colorNames) colorNames = getDefaultColorNames();
+
+    const options: [Blockly.ImageProperties, string][] = [];
+
+    if (includeTransparency) {
+        options.push([{
+            src: mkTransparentTileImage(16),
+            width: 16,
+            height: 16,
+            alt: lf("{id:color}transparency")
+        }, TRANSPARENT_OPTION_KEY]);
+    }
+
+    for (let i = 0; i < colors.length; i++) {
+        options.push([{
+            src: generateImageData(colors[i]),
+            width: 16,
+            height: 16,
+            alt: colorNames[i] || colors[i]
+        }, colors[i]]);
+    }
+
+    return options;
 }
 
 function generateImageData(color: string) {

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -62,7 +62,7 @@ export abstract class FieldMatrix extends Blockly.Field {
                     'stroke': cellStroke,
                     'data-x': x,
                     'data-y': y,
-                    'rx': Math.max(2, scale * cornerRadius)
+                    'rx': Math.max(0, scale * cornerRadius)
                 };
                 const cellRect = pxsim.svg.child(cellG, "rect", rectOptions) as SVGRectElement;
                 this.cells[x][y] = cellRect;

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -352,7 +352,7 @@ function constructTransparentTile(): TilesetDropdownOption {
     }, tile.id, tile];
 }
 
-function mkTransparentTileImage(sideLength: number) {
+export function mkTransparentTileImage(sideLength: number) {
     const canvas = document.createElement("canvas");
     const context = canvas.getContext("2d");
     canvas.width = sideLength;

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -332,7 +332,11 @@ function initBlock(block: Blockly.Block, info: pxtc.BlocksInfo, fn: pxtc.SymbolI
         let colors: string[];
         let colorNames: string[] = [];
 
-        if (fn.attributes.gridLiteralPalette) {
+        if (fn.attributes.gridLiteralUseProjectPalette) {
+            colors = pxt.appTarget.runtime.palette!;
+            colorNames = colors.map((c, i) => i === 0 ? lf("{id:color}transparency") : pxt.U.lf("{id:color}color {0}", i));
+        }
+        else if (fn.attributes.gridLiteralPalette) {
             colors = fn.attributes.gridLiteralPalette.split(",").map(c => c.trim());
         }
         else if (fn.attributes.gridLiteralOnColor || fn.attributes.gridLiteralOffColor) {
@@ -362,7 +366,15 @@ function initBlock(block: Blockly.Block, info: pxtc.BlocksInfo, fn: pxtc.SymbolI
 
         if (fn.attributes.colorGridLiteral) {
             // color 0 is the off color, so we don't need it to be in the color picker
-            topInput.appendField(new FieldLEDMatrixColorPicker(info, colors?.slice(1), colorNames?.slice(1)), "ON_COLOR");
+            topInput.appendField(
+                new FieldLEDMatrixColorPicker(
+                    info,
+                    colors?.slice(1),
+                    colorNames?.slice(1),
+                    !!fn.attributes.gridLiteralUseProjectPalette
+                ),
+                "ON_COLOR"
+            );
         }
 
         let ri = block.appendDummyInput();
@@ -373,6 +385,9 @@ function initBlock(block: Blockly.Block, info: pxtc.BlocksInfo, fn: pxtc.SymbolI
                 scale,
                 colors,
                 colorNames,
+                verticalSpacing: fn.attributes.gridLiteralVerticalSpacing,
+                horizontalSpacing: fn.attributes.gridLiteralHorizontalSpacing,
+                borderRadius: fn.attributes.gridLiteralBorderRadius,
                 hasOffColor: !!fn.attributes.gridLiteralOffColor,
                 isColorMatrix: !!fn.attributes.colorGridLiteral
             }),

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -31,6 +31,7 @@ import { ArgumentReporterBlock, FieldArgumentReporter, setArgumentReporterLocali
 import { getArgumentReporterParent } from "./plugins/functions/utils";
 import { isFunctionDefinition } from "./compiler/util";
 import { AUTO_DISABLED_REASON } from "./compiler/compiler";
+import { DEFAULT_LED_COLORS, FieldLEDMatrixColorPicker, getDefaultColorNames } from "./fields/field_ledmatrix_colorPicker";
 
 export const DRAGGABLE_PARAM_INPUT_PREFIX = "HANDLER_DRAG_PARAM_";
 
@@ -322,15 +323,61 @@ function initBlock(block: Blockly.Block, info: pxtc.BlocksInfo, fn: pxtc.SymbolI
         }
     });
 
-    const gridTemplateString = fn.attributes.imageLiteral || fn.attributes.gridLiteral;
+    const gridTemplateString = fn.attributes.imageLiteral || fn.attributes.gridLiteral || fn.attributes.colorGridLiteral;
     if (gridTemplateString) {
         const columns = (fn.attributes.imageLiteralColumns || 5) * gridTemplateString;
         const rows = fn.attributes.imageLiteralRows || 5;
         const scale = fn.attributes.imageLiteralScale;
-        const onColor = fn.attributes.gridLiteralOnColor;
-        const offColor = fn.attributes.gridLiteralOffColor;
+
+        let colors: string[];
+        let colorNames: string[] = [];
+
+        if (fn.attributes.gridLiteralPalette) {
+            colors = fn.attributes.gridLiteralPalette.split(",").map(c => c.trim());
+        }
+        else if (fn.attributes.gridLiteralOnColor || fn.attributes.gridLiteralOffColor) {
+            colors = [
+                fn.attributes.gridLiteralOffColor || "#000000",
+                fn.attributes.gridLiteralOnColor || "#ffffff"
+            ];
+            colorNames = [lf("off"), lf("on")];
+        }
+        else {
+            colors = ["#000000", ...DEFAULT_LED_COLORS];
+            colorNames = [lf("off"), ...getDefaultColorNames()];
+        }
+
+        if (fn.attributes.gridLiteralPaletteNames) {
+            colorNames = fn.attributes.gridLiteralPaletteNames.split(",").map(c => pxt.U.rlf(`{id:color}${c.trim()}`));
+        }
+
+        for (let i = 0; i < colors.length; i++) {
+            if (!colorNames[i]) {
+                colorNames[i] = colors[i];
+            }
+        }
+
+
+        const topInput = block.inputList[block.inputList.length - 1];
+
+        if (fn.attributes.colorGridLiteral) {
+            // color 0 is the off color, so we don't need it to be in the color picker
+            topInput.appendField(new FieldLEDMatrixColorPicker(info, colors?.slice(1), colorNames?.slice(1)), "ON_COLOR");
+        }
+
         let ri = block.appendDummyInput();
-        ri.appendField(new FieldLedMatrix("", { columns, rows, scale, onColor, offColor }), "LEDS");
+        ri.appendField(
+            new FieldLedMatrix("", {
+                columns,
+                rows,
+                scale,
+                colors,
+                colorNames,
+                hasOffColor: !!fn.attributes.gridLiteralOffColor,
+                isColorMatrix: !!fn.attributes.colorGridLiteral
+            }),
+            "LEDS"
+        );
     }
 
     if (fn.attributes.inlineInputMode === "external") {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1608,6 +1608,8 @@ ${output}</xml>`;
         }
 
         function getImageLiteralStatement(node: ts.CallExpression, info: pxtc.CallInfo) {
+            const chars = ".#23456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
             let arg = node.arguments[0];
             if (arg.kind != SK.StringLiteral && arg.kind != SK.NoSubstitutionTemplateLiteral) {
                 error(node)
@@ -1619,23 +1621,45 @@ ${output}</xml>`;
             res.fields = [];
 
             const leds = ((arg as ts.StringLiteral).text || '').replace(/\s+/g, '');
-            const nc = (attributes.imageLiteralColumns || 5) * (attributes.imageLiteral || attributes.gridLiteral);
+            const nc = (attributes.imageLiteralColumns || 5) * gridLiteralValue(attributes);
             const nr = attributes.imageLiteralRows || 5;
             const nleds = nc * nr;
             if (nleds != leds.length) {
                 error(node, Util.lf("Invalid image pattern ({0} expected vs {1} actual)", nleds, leds.length));
                 return undefined;
             }
+            const isColor = attributes.colorGridLiteral;
             let ledString = '';
             for (let r = 0; r < nr; ++r) {
                 for (let c = 0; c < nc; ++c) {
-                    ledString += /[#*1]/.test(leds[r * nc + c]) ? '#' : '.';
+                    if (isColor) {
+                        ledString += chars.charAt(parseCharacter(leds[r * nc + c]));
+                    }
+                    else {
+                        ledString += /[#*1]/.test(leds[r * nc + c]) ? '#' : '.';
+                    }
                 }
                 ledString += '\n';
             }
             res.fields.push(getField(`LEDS`, `\`${ledString}\``));
 
             return res;
+        }
+
+        function parseCharacter(c: string): number {
+            const chars = ".#23456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+            switch (c) {
+                case "#":
+                case "*":
+                case "1":
+                    return 1;
+                case ".":
+                case "_":
+                case "0":
+                    return 0;
+                default:
+                    return Math.max(0, chars.indexOf(c.toUpperCase()));
+            }
         }
 
         function getBinaryExpressionStatement(n: ts.BinaryExpression): StatementNode {
@@ -2061,7 +2085,7 @@ ${output}</xml>`;
                 attributes.blockId = builtin.blockId;
             }
 
-            if (attributes.imageLiteral || attributes.gridLiteral) {
+            if (gridLiteralValue(attributes)) {
                 return getImageLiteralStatement(node, info);
             }
 
@@ -2803,7 +2827,7 @@ ${output}</xml>`;
             const comp = env.compInfo(info);
             const totalDecompilableArgs = comp.parameters.length + (comp.thisParameter ? 1 : 0);
 
-            if (attributes.imageLiteral || attributes.gridLiteral) {
+            if (gridLiteralValue(attributes)) {
                 // Image literals do not show up in the block string, so it won't be in comp
                 if (info.args.length - totalDecompilableArgs > 1) {
                     return Util.lf("Function call has more arguments than are supported by its block");
@@ -2815,7 +2839,7 @@ ${output}</xml>`;
                 }
                 const leds = ((arg as ts.StringLiteral).text || '').replace(/\s+/g, '');
                 const nr = attributes.imageLiteralRows || 5;
-                const nc = (attributes.imageLiteralColumns || 5) * (attributes.imageLiteral || attributes.gridLiteral);
+                const nc = (attributes.imageLiteralColumns || 5) * gridLiteralValue(attributes);
                 const nleds = nc * nr;
                 if (nc * nr != leds.length) {
                     return Util.lf("Invalid image pattern ({0} expected vs {1} actual)", nleds, leds.length);
@@ -3985,5 +4009,9 @@ ${output}</xml>`;
         n.emitShadowOnly = emitShadowOnly;
 
         return emitShadowOnly;
+    }
+
+    function gridLiteralValue(attrs: CommentAttrs) {
+        return attrs.gridLiteral || attrs.imageLiteral || attrs.colorGridLiteral;
     }
 }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -901,8 +901,12 @@ namespace ts.pxtc {
         "weight",
         "imageLiteral",
         "gridLiteral",
+        "colorGridLiteral",
         "topblockWeight",
-        "inlineInputModeLimit"
+        "inlineInputModeLimit",
+        "gridLiteralVerticalSpacing",
+        "gridLiteralHorizontalSpacing",
+        "gridLiteralBorderRadius",
     ];
 
     const booleanAttributes: (keyof CommentAttrs)[] = [
@@ -923,6 +927,7 @@ namespace ts.pxtc {
         "argsNullable",
         "compileHiddenArguments",
         "expandArgumentsInToolbox",
+        "gridLiteralUseProjectPalette"
     ];
 
     export function parseCommentString(cmt: string): CommentAttrs {


### PR DESCRIPTION
for a long time we've been toying around with the idea of having an "arcade junior" for lower grades. one problem we've always run into, however, is our asset editors. they have a few features that make it harder for younger students to use them:
1. they're complicated with lots of features
2. they open in a modal, which breaks context while editing programs
3. the previews they show are tiny so they don't show up well in printed materials/screenshots
4. keyboard navigation is complicated

fast forward to last week, where someone sent me a link to the [diversibit](https://www.diversibit.org/en) which got me thinking about how hard it would be to take the matrix field editor that we use in micro:bit and make a version of it for a grid of neopixels, and i realized this would be a great way to kill two birds with one stone!

the matrix field pretty much solves all the arcade junior issues:

1. it's way simpler
2. it's inline in the code
3. the matrix is nice and big on the block
4. it already supports keyboard navigation

with the obvious downside that you can't resize the sprite, but that's probably a good restriction for arcade junior anyhow.

this PR takes our LED matrix field and adds optional support for color, plus some parameters that let you customize the appearance to make it more amenable to pixel grids (removing the corner radius, spacing between cells, etc.). the way the color switching works is through a second field which gets added before the matrix field on the block; this field just pops up a menu of color options that change the "on" color of the matrix. all the other keyboard/mouse interactions are the same: clicking a "lit" cell turns it off and clicking an "unlit" cell turns it on with the selected color.

as for the palette of colors, you can either take the project palette (for arcade) or specify the colors using a comment attribute (for diversibit/other neopixel grids). i briefly considered just using the project palette for the other case too, but realized that it might end up conflicting with the palette used by the display shield.

here's me messing around with keyboard controls:

<img width="1017" height="753" alt="inline-sprites" src="https://github.com/user-attachments/assets/c0ec8ebb-d644-4417-ba1c-ba4e518cd716" />

i'm probably going to have a follow up pr that adds support for tagged template literals with the field (right now it's always strings). i'm still trying to figure out how exactly to have the decompilation for that coexist with the regular image editor