### PR TITLE
Scope toolboxes to editor to ensure unique ids

### DIFF
--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -21,7 +21,7 @@ export interface UiProps {
     role?: string;
     title?: string;
     ariaLabel?: string;
-    ariaHasPopup?: boolean | "dialog" | "menu" | "false" | "listbox" | "grid" | "tree" | "true";
+    ariaHasPopup?: React.AriaAttributes["aria-haspopup"];
     ariaHidden?: boolean;
     tabIndex?: number;
     rightIcon?: boolean;

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -12,7 +12,6 @@ import Util = pxt.Util;
 import { fireClickOnEnter } from "./util"
 import { DeleteConfirmationModal } from "../../react-common/components/extensions/DeleteConfirmationModal"
 import { classList } from "../../react-common/components/util"
-import { Aria } from "react-modal"
 
 export const enum CategoryNameID {
     Loops = "loops",

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -14,8 +14,6 @@ import { DeleteConfirmationModal } from "../../react-common/components/extension
 import { classList } from "../../react-common/components/util"
 import { Aria } from "react-modal"
 
-type AriaHasPopup = boolean | "dialog" | "menu" | "false" | "listbox" | "grid" | "tree" | "true";
-
 export const enum CategoryNameID {
     Loops = "loops",
     Logic = "logic",
@@ -875,7 +873,7 @@ export interface CategoryItemProps extends TreeRowProps {
     ariaHidden?: boolean;
     ariaLabel?: string;
     ariaLevel?: number;
-    ariaHasPopup?: AriaHasPopup;
+    ariaHasPopup?: React.AriaAttributes["aria-haspopup"];
     isExpanded?: boolean;
     className?: string;
 }
@@ -1161,7 +1159,7 @@ export interface TreeItemProps {
     ariaLabel?: string
     ariaLevel: number;
     ariaExpanded: boolean | undefined;
-    ariaHasPopup?: AriaHasPopup;
+    ariaHasPopup?: React.AriaAttributes["aria-haspopup"];
     className?: string;
 }
 

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -12,6 +12,9 @@ import Util = pxt.Util;
 import { fireClickOnEnter } from "./util"
 import { DeleteConfirmationModal } from "../../react-common/components/extensions/DeleteConfirmationModal"
 import { classList } from "../../react-common/components/util"
+import { Aria } from "react-modal"
+
+type AriaHasPopup = boolean | "dialog" | "menu" | "false" | "listbox" | "grid" | "tree" | "true";
 
 export const enum CategoryNameID {
     Loops = "loops",
@@ -735,7 +738,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                     <div
                         className="blocklyTreeInner"
                         // Required for certain Blockly code to run.
-                        id="toolbox-tree"
+                        id={`${editorname}-toolbox-tree`}
                         role="tree"
                         aria-label={lf("Toolbox")}
                         tabIndex={0}
@@ -746,7 +749,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                         // Prevents focus handling from running on pointer down events.
                         onPointerDownCapture={this.handlePointerDownCapture}
                         onPointerUp={this.handlePointerUp}
-                        aria-activedescendant={selectedItem}
+                        aria-activedescendant={selectedItem ? `${editorname}-${selectedItem}` : null}
                     >
                         {tryToDeleteNamespace &&
                             <DeleteConfirmationModal
@@ -759,6 +762,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                             <CategoryItem
                                 key={"search"}
                                 ref="searchCategory"
+                                editorname={editorname}
                                 toolbox={this}
                                 index={index++}
                                 selectedIndex={this.selectedIndex}
@@ -772,6 +776,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                             <CategoryItem
                                 toolbox={this}
                                 index={index++}
+                                editorname={editorname}
                                 selectedIndex={this.selectedIndex}
                                 selected={selectedItem == treeRow.nameid}
                                 treeRow={treeRow}
@@ -780,6 +785,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                                 shouldAnimate={this.state.shouldAnimate}
                                 hasDeleteButton={treeRow.allowDelete}
                                 onDeleteClick={this.handleRemoveExtension}
+                                ariaHasPopup={treeRow.nameid === "addpackage" ? "dialog" : null}
                             >
                             </CategoryItem>
                             {treeRow.subcategories?.map(subTreeRow =>
@@ -787,6 +793,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                                     key={subTreeRow.nameid + subTreeRow.subns}
                                     className={classList(expandedItem != treeRow.nameid && "sr-only")}
                                     index={index++}
+                                    editorname={editorname}
                                     selectedIndex={this.selectedIndex}
                                     toolbox={this}
                                     selected={selectedItem == (subTreeRow.nameid + subTreeRow.subns)}
@@ -813,6 +820,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                                         subcategories: [],
                                     }}
                                     onCategoryClick={this.advancedClicked}
+                                    editorname={editorname}
                                     topRowIndex={topRowIndex++}
                                     ariaHidden={true}
                                 />
@@ -822,6 +830,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                                             className={classList(!showAdvanced && "sr-only")}
                                             toolbox={this}
                                             index={index++}
+                                            editorname={editorname}
                                             selectedIndex={this.selectedIndex}
                                             selected={selectedItem == treeRow.nameid}
                                             treeRow={treeRow}
@@ -835,6 +844,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                                                 className={classList(expandedItem != treeRow.nameid && "sr-only")}
                                                 toolbox={this}
                                                 index={index++}
+                                                editorname={editorname}
                                                 selectedIndex={this.selectedIndex}
                                                 selected={selectedItem == (subTreeRow.nameid + subTreeRow.subns)}
                                                 treeRow={subTreeRow}
@@ -855,6 +865,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
 
 export interface CategoryItemProps extends TreeRowProps {
     toolbox: Toolbox;
+    editorname: string;
     onCategoryClick?: (treeRow: ToolboxCategory, index: number, isClick?: boolean) => void;
     index?: number;
     selectedIndex?: number;
@@ -864,6 +875,7 @@ export interface CategoryItemProps extends TreeRowProps {
     ariaHidden?: boolean;
     ariaLabel?: string;
     ariaLevel?: number;
+    ariaHasPopup?: AriaHasPopup;
     isExpanded?: boolean;
     className?: string;
 }
@@ -942,13 +954,13 @@ export class CategoryItem extends data.Component<CategoryItemProps, CategoryItem
     }
 
     renderCore() {
-        const { className, toolbox, hasDeleteButton, treeRow, ariaHidden, ariaLabel, ariaLevel, isExpanded } = this.props;
+        const { className, toolbox, hasDeleteButton, treeRow, ariaHidden, ariaLabel, ariaLevel, ariaHasPopup, isExpanded, editorname } = this.props;
         const { selected } = this.state;
 
         const ariaExpanded = treeRow.subcategories ? isExpanded : undefined;
 
         return (
-            <TreeItem id={treeRow.nameid + (treeRow.subns ?? "")} className={className} selected={selected} ariaHidden={ariaHidden} ariaLabel={ariaLabel} ariaLevel={ariaLevel} ariaExpanded={ariaExpanded}>
+            <TreeItem id={`${editorname}-${treeRow.nameid}${(treeRow.subns ?? "")}`} className={className} selected={selected} ariaHidden={ariaHidden} ariaLabel={ariaLabel} ariaLevel={ariaLevel} ariaExpanded={ariaExpanded} ariaHasPopup={ariaHasPopup}>
                 <TreeRow
                     ref={this.handleTreeRowRef}
                     isRtl={toolbox.isRtl()}
@@ -997,6 +1009,7 @@ export interface TreeRowProps {
     shouldAnimate?: boolean;
     hasDeleteButton?: boolean;
     onDeleteClick?: (ns: string) => void;
+    editorname: string;
 }
 
 interface TreeRowPropsExtension extends React.CSSProperties {
@@ -1059,7 +1072,7 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
     }
 
     renderCore() {
-        const { selected, onClick, onKeyDown, topRowIndex, hasDeleteButton } = this.props;
+        const { selected, onClick, onKeyDown, topRowIndex, hasDeleteButton, editorname } = this.props;
         const { nameid, advancedButtonState, subns, name, icon } = this.props.treeRow;
         const appTheme = pxt.appTarget.appTheme;
         const metaColor = this.getMetaColor();
@@ -1115,7 +1128,7 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
                     >
                         {iconContent}
                     </span>
-                    <span id={`${nameid + (subns ?? "")}.label`} className="blocklyTreeLabel">
+                    <span id={`${editorname}-${nameid}${subns ?? ""}.label`} className="blocklyTreeLabel">
                         {rowTitle}
                     </span>
                     {hasDeleteButton &&
@@ -1148,12 +1161,13 @@ export interface TreeItemProps {
     ariaLabel?: string
     ariaLevel: number;
     ariaExpanded: boolean | undefined;
+    ariaHasPopup?: AriaHasPopup;
     className?: string;
 }
 
 export class TreeItem extends data.Component<TreeItemProps, {}> {
     renderCore() {
-        const { className, selected, id, ariaHidden, ariaLabel, ariaLevel, ariaExpanded } = this.props;
+        const { className, selected, id, ariaHidden, ariaLabel, ariaLevel, ariaExpanded, ariaHasPopup } = this.props;
         return (
             <div
                 id={id}
@@ -1164,6 +1178,7 @@ export class TreeItem extends data.Component<TreeItemProps, {}> {
                 aria-level={ariaLevel}
                 aria-expanded={ariaExpanded}
                 aria-labelledby={!ariaLabel ? `${id}.label` : undefined}
+                aria-haspopup={ariaHasPopup}
                 className={classList(className)}
                 aria-hidden={ariaHidden}
             >


### PR DESCRIPTION
This is required to ensure that screen reader works with both the blocks and monaco toolboxes.

This also improves semantics for the extensions tree item which tells users that it will open a dialog.