### PR TITLE
add more options to piano roll

### DIFF
--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -1046,10 +1046,10 @@ function getPlaceholderColor(row: number): string {
 }
 
 const offsetLookup = [0x09, 0x0b, 0x00, 0x02, 0x04, 0x05, 0x07];
-const REST = -0xffff;
+export const REST = -0xffff;
 
 // copied from pxt-microbit/libs/core/music.ts
-class MelodyStringReader {
+export class MelodyStringReader {
     currentOctave: number;
     currentNote: number;
     currentDuration: number;

--- a/pxtblocks/fields/field_piano_roll.ts
+++ b/pxtblocks/fields/field_piano_roll.ts
@@ -1,7 +1,190 @@
-import { FieldMusicEditor } from "./field_musiceditor";
+import { MelodyStringReader, REST } from "./field_melodySandbox";
+import { FieldMusicEditor, FieldMusicEditorOptions } from "./field_musiceditor";
+import { isTrue } from "./field_utils";
+
+interface FieldPianoRollOptions extends FieldMusicEditorOptions {
+    maxPolyphony?: number;
+    hideHeader?: boolean;
+    borderColor?: string;
+    encodeAsMelody?: boolean;
+    minOctave?: number;
+    maxOctave?: number;
+}
 
 export class FieldPianoRoll extends FieldMusicEditor {
+    protected showInWidgetDiv: boolean;
+    protected encodeAsMelody: boolean;
+
     protected override getEditorKind() {
         return "piano-roll-editor";
     }
+
+    protected override isFullscreen() {
+        return !this.showInWidgetDiv;
+    }
+
+    protected override getValueText(): string {
+        if (!this.encodeAsMelody) return super.getValueText();
+
+        const song = (this.asset as pxt.Song)?.song;
+
+        if (!song) return this.valueText || "";
+
+        let result = "";
+        const ticksPerSixteenth = song.ticksPerBeat / 4;
+        let currentTick = 0;
+
+        for (const noteEvent of song.tracks[0].notes) {
+            if (noteEvent.startTick > currentTick) {
+                const restDuration = Math.round((noteEvent.startTick - currentTick) / ticksPerSixteenth);
+                result += `r:${restDuration} `;
+            }
+            const note = noteEvent.notes[0].note - 1;
+            const duration = Math.round((noteEvent.endTick - noteEvent.startTick) / ticksPerSixteenth);
+
+            const notes = "CCDDEFFGGAAB";
+            const noteInOctave = note % 12;
+            const octave = Math.floor(note / 12) + 1;
+            const accidental = isBlackKey(note) ? "#" : "";
+            result += `${notes.charAt(noteInOctave)}${accidental}${octave}:${duration} `;
+
+            currentTick = noteEvent.endTick;
+        }
+
+        const maxTick = song.measures * song.ticksPerBeat * song.beatsPerMeasure;
+
+        if (currentTick < maxTick) {
+            const restDuration = Math.round((maxTick - currentTick) / ticksPerSixteenth);
+            result += `r:${restDuration} `;
+        }
+
+        return `"${result.trim()}"`;
+    }
+
+    protected override createNewAsset(text?: string): pxt.Asset {
+        if (!this.encodeAsMelody) return super.createNewAsset(text);
+
+        const song = createEmptyMelodySong(this.temporaryAssetId());
+
+        if (!text) return song;
+
+        text = text.replace(/"/g, "").trim();
+
+        const reader = new MelodyStringReader(text, true);
+        let currentTick = 0;
+
+        // melody duration is in 1/16 notes
+        const ticksPerSixteenth = song.song.ticksPerBeat / 4;
+
+        while (reader.hasNextNote()) {
+            reader.readNote();
+
+            const duration = reader.currentDuration * ticksPerSixteenth;
+
+            if (reader.currentNote !== REST) {
+                song.song.tracks[0].notes.push({
+                    startTick: currentTick,
+                    endTick: currentTick + duration,
+                    notes: [
+                        {
+                            note: reader.currentNote + 1 + (reader.currentOctave - 1) * 12,
+                            enharmonicSpelling: isBlackKey(reader.currentNote) ? "sharp" : "normal"
+                        }
+                    ]
+                });
+            }
+
+            currentTick += duration;
+        }
+
+        const measures = Math.ceil(currentTick / (song.song.ticksPerBeat * song.song.beatsPerMeasure));
+        song.song.measures = measures;
+
+        return song;
+    }
+
+    protected override parseFieldOptions(opts: any): FieldPianoRollOptions {
+        const result = super.parseFieldOptions(opts) as FieldPianoRollOptions;
+
+        this.showInWidgetDiv = isTrue(opts.showInWidgetDiv);
+
+        if (opts.maxPolyphony) {
+            const maxPolyphony = parseInt(opts.maxPolyphony);
+            if (!isNaN(maxPolyphony) && maxPolyphony > 0) {
+                result.maxPolyphony = maxPolyphony;
+            }
+        }
+
+        if (opts.minOctave) {
+            const minOctave = parseInt(opts.minOctave);
+            if (!isNaN(minOctave)) {
+                result.minOctave = minOctave;
+            }
+        }
+
+        if (opts.maxOctave) {
+            const maxOctave = parseInt(opts.maxOctave);
+            if (!isNaN(maxOctave)) {
+                result.maxOctave = maxOctave;
+            }
+        }
+
+        if (opts.hideHeader) {
+            result.hideHeader = isTrue(opts.hideHeader);
+        }
+
+        if (opts.borderColor) {
+            result.borderColor = opts.borderColor;
+        }
+
+        if (opts.encodeAsMelody) {
+            result.encodeAsMelody = isTrue(opts.encodeAsMelody);
+            this.encodeAsMelody = result.encodeAsMelody;
+            if (result.encodeAsMelody) {
+                result.maxPolyphony = 1;
+            }
+        }
+
+
+        return result;
+    }
+}
+
+function melodyInstrument(): pxt.assets.music.Instrument {
+    return {
+        waveform: 1,
+        ampEnvelope: {
+            attack: 10,
+            decay: 50,
+            sustain: 1024,
+            release: 10,
+            amplitude: 1024
+        }
+    };
+}
+
+function createEmptyMelodySong(assetId: string): pxt.Song {
+    const song = pxt.assets.music.getEmptySong(2);
+    song.tracks = [
+        {
+            name: "Melody",
+            id: 0xff,
+            instrument: melodyInstrument(),
+            notes: []
+        }
+    ];
+
+    return {
+        internalID: -1,
+        id: assetId,
+        type: pxt.AssetType.Song,
+        meta: {
+        },
+        song
+    }
+}
+
+function isBlackKey(note: number) {
+    const noteInOctave = note % 12;
+    return [1, 3, 6, 8, 10].includes(noteInOctave);
 }

--- a/pxtblocks/fields/field_sound_effect.ts
+++ b/pxtblocks/fields/field_sound_effect.ts
@@ -4,7 +4,7 @@ import * as Blockly from "blockly";
 
 import svg = pxt.svgUtil;
 import { FieldBase } from "./field_base";
-import { FieldCustomOptions, workspaceToScreenCoordinates } from "./field_utils";
+import { FieldCustomOptions, isTrue, workspaceToScreenCoordinates } from "./field_utils";
 
 export interface FieldSoundEffectParams extends FieldCustomOptions {
     durationInputName: string;
@@ -424,21 +424,3 @@ function reverseLookup(map: {[index: string]: string}, value: string) {
     return Object.keys(map).find(k => map[k] === value);
 }
 
-function isTrue(value: any) {
-    if (!value) return false;
-
-    if (typeof value === "string") {
-        switch (value.toLowerCase().trim()) {
-            case "1":
-            case "yes":
-            case "y":
-            case "on":
-            case "true":
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    return !!value;
-}

--- a/pxtblocks/fields/field_utils.ts
+++ b/pxtblocks/fields/field_utils.ts
@@ -713,3 +713,22 @@ export function isImageProperties(obj: any): obj is Blockly.ImageProperties {
     typeof obj.height === 'number'
   );
 }
+
+export function isTrue(value: any) {
+    if (!value) return false;
+
+    if (typeof value === "string") {
+        switch (value.toLowerCase().trim()) {
+            case "1":
+            case "yes":
+            case "y":
+            case "on":
+            case "true":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    return !!value;
+}

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -25,6 +25,7 @@
     --velocity-slider-color: var(--note-event-color);
 
     --header-background: #f0f0f0;
+    --piano-roll-border-color: var(--workspace-grid-line-color);
 }
 
 .piano-roll {
@@ -47,12 +48,13 @@
     height: 100%;
     overflow-x: hidden;
     overflow-y: hidden;
+    background: var(--workspace-grid-line-color);
 }
 
 .piano-roll-root {
     height: 100%;
     overflow-y: hidden;
-    background: var(--workspace-grid-line-color)
+    background: var(--piano-roll-border-color);
 }
 
 .piano-roll .header-container {
@@ -317,5 +319,15 @@
                 border: var(--note-event-border-hover);
             }
         }
+    }
+}
+
+/* Inline field editor */
+.blocklyWidgetDiv .piano-roll-root {
+    padding: 0.25rem;
+
+    /* Hide the done button */
+    .music-editor-edit-controls .common-button.green {
+        display: none;
     }
 }

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -6,7 +6,6 @@ import * as ReactDOM from "react-dom";
 import { ImageFieldEditor } from "./components/ImageFieldEditor";
 import { SoundEffectEditor } from "./components/soundEffectEditor/SoundEffectEditor";
 import { AssetFilePicker } from "./components/AssetFilePicker";
-import { PianoRollFieldEditor } from "./components/pianoRoll/FieldEditor";
 
 export interface EditorBounds {
     top: number;

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -32,6 +32,7 @@ export interface ImageFieldEditorState {
     galleryFilter: string;
     editingTile?: boolean;
     hideCloseButton?: boolean;
+    options?: any;
 }
 
 export interface AssetEditorCore {
@@ -50,7 +51,6 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
     protected blocksInfo: pxtc.BlocksInfo;
     protected ref: AssetEditorCore;
     protected closeEditor: () => void;
-    protected options: any;
     protected editID: string;
     protected galleryAssets: pxt.Asset[];
     protected userAssets: pxt.Asset[];
@@ -182,7 +182,8 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                                 <PianoRollAssetEditor
                                     ref="image-editor"
                                     onDoneClicked={this.onDoneClick}
-                                    hideDoneButton={this.props.hideDoneButton} /> :
+                                    hideDoneButton={this.props.hideDoneButton}
+                                    fieldEditorParams={this.state.options} /> :
                                 <ImageEditor
                                     ref="image-editor"
                                     singleFrame={this.props.singleFrame}
@@ -224,7 +225,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
 
     init(value: U, close: () => void, options?: any) {
         this.closeEditor = close;
-        this.options = options;
+        this.setState({ options });
         this.lightMode = options.lightMode;
 
         switch (value.type) {
@@ -306,7 +307,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
         if (this.ref) {
             this.ref.restorePersistentData(oldValue);
 
-            if (this.options && this.options.disableResize) {
+            if (this.state?.options?.disableResize) {
                 this.ref.disableResize();
             }
         }
@@ -424,7 +425,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
 
         if (useTags) {
             assets.forEach(a => {
-                if (!a.meta.tags && this.options) {
+                if (!a.meta.tags && this.state?.options) {
                     a.meta.tags = this.blocksInfo?.apis.byQName[a.id]?.attributes.tags?.split(" ") || [];
                 }})
 
@@ -553,7 +554,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
     protected showMyAssets = () => {
         this.setImageEditorShortcutsEnabled(false);
         tickImageEditorEvent("gallery-my-assets");
-        this.userAssets = getAssets(undefined, undefined, this.options.temporaryAssets);
+        this.userAssets = getAssets(undefined, undefined, this.state?.options?.temporaryAssets);
         this.setState({
             currentView: "my-assets",
             tileGalleryVisible: false

--- a/webapp/src/components/PianoRollFieldEditor.tsx
+++ b/webapp/src/components/PianoRollFieldEditor.tsx
@@ -7,6 +7,7 @@ import { PianoRollFieldEditor } from "./pianoRoll/FieldEditor";
 interface PianoRollAssetEditorProps {
     onDoneClicked: () => void;
     hideDoneButton?: boolean;
+    fieldEditorParams?: any;
 }
 
 export class PianoRollAssetEditor extends React.Component<PianoRollAssetEditorProps, {}> implements AssetEditorCore {
@@ -24,6 +25,7 @@ export class PianoRollAssetEditor extends React.Component<PianoRollAssetEditorPr
         return (
             <PianoRollFieldEditor
                 handleRef={this.handlePianoFieldEditorRef}
+                fieldEditorParams={this.props.fieldEditorParams}
             />
         )
     }

--- a/webapp/src/components/pianoRoll/FieldEditor.tsx
+++ b/webapp/src/components/pianoRoll/FieldEditor.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FieldEditorComponent } from "../../blocklyFieldView"
-import { PianoRoll, PianoRollState } from "./PianoRoll"
+import { FieldEditorParams, PianoRoll, PianoRollState } from "./PianoRoll"
 
 interface Props {
     handleRef: (e: FieldEditorComponent<any>) => void;
+    fieldEditorParams?: FieldEditorParams;
 }
 
 interface DoneCallback {
@@ -11,7 +12,7 @@ interface DoneCallback {
 }
 
 export const PianoRollFieldEditor = (props: Props) => {
-    const { handleRef } = props;
+    const { handleRef, fieldEditorParams } = props;
 
     const [asset, setAsset] = useState<pxt.Song>();
     const [onDoneClicked, setOnDoneClicked] = useState<DoneCallback>(undefined);
@@ -79,6 +80,7 @@ export const PianoRollFieldEditor = (props: Props) => {
             showEditControls={true}
             onDoneClicked={onDoneClicked?.onDoneClicked}
             name={asset?.meta?.displayName}
+            fieldEditorParams={fieldEditorParams}
         />
     )
 }

--- a/webapp/src/components/pianoRoll/PianoOctave.tsx
+++ b/webapp/src/components/pianoRoll/PianoOctave.tsx
@@ -57,7 +57,7 @@ export const PianoOctave = (props: Props) => {
             }
         }
         else {
-            await pxsim.music.playNoteAsync(note, instrument.instrument, 300)
+            await pxsim.music.playNoteAsync(note + 1, instrument.instrument, 300)
         }
 
         if (ref) {

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -1,4 +1,4 @@
-import { PianoRollThemeProvider, usePianoRollThemeContext } from "./context"
+import { PianoRollTheme, PianoRollThemeProvider, usePianoRollThemeContext } from "./context"
 import { Workspace } from "./Workspace"
 import { Sidebar } from "./Sidebar"
 import { useEffect, useRef, useState } from "react"
@@ -23,6 +23,7 @@ interface PianoRollProps {
     showEditControls?: boolean;
     name?: string;
     onDoneClicked?: () => void;
+    fieldEditorParams?: FieldEditorParams;
 }
 
 type modalType = "delete-track" | "delete-error" | "drum-warning";
@@ -50,6 +51,14 @@ export interface PianoRollState {
     name?: string;
 }
 
+export interface FieldEditorParams {
+    hideHeader?: boolean;
+    maxPolyphony?: number;
+    borderColor?: string;
+    minOctave?: number;
+    maxOctave?: number;
+}
+
 interface StateSnapshot {
     song: Song;
     selectedTrack: number;
@@ -66,7 +75,8 @@ const PianoRollInternal = (props: PianoRollProps) => {
         redoStack: initialRedoStack,
         name: initialName,
         showEditControls,
-        onDoneClicked
+        onDoneClicked,
+        fieldEditorParams
     } = props;
     const { state: theme, dispatch: updateTheme, } = usePianoRollThemeContext();
 
@@ -121,6 +131,20 @@ const PianoRollInternal = (props: PianoRollProps) => {
             fireStateChange({});
         }
     }, [onStateChanged])
+
+    useEffect(() => {
+        const newTheme: Partial<PianoRollTheme> = {};
+
+        if (fieldEditorParams?.maxPolyphony) {
+            newTheme.maxPolyphony = fieldEditorParams.maxPolyphony;
+        }
+
+        if (fieldEditorParams?.borderColor) {
+            newTheme.borderColor = fieldEditorParams.borderColor;
+        }
+
+        updateTheme(newTheme);
+    }, [fieldEditorParams, updateTheme])
 
     const fireStateChange = (newState: Partial<PianoRollState>) => {
         if (onStateChanged) {
@@ -226,7 +250,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
             pxsim.music.playDrumAsync(drum)
         }
         else {
-            pxsim.music.playNoteAsync(note, instrument.instrument, 300)
+            pxsim.music.playNoteAsync(note + 1, instrument.instrument, 300)
         }
     }
 
@@ -333,14 +357,30 @@ const PianoRollInternal = (props: PianoRollProps) => {
     const track = song.tracks.find(t => t.id === selectedTrack)!;
     const instrument = song.instruments.find(i => i.id === track.instrumentId)!;
 
-    const minOctave = isDrumInstrument(instrument) ? 0 : track.minOctave;
-    const maxOctave = isDrumInstrument(instrument) ? 1 : track.maxOctave;
+    let minOctave: number;
+    let maxOctave: number;
+
+    if (fieldEditorParams?.minOctave !== undefined) {
+        minOctave = fieldEditorParams.minOctave;
+    }
+    else {
+        minOctave = isDrumInstrument(instrument) ? 0 : track.minOctave;
+    }
+
+    if (fieldEditorParams?.maxOctave !== undefined) {
+        maxOctave = fieldEditorParams.maxOctave;
+    }
+    else {
+        maxOctave = isDrumInstrument(instrument) ? 1 : track.maxOctave;
+    }
 
     useEffect(() => {
         if (theme.minOctave !== minOctave || theme.maxOctave !== maxOctave || theme.measures !== song.measures) {
             updateTheme({ minOctave, maxOctave, measures: song.measures });
         }
     }, [minOctave, maxOctave, theme.minOctave, theme.maxOctave, updateTheme, song.measures])
+
+    const showHeader = !fieldEditorParams?.hideHeader;
 
     return (
         <div className="piano-roll">
@@ -353,19 +393,21 @@ const PianoRollInternal = (props: PianoRollProps) => {
             {modal?.type === "drum-warning" &&
                 <DrumWarningModal trackId={modal.trackId!} instrumentId={modal.instrumentId!} onClose={closeModal} onConfirm={setTrackInstrument} />
             }
-            <div className="header-container">
-                <Header
-                    song={song}
-                    selectedTrack={selectedTrack}
-                    velocityEditorVisible={velocityEditorVisible}
-                    onVelocityEditorToggle={onVelocityEditorToggle}
-                    onTrackSelected={onTrackSelected}
-                    onInstrumentSelected={onInstrumentSelected}
-                    onTrackCreated={onTrackCreated}
-                    onTrackDeleted={onTrackDeleted}
-                    onOctavesChanged={onOctavesChanged}
-                />
-            </div>
+            {showHeader &&
+                <div className="header-container">
+                    <Header
+                        song={song}
+                        selectedTrack={selectedTrack}
+                        velocityEditorVisible={velocityEditorVisible}
+                        onVelocityEditorToggle={onVelocityEditorToggle}
+                        onTrackSelected={onTrackSelected}
+                        onInstrumentSelected={onInstrumentSelected}
+                        onTrackCreated={onTrackCreated}
+                        onTrackDeleted={onTrackDeleted}
+                        onOctavesChanged={onOctavesChanged}
+                    />
+                </div>
+            }
             <MeasureHeader measures={song.measures} />
             <div className="scroll-container">
                 <div className="content-container">

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -78,7 +78,7 @@ export const Workspace = (props: Props) => {
             const coords = clientToNoteCoordinates(clientX, clientY);
             if (!coords) return 1;
 
-            const max = getMaxDuration(editing.note, editing.start + 1, track, measures);
+            const max = getMaxDuration(editing.note, editing.start, track, measures, theme.maxPolyphony);
 
             return Math.max(1, Math.min(max, coords.time - editing.start + 1));
         }
@@ -151,13 +151,13 @@ export const Workspace = (props: Props) => {
                     const coords = clientToNoteCoordinates(gestureState.current.startX, gestureState.current.startY);
 
                     if (coords) {
-                        onEdit(newNoteEvent(coords.note, coords.time, track, isDrumTrack, measures));
+                        onEdit(newNoteEvent(coords.note, coords.time, track, isDrumTrack, measures, theme.maxPolyphony));
                         playNote(coords.note);
                     }
                 }
             }
             else if (gestureState.current.noteEvent && !isDrumTrack) {
-                onEdit(changeNoteEventDuration(gestureState.current.noteEvent.id, getNewNoteDuration(e.clientX, e.clientY), track, measures));
+                onEdit(changeNoteEventDuration(gestureState.current.noteEvent.id, getNewNoteDuration(e.clientX, e.clientY), track, measures, theme.maxPolyphony));
             }
 
             gestureState.current = null;

--- a/webapp/src/components/pianoRoll/context.tsx
+++ b/webapp/src/components/pianoRoll/context.tsx
@@ -9,6 +9,8 @@ export interface PianoRollTheme {
     gridLineColor: string;
     whiteKeyWorkspaceColor: string;
     blackKeyWorkspaceColor: string;
+    maxPolyphony: number;
+    borderColor?: string;
 }
 
 const defaultTheme: PianoRollTheme = {
@@ -17,6 +19,7 @@ const defaultTheme: PianoRollTheme = {
     measures: 4,
     minOctave: 3,
     maxOctave: 5,
+    maxPolyphony: Infinity,
     gridLineColor: "#283547",
     whiteKeyWorkspaceColor: "#405470",
     blackKeyWorkspaceColor: "#36475f"
@@ -44,8 +47,8 @@ export function PianoRollThemeProvider(
     const value = { state, dispatch };
     const rootRef = useRef<HTMLDivElement | null>(null);
 
+    // read CSS variables on first mount
     useEffect(() => {
-        rootRef.current!.setAttribute("style", `--octave-width: ${value.state.octaveWidth}px; --white-key-height: ${value.state.whiteKeyHeight}px;`);
         const style = getComputedStyle(rootRef.current!);
 
         const gridLineColor = style.getPropertyValue("--workspace-grid-line-color");
@@ -64,6 +67,19 @@ export function PianoRollThemeProvider(
             });
         }
     }, [])
+
+    useEffect(() => {
+        const styleParts = [
+            `--octave-width: ${value.state.octaveWidth}px`,
+            `--white-key-height: ${value.state.whiteKeyHeight}px`,
+        ];
+
+        if (value.state.borderColor) {
+            styleParts.push(`--piano-roll-border-color: ${value.state.borderColor}`);
+        }
+
+        rootRef.current!.setAttribute("style", styleParts.join("; "));
+    }, [value.state.octaveWidth, value.state.whiteKeyHeight, value.state.borderColor])
 
     return (
         <PianoRollContext.Provider

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -104,35 +104,48 @@ export function getEmptySong(): Song {
     return song;
 }
 
-export function getNextNoteEvent(note: number, start: number, track: Track): NoteEvent | undefined {
+export function getNextNoteEvent(note: number, start: number, track: Track, maxPolyphony: number): NoteEvent | undefined {
     return track.events.find(e => e.note === note && e.start > start);
 }
 
-export function getMaxDuration(note: number, start: number, track: Track, measures: number): number {
-    const nextEvent = getNextNoteEvent(note, start, track);
-    if (!nextEvent) return measures * 4 * 4 - start;
+export function getMaxDuration(note: number, start: number, track: Track, measures: number, maxPolyphony: number): number {
+    let activeNotes: NoteEvent[] = [];
 
-    return nextEvent.start - start;
+    for (const event of track.events) {
+        if (event.start === start && event.note === note) continue;
+
+        activeNotes.push(event);
+        if (event.start >= start) {
+            if (event.note === note || activeNotes.length >= maxPolyphony) {
+                return event.start - start;
+            }
+        }
+        activeNotes = activeNotes.filter(e => e.start + e.duration < event.start);
+    }
+
+    return measures * 4 * 4 - start;
 }
 
-export function newNoteEvent(note: number, start: number, track: Track, isDrumTrack: boolean, measures: number): Track {
+export function newNoteEvent(note: number, start: number, track: Track, isDrumTrack: boolean, measures: number, maxPolyphony: number): Track {
+    track = removeEventAtTimeIfNeeded(start, track, maxPolyphony);
+
     const newEvent: NoteEvent = {
         id: track.nextId++,
         note,
         start,
-        duration: isDrumTrack ? 1 : Math.min(4, getMaxDuration(note, start, track, measures)),
+        duration: isDrumTrack ? 1 : Math.min(4, getMaxDuration(note, start, track, measures, maxPolyphony)),
         velocity: 128
     };
 
     return insertNoteEvent(newEvent, track);
 }
 
-export function changeNoteEventDuration(id: number, duration: number, track: Track, measures: number): Track {
+export function changeNoteEventDuration(id: number, duration: number, track: Track, measures: number, maxPolyphony: number): Track {
     const eventIndex = track.events.findIndex(e => e.id === id);
     if (eventIndex === -1) return track;
 
     const event = track.events[eventIndex];
-    const maxDuration = getMaxDuration(event.note, event.start, track, measures);
+    const maxDuration = getMaxDuration(event.note, event.start, track, measures, maxPolyphony);
 
     const updatedEvent = {
         ...event,
@@ -166,6 +179,20 @@ function insertNoteEvent(newEvent: NoteEvent, track: Track): Track {
     return {
         ...track,
         events: [...track.events, newEvent]
+    }
+}
+
+function removeEventAtTimeIfNeeded(start: number, track: Track, maxPolyphony: number): Track {
+    if (maxPolyphony === Infinity) return track;
+
+    const activeNotes = track.events.filter(e => e.start <= start && e.start + e.duration > start);
+    if (activeNotes.length < maxPolyphony) return track;
+
+    const eventToRemove = activeNotes.reduce((prev, current) => (prev.start > current.start) ? prev : current);
+
+    return {
+        ...track,
+        events: track.events.filter(e => e.id !== eventToRemove.id)
     }
 }
 
@@ -310,7 +337,7 @@ export function toPXTSong(song: Song): pxt.assets.music.Song {
                     startTick: e.start,
                     endTick: (e.start + e.duration),
                     notes: [{
-                        note: e.note,
+                        note: e.note + 1,
                         enharmonicSpelling: "normal"
                     }],
                     velocity: e.velocity
@@ -347,7 +374,7 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
         const newNoteEvent = (note: number, startTick: number, endTick: number, velocity: number): void => {
             const newEvent: NoteEvent = {
                 id: newTrack.nextId++,
-                note,
+                note: note - 1,
                 start: Math.round(startTick / ticksPerSixteenth),
                 duration: Math.max(1, Math.round((endTick - startTick) / ticksPerSixteenth)),
                 velocity: velocity ?? 128

--- a/webapp/src/components/pianoRoll/utils.ts
+++ b/webapp/src/components/pianoRoll/utils.ts
@@ -7,7 +7,7 @@ export function isBlackKey(note: number) {
 
 export function getNoteName(note: number, includeOctave: boolean = true) {
     const noteInOctave = note % 12;
-    const octave = Math.floor(note / 12);
+    const octave = Math.floor(note / 12) + 1;
     const noteNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
     return includeOctave ? `${noteNames[noteInOctave]}${octave}` : noteNames[noteInOctave];
 }


### PR DESCRIPTION
adds more options to the piano roll editor including:
* limiting polyphony per track
* hiding the header (velocity editor, range dropdown, and track selector)
* showing the editor in the widget div instead of full screen
* serializing to microbit's melody format instead of hex buffers
* setting the min/max octave

also fixes a bug where all the notes were off by 1 octave and 1 semitone which nobody noticed