### PR TITLE
Show keyboard controls hint on initial keyboard focus of the workspace

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -915,7 +915,7 @@ declare namespace pxt.editor {
         forceUpdate(): void;
 
         reloadEditor(): void;
-        openBlocks(showKeyboardControlsHint?: boolean): void;
+        openBlocks(): void;
         openJavaScript(giveFocusOnLoading?: boolean): void;
         openPython(giveFocusOnLoading?: boolean): void;
         openAssets(): void;

--- a/webapp/src/accessibility.tsx
+++ b/webapp/src/accessibility.tsx
@@ -32,7 +32,7 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
     }
 
     openBlocks(e: React.MouseEvent<HTMLElement>) {
-        this.props.parent.openBlocks(true);
+        this.props.parent.openBlocks();
     }
 
     openJavaScript() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -719,12 +719,8 @@ export class ProjectView
         pxt.shell.setEditorLanguagePref("js");
     }
 
-    openBlocks(showKeyboardControlsHint?: boolean) {
+    openBlocks() {
         if (this.updatingEditorFile) return; // already transitioning
-
-        if (showKeyboardControlsHint) {
-            this.blocksEditor.pendingKeyboardControlsHint = true;
-        }
 
         if (this.isBlocksActive()) {
             if (this.state.embedSimView) this.setState({ embedSimView: false });

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -62,7 +62,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     loadingXmlPromise: Promise<any>;
     compilationResult: pxtblockly.BlockCompilationResult;
     shouldFocusWorkspace = false;
-    pendingKeyboardControlsHint = false;
     functionsDialog: CreateFunctionDialog = null;
 
     showCategories: boolean = true;
@@ -92,7 +91,18 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.createTourFromResponse = this.createTourFromResponse.bind(this)
         this.getErrorHelp = this.getErrorHelp.bind(this)
         this.startDebugger = this.startDebugger.bind(this);
+
+        document.addEventListener("keydown", this.trackKeyboardInput, true);
+        document.addEventListener("pointerdown", this.trackPointerInput, true);
     }
+
+    private lastInputModality: "keyboard" | "pointer";
+    private trackKeyboardInput = () => {
+        this.lastInputModality = "keyboard";
+    };
+    private trackPointerInput = () => {
+        this.lastInputModality = "pointer";
+    };
     setBreakpointsMap(breakpoints: pxtc.Breakpoint[], procCallLocations: pxtc.LocationInfo[]): void {
         if (!breakpoints || !this.compilationResult) return;
         const blockToAllBreakpoints: { [index: string]: pxtc.Breakpoint[] } = {};
@@ -851,6 +861,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.editor = Blockly.inject(blocklyDiv, this.getBlocklyOptions(forceHasCategories)) as Blockly.WorkspaceSvg;
         pxtblockly.contextMenu.setupWorkspaceContextMenu(this.editor);
 
+        (this.editor.getSvgGroup() as SVGElement).addEventListener("focusin", this.onWorkspaceFocus);
+
         // set Blockly Colors
         (async () => {
             await Blockly.renderManagement.finishQueuedRenders();
@@ -1050,11 +1062,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     focusWorkspace() {
         (this.editor.getSvgGroup() as SVGElement).focus();
         Blockly.hideChaff();
-
-        if (this.pendingKeyboardControlsHint) {
-            this.pendingKeyboardControlsHint = false;
-            this.showKeyboardControlsHint();
-        }
     }
 
     // Screen reader mode is the MakeCode-persisted equivalent of Blockly's
@@ -1091,6 +1098,15 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             id: "screenreaderModeHint",
         });
     }
+
+    private workspaceHasBeenFocused = false;
+    private onWorkspaceFocus = () => {
+        if (this.workspaceHasBeenFocused) return;
+        this.workspaceHasBeenFocused = true;
+        if (this.lastInputModality === "keyboard") {
+            this.showKeyboardControlsHint();
+        }
+    };
 
     showKeyboardControlsHint() {
         if (!this.editor || !Blockly.Msg["HELP_PROMPT"]) return;


### PR DESCRIPTION
Previously the hint toast was only shown when the workspace was focused via the accessibility skip link.  Now show it whenever the first focus of the workspace was via the keyboard.  This way it covers tabbing all the way there or using the area menu.