### PR TITLE
Expose Blockly's screen reader mode as a setting

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -1048,6 +1048,7 @@ declare namespace pxt.editor {
 
         toggleHighContrast(): void;
         setHighContrast(on: boolean): void;
+        toggleScreenReaderMode(eventSource: string): void;
         toggleGreenScreen(): void;
         launchFullEditor(): void;
         resetWorkspace(): void;

--- a/pxtlib/auth.ts
+++ b/pxtlib/auth.ts
@@ -62,6 +62,7 @@ namespace pxt.auth {
     export type UserPreferences = {
         language?: string;
         highContrast?: boolean;
+        screenReaderMode?: boolean;
         colorThemeIds?: ColorThemeIdsState;
         reader?: string;
         skillmap?: UserSkillmapState;
@@ -72,6 +73,7 @@ namespace pxt.auth {
     export const DEFAULT_USER_PREFERENCES: () => UserPreferences = () => ({
         language: pxt.appTarget.appTheme.defaultLocale,
         highContrast: false,
+        screenReaderMode: false,
         colorThemeIds: {}, // Will lookup pxt.appTarget.appTheme.defaultColorTheme for active target
         reader: "",
         skillmap: { mapProgress: {}, completedTags: {} },

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5325,7 +5325,7 @@ export class ProjectView
         const nextEnabled = !this.getData<boolean>(auth.SCREEN_READER_MODE);
         await core.setScreenReaderMode(nextEnabled, eventSource);
         if (this.blocksEditor) {
-            this.blocksEditor.setScreenReaderMode(nextEnabled, /* showHint */ eventSource === "shortcut");
+            this.blocksEditor.setScreenReaderMode(nextEnabled, eventSource === "shortcut" ? "shortcut" : "menu");
         }
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -223,6 +223,7 @@ export class ProjectView
         this.openDeviceSerial = this.openDeviceSerial.bind(this);
         this.openSerial = this.openSerial.bind(this);
         this.toggleGreenScreen = this.toggleGreenScreen.bind(this);
+        this.toggleScreenReaderMode = this.toggleScreenReaderMode.bind(this);
         this.toggleSimulatorFullscreen = this.toggleSimulatorFullscreen.bind(this);
         this.toggleSimulatorCollapse = this.toggleSimulatorCollapse.bind(this);
         this.showKeymap = this.showKeymap.bind(this);
@@ -5318,6 +5319,14 @@ export class ProjectView
         pxt.tickEvent("app.highcontrast", { on: on ? 1 : 0 });
         sendUpdateFeedbackTheme(on);
         this.setColorThemeById(on ? pxt.appTarget.appTheme.highContrastColorTheme : pxt.appTarget.appTheme.defaultColorTheme, true);
+    }
+
+    async toggleScreenReaderMode(eventSource: string) {
+        const nextEnabled = !this.getData<boolean>(auth.SCREEN_READER_MODE);
+        await core.setScreenReaderMode(nextEnabled, eventSource);
+        if (this.blocksEditor) {
+            this.blocksEditor.setScreenReaderMode(nextEnabled, /* showHint */ eventSource === "shortcut");
+        }
     }
 
     toggleGreenScreen() {

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -15,11 +15,13 @@ export const LOGGED_IN = `${MODULE}:${FIELD_LOGGED_IN}`;
 const USER_PREF_MODULE = "user-pref";
 const FIELD_USER_PREFERENCES = "preferences";
 const FIELD_HIGHCONTRAST = "high-contrast";
+const FIELD_SCREEN_READER_MODE = "screen-reader-mode";
 const FIELD_COLOR_THEME_IDS = "colorThemeIds";
 const FIELD_LANGUAGE = "language";
 const FIELD_READER = "reader";
 export const USER_PREFERENCES = `${USER_PREF_MODULE}:${FIELD_USER_PREFERENCES}`
 export const HIGHCONTRAST = `${USER_PREF_MODULE}:${FIELD_HIGHCONTRAST}`
+export const SCREEN_READER_MODE = `${USER_PREF_MODULE}:${FIELD_SCREEN_READER_MODE}`
 export const COLOR_THEME_IDS = `${USER_PREF_MODULE}:${FIELD_COLOR_THEME_IDS}`
 export const LANGUAGE = `${USER_PREF_MODULE}:${FIELD_LANGUAGE}`
 export const READER = `${USER_PREF_MODULE}:${FIELD_READER}`
@@ -69,6 +71,7 @@ class AuthClient extends pxt.auth.AuthClient {
             switch (op.path.join('/')) {
                 case "language": data.invalidate(LANGUAGE); break;
                 case "highContrast": data.invalidate(HIGHCONTRAST); break;
+                case "screenReaderMode": data.invalidate(SCREEN_READER_MODE); break;
                 case "colorThemeIds": data.invalidate(COLOR_THEME_IDS); break;
                 case "reader": data.invalidate(READER); break;
             }
@@ -120,6 +123,7 @@ class AuthClient extends pxt.auth.AuthClient {
             // Identity not available, read from local storage
             switch (path) {
                 case HIGHCONTRAST: return /^true$/i.test(pxt.storage.getLocal(HIGHCONTRAST));
+                case SCREEN_READER_MODE: return /^true$/i.test(pxt.storage.getLocal(SCREEN_READER_MODE));
                 case COLOR_THEME_IDS: return pxt.U.jsonTryParse(pxt.storage.getLocal(COLOR_THEME_IDS)) as pxt.auth.ColorThemeIdsState;
                 case LANGUAGE: return pxt.storage.getLocal(LANGUAGE);
                 case READER: return pxt.storage.getLocal(READER);
@@ -136,6 +140,7 @@ class AuthClient extends pxt.auth.AuthClient {
             switch (field) {
                 case FIELD_USER_PREFERENCES: return { ...state.preferences };
                 case FIELD_HIGHCONTRAST: return state.preferences?.highContrast ?? pxt.auth.DEFAULT_USER_PREFERENCES().highContrast;
+                case FIELD_SCREEN_READER_MODE: return state.preferences?.screenReaderMode ?? pxt.auth.DEFAULT_USER_PREFERENCES().screenReaderMode;
                 case FIELD_COLOR_THEME_IDS: return state.preferences?.colorThemeIds ?? pxt.auth.DEFAULT_USER_PREFERENCES().colorThemeIds;
                 case FIELD_LANGUAGE: return state.preferences?.language ?? pxt.auth.DEFAULT_USER_PREFERENCES().language;
                 case FIELD_READER: return state.preferences?.reader ?? pxt.auth.DEFAULT_USER_PREFERENCES().reader;
@@ -246,6 +251,21 @@ export async function setHighContrastPrefAsync(highContrast: boolean): Promise<v
         // Identity not available, save this setting locally
         pxt.storage.setLocal(HIGHCONTRAST, highContrast.toString());
         data.invalidate(HIGHCONTRAST);
+    }
+}
+
+export async function setScreenReaderModePrefAsync(screenReaderMode: boolean): Promise<void> {
+    const cli = await clientAsync();
+    if (cli) {
+        await cli.patchUserPreferencesAsync({
+            op: 'replace',
+            path: ['screenReaderMode'],
+            value: screenReaderMode
+        });
+    } else {
+        // Identity not available, save this setting locally
+        pxt.storage.setLocal(SCREEN_READER_MODE, screenReaderMode.toString());
+        data.invalidate(SCREEN_READER_MODE);
     }
 }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1061,24 +1061,32 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     // built-in screenreader toggle: it disables navigation looping (so screen
     // reader users hit a clear start/end) and enables audio cues when keyboard
     // navigation changes nesting level.
-    setScreenReaderMode(enabled: boolean, showHint = false) {
+    setScreenReaderMode(enabled: boolean, hintStyle?: "shortcut" | "menu") {
         if (!this.editor) return;
         Blockly.keyboardNavigationController.setScopeChangeAudioCuesEnabled(enabled);
         this.editor.getNavigator().setNavigationLoops(!enabled);
         (this.editor.getToolbox() as Blockly.Toolbox)?.getNavigator()?.setNavigationLoops(!enabled);
         this.editor.getFlyout()?.getWorkspace().getNavigator().setNavigationLoops(!enabled);
-        if (showHint) this.showScreenReaderModeHint(enabled);
+        if (hintStyle) this.showScreenReaderModeHint(enabled, hintStyle);
     }
 
-    private showScreenReaderModeHint(enabled: boolean) {
+    private showScreenReaderModeHint(enabled: boolean, hintStyle: "shortcut" | "menu") {
         if (!this.editor) return;
-        const message = enabled
-            ? Blockly.Msg["SCREENREADER_MODE_ENABLED"]
-            : Blockly.Msg["SCREENREADER_MODE_DISABLED"];
-        if (!message) return;
-        const shortcut = getShortcutKeysShort(Blockly.ShortcutItems.names.TOGGLE_SCREENREADER);
+        let message: string;
+        if (hintStyle === "shortcut") {
+            const template = enabled
+                ? Blockly.Msg["SCREENREADER_MODE_ENABLED"]
+                : Blockly.Msg["SCREENREADER_MODE_DISABLED"];
+            if (!template) return;
+            const shortcut = getShortcutKeysShort(Blockly.ShortcutItems.names.TOGGLE_SCREENREADER);
+            message = shortcut ? template.replace("%1", shortcut) : template;
+        } else {
+            message = enabled
+                ? lf("Screen reader mode on")
+                : lf("Screen reader mode off");
+        }
         Blockly.Toast.show(this.editor, {
-            message: shortcut ? message.replace("%1", shortcut) : message,
+            message,
             duration: 7,
             id: "screenreaderModeHint",
         });

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -728,6 +728,22 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             }
         });
 
+        // Route Blockly's built-in screenreader toggle (Ctrl/Cmd+Alt+Z) through
+        // MakeCode's persistent setting so the keyboard shortcut, the Settings
+        // menu checkbox, and the stored preference all stay in sync.
+        const toggleScreenreader = Blockly.ShortcutRegistry.registry.getRegistry()[Blockly.ShortcutItems.names.TOGGLE_SCREENREADER];
+        if (toggleScreenreader) {
+            Blockly.ShortcutRegistry.registry.unregister(toggleScreenreader.name);
+            Blockly.ShortcutRegistry.registry.register({
+                ...toggleScreenreader,
+                callback: (workspace, e) => {
+                    this.parent.toggleScreenReaderMode("shortcut");
+                    e.preventDefault();
+                    return true;
+                }
+            });
+        }
+
         Blockly.ShortcutRegistry.registry.register({
             name: "toggle_simulator",
             keyCodes: [Blockly.ShortcutRegistry.registry.createSerializedKey(Blockly.utils.KeyCodes.S, null)],
@@ -958,6 +974,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         initCopyPaste();
         this.initKeyboardControls();
         this.initWorkspaceSearch();
+        this.setScreenReaderMode(data.getData<boolean>(auth.SCREEN_READER_MODE));
         this.setupIntersectionObserver();
         this.resize();
 
@@ -1038,6 +1055,33 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.pendingKeyboardControlsHint = false;
             this.showKeyboardControlsHint();
         }
+    }
+
+    // Screen reader mode is the MakeCode-persisted equivalent of Blockly's
+    // built-in screenreader toggle: it disables navigation looping (so screen
+    // reader users hit a clear start/end) and enables audio cues when keyboard
+    // navigation changes nesting level.
+    setScreenReaderMode(enabled: boolean, showHint = false) {
+        if (!this.editor) return;
+        Blockly.keyboardNavigationController.setScopeChangeAudioCuesEnabled(enabled);
+        this.editor.getNavigator().setNavigationLoops(!enabled);
+        (this.editor.getToolbox() as Blockly.Toolbox)?.getNavigator()?.setNavigationLoops(!enabled);
+        this.editor.getFlyout()?.getWorkspace().getNavigator().setNavigationLoops(!enabled);
+        if (showHint) this.showScreenReaderModeHint(enabled);
+    }
+
+    private showScreenReaderModeHint(enabled: boolean) {
+        if (!this.editor) return;
+        const message = enabled
+            ? Blockly.Msg["SCREENREADER_MODE_ENABLED"]
+            : Blockly.Msg["SCREENREADER_MODE_DISABLED"];
+        if (!message) return;
+        const shortcut = getShortcutKeysShort(Blockly.ShortcutItems.names.TOGGLE_SCREENREADER);
+        Blockly.Toast.show(this.editor, {
+            message: shortcut ? message.replace("%1", shortcut) : message,
+            duration: 7,
+            id: "screenreaderModeHint",
+        });
     }
 
     showKeyboardControlsHint() {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -171,6 +171,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         this.showLanguagePicker = this.showLanguagePicker.bind(this);
         this.showThemePicker = this.showThemePicker.bind(this);
         this.toggleHighContrast = this.toggleHighContrast.bind(this);
+        this.toggleScreenReaderMode = this.toggleScreenReaderMode.bind(this);
         this.toggleGreenScreen = this.toggleGreenScreen.bind(this);
         this.showResetDialog = this.showResetDialog.bind(this);
         this.showShareDialog = this.showShareDialog.bind(this);
@@ -250,6 +251,11 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
     toggleHighContrast() {
         pxt.tickEvent("menu.togglecontrast", undefined, { interactiveConsent: true });
         this.props.parent.toggleHighContrast();
+    }
+
+    toggleScreenReaderMode() {
+        pxt.tickEvent("menu.togglescreenreadermode", undefined, { interactiveConsent: true });
+        this.props.parent.toggleScreenReaderMode("settings");
     }
 
     toggleGreenScreen() {
@@ -512,6 +518,15 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
                 label: lf("Green Screen"),
                 isChecked: greenScreen,
                 onChange: this.toggleGreenScreen
+            });
+        }
+
+        if (this.props.inBlocks) {
+            items.push({
+                role: "menuitemcheckbox",
+                label: lf("Screen Reader Mode"),
+                isChecked: this.getData<boolean>(auth.SCREEN_READER_MODE),
+                onChange: this.toggleScreenReaderMode
             });
         }
 

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -343,6 +343,15 @@ export function getHighContrastOnce(): boolean {
     return ThemeManager.isCurrentThemeHighContrast();
 }
 
+export async function toggleScreenReaderMode(eventSource: string) {
+    await setScreenReaderMode(!data.getData<boolean>(auth.SCREEN_READER_MODE), eventSource);
+}
+
+export async function setScreenReaderMode(on: boolean, eventSource: string) {
+    pxt.tickEvent("app.screenreadermode", { on: on ? 1 : 0, eventSource });
+    await auth.setScreenReaderModePrefAsync(on);
+}
+
 export async function setLanguage(lang: string) {
     pxt.BrowserUtils.setCookieLang(lang);
     pxt.Util.setUserLanguage(lang);


### PR DESCRIPTION
Expose Blockly's screen reader mode as a setting.

This provides state visibility via the menu and will also help sighted folks
working with screen reader users.

Aligns with the suggestion in [Blockly's best practice docs](https://github.com/google/blockly/blob/v13/packages/docs/docs/guides/app-integration/accessibility/best-practices.mdx?plain=1#L129) (to be published with v13). I think Blockly itself [is intending to handle the first part](https://github.com/google/blockly/blob/v13/packages/blockly/core/workspace_svg.ts?plain=1#L2760-L2773), though there are some practical issues at the mo where a block typically takes focus and so this can be missed (we'll provide feedback on this to Blockly).

@riknoll I imagine this one might need some discussion but wanted to prep something ahead of our call today.

Behaviour differences in Blockly's screen reader mode:
- **Up/down have hard stops**: In keyboard nav user testing not looping caused some users to get stuck/lose track of the cursor, looping helped unstick these folks. In screen reader user testing there was a strong need to understand the start/end of the code via hard stops.
- **Audio cues for scope changes**: tones when changing nesting level.

This setting is designed to work in conjunction with a screen reader, obviously it cannot itself enable a screen reader. The behaviour changes do not rely on a screen reader.

Demo: https://screen-reader-mode.review-pxt.pages.dev/#editor
You'll need to run it locally for working login.