### PR TITLE
Populate Blockly toolbox with category information for screen reader shortcuts

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1740,7 +1740,17 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (this.editor.options.hasCategories === hasCategories) {
             // Toolbox is consistent with current mode, safe to update
             if (hasCategories) {
-                this.toolbox.setState({ loading: false, categories: this.getAllCategories(), showSearchBox: this.shouldShowSearch() });
+                const allCategories = this.getAllCategories()
+                this.toolbox.setState({ loading: false, categories: allCategories, showSearchBox: this.shouldShowSearch() });
+                // To include the toolbox category in the Blockly 'where am I' screen reader shortcuts (i and shift + i),
+                // the Blockly toolbox must be populated with categories that include their color and name.
+                const allCategoriesToToolboxItemInfo = allCategories.map(c => ({
+                    kind: "category",
+                    name: c.name ? c.name : Util.capitalize(c.nameid),
+                    colour: c.color,
+                    contents: [] as Blockly.utils.toolbox.ToolboxItemInfo[]
+                }));
+                (Blockly.getMainWorkspace() as Blockly.WorkspaceSvg).getToolbox().render({contents: allCategoriesToToolboxItemInfo});
             } else {
                 this.showFlyoutOnlyToolbox();
             }


### PR DESCRIPTION
Blockly have introduced two 'where am I' screen reader shortcuts (i and shift + i). To ensure that these verbose outputs include the category name, the Blockly toolbox must be populated with categories that include their color and name.

E.g., when the 'i' shortcut is pressed, this change provides "Begin stack, on start, Basic category" instead of just "Begin stack, on start".