### PR TITLE
make the variable validator wording closer to the function validator

### DIFF
--- a/common-docs/teachertool/catalog-shared.json
+++ b/common-docs/teachertool/catalog-shared.json
@@ -123,7 +123,7 @@
             "use": "variable_usage",
             "template": "Uses at least ${count} variable(s)",
             "docPath": "/teachertool",
-            "description": "The program creates and uses at least this many user-defined variables.",
+            "description": "At least this many user-defined variables are both set and read — auto-generated variables like loop indices do not count.",
             "maxCount": 1,
             "tags": ["Code Elements"],
             "params": [


### PR DESCRIPTION
As discussed, I've changed the copy for the variable usage criterion. This aligns with what is said for the function validator, and is clearer about included variables.

Part of a fix for https://github.com/microsoft/pxt-microbit/issues/6917, but probably should keep the issue open if we are interested in making a separate "just looking for all project variables" validator.