### PR TITLE
Remove use on menubar and place with group

### DIFF
--- a/react-common/components/controls/MenuDropdown.tsx
+++ b/react-common/components/controls/MenuDropdown.tsx
@@ -133,7 +133,7 @@ export const MenuDropdown = (props: MenuDropdownProps) => {
             buttonRef={handleButtonRef}
             title={title}
             leftIcon={icon}
-            role={role || "menuitem"}
+            role={role || "button"}
             className={classList("menu-button", expanded && "expanded")}
             onClick={null}
             onClickEvent={onMenuButtonClick}

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -132,7 +132,6 @@ export class DocsMenu extends data.PureComponent<DocsMenuProps, {}> {
         return (
             <MenuDropdown
                 id="docs-menuitem"
-                role="menuitem"
                 title={lf("Help")}
                 className="mobile-hidden help-dropdown-menuitem"
                 icon="icon help circle large"
@@ -599,6 +598,7 @@ interface IBaseMenuItemProps extends ISettingsProps {
     title?: string;
     className?: string;
     ariaLabel?: string;
+    role?: string;
 }
 
 class BaseMenuItemProps extends data.Component<IBaseMenuItemProps, {}> {
@@ -608,13 +608,13 @@ class BaseMenuItemProps extends data.Component<IBaseMenuItemProps, {}> {
 
     renderCore() {
         const active = this.props.isActive();
-        return <sui.Item className={`base-menuitem ${this.props.className} ${active ? "selected" : ""}`} role="option" textClass="landscape only"
+        return <sui.Item className={`base-menuitem ${this.props.className} ${active ? "selected" : ""}`} role={this.props.role || "button"} textClass="landscape only"
             text={this.props.text} icon={this.props.icon} active={active} onClick={this.props.onClick} title={this.props.title} ariaLabel={this.props.ariaLabel} />
     }
 }
 
-class JavascriptMenuItem extends data.Component<ISettingsProps, {}> {
-    constructor(props: ISettingsProps) {
+class JavascriptMenuItem extends data.Component<ISettingsProps & { role?: string }, {}> {
+    constructor(props: ISettingsProps & { role?: string }) {
         super(props);
     }
 
@@ -628,12 +628,12 @@ class JavascriptMenuItem extends data.Component<ISettingsProps, {}> {
     }
 
     renderCore() {
-        return <BaseMenuItemProps className="javascript-menuitem" icon="xicon js" text="JavaScript" title={lf("Convert code to JavaScript")} onClick={this.onClick} isActive={this.isActive} parent={this.props.parent} ariaLabel={lf("Convert code to JavaScript")}/>
+        return <BaseMenuItemProps className="javascript-menuitem" icon="xicon js" text="JavaScript" title={lf("Convert code to JavaScript")} onClick={this.onClick} isActive={this.isActive} parent={this.props.parent} ariaLabel={lf("Convert code to JavaScript")} role={this.props.role}/>
     }
 }
 
-class PythonMenuItem extends data.Component<ISettingsProps, {}> {
-    constructor(props: ISettingsProps) {
+class PythonMenuItem extends data.Component<ISettingsProps & { role?: string }, {}> {
+    constructor(props: ISettingsProps & { role?: string }) {
         super(props);
     }
 
@@ -647,7 +647,7 @@ class PythonMenuItem extends data.Component<ISettingsProps, {}> {
     }
 
     renderCore() {
-        return <BaseMenuItemProps className="python-menuitem" icon="xicon python" text="Python" title={lf("Convert code to Python")} onClick={this.onClick} isActive={this.isActive} parent={this.props.parent} ariaLabel={lf("Convert code to Python")} />
+        return <BaseMenuItemProps className="python-menuitem" icon="xicon python" text="Python" title={lf("Convert code to Python")} onClick={this.onClick} isActive={this.isActive} parent={this.props.parent} ariaLabel={lf("Convert code to Python")} role={this.props.role} />
     }
 }
 
@@ -761,14 +761,14 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
         }
 
         return (
-            <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`} role="listbox" aria-orientation="horizontal" aria-label={lf("Editor toggle")}>
+            <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`} role="group" aria-label={lf("Editor toggle")}>
                 {showSandbox && <SandboxMenuItem parent={parent} />}
                 {showBlocks && <BlocksMenuItem parent={parent} />}
                 {textLanguage}
                 {secondTextLanguage}
-                {showDropdown && <sui.DropdownMenu id="editordropdown" role="option" icon="chevron down" rightIcon title={lf("Select code editor language")} className={`item button attached right ${dropdownActive ? "active" : ""}`}>
-                    <JavascriptMenuItem parent={parent} />
-                    <PythonMenuItem parent={parent} />
+                {showDropdown && <sui.DropdownMenu id="editordropdown" role="button" icon="chevron down" rightIcon title={lf("Select code editor language")} className={`item button attached right ${dropdownActive ? "active" : ""}`}>
+                    <JavascriptMenuItem parent={parent} role="menuitem" />
+                    <PythonMenuItem parent={parent} role="menuitem" />
                 </sui.DropdownMenu>}
                 {showAssets && <AssetMenuItem parent={parent} />}
                 <div className={`ui item toggle ${dropdownActive ? 'dropdown-attached' : ''}`}></div>

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -355,7 +355,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         // Add the ... menu
         const usbIcon = pxt.appTarget.appTheme.downloadDialogTheme?.deviceIcon || "usb";
         el.push(
-            <sui.DropdownMenu ref={getMenuRef()} key="downloadmenu" role="menuitem" icon={`${downloadButtonIcon} horizontal ${hwIconClasses}`} title={lf("Download options")} className={`${hwIconClasses} right attached editortools-btn hw-button button`} dataTooltip={tooltip} displayAbove={true} displayRight={displayRight} closeOnItemClick={true} onShow={
+            <sui.DropdownMenu ref={getMenuRef()} key="downloadmenu" role="button" icon={`${downloadButtonIcon} horizontal ${hwIconClasses}`} title={lf("Download options")} className={`${hwIconClasses} right attached editortools-btn hw-button button`} dataTooltip={tooltip} displayAbove={true} displayRight={displayRight} closeOnItemClick={true} onShow={
                 () => this.forceUpdate() // force update to refresh extMenuItems
             }>
                 {webUSBSupported && !packetioConnected && <sui.Item role="menuitem" icon={usbIcon} text={lf("Connect Device")} tabIndex={-1} onClick={() => this.onPairClick(returnFocus)} />}
@@ -435,7 +435,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         }
 
         return <div id="editortools" className="ui" role="region" aria-label={lf("Editor toolbar")}>
-            <div id="downloadArea" role="menubar" className="ui column items">
+            <div id="downloadArea" role="group" aria-label={lf("Download and device connection")} className="ui column items">
                 {showCompileBtn && <div className="ui item portrait hide">
                     {this.getCompileButton(computer)}
                 </div>}
@@ -451,7 +451,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
                         <identity.CloudSaveStatus headerId={header.id} />
                     </div>
                 </div>}
-            <div id="editorToolbarArea" role="menubar" className="ui column items">
+            <div id="editorToolbarArea" role="group" aria-label={lf("Editor tools")} className="ui column items">
                 {showUndoRedo && <div className="ui icon buttons">{this.getUndoRedo(computer)}</div>}
                 {showZoomControls && <div className="ui icon buttons mobile hide">{this.getZoomControl(computer)}</div>}
                 {targetTheme.bigRunButton && !pxt.shell.isTimeMachineEmbed() &&
@@ -600,7 +600,7 @@ class EditorToolbarButton extends sui.StatelessUIElement<EditorToolbarButtonProp
 
     renderCore() {
         const { onClick, onButtonClick, role, ...rest } = this.props;
-        return <sui.Button role={role || "menuitem"} {...rest} onClick={this.handleClick} />;
+        return <sui.Button role={role || "button"} {...rest} onClick={this.handleClick} />;
     }
 }
 

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -123,10 +123,8 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
 
         const shouldLinkHome = pxt.shell.hasHomeScreen() && view !== "home";
 
-        const role = shouldLinkHome ? "menuitem" : "presentation";
-
         // TODO: "sandbox" view components are temporary share page layout
-        return <div aria-hidden={!shouldLinkHome} role={role} className={`ui item logo brand ${view !== "sandbox" && view !== "home" ? "mobile hide" : ""}`}>
+        return <div aria-hidden={!shouldLinkHome} className={`ui item logo brand ${view !== "sandbox" && view !== "home" ? "mobile hide" : ""}`}>
             {targetTheme.useTextLogo
             ? (shouldLinkHome
                 ? [<Button className="name menu-button" key="org-name"
@@ -211,7 +209,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
                             break;
                     }
                 } else {
-                    return <div className="ui item link editor-menuitem" role="menuitem">
+                    return <div className="ui item link editor-menuitem">
                         <container.EditorSelector parent={this.props.parent} sandbox={view === "sandbox"} python={targetTheme.python} languageRestriction={languageRestriction} headless={pxt.appTarget.simulator?.headless} />
                     </div>
                 }
@@ -223,22 +221,22 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
     getExitButtons(targetTheme: pxt.AppTheme, view: HeaderBarView, tutorialOptions?: pxt.tutorial.TutorialOptions) {
         switch (view) {
             case "debugging":
-                return <sui.ButtonMenuItem className="exit-debugmode-btn" role="menuitem" icon="external" text={lf("Exit Debug Mode")} textClass="landscape only" onClick={this.toggleDebug} />
+                return <sui.ButtonMenuItem className="exit-debugmode-btn" role="button" icon="external" text={lf("Exit Debug Mode")} textClass="landscape only" onClick={this.toggleDebug} />
             case "sandbox":
-                if (!targetTheme.hideEmbedEdit) return <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit")} onClick={this.launchFullEditor} />
+                if (!targetTheme.hideEmbedEdit) return <sui.Item role="button" icon="external" textClass="mobile hide" text={lf("Edit")} onClick={this.launchFullEditor} />
                 break;
             case "tutorial":
             case "tutorial-tab":
                 const tutorialButtons = [];
                 if (tutorialOptions?.tutorialReportId) {
                     const reportTutorialLabel = lf("Unapproved Content");
-                    tutorialButtons.push(<sui.Item key="tutorial-report" role="menuitem" icon="exclamation triangle"
+                    tutorialButtons.push(<sui.Item key="tutorial-report" role="button" icon="exclamation triangle"
                         className="report-tutorial-btn link-button icon-and-text" textClass="landscape only"
                         text={reportTutorialLabel} ariaLabel={reportTutorialLabel} onClick={this.showReportAbuse} />);
                 }
                 if (!targetTheme.lockedEditor && !tutorialOptions?.metadata?.hideIteration && (view !== "tutorial-tab" || pxt.appTarget.simulator?.headless)) {
                     const exitTutorialLabel = lf("Exit tutorial");
-                    tutorialButtons.push(<sui.Item key="tutorial-exit" role="menuitem" icon="sign out large"
+                    tutorialButtons.push(<sui.Item key="tutorial-exit" role="button" icon="sign out large"
                         className="exit-tutorial-btn link-button icon-and-text" textClass="landscape only"
                         text={exitTutorialLabel} ariaLabel={exitTutorialLabel} onClick={this.exitTutorial} />);
                 }
@@ -291,9 +289,9 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
         // Approximate each tutorial step to be 22 px
         const manyTutorialSteps = view == "tutorial" && (tutorialOptions.tutorialStepInfo.length * 22 > window.innerWidth / 3);
 
-        return <div id="mainmenu" className={`ui borderless fixed menu ${targetTheme.invertedMenu ? `inverted` : ''} ${manyTutorialSteps ? "thin" : ""}`} role="menubar">
+        return <div id="mainmenu" className={`ui borderless fixed menu ${targetTheme.invertedMenu ? `inverted` : ''} ${manyTutorialSteps ? "thin" : ""}`} role="group" aria-label={lf("Main menu")}>
             <div className="left menu">
-                {isNativeHost && <sui.Item className="icon nativeback" role="menuitem" icon="chevron left large" ariaLabel={lf("Back to application")}
+                {isNativeHost && <sui.Item className="icon nativeback" role="button" icon="chevron left large" ariaLabel={lf("Back to application")}
                     onClick={cmds.nativeHostBackAsync} onMouseDown={this.backButtonTouchStart} onMouseUp={this.backButtonTouchEnd} onMouseLeave={this.backButtonTouchEnd} />}
                 {this.getOrganizationLogo(targetTheme, highContrast, view)}
                 {view === "tutorial"
@@ -306,8 +304,8 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
             </div>}
             <div className="right menu">
                 {this.getExitButtons(targetTheme, view, tutorialOptions)}
-                {showHomeButton && <sui.Item className={`icon openproject ${hasIdentity ? "mobile hide" : ""}`} role="menuitem" title={lf("Home")} icon="home large" ariaLabel={lf("Home screen")} onClick={this.goHome} />}
-                {showShareButton && <sui.Item className="icon shareproject mobile hide" role="menuitem" title={lf("Publish your game to create a shareable link")} icon="share alternate large" ariaLabel={lf("Share Project")} onClick={this.showShareDialog} />}
+                {showHomeButton && <sui.Item className={`icon openproject ${hasIdentity ? "mobile hide" : ""}`} role="button" title={lf("Home")} icon="home large" ariaLabel={lf("Home screen")} onClick={this.goHome} />}
+                {showShareButton && <sui.Item className="icon shareproject mobile hide" role="button" title={lf("Publish your game to create a shareable link")} icon="share alternate large" ariaLabel={lf("Share Project")} onClick={this.showShareDialog} />}
                 {showHelpButton && <container.DocsMenu parent={this.props.parent} editor={activeEditor} inBlocks={this.props.parent.isBlocksActive()} />}
                 {this.getSettingsMenu(view)}
                 {hasIdentity && (view === "home" || view === "editor" || view === "tutorial-tab") && <identity.UserMenu parent={this.props.parent} />}

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -159,8 +159,9 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
         const githubUser = this.getData("github:user") as UserInfo;
 
         return (
-            <sui.DropdownMenu role="menuitem"
+            <sui.DropdownMenu role="button"
                 title={title}
+                ariaHasPopup={(loggedIn || githubUser) ? "menu" : "dialog"}
                 className={`item icon user-dropdown-menuitem ${loggedIn ? 'logged-in-dropdown' : 'sign-in-dropdown'}`}
                 titleContent={loggedIn ? signedInElem : signedOutElem}
                 tabIndex={loggedIn ? 0 : -1}

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -327,14 +327,17 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
 
     renderCore() {
         const { disabled, title, role, icon, className, titleContent, children,
-            displayAbove, displayLeft, displayRight, dataTooltip } = this.props;
+            displayAbove, displayLeft, displayRight, dataTooltip, ariaHasPopup } = this.props;
         const { open } = this.state;
 
+        const hasPopup = ariaHasPopup ?? !disabled;
         const aria = {
             'role': role || 'combobox',
             'aria-disabled': disabled,
-            'aria-haspopup': !disabled,
-            ...(role !== 'option' && { 'aria-expanded': open }) // Exclude aria-expanded when the dropdown is an option
+            'aria-haspopup': hasPopup,
+            // Exclude aria-expanded when the dropdown is an option, or when it opens a dialog
+            // (the dialog is modal and not a region owned/expanded by this control).
+            ...(role !== 'option' && hasPopup !== 'dialog' && { 'aria-expanded': open })
             }
         const menuAria = {
             'role': 'menu',
@@ -467,7 +470,7 @@ export class Item extends data.Component<ItemProps, {}> {
             <div className={genericClassName("ui item link", this.props, true) + ` ${this.props.active ? 'active' : ''}`}
                 role={this.props.role}
                 aria-label={(!this.props.role || this.props.role === "presentation") ? "" : ariaLabel || title || text}
-                aria-selected={this.props.active}
+                aria-selected={this.props.role === "option" ? this.props.active : undefined}
                 aria-hidden={ariaHidden}
                 aria-haspopup={ariaHasPopup}
                 title={title || text}


### PR DESCRIPTION
This PR replaces uses of menubar with groups. The current menubars do not implement the expected keyboard controls. The change in role means that the current tab behaviour can be preserved.

- Changes the role of existing menubars to groups
    - Changes the children of these elements from menuitems to buttons
- Fix-up Blocks / JavaScript toggle semantics
    - This is now a group
    - The correct semantics for the dropdown inside this toggle are preserved
- Fix-up sign in semantics
    - This is now a button that opens a menu or a dialog depending on login state
    
Closes https://github.com/microsoft/pxt-microbit/issues/6732