### PR TITLE
fix asset editor to save undo/redo even if asset didn't change

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -287,6 +287,8 @@ export abstract class FieldAssetEditor<U extends FieldAssetEditorOptions, V exte
 
         if (result) {
             const old = this.getValue();
+            this.undoRedoState = fv.getPersistentData();
+
             if (pxt.assetEquals(this.asset, result)) return;
 
             result = pxt.patchTemporaryAsset(this.asset, result, project);
@@ -304,8 +306,6 @@ export abstract class FieldAssetEditor<U extends FieldAssetEditorOptions, V exte
             this.updateAssetListener();
             this.updateAssetMeta();
             this.redrawPreview();
-
-            this.undoRedoState = fv.getPersistentData();
 
             if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
                 const event = new BlocklyTilemapChange(


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6900

tweaking the asset editor field to always record undo/redo state, even if the asset didn't change