### PR TITLE
Select extensions in toolbox when returning from extensions page

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -822,6 +822,7 @@ declare namespace pxt.editor {
         errorListCollapsed?: boolean;
         screenshoting?: boolean;
         extensionsVisible?: boolean;
+        extensionsToolboxTriggered?: boolean;
         isMultiplayerGame?: boolean; // Arcade: Does the current project contain multiplayer blocks?
         activeTourConfig?: pxt.tour.TourConfig;
         areaMenuOpen?: boolean;
@@ -1093,7 +1094,7 @@ declare namespace pxt.editor {
         showChooseHwDialog(skipDownload?: boolean): void;
         showExperimentsDialog(): void;
 
-        showPackageDialog(query?: string): void;
+        showPackageDialog(toolboxTriggered?: boolean): void;
         showBoardDialogAsync(features?: string[], closeIcon?: boolean): Promise<void>;
         checkForHwVariant(): boolean;
         pairAsync(): Promise<boolean>;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4796,17 +4796,22 @@ export class ProjectView
     }
 
     hidePackageDialog() {
+        const focusToolbox = this.state.extensionsToolboxTriggered;
         this.setState({
             ...this.state,
+            extensionsToolboxTriggered: false,
             extensionsVisible: false
         })
 
-        this.editor.focusToolbox(CategoryNameID.Extensions);
+        if (focusToolbox) {
+            this.editor.focusToolbox(CategoryNameID.Extensions);
+        }
     }
 
-    showPackageDialog() {
+    showPackageDialog(toolboxTriggered?: boolean) {
         this.setState({
             ...this.state,
+            extensionsToolboxTriggered: toolboxTriggered,
             extensionsVisible: true
         })
     }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1332,7 +1332,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     showPackageDialog() {
         pxt.tickEvent("blocks.addpackage");
         if (this.editor.getToolbox()) this.editor.getToolbox().clearSelection();
-        this.parent.showPackageDialog();
+        this.parent.showPackageDialog(true);
     }
 
     showVariablesFlyout() {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -795,7 +795,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     public showPackageDialog() {
         pxt.tickEvent("monaco.addpackage", undefined, { interactiveConsent: true });
         this.hideFlyout();
-        this.parent.showPackageDialog();
+        this.parent.showPackageDialog(true);
     }
 
     private defineEditorTheme(hc?: boolean, withNamespaces?: boolean) {


### PR DESCRIPTION
This fixes a bug where the toolbox extensions category was focused even when the extensions page was opened via the settings menu rather than the toolbox.