### PR TITLE
fix --multi hash decoding and add saner options

### DIFF
--- a/docs/multi.html
+++ b/docs/multi.html
@@ -146,10 +146,30 @@
                 ifrm.src = select.value + flags + h;
             }
             function handleHash() {
-                var route = (window.location.hash || "#");
-                var parts = route.replace(/^#/, '').split(':|:', 2);
-                updateSrc(left, selectLeft, parts[0]);
-                updateSrc(right, selectRight, parts[1]);
+                var route = decodeURIComponent(window.location.hash || "#");
+
+                if (route.indexOf(":|:") !== -1) {
+                    var parts = route.replace(/^#/, '').split(':|:', 2);
+                    updateSrc(left, selectLeft, parts[0]);
+                    updateSrc(right, selectRight, parts[1]);
+                }
+                else {
+                    route = route.replace(/^#/, '');
+                    var params = new URLSearchParams(route);
+                    if (params.has("left")) {
+                        updateSrc(left, selectLeft, params.get("left"));
+                    }
+                    else if (params.has("leftscript")) {
+                        updateSrc(left, selectLeft, "pub:" + params.get("leftscript"));
+                    }
+                    if (params.has("right")) {
+                        updateSrc(right, selectRight, params.get("right"));
+                    }
+                    else if (params.has("rightscript")) {
+                        updateSrc(right, selectRight, "pub:" + params.get("rightscript"));
+                    }
+                }
+
                 window.history.replaceState('', '', '#')
             }
 

--- a/docs/multi.html
+++ b/docs/multi.html
@@ -162,11 +162,17 @@
                     else if (params.has("leftscript")) {
                         updateSrc(left, selectLeft, "pub:" + params.get("leftscript"));
                     }
+                    else {
+                        updateSrc(left, selectLeft);
+                    }
                     if (params.has("right")) {
                         updateSrc(right, selectRight, params.get("right"));
                     }
                     else if (params.has("rightscript")) {
                         updateSrc(right, selectRight, "pub:" + params.get("rightscript"));
+                    }
+                    else {
+                        updateSrc(right, selectRight);
                     }
                 }
 

--- a/webapp/public/multi.html
+++ b/webapp/public/multi.html
@@ -70,10 +70,36 @@
             function handleHash() {
                 var hashLeft = ""
                 var hashRight = ""
-                var route = (window.location.hash || "#");
-                var parts = route.replace(/^#/, '').split(':|:', 2);
-                updateSrc(left, parts[0]);
-                updateSrc(right, parts[1]);
+                var route = decodeURIComponent(window.location.hash || "#");
+
+                if (route.indexOf(":|:") !== -1) {
+                    var parts = route.replace(/^#/, '').split(':|:', 2);
+                    updateSrc(left, parts[0]);
+                    updateSrc(right, parts[1]);
+                }
+                else {
+                    route = route.replace(/^#/, '');
+                    var params = new URLSearchParams(route);
+                    if (params.has("left")) {
+                        updateSrc(left, params.get("left"));
+                    }
+                    else if (params.has("leftscript")) {
+                        updateSrc(left, "pub:" + params.get("leftscript"));
+                    }
+                    else {
+                        updateSrc(left);
+                    }
+                    if (params.has("right")) {
+                        updateSrc(right, params.get("right"));
+                    }
+                    else if (params.has("rightscript")) {
+                        updateSrc(right, "pub:" + params.get("rightscript"));
+                    }
+                    else {
+                        updateSrc(right);
+                    }
+                }
+
                 window.history.replaceState('', '', '#')
             }
             function handleMessage(msg) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/5397

as noted in that issue, the way to use the --multi page was to include a hash like this:

```
makecode.microbit.org/--multi#lefthash:|:righthash
```

where `lefthash` will end up being applied to the left iframe and `righthash` to the right iframe. however, because the delimeter includes the character `|`, it was often getting encoded automatically as `%7c` which breaks the parsing. this fixes that bug by calling `decodeURIComponent` on the hash to make sure all the percent encoded characters are parsed.

still, this is imo a silly way to structure that URL, so i've also added a new format that is easier to use. you can now add arguments using query string syntax like so:

```
makecode.microbit.org/--multi#left=lefthash&right=righthash
```

or, if you're just referencing two scripts, you can do this:

```
makecode.microbit.org/--multi#left=leftscript=_xxxxxxxxx&rightscript=_xxxxxxxxx
```

which will automatically add the `pub:` prefix to the hash for the iframes