### PR TITLE
guard note picker htmlinput

### DIFF
--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -259,7 +259,9 @@ export class FieldNote extends Blockly.FieldNumber implements FieldCustom {
     };
 
     protected widgetDispose_(): void {
-        this.htmlInput_.removeEventListener("keydown", this.keyHandler);
+        if (this.htmlInput_) {
+            this.htmlInput_.removeEventListener("keydown", this.keyHandler);
+        }
         super.widgetDispose_();
     }
 
@@ -274,9 +276,14 @@ export class FieldNote extends Blockly.FieldNumber implements FieldCustom {
         Blockly.DropDownDiv.hideWithoutAnimation();
         clearDropDownDiv();
 
-        const isMobile = pxt.BrowserUtils.isMobile() || pxt.BrowserUtils.isIOS();
-        // invoke FieldTextInputs showeditor, so we can set quiet explicitly / not have a pop up dialogue
-        super.showEditor_(e, isMobile);
+        const quietInput = pxt.BrowserUtils.isMobile()
+            || pxt.BrowserUtils.isIOS()
+            || pxt.BrowserUtils.isAndroid()
+            || Blockly.utils.userAgent.MOBILE
+            || Blockly.utils.userAgent.ANDROID
+            || Blockly.utils.userAgent.IPAD;
+        // invoke FieldTextInput's showEditor, so we can set quiet explicitly / not have a pop up dialogue
+        super.showEditor_(e, quietInput);
         this.refreshText();
 
         // save all changes in the same group of events
@@ -346,8 +353,10 @@ export class FieldNote extends Blockly.FieldNumber implements FieldCustom {
         Blockly.DropDownDiv.setColour(this.primaryColour, this.borderColour);
         Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_ as Blockly.BlockSvg, () => this.onHide(), undefined, false);
 
-        this.htmlInput_.ariaLabel = lf("Press the up and down arrow keys to select the next or previous note, or enter a value in hertz");
-        this.htmlInput_.addEventListener("keydown", this.keyHandler);
+        if (this.htmlInput_) {
+            this.htmlInput_.ariaLabel = lf("Press the up and down arrow keys to select the next or previous note, or enter a value in hertz");
+            this.htmlInput_.addEventListener("keydown", this.keyHandler);
+        }
     }
 
     protected keyHandler = (ev: KeyboardEvent) => {
@@ -381,7 +390,9 @@ export class FieldNote extends Blockly.FieldNumber implements FieldCustom {
          * do not show up on the block itself until after the fieldeditor is closed,
          * as it is currently in an editable state.
          **/
-        (this as any).htmlInput_.value = this.getText();
+        if (this.htmlInput_) {
+            this.htmlInput_.value = this.getText();
+        }
 
         pxt.AudioContextManager.tone(frequency);
         setTimeout(() => {


### PR DESCRIPTION
should fix https://github.com/microsoft/pxt-microbit/issues/6587 but none of my personal devices reproduce this issue / user agent specific.
Potentially also fix for https://github.com/microsoft/pxt/issues/11402 / sounds like effectively same cause


Build for anyone who *can* reproduce it to test with https://makecode.microbit.org/app/6ca475a7f496efabd65dac9cc50487981a94b39b-2cf5691c99