### PR TITLE
a few accessibility fixes

### DIFF
--- a/react-common/styles/react-common-variables.less
+++ b/react-common/styles/react-common-variables.less
@@ -23,7 +23,7 @@
  *                    Checkboxes                    *
  ****************************************************/
 
-@checkboxFocusOutline: var(--pxt-neutral-stencil1) solid 1px;
+@checkboxFocusOutline: var(--pxt-focus-border) solid 3px;
 
 /****************************************************
  *              EditorToggle                        *

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -531,6 +531,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                     <Input
                         placeholder={lf("Search or enter project URL...")}
                         ariaLabel={lf("Search or enter project URL...")}
+                        iconTitle={lf("Search")}
                         onEnterKey={onSearchBarChange}
                         onIconClick={onSearchBarChange}
                         preserveValueOnBlur={true}

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -61,8 +61,10 @@ export class Editor extends srceditor.Editor {
         this.isSaving = false;
         this.changeMade = true;
         // switch to previous coding experience
-        if (!stayInEditor) this.parent.openPreviousEditor();
-        core.resetFocus();
+        if (!stayInEditor) {
+            this.parent.openPreviousEditor();
+            core.resetFocus();
+        }
     }
 
     protected async saveConfigContentAsync() {


### PR DESCRIPTION
contains fixes for the following issues:

https://github.com/microsoft/pxt-microbit/issues/6831

fixed by adding a title to the search button in the extensions page search bar

https://github.com/microsoft/pxt-microbit/issues/6833

fixed by changing the checkbox to use our standard focus outline

https://github.com/microsoft/pxt-microbit/issues/6834

fixed by preventing resetFocus from being called when checkboxes are toggled

