### PR TITLE
Ensure existing SVG overflows are respected for widget and dropdown divs

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -39,6 +39,10 @@ svg.blocklySvg {
     .injectionDiv svg {
         overflow: visible;
     }
+    .injectionDiv .blocklyWidgetDiv svg,
+    .injectionDiv .blocklyDropDownDiv svg {
+        overflow: revert;
+    }
     > div.loading {
         position: absolute;
         left: 0;


### PR DESCRIPTION
The upgrade to Blockly v13 renders the widget and dropdown divs inside the injection div. As a result, the existing `.injectionDiv svg { overflow: visible }` rule now also matches SVGs inside those divs. To counter this, overflow is reverted for SVGs in the widget and dropdown divs. This allows existing styles and browser defaults to take effect. See sound effect editor example below.

Before (current beta):
<img width="442" height="548" alt="Screenshot 2026-06-12 at 16 33 30" src="https://github.com/user-attachments/assets/eca0162e-3974-4abf-911a-3685c4cb263e" />

After:
<img width="446" height="554" alt="Screenshot 2026-06-12 at 16 33 03" src="https://github.com/user-attachments/assets/78531f43-7cfe-4fb1-a6d1-3aedeb80bb82" />