### PR TITLE
Update keyboard controls help

### DIFF
--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -321,6 +321,24 @@ namespace pxt {
         pxt.debug(`hwVariant: ${hwVariant} (${hwName})`)
     }
 
+    /**
+     * Whether the current target compiles user code to a file the user can
+     * download (hex, PNG or UF2).
+     */
+    function compilesToDownloadableFile(): boolean {
+        const compile = pxt.appTarget.compile;
+        return !!(compile?.hasHex || compile?.saveAsPNG || compile?.useUF2);
+    }
+
+    /**
+     * Whether a download action is available, either because the target
+     * produces a downloadable file or an extension overrides the download
+     * button.
+     */
+    export function canDownload(): boolean {
+        return compilesToDownloadableFile() || !!pxt.commands.onDownloadButtonClick;
+    }
+
     export function hasHwVariants(): boolean {
         return !!pxt.appTarget.variants
             && Object.keys(pxt.appTarget.bundledpkgs).some(pkg => /^hw---/.test(pkg));

--- a/webapp/src/components/KeyboardControlsHelp.tsx
+++ b/webapp/src/components/KeyboardControlsHelp.tsx
@@ -12,75 +12,76 @@ const KeyboardControlsHelp = () => {
     }, []);
     const ctrl = lf("{id:keyboard symbol}Ctrl");
     const cmd = isMacPlatform ? "⌘" : ctrl;
-    const contextMenuRow = <Row name={lf("Open context menu")} shortcuts={[names.MENU]} />
-    const cleanUpRow = <Row name={lf("Workspace: Format code")} shortcuts={[names.CLEANUP]} />
     const orAsJoiner = lf("or")
     const enterOrSpace = { shortcuts: getShortcutKeysShortAll(names.PERFORM_ACTION), joiner: orAsJoiner}
-    const editOrConfirmRow = <Row name={lf("Edit or confirm")} {...enterOrSpace} />
     return (
         <aside id="keyboardnavhelp" aria-label={lf("Keyboard Controls")} ref={ref} tabIndex={0}>
             <h2>{lf("Keyboard Controls")}</h2>
+            <h3>{lf("Global")}</h3>
             <table>
                 <tbody>
                     <Row name={lf("Show/hide shortcut help")} shortcuts={[LIST_SHORTCUTS_SHORTCUT]} />
-                    <Row name={lf("Open/close area menu")} shortcuts={[[cmd, "B"]]} />
-                    <Row name={lf("Block and toolbox navigation")} shortcuts={[names.NAVIGATE_UP, names.NAVIGATE_DOWN, names.NAVIGATE_LEFT, names.NAVIGATE_RIGHT]} />
-                    <Row name={lf("Toolbox")} shortcuts={[names.FOCUS_TOOLBOX]} />
-                    {editOrConfirmRow}
-                    <Row name={lf("Move mode")} shortcuts={[names.START_MOVE]} >
-                        <p className="hint">{lf("Press arrow keys to move to connections")}</p>
-                        <p className="hint">{lf("Hold {0} to move anywhere", cmd)}</p>
+                    <Row name={lf("Screen reader mode")} shortcuts={[names.TOGGLE_SCREENREADER]}>
+                        <p className="hint">{lf("Additional audio cues and navigation aids for screen reader users")}</p>
                     </Row>
-                    <Row name={lf("Copy / paste")} shortcuts={[names.COPY, names.PASTE]} joiner="/" />
-                    {cleanUpRow}
-                    {contextMenuRow}
-                    <Row name={lf("Start / stop simulator")} shortcuts={[["S"]]} />
-                    <Row name={lf("Download your code to the {0}", pxt.appTarget.appTheme.boardName)} shortcuts={[["L"]]} />
+                    <Row name={lf("Move between menus, simulator and the workspace")} shortcuts={[[lf("{id:keyboard symbol}Tab")], [lf("{id:keyboard symbol}Shift"), lf("{id:keyboard symbol}Tab")]]} joiner="row"/>
+                    <Row name={lf("Area menu")} shortcuts={[[cmd, "B"]]}>
+                        <p className="hint">{lf("Then press an area's number, or Tab to it and press Enter")}</p>
+                    </Row>
                 </tbody>
             </table>
-            <h3>{lf("Editor Overview")}</h3>
+            <h3>{lf("Blocks Workspace")}</h3>
             <table>
                 <tbody>
-                    <Row name={lf("Move between menus, simulator and the workspace")} shortcuts={[[lf("{id:keyboard symbol}Tab")], [lf("{id:keyboard symbol}Shift"), lf("{id:keyboard symbol}Tab")]]} joiner="row"/>
-                    <Row name={lf("Open/close area menu")} shortcuts={[[cmd, "B"]]} />
-                    <Row name={lf("Exit")} shortcuts={[names.ESCAPE]} />
-                    <Row name={lf("Toolbox")} shortcuts={[names.FOCUS_TOOLBOX]} />
-                    <Row name={lf("Toolbox: Move in and out of categories")} shortcuts={[names.NAVIGATE_LEFT, names.NAVIGATE_RIGHT]} />
-                    <Row name={lf("Toolbox: Navigate categories or blocks")} shortcuts={[names.NAVIGATE_UP, names.NAVIGATE_DOWN]} />
-                    <Row name={lf("Toolbox: Insert block")} {...enterOrSpace} />
-                    <Row name={lf("Workspace: Select workspace")} shortcuts={[names.FOCUS_WORKSPACE]} />
-                    {cleanUpRow}
+                    <Row name={lf("Navigate blocks")} shortcuts={[names.NAVIGATE_UP, names.NAVIGATE_DOWN, names.NAVIGATE_LEFT, names.NAVIGATE_RIGHT]} />
                     <Row name={lf("Next block stack")} shortcuts={[names.NEXT_STACK]} />
                     <Row name={lf("Previous block stack")} shortcuts={[names.PREVIOUS_STACK]} />
+                    <Row name={lf("Select workspace")} shortcuts={[names.FOCUS_WORKSPACE]} />
+                    <Row name={lf("Open context menu")} shortcuts={[names.MENU]} />
+                    <Row name={lf("Format code")} shortcuts={[names.CLEANUP]} />
+                    <Row name={lf("Undo / redo")} shortcuts={[names.UNDO, names.REDO]} joiner="/" />
+                    {pxt.canDownload() &&
+                        <Row name={lf("Download your code to the {0}", pxt.appTarget.appTheme.boardName)} shortcuts={[["L"]]} />}
+                    <Row name={lf("Toolbox")} shortcuts={[names.FOCUS_TOOLBOX]} />
+                    {pxt.appTarget.simulator &&
+                        <Row name={lf("Start or stop simulator")} shortcuts={[["S"]]} />}
                 </tbody>
             </table>
-            <h3>{lf("Edit Blocks")}</h3>
+            <h3>{lf("Toolbox")}</h3>
             <table>
                 <tbody>
-                    <Row name={lf("Move in and out of a block")} shortcuts={[names.NAVIGATE_LEFT, names.NAVIGATE_RIGHT]} />
-                    {editOrConfirmRow}
+                    <Row name={lf("Move in and out of categories")} shortcuts={[names.NAVIGATE_LEFT, names.NAVIGATE_RIGHT]} />
+                    <Row name={lf("Navigate categories or blocks")} shortcuts={[names.NAVIGATE_UP, names.NAVIGATE_DOWN]} />
+                    <Row name={lf("Insert block")} {...enterOrSpace} />
+                    <Row name={lf("Next / previous heading")} shortcuts={[names.NEXT_HEADING, names.PREVIOUS_HEADING]} joiner="/" />
+                </tbody>
+            </table>
+            <h3>{lf("Selected Block")}</h3>
+            <table>
+                <tbody>
+                    <Row name={lf("Move in and out of a block")} shortcuts={[names.NAVIGATE_RIGHT, names.NAVIGATE_LEFT]} />
+                    <Row name={lf("Edit or confirm")} {...enterOrSpace} />
                     <Row name={lf("Cancel or exit")} shortcuts={[names.ESCAPE]} />
-                    <Row name={lf("Copy")} shortcuts={[names.COPY]} />
-                    <Row name={lf("Paste")} shortcuts={[names.PASTE]} />
+                    <Row name={lf("Move mode")} shortcuts={[names.START_MOVE]} />
+                    <Row name={lf("Move mode for a stack")} shortcuts={[names.START_MOVE_STACK]} />
+                    <Row name={lf("Copy / paste")} shortcuts={[names.COPY, names.PASTE]} joiner="/" />
                     <Row name={lf("Cut")} shortcuts={[names.CUT]} />
                     <Row name={lf("Duplicate")} shortcuts={[names.DUPLICATE]} />
+                    <Row name={lf("Disconnect block")} shortcuts={[names.DISCONNECT]} />
                     <Row name={lf("Delete")} shortcuts={getShortcutKeysShortAll(names.DELETE)} joiner={orAsJoiner} />
-                    <Row name={lf("Undo")} shortcuts={[names.UNDO]} />
-                    <Row name={lf("Redo")} shortcuts={[names.REDO]} />
-                    {contextMenuRow}
+                    <Row name={lf("Screen reader: More block info")} shortcuts={[names.INFORMATION]} />
+                    <Row name={lf("Screen reader: Container block info")} shortcuts={[names.EXTENDED_INFORMATION]} />
                 </tbody>
             </table>
-            <h3>{lf("Moving Blocks")}</h3>
+            <h3>{lf("Move Mode")}</h3>
             <table>
                 <tbody>
-                    <Row name={lf("Move mode")} shortcuts={[names.START_MOVE]} />
-                    <Row name={lf("Move mode: Move to connections")} shortcuts={[names.NAVIGATE_UP, names.NAVIGATE_DOWN, names.NAVIGATE_LEFT, names.NAVIGATE_RIGHT]} />
-                    <Row name={lf("Move mode: Move anywhere")}>
+                    <Row name={lf("Move to positions")} shortcuts={[names.NAVIGATE_UP, names.NAVIGATE_DOWN, names.NAVIGATE_LEFT, names.NAVIGATE_RIGHT]} />
+                    <Row name={lf("Move anywhere")}>
                         {lf("Hold {0} and press arrow keys", cmd)}
                     </Row>
-                    <Row name={lf("Move mode: Confirm")} {...enterOrSpace} />
-                    <Row name={lf("Move mode: Cancel")} shortcuts={[names.ABORT_MOVE]} />
-                    <Row name={lf("Disconnect block")} shortcuts={[names.DISCONNECT]} />
+                    <Row name={lf("Confirm")} {...enterOrSpace} />
+                    <Row name={lf("Cancel")} shortcuts={[names.ABORT_MOVE]} />
                 </tbody>
             </table>
         </aside>

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -393,10 +393,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         const showProjectRename = !tutorial && !readOnly && !isController
             && !targetTheme.hideProjectRename && !debugging;
         const showProjectRenameReadonly = false; // always allow renaming, even for github projects
-        const compile = pxt.appTarget.compile;
-        const compilesToDownloadableFile = compile.hasHex || compile.saveAsPNG || compile.useUF2;
-        const hasCompileButtonOverride = !!pxt.commands.onDownloadButtonClick;
-        const showCompileBtn = !isTimeMachineEmbed && (compilesToDownloadableFile || hasCompileButtonOverride);
+        const showCompileBtn = !isTimeMachineEmbed && pxt.canDownload();
         const compileLoading = !!compiling;
         const running = simState == SimState.Running;
         const starting = simState == SimState.Starting;


### PR DESCRIPTION
Group shortcuts by where they apply (Global, Workspace, Toolbox, Blocks, Move Mode) and add newer Blockly shortcuts: block stack navigation, toolbox headings, move-stack, block info, and screen reader mode.

Gate the download and simulator rows on target capability, adding pxt.canDownload() (shared with the editor toolbar's compile button). Please review this bit carefully, I don't have full context for other targets.

~~Draft for now as I want feedback from Foundation folks more involved in the user testing and keyboard controls resources (which has some similar presentations of keyboard shortcuts). Thoughts welcome.~~

Demo: https://scoped-keyboard-controls.review-pxt.pages.dev/#editor

Closes https://github.com/microsoft/pxt-microbit/issues/6890 (or at least helps, it's quite subjective!)