### PR TITLE
make sure config is up to date before calculating extinfo

### DIFF
--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -164,6 +164,8 @@ namespace pxt.cpp {
         let disabledDeps = ""
         let mainDeps: Package[] = []
 
+        mainPkg.loadConfig();
+
         // order shouldn't matter for c++ compilation,
         // so use a stable order to prevent order changes from fetching a new hex file
         const mainPkgDeps = mainPkg.sortedDeps(true)

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -164,7 +164,7 @@ namespace pxt.cpp {
         let disabledDeps = ""
         let mainDeps: Package[] = []
 
-        mainPkg.loadConfig();
+        mainPkg.loadConfig(true);
 
         // order shouldn't matter for c++ compilation,
         // so use a stable order to prevent order changes from fetching a new hex file

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -330,7 +330,7 @@ namespace pxt {
                 })
         }
 
-        loadConfig() {
+        loadConfig(skipSave = false) {
             if (this.level != 0 && this.invalid())
                 return; // don't try load invalid dependency
 
@@ -340,7 +340,9 @@ namespace pxt {
             this.parseConfig(confStr);
             if (this.level != 0)
                 this.installedVersion = this.version()
-            this.saveConfig()
+            if (!skipSave) {
+                this.saveConfig()
+            }
         }
 
         protected validateConfig() {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5996
fixes https://github.com/microsoft/pxt-microbit/issues/5416
fixes https://github.com/microsoft/pxt-microbit/issues/4378

changes to the yotta config weren't being propagated into the extinfo we send to the compile worker. the root cause seemed to be that the config in memory on the mainpkg wasn't being re-parsed from the source. this fixes that by calling loadconfig explicitly in getExtInfo

upload target: https://makecode.microbit.org/app/a11e88665242c03f4c3fce840289aa8ee15b4fc5-a9b7f8066f

@microbit-carlos @martinwork can you try the above upload link and make sure it works with your test projects? my dev laptop is having webusb problems for some reason. i'm going to try another computer