### PR TITLE
Change skip links from menubars to nav elements

### DIFF
--- a/webapp/src/accessibility.tsx
+++ b/webapp/src/accessibility.tsx
@@ -78,17 +78,17 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
 
         const menuClass = classList(targetTheme.invertedMenu && "inverted", "menu");
 
-        return <div className="ui accessibleMenu borderless fixed menu" role="menubar">
+        return <nav className="ui accessibleMenu borderless fixed menu" aria-label={lf("Skip links")}>
             <sui.Item
                 className={menuClass}
-                role="menuitem"
+                role="button"
                 icon="xicon blocks"
                 text={lf("Skip to Blocks workspace")}
                 onClick={this.openBlocks}
             />
             <sui.Item
                 className={menuClass}
-                role="menuitem"
+                role="button"
                 icon="xicon js"
                 text={lf("Skip to JavaScript editor")}
                 onClick={this.openJavaScript}
@@ -96,7 +96,7 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
             {targetTheme.python &&
                 <sui.Item
                     className={menuClass}
-                    role="menuitem"
+                    role="button"
                     icon="xicon python"
                     text={lf("Skip to Python editor")}
                     onClick={this.openPython}
@@ -105,31 +105,33 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
             {targetTheme.selectLanguage &&
                 <sui.Item
                     className={menuClass}
-                    role="menuitem"
+                    role="button"
                     icon="xicon globe"
                     text={lf("Select Language")}
                     onClick={this.showLanguagePicker}
+                    ariaHasPopup="dialog"
                 />
             }
             {targetTheme.defaultColorTheme &&
                 <sui.Item
                     className={menuClass}
-                    role="menuitem"
+                    role="button"
                     icon="paint brush"
                     text={lf("Select Theme")}
                     onClick={this.showThemePicker}
+                    ariaHasPopup="dialog"
                 />
             }
             {hasHome &&
                 <sui.Item
                     className={menuClass}
-                    role="menuitem"
+                    role="button"
                     icon="home"
                     text={lf("Go Home")}
                     onClick={this.goHome}
                 />
             }
-        </div>;
+        </nav>;
     }
 }
 
@@ -192,11 +194,11 @@ export class HomeAccessibilityMenu extends data.Component<HomeAccessibilityMenuP
     renderCore() {
         const { highContrast } = this.state;
         const targetTheme = pxt.appTarget.appTheme;
-        return <div className="ui accessibleMenu borderless fixed menu" role="menubar">
-            <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="add circle" text={lf("New Project")} onClick={this.newProject} />
-            <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="upload" text={lf("Import Project")} onClick={this.importProjectDialog} />
-            {targetTheme.selectLanguage ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon globe" text={lf("Select Language")} onClick={this.showLanguagePicker} /> : undefined}
-            {targetTheme.defaultColorTheme ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="paint brush" text={("Select Theme")} onClick={this.showThemePicker} /> : undefined}
-        </div>;
+        return <nav className="ui accessibleMenu borderless fixed menu" aria-label={lf("Skip links")}>
+            <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="button" icon="add circle" text={lf("New Project")} ariaHasPopup="dialog" onClick={this.newProject} />
+            <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="button" icon="upload" text={lf("Import Project")} ariaHasPopup="dialog" onClick={this.importProjectDialog} />
+            {targetTheme.selectLanguage ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="button" icon="xicon globe" text={lf("Select Language")} ariaHasPopup="dialog" onClick={this.showLanguagePicker} /> : undefined}
+            {targetTheme.defaultColorTheme ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="button" icon="paint brush" text={lf("Select Theme")} ariaHasPopup="dialog" onClick={this.showThemePicker} /> : undefined}
+        </nav>;
     }
 }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -21,6 +21,7 @@ export interface UiProps {
     role?: string;
     title?: string;
     ariaLabel?: string;
+    ariaHasPopup?: boolean | "dialog" | "menu" | "false" | "listbox" | "grid" | "tree" | "true";
     ariaHidden?: boolean;
     tabIndex?: number;
     rightIcon?: boolean;
@@ -458,7 +459,8 @@ export class Item extends data.Component<ItemProps, {}> {
             text,
             title,
             ariaLabel,
-            ariaHidden
+            ariaHidden,
+            ariaHasPopup
         } = this.props;
 
         return (
@@ -467,6 +469,7 @@ export class Item extends data.Component<ItemProps, {}> {
                 aria-label={(!this.props.role || this.props.role === "presentation") ? "" : ariaLabel || title || text}
                 aria-selected={this.props.active}
                 aria-hidden={ariaHidden}
+                aria-haspopup={ariaHasPopup}
                 title={title || text}
                 tabIndex={this.props.tabIndex || 0}
                 key={this.props.value}


### PR DESCRIPTION
This PR changes the skip link elements from menbars to nav elements and the children from menuitems to buttons. This PR also:
- ensures that the "Select Theme" skip link on home page is translated
- uses aria-haspopup to communicate that certain actions will popup a dialog to screen reader users (e.g., theme, language)

Partially addresses https://github.com/microsoft/pxt-microbit/issues/6732 (there are four more instances to update, main header x2, download button, zoom controls).