### PR TITLE
add apptarget flag for blockly keyboard controls default

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -397,6 +397,7 @@ declare namespace pxt {
         lightToc?: boolean; // if true: do NOT use inverted style in docs toc
         // FIXME (riknoll): Can't use Blockly types here
         blocklyOptions?: any; // Blockly options, see Configuration: https://developers.google.com/blockly/guides/get-started/web
+        blocklyKeyboardControlsByDefault?: boolean; // if true, keyboard controls will be enabled by default in the blockly editor
         hideFlyoutHeadings?: boolean; // Hide the flyout headings at the top of the flyout when on a mobile device.
         monacoColors?: pxt.Map<string>; // Monaco theme colors, see https://code.visualstudio.com/docs/getstarted/theme-color-reference
         simAnimationEnter?: string; // Simulator enter animation

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -347,7 +347,7 @@ export function getHighContrastOnce(): boolean {
  * Returns true if keyboard controls should be enabled by default.
  */
 export function isKeyboardControlsByDefault(): boolean {
-    return /keyboardcontrols=1/i.test(window.location.href);
+    return /keyboardcontrols=1/i.test(window.location.href) || pxt.appTarget.appTheme?.blocklyKeyboardControlsByDefault;
 }
 
 export async function toggleAccessibleBlocks(eventSource: string) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6745

there will be a corresponding PR in pxt-microbit shortly