### PR TITLE
remove arm and ie special cases

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -6239,7 +6239,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (optsQuery["dbg"] == "1") {
         pxt.setLogLevel(pxt.LogLevel.Debug);
     }
-    pxt.options.light = optsQuery["light"] == "1" || pxt.BrowserUtils.isARM() || pxt.BrowserUtils.isIE();
+    pxt.options.light = optsQuery["light"] == "1";
     if (pxt.options.light) {
         pxsim.U.addClass(document.body, 'light');
     }


### PR DESCRIPTION
the arm one was added in https://github.com/microsoft/pxt/commit/4f27a19fe517ac0b2ac682e8663355bc31801172 specifically for raspberry pi, and ie not supported in the first place; no reason to keep these around anymore. We have other ways you can fall into the light mode case if device truly needs it (e.g. giga slow typecheck)

fix https://github.com/microsoft/pxt-microbit/issues/6477