### PR TITLE
detailview action cards mobile/ipad responsiveness

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -259,7 +259,13 @@
                 grid-column-start: 1;
                 grid-column-end: -1;
                 min-width: 0;
-                width: 100%;
+                // Negative horizontal margins extend the detail view past the
+                // `.search-segment` horizontal padding so it spans edge-to-edge,
+                // matching the non-search detail view (which is a sibling of
+                // the padded `.carouselcontainer`).
+                margin-left: -@carouselArrowSize;
+                margin-right: -@carouselArrowSize;
+                width: calc(100% + 2 * @carouselArrowSize);
             }
 
             .search-empty-state {
@@ -926,6 +932,12 @@
     /* Carousel */
     .gallerysegment.search-segment {
         padding: 1rem @carouselArrowSizeTablet;
+
+        .search-detailview.detailview {
+            margin-left: -@carouselArrowSizeTablet;
+            margin-right: -@carouselArrowSizeTablet;
+            width: calc(100% + 2 * @carouselArrowSizeTablet);
+        }
     }
     .ui.segment.gallerysegment.mystuff-segment.search-mode {
         .gallery-heading-column {
@@ -1042,6 +1054,12 @@
     /* Carousel */
     .gallerysegment.search-segment {
         padding: 1rem @carouselArrowSizeMobile;
+
+        .search-detailview.detailview {
+            margin-left: -@carouselArrowSizeMobile;
+            margin-right: -@carouselArrowSizeMobile;
+            width: calc(100% + 2 * @carouselArrowSizeMobile);
+        }
     }
     .ui.segment.gallerysegment.mystuff-segment.search-mode {
         .gallery-heading-column {

--- a/theme/home.less
+++ b/theme/home.less
@@ -966,25 +966,57 @@
             }
         }
         .detailview {
-            .actions .card-action {
-                max-width: 10rem;
-                .button.attached .icon:not(.xicon) {
-                    line-height: 6rem;
+            .project-info .segment {
+                padding-bottom: 1.5rem;
+            }
+            .ui.grid.stackable .actions {
+                // Switch to flex so multiple action cards shrink to fit on
+                // narrower (e.g. iPad portrait, ~834px) viewports instead of
+                // overflowing the column and being clipped by the parent
+                // `.detailview { overflow: hidden }`.
+                padding-right: 1.5rem !important;
+
+                .segment {
+                    display: flex;
+                    flex-wrap: nowrap;
+                    justify-content: flex-end;
+                    align-items: flex-start;
+                    gap: 0.75rem;
+                    margin-top: 4rem;
+                    margin-right: 0.5rem;
+                    white-space: normal;
+                }
+
+                .card-action {
+                    flex: 0 1 8rem;
+                    min-width: 0;
+                    max-width: 8rem;
+                    margin: 0;
+
+                    .button.attached .icon:not(.xicon) {
+                        font-size: 3.5rem;
+                        line-height: 6rem;
+                    }
+                }
+                .card-action.custom-icon i.xicon {
+                    font-size: 4.5rem;
+                    padding-top: 2rem;
+                }
+                .card-action > .item,
+                .card-action > .icon {
+                    height: 6rem;
+                    max-width: 100%;
+                    background-size: 60%;
+                }
+                .card-action-title {
+                    font-size: 1.1rem;
                 }
             }
-            .actions .card-action > .item,
-            .actions .card-action > .icon {
-                height: 6rem;
-                max-width: 10rem;
-                background-size: 60%;
-            }
-            .actions .segment {
-                margin-top: 4rem;
-                margin-right: 2rem;
-            }
             .ui.button.approve {
-                font-size: 1rem!important;
-                padding: 0.7rem 1rem;
+                font-size: 0.9rem!important;
+                padding: 0.6rem 0.75rem;
+                white-space: normal;
+                line-height: 1.2;
             }
         }
     }
@@ -1127,9 +1159,12 @@
                     padding-bottom: 1rem;
                 }
             }
+            // Match the `.ui.grid.stackable` specificity used at the tablet
+            // breakpoint so the mobile segment overrides win when stacked.
+            .ui.grid.stackable .actions,
             .actions {
                 height: auto;
-                padding-right: @carouselArrowSizeMobile !important;
+                padding-right: 0.5rem !important;
                 .card-action {
                     display: inline-block;
                     width: 8rem;
@@ -1145,6 +1180,8 @@
                     .button.approve {
                         font-size: 0.9rem !important;
                         padding: .35em 0.75em .5em;
+                        white-space: normal;
+                        line-height: 1.2;
                     }
                     .button.attached .icon:not(.xicon) {
                         font-size: 2rem;
@@ -1159,7 +1196,7 @@
 
                 .segment {
                     position: static;
-                    margin: 0 0.5rem 0.5rem;
+                    margin: 0 0 0.5rem;
                     text-align: right;
                     white-space: nowrap;
                 }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/6812

https://makecode.microbit.org/app/f03d1fc65ad43d2bd5a4ac91faa683b82513229d-6b9a4827d7

this one's not specific to search, has always been iffy on different dimensions for tutorials with 3 choices. worked on the logic a bit,  build is above but here's some examples at different breakpoints with these changes (old first, then new after this change):

besides that, expanded detailview in search so that it goes fully across screen rather than constrained to same dimensions, so that we don't end up having to special case it extra for scenarios like this (/ everything shares same size as normal projects carousels)

ipad mini
<img width="1295" height="1284" alt="image" src="https://github.com/user-attachments/assets/a8308dde-12b9-4111-92c2-786bfc8d6851" />

<img width="1389" height="875" alt="image" src="https://github.com/user-attachments/assets/03f1a2f8-dc34-4e56-ae02-f83077eddb78" />

ipad air 
<img width="1333" height="1057" alt="image" src="https://github.com/user-attachments/assets/229c2eec-9f28-401a-8e1e-fa0e991424b0" />

<img width="1285" height="1008" alt="image" src="https://github.com/user-attachments/assets/93c4adda-0630-41d5-b2b0-398adb13c330" />

iphone se
<img width="1316" height="1184" alt="image" src="https://github.com/user-attachments/assets/d8a3c41e-e8f4-4fe8-95aa-368728087447" />

<img width="704" height="1066" alt="image" src="https://github.com/user-attachments/assets/9c880cc5-8f23-4168-9dfa-11b401c068ea" />

samsung galaxy 8
<img width="1424" height="1280" alt="image" src="https://github.com/user-attachments/assets/e39938b6-500a-44e9-9095-b18e41ebd1fc" />

<img width="636" height="1168" alt="image" src="https://github.com/user-attachments/assets/a2c4b93a-0a1a-4e34-8a65-09eafb6009a3" />
