### PR TITLE
Fix iPad toolbox flyout toggling on category re-tap

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1842,6 +1842,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (this.toolbox) this.toolbox.clear();
     }
 
+    public isFlyoutVisible(): boolean {
+        return !!this.editor?.getFlyout()?.isVisible();
+    }
+
     public setFlyoutForceOpen(forceOpen: boolean) {
         const flyout = this.editor.getFlyout() as pxtblockly.CachingFlyout
         if (flyout && typeof flyout.setForceOpen === 'function') {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1357,6 +1357,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.hideFlyout();
     }
 
+    public isFlyoutVisible(): boolean {
+        return !!(this.flyout?.state?.groups && !this.flyout.state.hide);
+    }
+
     public hideFlyout() {
         if (this.flyout) this.flyout.setState({ groups: undefined });
 

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -247,7 +247,8 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
 
         let id = subns ? nameid + subns : nameid;
 
-        if (this.state.selectedItem == id && !force && !onlyTriggerOnClick) {
+        if (this.state.selectedItem == id && !force && !onlyTriggerOnClick
+            && (customClick || this.props.parent.isFlyoutVisible())) {
             this.clearSelection();
 
             // Hide flyout
@@ -279,6 +280,9 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
     }
 
     onCategoryClick = (treeRow: ToolboxCategory, index: number, isClick = true) => {
+        // The pointer gesture is ending; re-enable the keyboard focus handling
+        // that handlePointerDownCapture disabled for the duration of the tap.
+        this.shouldHandleCategoryTreeFocus = true;
         if (isClick) {
             return this.setSelection(treeRow, index, undefined, isClick);
         }
@@ -521,15 +525,19 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
 
     handlePointerDownCapture = (e: React.PointerEvent) => {
         e.preventDefault();
+        // A pointer tap focuses the tree, which would make handleCategoryTreeFocus
+        // auto-select the remembered category. On touch that focus event can arrive
+        // asynchronously after pointerup (and before the click), so keep focus
+        // handling disabled for the whole gesture until the final click.
         this.shouldHandleCategoryTreeFocus = false;
         (this.refs.categoryTree as HTMLElement).focus();
-        this.shouldHandleCategoryTreeFocus = true;
     }
 
     handlePointerUp = (e: React.PointerEvent) => {
-        // On iPad Safari, preventDefault() on pointerdown suppresses click events.
-        // Handle category selection on pointerup so tapping works on touch devices.
-        // Only needed for Monaco — Blockly has its own pointerdown handler for selection.
+        // On iOS Safari the *first* toolbox tap after Monaco's textarea has
+        // focus produces no synthesized mousedown/click. There's no clear cause
+        // (doesn't seem to be preventDefault, target element type, the manual
+        // focus call, or user-select) so we use pointerup for touch.
         if (e.pointerType === "mouse" || this.props.editorname !== MONACO_EDITOR_NAME) return;
 
         const target = e.target as HTMLElement;

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -285,6 +285,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
 
     abstract showFlyout(treeRow: toolbox.ToolboxCategory): void;
     abstract hideFlyout(): void;
+    abstract isFlyoutVisible(): boolean;
     abstract setFlyoutForceOpen(forceOpen: boolean): void;
     moveFocusToFlyout() { }
 


### PR DESCRIPTION
Keep focus-driven selection suppressed for the whole touch gesture so re-tapping a category correctly toggles its flyout.

Also gate the toggle-close on the flyout actually being visible as a defensive in depth against selectedItem drifting out of sync.

Fixes https://github.com/microsoft/pxt-microbit/issues/6827