### PR TITLE
decompile shims for primitive types correctly and include minmax label

### DIFF
--- a/pxtblocks/toolbox.ts
+++ b/pxtblocks/toolbox.ts
@@ -189,19 +189,19 @@ export function createShadowValue(info: pxtc.BlocksInfo, p: pxt.blocks.BlockPara
 
     let mut: HTMLElement;
     if (p.range) {
-        mut = document.createElement('mutation');
-        mut.setAttribute('min', p.range.min.toString());
-        mut.setAttribute('max', p.range.max.toString());
-        mut.setAttribute('label', p.actualName.charAt(0).toUpperCase() + p.actualName.slice(1));
+        mut = document.createElement("mutation");
+        mut.setAttribute("min", p.range.min.toString());
+        mut.setAttribute("max", p.range.max.toString());
+        mut.setAttribute("label", p.actualName.charAt(0).toUpperCase() + p.actualName.slice(1));
         if (p.fieldOptions) {
-            if (p.fieldOptions['step']) mut.setAttribute('step', p.fieldOptions['step']);
-            if (p.fieldOptions['color']) mut.setAttribute('color', p.fieldOptions['color']);
-            if (p.fieldOptions['precision']) mut.setAttribute('precision', p.fieldOptions['precision']);
+            if (p.fieldOptions["step"]) mut.setAttribute("step", p.fieldOptions["step"]);
+            if (p.fieldOptions["color"]) mut.setAttribute("color", p.fieldOptions["color"]);
+            if (p.fieldOptions["precision"]) mut.setAttribute("precision", p.fieldOptions["precision"]);
         }
     }
 
     if (p.fieldOptions) {
-        if (!mut) mut = document.createElement('mutation');
+        if (!mut) mut = document.createElement("mutation");
         mut.setAttribute(`customfield`, JSON.stringify(p.fieldOptions));
     }
 

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -782,7 +782,7 @@ ${output}</xml>`;
         function emitValueNode(n: ValueNode) {
             write(`<value name="${n.name}">`)
 
-            if (shouldEmitShadowOnly(n)) {
+            if (shouldEmitShadowOnly(n, blocksInfo)) {
                 emitOutputNode(n.value, true);
             }
             else {
@@ -2152,9 +2152,9 @@ ${output}</xml>`;
                 const paramComp = comp.parameters[comp.thisParameter ? i - 1 : i];
                 const paramRange = paramComp && paramComp.range;
                 if (paramRange) {
-                    const min = paramRange['min'];
-                    const max = paramRange['max'];
-                    shadowMutation = { 'min': min.toString(), 'max': max.toString() };
+                    const min = paramRange["min"];
+                    const max = paramRange["max"];
+                    shadowMutation = { "min": min.toString(), "max": max.toString(), "label": paramComp.actualName.charAt(0).toUpperCase() + paramComp.actualName.slice(1) };
                 }
 
                 if (i === 0 && attributes.defaultInstance) {
@@ -2357,7 +2357,7 @@ ${output}</xml>`;
                         if (!arg.param.isOptional) {
                             nonOptional++;
                         }
-                        else if (input && !shouldEmitShadowOnly(input)) {
+                        else if (input && !shouldEmitShadowOnly(input, blocksInfo)) {
                             expandCount = Math.max(arg.param.definitionIndex - nonOptional + 1, expandCount)
                         }
                     }
@@ -3996,7 +3996,7 @@ ${output}</xml>`;
         }
     }
 
-    function shouldEmitShadowOnly(n: ValueNode) {
+    function shouldEmitShadowOnly(n: ValueNode, blocksInfo: BlocksInfo) {
         if (n.emitShadowOnly !== undefined) {
             return n.emitShadowOnly;
         }
@@ -4004,6 +4004,32 @@ ${output}</xml>`;
         let emitShadowOnly = false;
 
         if (n.value.kind === "expr") {
+            if (n.value.type !== n.shadowType) {
+                const shadowBlockInfo = blocksInfo.blocksById[n.shadowType];
+                let shadowBlockShimType: string;
+                let shadowFieldName: string;
+
+                if (shadowBlockInfo?.attributes?.shim === "TD_ID") {
+                    const argType = shadowBlockInfo.parameters[0]?.type;
+                    const blockInfo = pxt.blocks.compileInfo(shadowBlockInfo);
+
+                    if (argType === shadowBlockInfo.retType) {
+                        shadowBlockShimType = argType;
+                        shadowFieldName = blockInfo.parameters[0].definitionName;
+                    }
+                }
+
+                if (
+                    shadowBlockShimType === "boolean" && isBooleanBlockType(n.value.type) ||
+                    shadowBlockShimType === "number" && isNumberBlockType(n.value.type) ||
+                    shadowBlockShimType === "string" && isStringBlockType(n.value.type)
+                ) {
+                    n.value.type = n.shadowType;
+                    n.value.fields[0].name = shadowFieldName;
+                    n.value.mutation = n.shadowMutation;
+                }
+            }
+
             const value = n.value as ExpressionNode;
             if (value.type === numberType && n.shadowType === minmaxNumberType) {
                 value.type = minmaxNumberType;
@@ -4019,23 +4045,14 @@ ${output}</xml>`;
 
             emitShadowOnly = value.type === n.shadowType;
             if (!emitShadowOnly) {
-                switch (value.type) {
-                    case "math_number":
-                    case "math_number_minmax":
-                    case "math_integer":
-                    case "math_whole_number":
-                    case "logic_boolean":
-                    case "text":
-                    case colorPickerNumber:
-                    case colorPickerString:
-                        emitShadowOnly = !n.shadowType;
-                        break;
+                if (isNumberBlockType(value.type) || isBooleanBlockType(value.type) || isStringBlockType(value.type)) {
+                    emitShadowOnly = !n.shadowType
                 }
             }
 
             if (emitShadowOnly && value.inputs) {
                 for (const input of value.inputs) {
-                    if (!shouldEmitShadowOnly(input)) {
+                    if (!shouldEmitShadowOnly(input, blocksInfo)) {
                         emitShadowOnly = false;
                         break;
                     }
@@ -4046,6 +4063,27 @@ ${output}</xml>`;
         n.emitShadowOnly = emitShadowOnly;
 
         return emitShadowOnly;
+    }
+
+    function isNumberBlockType(type: string) {
+        switch (type) {
+            case numberType:
+            case minmaxNumberType:
+            case integerNumberType:
+            case wholeNumberType:
+            case colorPickerNumber:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    function isBooleanBlockType(type: string) {
+        return type === booleanType;
+    }
+
+    function isStringBlockType(type: string) {
+        return type === stringType || type === colorPickerString;
     }
 
     function gridLiteralValue(attrs: CommentAttrs) {

--- a/tests/decompile-test/baselines/compile_hidden_arguments.blocks
+++ b/tests/decompile-test/baselines/compile_hidden_arguments.blocks
@@ -11,31 +11,31 @@
 <field name="interpolation">InterpolationCurve.Linear</field>
 <value name="startFrequency">
 <shadow type="math_number_minmax">
-<mutation min="0" max="5000" />
+<mutation min="0" max="5000" label="StartFrequency" />
 <field name="SLIDER">23</field>
 </shadow>
 </value>
 <value name="endFrequency">
 <shadow type="math_number_minmax">
-<mutation min="0" max="5000" />
+<mutation min="0" max="5000" label="EndFrequency" />
 <field name="SLIDER">0</field>
 </shadow>
 </value>
 <value name="startVolume">
 <shadow type="math_number_minmax">
-<mutation min="0" max="255" />
+<mutation min="0" max="255" label="StartVolume" />
 <field name="SLIDER">25</field>
 </shadow>
 </value>
 <value name="endVolume">
 <shadow type="math_number_minmax">
-<mutation min="0" max="255" />
+<mutation min="0" max="255" label="EndVolume" />
 <field name="SLIDER">1</field>
 </shadow>
 </value>
 <value name="duration">
 <shadow type="math_number_minmax">
-<mutation min="1" max="9999" />
+<mutation min="1" max="9999" label="Duration" />
 <field name="SLIDER">50</field>
 </shadow>
 </value>
@@ -53,25 +53,25 @@
 <field name="interpolation">InterpolationCurve.Linear</field>
 <value name="startFrequency">
 <shadow type="math_number_minmax">
-<mutation min="0" max="5000" />
+<mutation min="0" max="5000" label="StartFrequency" />
 <field name="SLIDER">23</field>
 </shadow>
 </value>
 <value name="endFrequency">
 <shadow type="math_number_minmax">
-<mutation min="0" max="5000" />
+<mutation min="0" max="5000" label="EndFrequency" />
 <field name="SLIDER">0</field>
 </shadow>
 </value>
 <value name="startVolume">
 <shadow type="math_number_minmax">
-<mutation min="0" max="255" />
+<mutation min="0" max="255" label="StartVolume" />
 <field name="SLIDER">25</field>
 </shadow>
 </value>
 <value name="endVolume">
 <shadow type="math_number_minmax">
-<mutation min="0" max="255" />
+<mutation min="0" max="255" label="EndVolume" />
 <field name="SLIDER">0</field></shadow>
 <block type="math_arithmetic">
 <field name="OP">ADD</field>
@@ -89,7 +89,7 @@
 </value>
 <value name="duration">
 <shadow type="math_number_minmax">
-<mutation min="1" max="9999" />
+<mutation min="1" max="9999" label="Duration" />
 <field name="SLIDER">50</field>
 </shadow>
 </value>
@@ -107,31 +107,31 @@
 <field name="interpolation">InterpolationCurve.Linear</field>
 <value name="startFrequency">
 <shadow type="math_number_minmax">
-<mutation min="0" max="5000" />
+<mutation min="0" max="5000" label="StartFrequency" />
 <field name="SLIDER">23</field>
 </shadow>
 </value>
 <value name="endFrequency">
 <shadow type="math_number_minmax">
-<mutation min="0" max="5000" />
+<mutation min="0" max="5000" label="EndFrequency" />
 <field name="SLIDER">0</field>
 </shadow>
 </value>
 <value name="startVolume">
 <shadow type="math_number_minmax">
-<mutation min="0" max="255" />
+<mutation min="0" max="255" label="StartVolume" />
 <field name="SLIDER">25</field>
 </shadow>
 </value>
 <value name="endVolume">
 <shadow type="math_number_minmax">
-<mutation min="0" max="255" />
+<mutation min="0" max="255" label="EndVolume" />
 <field name="SLIDER">1</field>
 </shadow>
 </value>
 <value name="duration">
 <shadow type="math_number_minmax">
-<mutation min="1" max="9999" />
+<mutation min="1" max="9999" label="Duration" />
 <field name="SLIDER">0</field></shadow>
 <block type="math_arithmetic">
 <field name="OP">ADD</field>

--- a/tests/decompile-test/baselines/custom_field_editors.blocks
+++ b/tests/decompile-test/baselines/custom_field_editors.blocks
@@ -4,7 +4,7 @@
 <block type="test_sliderFieldEditor">
 <value name="value">
 <shadow type="math_number_minmax">
-<mutation min="0" max="500" />
+<mutation min="0" max="500" label="Value" />
 <field name="SLIDER">10</field>
 </shadow>
 </value>

--- a/tests/decompile-test/baselines/decompiler_shadow_alias.blocks
+++ b/tests/decompile-test/baselines/decompiler_shadow_alias.blocks
@@ -9,7 +9,7 @@
 </value>
 <value name="value">
 <shadow type="math_number_minmax">
-<mutation min="0" max="1" />
+<mutation min="0" max="1" label="Value" />
 <field name="SLIDER">2</field>
 </shadow>
 </value>

--- a/tests/decompile-test/baselines/shadow_primitive_shims.blocks
+++ b/tests/decompile-test/baselines/shadow_primitive_shims.blocks
@@ -1,0 +1,40 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="robot_motorSteer">
+<value name="turnRatio">
+<shadow type="turnRatioPicker">
+<mutation min="-200" max="200" label="TurnRatio" />
+<field name="turnratio">10</field>
+</shadow>
+</value>
+<value name="speed">
+<shadow type="speedPicker">
+<field name="speed">-20</field>
+</shadow>
+</value>
+<next>
+<block type="robot_motorSteer">
+<mutation _expanded="1" />
+<value name="turnRatio">
+<shadow type="turnRatioPicker">
+<mutation min="-200" max="200" label="TurnRatio" />
+<field name="turnratio">10</field>
+</shadow>
+</value>
+<value name="speed">
+<shadow type="speedPicker">
+<field name="speed">-20</field>
+</shadow>
+</value>
+<value name="duration">
+<shadow type="timePicker">
+<field name="ms">100</field>
+</shadow>
+</value>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/shadow_primitive_shims.ts
+++ b/tests/decompile-test/cases/shadow_primitive_shims.ts
@@ -1,0 +1,2 @@
+robot.motorSteer(10, -20)
+robot.motorSteer(10, -20, 100)

--- a/tests/decompile-test/cases/testBlocks/pxt.json
+++ b/tests/decompile-test/cases/testBlocks/pxt.json
@@ -17,7 +17,8 @@
         "spritekind.ts",
         "decompilerShadowAlias.ts",
         "blockAliasFor.ts",
-        "forceStatement.ts"
+        "forceStatement.ts",
+        "robot.ts"
     ],
     "public": true,
     "dependencies": {},

--- a/tests/decompile-test/cases/testBlocks/robot.ts
+++ b/tests/decompile-test/cases/testBlocks/robot.ts
@@ -1,0 +1,25 @@
+namespace robot {
+    /**
+     * Steers the robot.
+     */
+    //% weight=97
+    //% group="Motors"
+    //% block="robot motor steer $turnRatio at $speed \\% || for $duration ms"
+    //% blockid="mbitrobotmotorsteer"
+    //% expandableArgumentMode="toggle"
+    //% speed.defl=100
+    //% speed.min=-100
+    //% speed.max=100
+    //% speed.shadow=speedPicker
+    //% turnRatio.shadow=turnRatioPicker
+    //% turnRatio.min=-200
+    //% turnRatio.max=200
+    //% duration.shadow=timePicker
+    export function motorSteer(
+        turnRatio: number = 0,
+        speed: number = 100,
+        duration?: number
+    ) {
+
+    }
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6555

this fixes two issues:
1. the decompiler wasn't emitting the label attribute in the mutation for slider blocks
2. when decompiling `shim=TD_ID` functions that just wrap a primitive type, the decompiler was emitting the generic shadow for the type (e.g. math_number for number) instead of the shim function

in regards to that second issue, we basically have two types of blocks that get the `shim=TD_ID` annotation on their functions: ones that change the return type (e.g. converting an enum to a number) and ones that just wrap a primitive type (both the argument and return type of the function have the same type). this change only applies to the latter, the former are handled by adding the `blockIdentity="whatever"` annotation on the type that's being converted from.

i also replaced a bunch of single quotes because i hate them