### PR TITLE
Set Blockly keyboard focus styles when using area menu

### DIFF
--- a/webapp/src/components/AreaMenuOverlay.tsx
+++ b/webapp/src/components/AreaMenuOverlay.tsx
@@ -141,6 +141,7 @@ const areas: Area[] = [
         },
         focus(projectView: IProjectView) {
             projectView.editor.focusToolbox();
+            Blockly.keyboardNavigationController.setIsActive(true);
         }
     },
     {
@@ -176,6 +177,7 @@ const areas: Area[] = [
                 findFirstFocusableDescendant(document.querySelector("#pxtJsonEditor"))?.focus();
             } else {
                 projectView.editor.focusWorkspace();
+                Blockly.keyboardNavigationController.setIsActive(true);
             }
         }
     },


### PR DESCRIPTION
Ensures that Blockly focus outlines are shown when the user navigates to the Blockly workspace or toolbox via the area menu.