### PR TITLE
Blockly v13.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@zip.js/zip.js": "2.4.20",
     "adm-zip": "^0.5.12",
     "axios": "^1.12.2",
-    "blockly": "13.0.0-beta.9",
+    "blockly": "13.0.0",
     "browserify": "17.0.0",
     "chai": "^3.5.0",
     "chalk": "^4.1.2",
@@ -151,10 +151,10 @@
   },
   "overrides": {
     "@blockly/field-grid-dropdown": {
-      "blockly": "13.0.0-beta.9"
+      "blockly": "13.0.0"
     },
     "@blockly/plugin-workspace-search": {
-      "blockly": "13.0.0-beta.9"
+      "blockly": "13.0.0"
     },
     "combine-source-map": {
       "source-map": "0.4.4"

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -876,6 +876,7 @@ function initAccessibilityMessages() {
         // Field type labels for screen readers.
         ARIA_TYPE_FIELD_CHECKBOX: lf("checkbox"),
         ARIA_TYPE_FIELD_DROPDOWN: lf("dropdown"),
+        ARIA_TYPE_FIELD_GRID: lf("grid dropdown"),
         ARIA_TYPE_FIELD_IMAGE: lf("image"),
         ARIA_TYPE_FIELD_INPUT: lf("{id:field type}input"),
         ARIA_TYPE_FIELD_NUMBER: lf("{id:field type}number"),


### PR DESCRIPTION
- Add a message that will be used by a future release of the grid plugin
- Notable Blockly change: the workspace rather than a block takes initial focus when moving to the workspace. This allows for the explanation of SR mode to be read out and is less of an information overload than hearing block + region + onboarding all at once.

Plugins are still on 12.x so we need the overrides for now. https://github.com/microsoft/pxt-microbit/pull/6933 bumps them in pxt-microbit for when you do the pxt upgrade.

Closes https://github.com/microsoft/pxt-microbit/issues/6690 (I guess, probably at the point where we should move to fine grained issues for improvements).