### PR TITLE
Ensure all mutator buttons have alt text

### DIFF
--- a/pxtblocks/monkeyPatches/blockSvg.ts
+++ b/pxtblocks/monkeyPatches/blockSvg.ts
@@ -14,8 +14,8 @@ export function monkeyPatchBlockSvg() {
 
             const image = ConstantProvider.EXPAND_IMAGE_DATAURI;
             if (image) {
-                input.appendField(new FieldImageNoText(image, 24, 24, "", () => {
-                    this.setCollapsed(false)
+                input.appendField(new FieldImageNoText(image, 24, 24, lf("Expand block"), () => {
+                    this.setCollapsed(false);
                 }, false));
             }
         }

--- a/pxtblocks/plugins/arrays/createList.ts
+++ b/pxtblocks/plugins/arrays/createList.ts
@@ -222,9 +222,9 @@ const LIST_CREATE_MIXIN = {
         if (this.getInput('BUTTONS')) this.removeInput('BUTTONS');
         const buttons = this.appendDummyInput('BUTTONS');
         if (this.itemCount_ > 0) {
-            buttons.appendField(new FieldImageNoText(this.REMOVE_IMAGE_DATAURI, 24, 24, "*", remove, false));
+            buttons.appendField(new FieldImageNoText(this.REMOVE_IMAGE_DATAURI, 24, 24, lf("remove argument"), remove, false));
         }
-        buttons.appendField(new FieldImageNoText(this.ADD_IMAGE_DATAURI, 24, 24, "*", add, false));
+        buttons.appendField(new FieldImageNoText(this.ADD_IMAGE_DATAURI, 24, 24, lf("add argument"), add, false));
 
         /* Switch to vertical list when the list is too long */
         const showHorizontalList = this.itemCount_ <= this.horizontalAfter_;

--- a/pxtblocks/plugins/functions/blocks/functionDefinitionBlock.ts
+++ b/pxtblocks/plugins/functions/blocks/functionDefinitionBlock.ts
@@ -198,7 +198,7 @@ Blockly.Blocks[FUNCTION_DEFINITION_BLOCK_TYPE] = {
                     image,
                     24,
                     24,
-                    "",
+                    lf("Collapse block"),
                     () => {
                         this.setCollapsed(true);
                     },

--- a/pxtblocks/plugins/logic/ifElse.ts
+++ b/pxtblocks/plugins/logic/ifElse.ts
@@ -163,7 +163,7 @@ const IF_ELSE_MIXIN = {
                 .appendField(Blockly.Msg.CONTROLS_IF_MSG_THEN);
             this.appendDummyInput('IFBUTTONS' + i)
                 .appendField(
-                    new FieldImageNoText(this.REMOVE_IMAGE_DATAURI, 24, 24, "*", removeElseIf, false))
+                    new FieldImageNoText(this.REMOVE_IMAGE_DATAURI, 24, 24, pxt.Util.lf("remove else if branch"), removeElseIf, false))
                 .setAlign(Blockly.inputs.Align.RIGHT);
             this.appendStatementInput('DO' + i);
         }
@@ -173,7 +173,7 @@ const IF_ELSE_MIXIN = {
             this.appendDummyInput('ELSEBUTTONS')
                 .setAlign(Blockly.inputs.Align.RIGHT)
                 .appendField(
-                    new FieldImageNoText(this.REMOVE_IMAGE_DATAURI, 24, 24, "*", this.removeElse_.bind(this), false));
+                    new FieldImageNoText(this.REMOVE_IMAGE_DATAURI, 24, 24, pxt.Util.lf("remove else branch"), this.removeElse_.bind(this), false));
             this.appendStatementInput('ELSE');
         }
         if (this.getInput('ADDBUTTON')) this.removeInput('ADDBUTTON');
@@ -190,7 +190,7 @@ const IF_ELSE_MIXIN = {
         }();
         this.appendDummyInput('ADDBUTTON')
             .appendField(
-                new FieldImageNoText(this.ADD_IMAGE_DATAURI, 24, 24, "*", addElseIf, false));
+                new FieldImageNoText(this.ADD_IMAGE_DATAURI, 24, 24, this.elseCount_ ? pxt.Util.lf("add else if branch") : pxt.Util.lf("add else branch"), addElseIf, false));
     },
     /**
      * Reconstructs the block with all child blocks attached.

--- a/pxtblocks/plugins/text/join.ts
+++ b/pxtblocks/plugins/text/join.ts
@@ -144,9 +144,9 @@ const TEXT_JOIN_MUTATOR_MIXIN = {
         if (this.getInput('BUTTONS')) this.removeInput('BUTTONS');
         const buttons = this.appendDummyInput('BUTTONS');
         if (this.itemCount_ > 1) {
-            buttons.appendField(new FieldImageNoText(this.REMOVE_IMAGE_DATAURI, 24, 24, "*", remove, false));
+            buttons.appendField(new FieldImageNoText(this.REMOVE_IMAGE_DATAURI, 24, 24, lf("remove argument"), remove, false));
         }
-        buttons.appendField(new FieldImageNoText(this.ADD_IMAGE_DATAURI, 24, 24, "*", add, false));
+        buttons.appendField(new FieldImageNoText(this.ADD_IMAGE_DATAURI, 24, 24, lf("add argument"), add, false));
 
         // Switch to vertical list when there are too many items
         const horizontalLayout = this.itemCount_ <= 4;


### PR DESCRIPTION
This text is used for aria-labels and exposed to screen reader users.

May conflict with https://github.com/microsoft/pxt/pull/11362 but I can deal with any merge conflicts when they arise.