### PR TITLE
Fix to return focus properly if the dropdown menu is used

### DIFF
--- a/pxtblocks/fields/field_textdropdown.ts
+++ b/pxtblocks/fields/field_textdropdown.ts
@@ -275,13 +275,13 @@ export class BaseFieldTextDropdown extends Blockly.FieldTextInput {
     }
 
     private handleMenuActionEvent(menuItem: Blockly.MenuItem) {
-        Blockly.DropDownDiv.hideIfOwner(this, true);
         this.onItemSelected_(this.menu_ as Blockly.Menu, menuItem);
     }
 
     protected onItemSelected_(menu: Blockly.Menu, menuItem: Blockly.MenuItem) {
         this.setValue(menuItem.getValue());
-
+        this.htmlInput_.focus();
+        Blockly.DropDownDiv.hideIfOwner(this, true);
         Blockly.WidgetDiv.hideIfOwner(this);
     }
 }


### PR DESCRIPTION
The current bug in the beta is that if the widget div is used to change the value (text input) focus is returned properly (the field if using keyboard, the parent block if using mouse), but when selecting a dropdown item, focus is lost to the body in both keyboard and mouse cases. This PR fixes this behaviour by first returning focus to the widget div and then letting the Blockly focus handler do its thing in the widget div code.