### PR TITLE
fix field slider text color in dark theme and high contrast

### DIFF
--- a/pxtblocks/plugins/math/fieldSlider.ts
+++ b/pxtblocks/plugins/math/fieldSlider.ts
@@ -192,9 +192,13 @@ export class FieldSlider extends Blockly.FieldNumber {
 
         Blockly.DropDownDiv.hideWithoutAnimation();
         Blockly.DropDownDiv.clearContent();
-        Blockly.DropDownDiv.getContentDiv().style.height = "";
+
 
         const contentDiv = Blockly.DropDownDiv.getContentDiv();
+        contentDiv.style.height = "";
+
+        // Used for high contrast styling
+        contentDiv.parentElement.classList.add("blocklyFieldSliderDropdown");
 
         // Accessibility properties
         contentDiv.setAttribute('role', 'menu');
@@ -327,7 +331,7 @@ Blockly.Css.register(`
 .blocklyFieldSliderLabel {
     font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;
     font-size: 0.65rem;
-    color: $colour_toolboxText;
+    color: #000000;
     margin: 8px;
 }
 .blocklyFieldSliderLabelText {

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -21,14 +21,14 @@ but still use a fairly opaque one to keep focus/visibility on the main buttons.
     background-color: var(--pxt-neutral-alpha80) !important;
 }
 
-/* 
+/*
  * "User-provided content" header in the import modal.
  */
 .ui.violet.message .header {
     color: var(--pxt-colors-purple-background) !important;
 }
 
-/* 
+/*
  * Checkbox styles
  * In HC the neutral and primary colors are the same, so we need to differentiate with
  * a different background color when checked.
@@ -79,7 +79,7 @@ div.field .ui.toggle.checkbox input:checked~label:before {
     opacity: 1;
 }
 
-/* 
+/*
  * Inverted image colors
  */
 .barcharticon,
@@ -223,4 +223,39 @@ div.field .ui.toggle.checkbox input:checked~label:before {
 table.diffview.update .diff-added .ch-added {
     color: var(--pxt-neutral-background1) !important;
     outline-color: var(--pxt-neutral-background1) !important;
+}
+
+.blocklyFieldSliderDropdown {
+    background-color: var(--pxt-neutral-background1) !important;
+    border-color: var(--pxt-neutral-foreground1) !important;
+}
+
+.blocklyFieldSliderDropdown .blocklyFieldSliderLabel {
+    color: var(--pxt-neutral-foreground1) !important;
+}
+
+.blocklyFieldSliderDropdown input[type=range].blocklyFieldSlider {
+    outline: none !important;
+    background-color: var(--pxt-neutral-background1) !important;
+    --blocklyFieldSliderBackgroundColor: var(--pxt-neutral-background1) !important;
+    --blocklyFieldSliderThumbColor: var(--pxt-neutral-foreground1) !important;
+    --blocklyFieldSliderThumbBorderColor: var(--pxt-neutral-foreground1) !important;
+}
+
+.blocklyFieldSliderDropdown input[type=range].blocklyFieldSlider:hover::-webkit-slider-runnable-track, .blocklyFieldSliderDropdown input[type=range].blocklyFieldSlider:focus-visible::-webkit-slider-runnable-track {
+    outline: solid 3px var(--pxt-focus-border) !important;
+}
+
+input[type=range].blocklyFieldSlider::-webkit-slider-runnable-track {
+    border: solid 1px var(--pxt-neutral-foreground1) !important;
+    box-sizing: content-box;
+}
+
+input[type=range].blocklyFieldSlider::-moz-range-track {
+    border: solid 1px var(--pxt-neutral-foreground1) !important;
+    box-sizing: content-box;
+}
+
+.blocklyFieldSliderDropdown input[type=range].blocklyFieldSlider:hover::-moz-range-track, .blocklyFieldSliderDropdown input[type=range].blocklyFieldSlider:focus-visible::-moz-range-track {
+    outline: solid 3px var(--pxt-focus-border) !important;
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6891

this fixes the text color for the slider field dropdown in all non-light themes. for dark mode, it was as simple as forcing the text to be black since we have the background of the div hardcoded to be white.

for high contrast mode, i did a complete overhaul of the colors so that it matches our other UI elements:

<img width="287" height="151" alt="image" src="https://github.com/user-attachments/assets/9a457570-23c6-42f2-aa42-17165792cc28" />
