### PR TITLE
give sign up link darker outline

### DIFF
--- a/react-common/styles/profile/profile.less
+++ b/react-common/styles/profile/profile.less
@@ -444,6 +444,13 @@
             display: flex;
             gap: 0.5rem;
             justify-content: center;
+
+            .link-button:focus-visible {
+                outline: var(--pxt-neutral-foreground1) solid 3px;
+                outline-offset: 2px;
+                border-radius: 0.1em;
+                text-decoration: none;
+            }
         }
 
         .learn {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6824

When I was first addressing the issue, I thought that the underline was a good enough indicator for the sign up link, but we should be consistent with our styling. The link now looks like this when tabbed onto it:

<img width="570" height="374" alt="image" src="https://github.com/user-attachments/assets/82ca1405-35e0-4725-83f2-bf58e85c5d5c" />

