### PR TITLE
make tabbing in the monaco editor navigate instead of inserting a character

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -122,7 +122,7 @@ To close a dialog, press the `Escape` key or navigate to the close button (shown
 ### JavaScript and Python editor navigation
 
 These keyboard shortcuts are used in the JavaScript editor:
->By default, pressing `Tab` in the editor will insert the tab character. Toggle this behavior by pressing `Control`+`M` on **Windows** or `Control`+`Shift`+`M` on **Mac**. In order to jump to the toolbox from the editor. Press `Control`+`Alt`+`T` on **Windows** or `⌘`+`Alt`+`T` on **Mac**.
+>By default, pressing `Tab` in the editor moves focus to the next interactive element and `Shift`+`Tab` moves focus to the previous one, so the editor never traps the keyboard. To insert a tab character instead, toggle tab-trapping mode by pressing `Control`+`M` on **Windows** or `Control`+`Shift`+`M` on **Mac**. In order to jump to the toolbox from the editor. Press `Control`+`Alt`+`T` on **Windows** or `⌘`+`Alt`+`T` on **Mac**.
 
 ## Drop-down menu
 

--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -129,6 +129,17 @@ export function createEditor(element: HTMLElement): monaco.editor.IStandaloneCod
         accessibilitySupport: "on"
     });
 
+    // Make Tab/Shift+Tab move focus out of the editor by default to avoid a
+    // keyboard trap (WCAG 2.1.2). Users can still press Ctrl+M (Ctrl+Shift+M on
+    // Mac) to toggle back to inserting tab characters. tabFocusMode is a
+    // computed-only Monaco option so we flip it via the built-in action, and
+    // guard against re-toggling because the underlying TabFocus setting is
+    // shared across editor instances.
+    if (!editor.getOption(monaco.editor.EditorOption.tabFocusMode)) {
+        const toggleTabFocus = editor.getAction("editor.action.toggleTabFocusMode");
+        if (toggleTabFocus) toggleTabFocus.run();
+    }
+
     editor.layout();
 
     return editor;


### PR DESCRIPTION
Addresses https://github.com/microsoft/pxt-microbit/issues/6859

This is a draft PR because this needs to be discussed within the team first. Right now in monaco, the toggle (Ctrl+M) to use tab to continue to navigate the page is available, but the user has to know about it. The default behavior is tabbing will insert a tab in the editor space. The proposition in this issue, and which has been implemented in this PR, is to make "tab navigation mode" be the default in the monaco editor. As in, if the user is focused on the workspace and tab, they will continue to navigate the page rather than insert a tab in the document. I think this is pretty big breaking behavior to have this on by default, but copilot cli did this well earlier, and I figured if we do want to ship this, I should have this available.

Upload target: https://makecode.microbit.org/app/68bc469e9693f2c198f3b1007f0bd65e82f9325f-9ec3d8863d#