### PR TITLE
various piano roll fixes

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -214,7 +214,7 @@ export abstract class FieldAssetEditor<U extends FieldAssetEditorOptions, V exte
         widgetDiv.style.left = left + "px";
         widgetDiv.style.top = top + "px";
         widgetDiv.style.width = "50rem";
-        widgetDiv.style.height = "34.25rem";
+        widgetDiv.style.height = "39.5rem";
         widgetDiv.style.display = "flex";
         widgetDiv.style.alignItems = "center";
         widgetDiv.style.transition = "transform 0.25s ease 0s, opacity 0.25s ease 0s";

--- a/pxtblocks/fields/field_piano_roll.ts
+++ b/pxtblocks/fields/field_piano_roll.ts
@@ -1,6 +1,7 @@
 import { MelodyStringReader, REST } from "./field_melodySandbox";
 import { FieldMusicEditor, FieldMusicEditorOptions } from "./field_musiceditor";
 import { isTrue } from "./field_utils";
+import * as Blockly from "blockly";
 
 interface FieldPianoRollOptions extends FieldMusicEditorOptions {
     maxPolyphony?: number;
@@ -14,6 +15,20 @@ interface FieldPianoRollOptions extends FieldMusicEditorOptions {
 export class FieldPianoRoll extends FieldMusicEditor {
     protected showInWidgetDiv: boolean;
     protected encodeAsMelody: boolean;
+
+    override showEditor_() {
+        if (this.asset && this.encodeAsMelody) {
+            const field = this.getTempoField();
+            if (field) {
+                const bpm = parseInt(field.getValue() as string);
+
+                if (!isNaN(bpm)) {
+                    (this.asset as pxt.Song).song.beatsPerMinute = bpm;
+                }
+            }
+        }
+        super.showEditor_();
+    }
 
     protected override getEditorKind() {
         return "piano-roll-editor";
@@ -147,6 +162,42 @@ export class FieldPianoRoll extends FieldMusicEditor {
 
 
         return result;
+    }
+
+    protected override onEditorClose(newValue: pxt.Asset) {
+        super.onEditorClose(newValue);
+
+        if (this.encodeAsMelody) {
+            this.syncTempoField((newValue as pxt.Song).song.beatsPerMinute);
+        }
+    }
+
+    protected syncTempoField(bpm: number): void {
+        const field = this.getTempoField();
+        if (field) {
+            field.setValue(bpm);
+        }
+    }
+
+    protected getTempoField(): Blockly.Field {
+        const s = this.sourceBlock_;
+        if (s) {
+            for (const input of s.inputList) {
+                if (input.name === "tempo" || input.name === "bpm") {
+                    const tempoBlock = input.connection.targetBlock();
+                    if (tempoBlock) {
+                        if (tempoBlock.type === "math_number_minmax") {
+                            return tempoBlock.getField("SLIDER");
+                        }
+                        else {
+                            return tempoBlock.getField("NUM");
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        return null;
     }
 }
 

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -203,6 +203,7 @@
     flex: 1;
     overflow-x: hidden;
     overflow-y: hidden;
+    touch-action: none;
 }
 
 .piano-roll .workspace {

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -426,6 +426,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                             isDrumTrack={isDrumInstrument(instrument)}
                             playNote={playNote}
                             measures={song.measures}
+                            bpm={song.tempo}
                         />
                     </div>
                 </div>

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -12,6 +12,7 @@ interface Props {
     playNote: (note: number) => void;
     onEdit: (track: Track) => void;
     measures: number;
+    bpm: number;
 }
 
 interface GestureState {
@@ -25,7 +26,7 @@ interface GestureState {
 }
 
 export const Workspace = (props: Props) => {
-    const { track, onEdit, isDrumTrack, playNote, measures } = props;
+    const { track, onEdit, isDrumTrack, playNote, measures, bpm } = props;
 
     const bg = useWorkspaceBackground();
     const theme = usePianoRollTheme();
@@ -180,7 +181,7 @@ export const Workspace = (props: Props) => {
 
 
     useEffect(() => {
-        const tickTime = pxsim.music.tickToMs(120, 4, 1);
+        const tickTime = pxsim.music.tickToMs(bpm, 4, 1);
         const tickDistance = noteWidth(theme, 1);
         let playbackHeadPosition = 0;
         let isPlaying = false;
@@ -218,7 +219,7 @@ export const Workspace = (props: Props) => {
             removePlaybackStateListener(onStop);
             if (animationFrameRef) cancelAnimationFrame(animationFrameRef);
         }
-    }, [theme])
+    }, [theme, bpm])
 
     return (
         <div className="workspace" style={{

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -354,6 +354,7 @@ export function toPXTSong(song: Song): pxt.assets.music.Song {
 export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
     const result = getEmptySong();
     result.measures = pxtSong.measures;
+    result.tempo = pxtSong.beatsPerMinute;
 
     result.tracks = [];
     result.nextId += 1000;


### PR DESCRIPTION
each commit is one fix!

fixes https://github.com/microsoft/pxt-microbit/issues/6909

the bpm of the playhead animation was hardcoded to 120

fixes https://github.com/microsoft/pxt-microbit/issues/6910

bpm is now synced to the parent block if there is an input named tempo or bpm. same behavior as the melody editor

fixes https://github.com/microsoft/pxt-microbit/issues/6907

added `touch-action: none` to prevent the browser from trying to hijack the panning logic

fixes https://github.com/microsoft/pxt-microbit/issues/6906

bumped up the initial height a little bit