### PR TITLE
Only show paste hint toast when copy/cut triggered via keyboard

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -2740,7 +2740,9 @@ function copy(workspace: Blockly.WorkspaceSvg, e: Event, _shortcut: Blockly.Shor
             copyWorkspace,
             pkg.mainEditorPkg().header.id
         );
-        showCopiedHint(workspace);
+        if (e instanceof KeyboardEvent) {
+            showCopiedHint(workspace);
+        }
     }
 
     return !!copyData;
@@ -2785,7 +2787,7 @@ function cut(workspace: Blockly.WorkspaceSvg, e: Event, _shortcut: Blockly.Short
         copied = true;
     }
 
-    if (copied) {
+    if (copied && e instanceof KeyboardEvent) {
         showCutHint(workspace);
     }
     return copied;


### PR DESCRIPTION
I've opened an equivalent [issue](https://github.com/RaspberryPiFoundation/blockly/issues/9961)/[PR](https://github.com/RaspberryPiFoundation/blockly/pull/9962) for Blockly so we can confirm we're aligned on this.

By default they don't have a context menu for copy so this isn't obvious from their playground and it wasn't really an issue when keyboard nav was opt in. It's especially weird on a small screen touch device.