### PR TITLE
Add single letter shortcut to download program

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -1097,6 +1097,7 @@ declare namespace pxt.editor {
         showBoardDialogAsync(features?: string[], closeIcon?: boolean): Promise<void>;
         checkForHwVariant(): boolean;
         pairAsync(): Promise<boolean>;
+        shouldShowPairingDialogOnDownload(): boolean;
 
         createModalClasses(classes?: string): string;
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3369,6 +3369,13 @@ export class ProjectView
         return cmds.pairAsync();
     }
 
+    shouldShowPairingDialogOnDownload(): boolean {
+        return pxt.appTarget.appTheme.preferWebUSBDownload
+            && pxt.appTarget?.compile?.webUSB
+            && pxt.usb.isEnabled
+            && !webusb.userPrefersDownloadFlagSet();
+    }
+
     ///////////////////////////////////////////////////////////
     ////////////             Compile              /////////////
     ///////////////////////////////////////////////////////////

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -5,6 +5,7 @@ import * as pkg from "./package";
 import * as data from "./data";
 import * as auth from "./auth";
 import * as core from "./core";
+import * as cmds from "./cmds"
 import * as toolboxeditor from "./toolboxeditor"
 import * as compiler from "./compiler"
 import * as toolbox from "./toolbox";
@@ -686,6 +687,32 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 maybeCloneBlockForMove(workspace);
 
                 return startMoveShortcut.callback!(workspace, e, shortcut, scope);
+            }
+        });
+
+        Blockly.ShortcutRegistry.registry.register({
+            name: "download",
+            keyCodes: [Blockly.ShortcutRegistry.registry.createSerializedKey(Blockly.utils.KeyCodes.L, null)],
+            preconditionFn: (workspace, scope) => {
+                if (workspace.isFlyout || !scope.focusedNode) {
+                    return false
+                }
+                return true;
+            },
+            callback: () => {
+                if (pxt.commands.onDownloadButtonClick) {
+                    pxt.commands.onDownloadButtonClick();
+                } else {
+                    if (this.parent.shouldShowPairingDialogOnDownload()
+                        && !pxt.packetio.isConnected()
+                        && !pxt.packetio.isConnecting()
+                    ) {
+                        cmds.pairAsync(true).then(() => this.parent.compile());
+                    } else {
+                        this.parent.compile();
+                    }
+                }
+                return true
             }
         });
     }

--- a/webapp/src/components/KeyboardControlsHelp.tsx
+++ b/webapp/src/components/KeyboardControlsHelp.tsx
@@ -34,6 +34,7 @@ const KeyboardControlsHelp = () => {
                     <Row name={lf("Copy / paste")} shortcuts={[names.COPY, names.PASTE]} joiner="/" />
                     {cleanUpRow}
                     {contextMenuRow}
+                    <Row name={lf("Download your code to the {0}", pxt.appTarget.appTheme.boardName)} shortcuts={[["L"]]} />
                 </tbody>
             </table>
             <h3>{lf("Editor Overview")}</h3>

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -191,7 +191,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     protected onDownloadButtonClick = async () => {
         pxt.tickEvent("editortools.downloadbutton", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
-        if (this.shouldShowPairingDialogOnDownload()
+        if (this.props.parent.shouldShowPairingDialogOnDownload()
             && !pxt.packetio.isConnected()
             && !pxt.packetio.isConnecting()
         ) {
@@ -261,13 +261,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         window.open(pxt.appTarget.appTheme.downloadDialogTheme?.downloadMenuHelpURL);
     }
 
-    protected shouldShowPairingDialogOnDownload = () => {
-        return pxt.appTarget.appTheme.preferWebUSBDownload
-            && pxt.appTarget?.compile?.webUSB
-            && pxt.usb.isEnabled
-            && !userPrefersDownloadFlagSet();
-    }
-
     protected getCompileButton(view: View): JSX.Element[] {
         const collapsed = true; // TODO: Cleanup this
         const targetTheme = pxt.appTarget.appTheme;
@@ -297,7 +290,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         const packetioConnected = !!this.getData("packetio:connected");
         const packetioConnecting = !!this.getData("packetio:connecting");
         const packetioIcon = this.getData("packetio:icon") as string;
-        const hideFileDownloadIcon = view === View.Computer && this.shouldShowPairingDialogOnDownload();
+        const hideFileDownloadIcon = view === View.Computer && this.props.parent.shouldShowPairingDialogOnDownload();
         const fileDownloadIcon = targetTheme.downloadIcon || "xicon file-download";
 
         const successIcon = (packetioConnected && pxt.appTarget.appTheme.downloadDialogTheme?.deviceSuccessIcon)


### PR DESCRIPTION
This PR:
- adds a single letter shortcut to the blocks workspace to start the download flow to your device
- adds this shortcut to the keyboard controls help documentation

This only targets the blocks workspace.

See https://github.com/microsoft/pxt-microbit/issues/6616 (this issue should remain open if a similar shortcut should be added to the Monaco editor - not single letter for obvious reasons)

We completed user testing with this shortcut in place and it greatly reduces the friction of having to navigate out of the workspace to download code to your device, then needing to remember to navigate back into the workspace after you finished testing your code on your device. This means users can iterate easily and when they come back to the computer, focus is where they left it on the workspace, perhaps on a particular block or input.