### PR TITLE
Workaround for codegen issue on older Safari

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1127,7 +1127,7 @@ export class ProjectView
 
     public async componentDidMount() {
         this.allEditors.forEach(e => e.prepare())
-        await simulator.initAsync(getBoardView(), {
+        await simulator.initAsync({
             orphanException: brk => {
                 // TODO: start debugging session
                 // TODO: user friendly error message
@@ -5722,10 +5722,6 @@ function render() {
 
 function getEditor() {
     return theEditor
-}
-
-function getBoardView() {
-    return document.getElementById("boardview");
 }
 
 function parseLocalToken() {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -39,7 +39,9 @@ export function setTranslations(translations: pxt.Map<string>) {
     }
 }
 
-export async function initAsync(root: HTMLElement, cfg: SimulatorConfig) {
+export async function initAsync(cfg: SimulatorConfig) {
+    // We previously hit a Safari < 18 codegen issue with root as a parameter.
+    const root = document.getElementById("boardview");
     if (!root) return;
     pxsim.U.clear(root);
     const simulatorsDiv = document.createElement('div');


### PR DESCRIPTION
In Safari < 18 `pxt staticpkg --minify` builds, I see getBoardView return a value but undefined is received by initAsync as the first parameter. This causes initAsync to bail, fail to init the driver and the initial header load to error on the undefined driver.

This doesn't happen with `pxt serve` so is likely triggered by the minification (which itself seems correct).

As an example of a `pxt staticpkg --minify` deployment with this issue, see https://blockly-v13-0-0-beta-9.review-pxt.pages.dev/. It doesn't seem to happen on the current beta, perhaps due to some difference in the build setup vs staticpkg (we also have npm linked pxt). A real puzzle.