### PR TITLE
Account for duplicate-on-drag and shadows in keyboard disconnect (X)

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -691,6 +691,43 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             }
         });
 
+        // Blockly's disconnect action unplugs the focused block, which would
+        // pull a duplicate-on-drag block out of its slot. Match the drag/move
+        // behavior instead: leave the original in place and disconnect a clone.
+        const disconnectShortcut = Blockly.ShortcutRegistry.registry.getRegistry()[Blockly.ShortcutItems.names.DISCONNECT];
+        Blockly.ShortcutRegistry.registry.unregister(disconnectShortcut.name);
+        Blockly.ShortcutRegistry.registry.register({
+            ...disconnectShortcut,
+            preconditionFn: (workspace, scope) => {
+                const focused = scope.focusedNode;
+                // duplicate-on-drag blocks (including allowlisted shadows) have special
+                // casing below so allow them through. 
+                if (focused instanceof Blockly.BlockSvg && shouldDuplicateOnDrag(focused)) {
+                    return !workspace.isReadOnly() && !workspace.isDragging();
+                }
+                // Workaround: https://github.com/RaspberryPiFoundation/blockly/issues/9963
+                if (focused instanceof Blockly.BlockSvg && focused.isShadow()) {
+                    workspace.getAudioManager().playErrorBeep();
+                    return false;
+                }
+                return disconnectShortcut.preconditionFn!(workspace, scope);
+            },
+            callback: (workspace, e, shortcut, scope) => {
+                const focused = Blockly.getFocusManager().getFocusedNode();
+                if (focused instanceof Blockly.BlockSvg && shouldDuplicateOnDrag(focused)) {
+                    Blockly.Events.setGroup(true);
+                    try {
+                        cloneDuplicateOnDragBlock(workspace, focused);
+                    } finally {
+                        Blockly.Events.setGroup(false);
+                    }
+                    return true;
+                }
+
+                return disconnectShortcut.callback!(workspace, e, shortcut, scope);
+            }
+        });
+
         Blockly.ShortcutRegistry.registry.register({
             name: "toggle_simulator",
             keyCodes: [Blockly.ShortcutRegistry.registry.createSerializedKey(Blockly.utils.KeyCodes.S, null)],
@@ -2829,21 +2866,29 @@ function maybeCloneBlockForMove(workspace: Blockly.WorkspaceSvg) {
     const block = Blockly.getFocusManager().getFocusedNode();
     if (!(block instanceof Blockly.BlockSvg)) return;
     if (block && shouldDuplicateOnDrag(block)) {
+        // Open a group and deliberately leave it open: the keyboard mover's
+        // dragger adopts an already-open group (Dragger.onDragStart) so the
+        // clone and the subsequent move become a single undo step, and the
+        // dragger closes the group when the move ends.
         Blockly.Events.setGroup(true);
-        const xml = Blockly.Xml.blockToDom(block);
-        const clone = Blockly.Xml.domToBlock(xml as Element, workspace);
-        clone.setShadow(false);
-
-        const position = block.getRelativeToSurfaceXY();
-        const snapRadius = Blockly.config.snapRadius;
-
-        clone.moveBy(
-            position.x + snapRadius,
-            position.y + snapRadius,
-        );
-
-        Blockly.getFocusManager().focusNode(clone as Blockly.BlockSvg);
+        cloneDuplicateOnDragBlock(workspace, block);
     }
+}
+
+function cloneDuplicateOnDragBlock(workspace: Blockly.WorkspaceSvg, block: Blockly.BlockSvg): Blockly.BlockSvg {
+    const state = Blockly.serialization.blocks.save(block, { saveIds: false });
+    const clone = Blockly.serialization.blocks.append(state, workspace, { recordUndo: true }) as Blockly.BlockSvg;
+
+    const position = block.getRelativeToSurfaceXY();
+    const snapRadius = Blockly.config.snapRadius;
+
+    clone.moveBy(
+        position.x + snapRadius,
+        position.y + snapRadius,
+    );
+
+    Blockly.getFocusManager().focusNode(clone);
+    return clone;
 }
 
 function getBlockConfigXml(block: toolbox.BlockDefinition, blockConfig: pxt.tutorial.TutorialBlockConfig): Element | undefined {


### PR DESCRIPTION
For duplicate on drag blocks we clone the block like we already do for move (M).

Change how we clone as it's important for undo that the block is a non-shadow from the beginning otherwise the create undo event is skipped.

The shadow part of the precondition works around this blockly issue which I've opened an upstream PR for:
https://github.com/RaspberryPiFoundation/blockly/issues/9963