### PR TITLE
darker outline border on tab for sign in modal

### DIFF
--- a/react-common/styles/profile/profile.less
+++ b/react-common/styles/profile/profile.less
@@ -403,6 +403,10 @@
                 position: relative;
                 overflow: visible;
 
+                &:focus-visible::after {
+                    outline: var(--pxt-neutral-foreground1) solid 1px;
+                }
+
                 .label {
                     display: flex;
                     flex-direction: row;
@@ -427,6 +431,10 @@
                         text-align: left;
                     }
                 }
+            }
+
+            .rememberme .common-checkbox:focus-within {
+                outline: var(--pxt-neutral-foreground1) solid 1px;
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6824 
And I also added similar styling for the remember me check box since that was very light as well

**Before:**

<img width="679" height="469" alt="image" src="https://github.com/user-attachments/assets/46e0c3ec-3246-4212-9dcb-77b0fb587aac" />


<img width="258" height="71" alt="image" src="https://github.com/user-attachments/assets/610a582b-b1de-4cd2-952e-0be4ac40fb09" />



**After:**
<img width="569" height="379" alt="image" src="https://github.com/user-attachments/assets/fae17c77-640c-4e6a-8807-909c54eb3859" />

<img width="199" height="47" alt="image" src="https://github.com/user-attachments/assets/6569b3b4-8ac7-40fc-9617-37a5800cb027" />


