### PR TITLE
Comment screen reader tweaks

### DIFF
--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -784,7 +784,9 @@ export function setOutputCheck(block: Blockly.Block, retType: string, info: pxtc
 }
 
 function initComments() {
-    Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT = '';
+    // Exposed to screen readers as placeholder text, but hidden from sighted users via
+    // the .blocklyCommentText::placeholder rule in blockly-core.less (no visual change).
+    Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT = lf("Add a comment");
 }
 
 function initAccessibilityMessages() {

--- a/pxtblocks/plugins/comments/blockComment.ts
+++ b/pxtblocks/plugins/comments/blockComment.ts
@@ -59,6 +59,10 @@ export class CommentIcon extends Blockly.icons.Icon implements Blockly.IHasBubbl
         return CommentIcon.TYPE;
     }
 
+    protected override getAriaLabel(): string | null {
+        return lf("Open comment");
+    }
+
     override initView(pointerdownListener: (e: PointerEvent) => void): void {
         if (this.svgRoot) return; // Already initialized.
 

--- a/pxtblocks/plugins/comments/blockComment.ts
+++ b/pxtblocks/plugins/comments/blockComment.ts
@@ -60,7 +60,7 @@ export class CommentIcon extends Blockly.icons.Icon implements Blockly.IHasBubbl
     }
 
     protected override getAriaLabel(): string | null {
-        return lf("Open comment");
+        return Blockly.Msg.ICON_LABEL_COMMENT_CLOSED;
     }
 
     override initView(pointerdownListener: (e: PointerEvent) => void): void {

--- a/pxtblocks/plugins/comments/textinput_bubble.ts
+++ b/pxtblocks/plugins/comments/textinput_bubble.ts
@@ -123,6 +123,7 @@ export class TextInputBubble extends Bubble {
             'textarea',
         ) as HTMLTextAreaElement;
         textArea.className = 'blocklyTextarea blocklyText';
+        textArea.setAttribute('aria-label', Blockly.Msg.ARIA_LABEL_COMMENT);
         return textArea;
     }
 

--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -379,6 +379,11 @@ text.blocklyCheckbox {
     color: #575E75;
 }
 
+/* Hide the comment placeholder from sighted users; it remains for screen readers. */
+.blocklyCommentText::placeholder {
+    opacity: 0;
+}
+
 /*******************************
         Workspace Search
 *******************************/


### PR DESCRIPTION
I think this experience is still needs some iteration and discussion around where Blockly and pxt make different choices.

These are just tweaks to improve:

- For better or worse, Blockly is relying on the placeholder for the workspace comment accessible name (for the comment as a whole) and pxt intentionally removes it. The wrapper group is using labelledby to use the actual comment text in the wrapper's label (falling back to the placeholder). So e.g. adding an aria-label undercuts that. Reinstate it for screen reader, hiding it for sighted users.
- Give the block comment icon a label and the text area for block comments.

I'd welcome a chance to talk this one through at some point to be able to give clear feedback to Blockly. The difference in focus behaviour and, related, keyboard access to the block comment icons are some important points of deviation from upstream.
