### PR TITLE
Fix the black leds in the led matrix field

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -349,14 +349,19 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
 
     private updateCell(x: number, y: number) {
         const cellGroup = this.cells[x][y];
-        const cellRect = getFirstRect(cellGroup);
+        const cellRect = getChildElementOfTag(cellGroup, "rect");
         if (!cellRect) return;
         cellRect.setAttribute("fill", this.getColor(x, y));
         cellRect.setAttribute("fill-opacity", this.getOpacity(x, y));
         cellRect.setAttribute('class', `blocklyLed${this.cellState[x][y] ? 'On' : 'Off'}`);
         cellRect.setAttribute("aria-checked", (!!this.cellState[x][y]).toString());
         if (this.isColorMatrix) {
-            cellRect.setAttribute("aria-label", this.colorNames[this.cellState[x][y]] || this.palette[this.cellState[x][y]] || lf("color {0}", this.cellState[x][y]));
+            const cellLabel = getChildElementOfTag(cellGroup, "text");
+            if (cellLabel) {
+                const colorIndex = this.cellState[x][y];
+                const colorName = this.colorNames[colorIndex] || this.palette[colorIndex] || lf("color {0}", colorIndex);
+                cellLabel.textContent = lf("{0} LED", colorName);
+            }
         }
     }
 

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -471,13 +471,13 @@ function removeQuotes(str: string) {
     return str;
 }
 
-function getFirstRect(element: Element): SVGRectElement | null {
-    if (element.tagName === "rect") {
-        return element as SVGRectElement;
+function getChildElementOfTag(element: Element, tagName: string): Element | null {
+    if (element.tagName.toLowerCase() === tagName.toLowerCase()) {
+        return element;
     }
     for (const child of element.children) {
-        if (child.tagName === "rect") {
-            return child as SVGRectElement;
+        if (child.tagName.toLowerCase() === tagName.toLowerCase()) {
+            return child;
         }
     }
     return null;

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -32,7 +32,6 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     private palette: string[];
 
     private static DEFAULT_OFF_COLOR = "#000000";
-    private static DEFAULT_ON_COLOR = "#FFFFFF";
     private offOpacity = 0.2;
 
     private scale = 1;
@@ -349,7 +348,9 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
     }
 
     private updateCell(x: number, y: number) {
-        const cellRect = this.cells[x][y];
+        const cellGroup = this.cells[x][y];
+        const cellRect = getFirstRect(cellGroup);
+        if (!cellRect) return;
         cellRect.setAttribute("fill", this.getColor(x, y));
         cellRect.setAttribute("fill-opacity", this.getOpacity(x, y));
         cellRect.setAttribute('class', `blocklyLed${this.cellState[x][y] ? 'On' : 'Off'}`);
@@ -468,6 +469,18 @@ function removeQuotes(str: string) {
         return str.substr(1, str.length - 2).trim();
     }
     return str;
+}
+
+function getFirstRect(element: Element): SVGRectElement | null {
+    if (element.tagName === "rect") {
+        return element as SVGRectElement;
+    }
+    for (const child of element.children) {
+        if (child.tagName === "rect") {
+            return child as SVGRectElement;
+        }
+    }
+    return null;
 }
 
 // Override the hover stroke which doesn't make sense here.


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6889

turns out the culprit was not past richard, just a side effect of some of the accessibility changes. the cells property now consists of groups that contain a rect element and a text element. 