### PR TITLE
Use Blockly live region to announce `if` block mutations

### DIFF
--- a/pxtblocks/plugins/logic/ifElse.ts
+++ b/pxtblocks/plugins/logic/ifElse.ts
@@ -71,6 +71,7 @@ const IF_ELSE_MIXIN = {
         if (this.getInput('ELSE')) this.elseStatementConnection_?.reconnect(this, 'ELSE');
     },
     addElse_: function (this: IfElseBlock) {
+        Blockly.utils.aria.announceDynamicAriaState(pxt.Util.lf("Else branch added."));
         const update = () => {
             this.elseCount_++;
         };
@@ -78,18 +79,21 @@ const IF_ELSE_MIXIN = {
 
     },
     removeElse_: function (this: IfElseBlock) {
+        Blockly.utils.aria.announceDynamicAriaState(pxt.Util.lf("Else branch removed."));
         const update = () => {
             this.elseCount_--;
         };
         this.update_(update);
     },
     addElseIf_: function (this: IfElseBlock) {
+        Blockly.utils.aria.announceDynamicAriaState(pxt.Util.lf("Else if branch added."));
         const update = () => {
             this.elseifCount_++;
         };
         this.update_(update);
     },
     removeElseIf_: function (this: IfElseBlock, arg: number) {
+        Blockly.utils.aria.announceDynamicAriaState(pxt.Util.lf("Else if branch removed."));
         const update = () => {
             this.elseifCount_--;
         };


### PR DESCRIPTION
This PR uses the Blockly live region to provide confirmatory feedback that the `if` block was mutated successfully following an interaction with the mutator buttons.