### PR TITLE
Add combobox role to field_textdropdown

### DIFF
--- a/pxtblocks/fields/field_textdropdown.ts
+++ b/pxtblocks/fields/field_textdropdown.ts
@@ -80,6 +80,7 @@ export class BaseFieldTextDropdown extends Blockly.FieldTextInput {
         this.inputKeydownHandler = this.inputKeydownListener.bind(this);
         this.htmlInput_.addEventListener('keydown', this.inputKeydownHandler);
         this.htmlInput_.setAttribute("role", "combobox");
+        this.htmlInput_.ariaExpanded = "true";
 
         if (!quietInput) {
             this.htmlInput_.focus();

--- a/pxtblocks/fields/field_textdropdown.ts
+++ b/pxtblocks/fields/field_textdropdown.ts
@@ -79,6 +79,7 @@ export class BaseFieldTextDropdown extends Blockly.FieldTextInput {
 
         this.inputKeydownHandler = this.inputKeydownListener.bind(this);
         this.htmlInput_.addEventListener('keydown', this.inputKeydownHandler);
+        this.htmlInput_.setAttribute("role", "combobox");
 
         if (!quietInput) {
             this.htmlInput_.focus();


### PR DESCRIPTION
This informs screen reader users that they can use the down arrow to navigate options in a dropdown.