### PR TITLE
Add grid row ids to ensure VoiceOver compatibility

### DIFF
--- a/pxtblocks/fields/field_dropdowngrid.ts
+++ b/pxtblocks/fields/field_dropdowngrid.ts
@@ -41,7 +41,7 @@ export abstract class FieldDropdownGrid extends FieldDropdown {
     private setFocusedItem(gridItemContainer: HTMLElement, e: KeyboardEvent) {
         this.lastUserInputAction = 'keymove';
         this.setFocusedItem_(gridItemContainer);
-        gridItemContainer.setAttribute('aria-activedescendant', ":" + this.activeDescendantIndex);
+        gridItemContainer.setAttribute('aria-activedescendant', `${this.sourceBlock_.id}:${this.activeDescendantIndex}`);
         e.preventDefault();
         e.stopPropagation();
     }

--- a/pxtblocks/fields/field_gridpicker.ts
+++ b/pxtblocks/fields/field_gridpicker.ts
@@ -144,6 +144,8 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
 
         const rowContent = document.createElement('div');
         rowContent.className = 'blocklyGridPickerRow';
+        rowContent.setAttribute('role', 'row');
+        rowContent.id = `${this.sourceBlock_.id}:row-${row}`;
 
         for (let i = (columns * row); i < Math.min((columns * row) + columns, options.length); i++) {
             let content = (options[i] as any)[0]; // Human-readable text or image.
@@ -151,7 +153,7 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
 
             const menuItem = document.createElement('div');
             menuItem.className = 'gridpicker-menuitem gridpicker-option';
-            menuItem.setAttribute('id', ':' + i); // For aria-activedescendant
+            menuItem.setAttribute('id', `${this.sourceBlock_.id}:${i}`); // For aria-activedescendant
             menuItem.setAttribute('role', 'gridcell');
             menuItem.setAttribute('aria-selected', 'false');
             menuItem.style.userSelect = 'none';
@@ -171,6 +173,7 @@ export class FieldGridPicker extends FieldDropdownGrid implements FieldCustom {
                 menuItem.setAttribute('aria-selected', 'true');
                 this.activeDescendantIndex = i;
                 pxt.BrowserUtils.addClass(menuItem, `gridpicker-option-selected ${!this.openingPointerCoords ? 'gridpicker-option-focused' : '' }`);
+                tableContainer.setAttribute('aria-activedescendant', menuItem.id);
                 backgroundColour = (this.sourceBlock_ as Blockly.BlockSvg).getColourTertiary();
 
                 // Save so we can scroll to it later

--- a/pxtblocks/fields/field_imagedropdown.ts
+++ b/pxtblocks/fields/field_imagedropdown.ts
@@ -45,9 +45,10 @@ export class FieldImageDropdown extends FieldDropdownGrid implements FieldCustom
         }
     }
 
-    protected createRow() {
+    protected createRow(rowIndex: number) {
         const row = document.createElement('div');
         row.setAttribute('role', 'row');
+        row.id = `${this.sourceBlock_.id}:row-${rowIndex}`;
         return row;
     }
 
@@ -121,8 +122,8 @@ export class FieldImageDropdown extends FieldDropdownGrid implements FieldCustom
         let descendantIndex = 0;
 
         // now create the actual row elements
-        for (const row of rows) {
-            const rowDiv = this.createRow();
+        for (const [rowIndex, row] of rows.entries()) {
+            const rowDiv = this.createRow(rowIndex);
             rowDiv.style.width = row.width + "px";
             rowDiv.style.height = row.height + "px";
             contentDiv.appendChild(rowDiv);
@@ -144,7 +145,7 @@ export class FieldImageDropdown extends FieldDropdownGrid implements FieldCustom
                 const buttonContainer = document.createElement('div');
                 buttonContainer.setAttribute('class', 'blocklyDropDownButtonContainer')
                 const button = document.createElement('div');
-                button.setAttribute('id', ':' + localDescendantIndex); // For aria-activedescendant
+                button.setAttribute('id', `${this.sourceBlock_.id}:${localDescendantIndex}`); // For aria-activedescendant
                 button.setAttribute('role', 'gridcell');
                 button.setAttribute('aria-selected', 'false');
                 button.classList.add('blocklyDropDownButton');

--- a/pxtblocks/fields/field_images.ts
+++ b/pxtblocks/fields/field_images.ts
@@ -46,7 +46,8 @@ export class FieldImages extends FieldImageDropdown implements FieldCustom {
         this.addKeyDownHandler(contentDiv)
         const options = this.getOptions();
         if (this.shouldSort_) options.sort();
-        let row = this.createRow();
+        let rowNum = 0;
+        let row = this.createRow(rowNum);
         for (let i = 0; i < options.length; i++) {
             const content = (options[i] as any)[0]; // Human-readable text or image.
             const value = (options[i] as any)[1]; // Language-neutral value.
@@ -63,7 +64,7 @@ export class FieldImages extends FieldImageDropdown implements FieldCustom {
             const buttonContainer = document.createElement('div');
             buttonContainer.setAttribute('class', 'blocklyDropDownButtonContainer')
             let button = document.createElement('div');
-            button.setAttribute('id', ':' + i); // For aria-activedescendant
+            button.setAttribute('id', `${this.sourceBlock_.id}:${i}`); // For aria-activedescendant
             button.setAttribute('role', 'gridcell');
             button.setAttribute('aria-selected', 'false');
             button.setAttribute('class', 'blocklyDropDownButton');
@@ -120,7 +121,7 @@ export class FieldImages extends FieldImageDropdown implements FieldCustom {
             row.append(buttonContainer)
             if (row.childElementCount === this.columns_) {
                 contentDiv.appendChild(row);
-                row = this.createRow();
+                row = this.createRow(++rowNum);
             }
         }
         if (row.childElementCount) {


### PR DESCRIPTION
If grid rows are missing ids, the latest VoiceOver version outputs the entire row, not just the selected cell. This change also ensures that grid ids are unique.