### PR TITLE
Improve screen reader output for show leds block

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -133,6 +133,28 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
         }
     }
 
+    computeAriaLabel(includeTypeInfo?: boolean) {
+        const numLedsOn = this.cellState.reduce((total, column) => total + column.filter(Boolean).length, 0);
+        if (includeTypeInfo) {
+            return numLedsOn === 1 ? lf("dropdown: LED, {0} LEDs on", numLedsOn) : lf("dropdown: LEDs, {0} LEDs on", numLedsOn);
+        }
+        return numLedsOn === 1 ? lf("{0} LED on", numLedsOn) : lf("{0} LEDs on", numLedsOn);
+    }
+
+    recomputeAriaContext() {
+        const result = super.recomputeAriaContext();
+        if (!this.fieldGroup_) return false; // There's no element to set currently.
+        const element = this.getFocusableElement();
+        const isInFlyout = this.getSourceBlock()?.workspace?.isFlyout || false;
+        if (!isInFlyout) {
+            element.ariaHasPopup = "grid";
+            element.setAttribute("role", "button");
+            element.ariaLabel = lf("dropdown: LEDs");
+            element.ariaExpanded = "false";
+        }
+        return result;
+    }
+
     /**
      * Show the inline free-text editor on top of the text.
      * @private
@@ -160,15 +182,17 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
             widgetDiv.style.top = "";
             widgetDiv.style.transform = "";
             widgetDiv.style.transformOrigin = "";
+            this.getFocusableElement().ariaExpanded = "false";
         });
 
         this.matrixSvg.focus();
         this.focusCell(0, 0);
+        this.getFocusableElement().ariaExpanded = "true";
     }
 
     private initMatrix() {
         if (!this.sourceBlock_.isInsertionMarker()) {
-            this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" width="${this.size_.width}" height="${this.size_.height}"/>`);
+            this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="${this.sourceBlock_.id}:field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" width="${this.size_.width}" height="${this.size_.height}"/>`);
             this.matrixSvg.ariaLabel = lf("LED grid");
             const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg
             this.matrixSvg.style.boxShadow = `rgba(255, 255, 255, 0.3) 0 0 0 ${4 * workspace.getAbsoluteScale()}px`;
@@ -355,12 +379,19 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
         cellRect.setAttribute("fill-opacity", this.getOpacity(x, y));
         cellRect.setAttribute('class', `blocklyLed${this.cellState[x][y] ? 'On' : 'Off'}`);
         cellRect.setAttribute("aria-checked", (!!this.cellState[x][y]).toString());
-        if (this.isColorMatrix) {
-            const cellLabel = getChildElementOfTag(cellGroup, "text");
-            if (cellLabel) {
+        this.updateCellLabel(x, y);
+    }
+
+    private updateCellLabel(x: number, y: number) {
+        const cellGroup = this.cells[x][y];
+        const cellLabel = getChildElementOfTag(cellGroup, "text");
+        if (cellLabel) {
+            if (this.isColorMatrix) {
                 const colorIndex = this.cellState[x][y];
                 const colorName = this.colorNames[colorIndex] || this.palette[colorIndex] || lf("color {0}", colorIndex);
-                cellLabel.textContent = lf("{0} LED", colorName);
+                cellLabel.textContent = colorIndex ? lf("{0} LED on", colorName) : lf("{0} LED off", colorName);
+            } else {
+                cellLabel.textContent = this.cellState[x][y] ? lf("LED on") : lf("LED off");
             }
         }
     }
@@ -389,6 +420,7 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
             this.initMatrix();
         }
 
+        this.recomputeAriaContext();
     }
 
     // The return value of this function is inserted in the code

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -192,7 +192,7 @@ export class FieldLedMatrix extends FieldMatrix implements FieldCustom {
 
     private initMatrix() {
         if (!this.sourceBlock_.isInsertionMarker()) {
-            this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="${this.sourceBlock_.id}:field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" width="${this.size_.width}" height="${this.size_.height}"/>`);
+            this.matrixSvg = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="${this.domId}:field-matrix" class="blocklyMatrix" tabindex="-1" role="grid" width="${this.size_.width}" height="${this.size_.height}"/>`);
             this.matrixSvg.ariaLabel = lf("LED grid");
             const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg
             this.matrixSvg.style.boxShadow = `rgba(255, 255, 255, 0.3) 0 0 0 ${4 * workspace.getAbsoluteScale()}px`;

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -304,9 +304,12 @@ export abstract class FieldMatrix extends Blockly.Field {
         }
     }
 
-    protected getCellId = (x: number, y: number) => `${this.sourceBlock_.id}:${x}-${y}`;
+    // sourceBlock._id can clash between flyout and main workspace
+    protected domId = Blockly.utils.idGenerator.getNextUniqueId();
 
-    protected getRowId = (index: number) => `${this.sourceBlock_.id}:row-${index}`;
+    protected getCellId = (x: number, y: number) => `${this.domId}:${x}-${y}`;
+
+    protected getRowId = (index: number) => `${this.domId}:row-${index}`;
 
     protected abstract attachPointerEventHandlersToCell(x: number, y: number, cellRect: SVGElement): void;
 

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -1,5 +1,7 @@
 import * as Blockly from "blockly";
 
+const twoToneDataAttr = "data-two-tone-focus-rect";
+
 interface MatrixDisplayProps {
     cellWidth: number;
     cellHeight: number;
@@ -223,7 +225,8 @@ export abstract class FieldMatrix extends Blockly.Field {
                 stroke: "#000",
                 "stroke-width": 2,
                 fill: "none",
-                "aria-hidden": "true"
+                "aria-hidden": "true",
+                [twoToneDataAttr]: "true"
             });
         }
         const cellTextEl = cell.firstElementChild;
@@ -238,7 +241,8 @@ export abstract class FieldMatrix extends Blockly.Field {
         const cellRect = cell.children[1];
         const cellWidth = parseInt(cellRect.getAttribute("width"))
         const cornerRadius = parseInt(cellRect.getAttribute("rx"));
-        if (useTwoToneFocusIndicator && !cell.children[3]) {
+        const twoToneRect = Array.from(cell.children).find(c => c.hasAttribute(twoToneDataAttr));
+        if (useTwoToneFocusIndicator && !twoToneRect) {
             pxsim.svg.child(cell, "rect", {
                 transform: 'translate(-1, -1)',
                 width: cellWidth + 2,
@@ -247,10 +251,11 @@ export abstract class FieldMatrix extends Blockly.Field {
                 stroke: "#000",
                 "stroke-width": 2,
                 fill: "none",
-                "aria-hidden": "true"
+                "aria-hidden": "true",
+                [twoToneDataAttr]: "true"
             });
-        } else {
-            cell.children[3]?.remove();
+        } else if (!useTwoToneFocusIndicator && twoToneRect) {
+            twoToneRect.remove();
         }
     }
 

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -147,6 +147,7 @@ export abstract class FieldMatrix extends Blockly.Field {
                 case "Enter":
                 case "Space": {
                     this.toggleCell(x, y, !this.getCellToggled(x, y));
+                    this.updateFocusIndicator(this.cells[x][y], this.useTwoToneFocusIndicator(x, y))
                     e.preventDefault();
                     e.stopPropagation();
                     return;
@@ -229,6 +230,28 @@ export abstract class FieldMatrix extends Blockly.Field {
         // Don't take effect for initial gridcell focus.
         // Only announce gridcells being toggled on/off, not navigated to.
         setTimeout(() => cellTextEl.setAttribute("aria-live", "polite"), 0);
+    }
+
+    private updateFocusIndicator(cell: SVGElement, useTwoToneFocusIndicator: boolean) {
+        const focusVisible = this.matrixSvg.matches(":focus-visible");
+        if (!focusVisible && !this.forceFocusVisible) return;
+        const cellRect = cell.children[1];
+        const cellWidth = parseInt(cellRect.getAttribute("width"))
+        const cornerRadius = parseInt(cellRect.getAttribute("rx"));
+        if (useTwoToneFocusIndicator && !cell.children[3]) {
+            pxsim.svg.child(cell, "rect", {
+                transform: 'translate(-1, -1)',
+                width: cellWidth + 2,
+                height: cellWidth + 2,
+                rx: `${Math.max(2, cornerRadius)}px`,
+                stroke: "#000",
+                "stroke-width": 2,
+                fill: "none",
+                "aria-hidden": "true"
+            });
+        } else {
+            cell.children[3]?.remove();
+        }
     }
 
     protected clearFocusIndicator() {


### PR DESCRIPTION
This PR:
- Provides aria information for the show leds block
    - Adds a label that includes how many LEDs are on
    - Adds grid popup semantics (not exactly what a sighted user sees, but a consistent approach across field editors)
- Updates individual LED labels to indicate if they are on or off
- Addresses an id clash which is a result of using sourceBlock_.id
    - The same id is used for the flyout and workspace for the first inserted show leds block - this causes aria-activedescendant to fail causing screen reader problems when navigating inside the grid
-  Adds a `updateFocusIndicator` method to ensure that the two tone focus indicator is updated when the LEDs are toggled on and off (unintentionally broken by https://github.com/microsoft/pxt/pull/11301/changes#diff-84524797c860e262a8416d54b981fa43859564638b17676b040481db4ee05b7dR150-R152)