### PR TITLE
fix blocks rendering for code eval tool

### DIFF
--- a/pxtblocks/layout.ts
+++ b/pxtblocks/layout.ts
@@ -407,8 +407,10 @@ export async function blocklyToSvgAsync(sg: SVGElement, x: number, y: number, wi
     const blocklySvg = pxt.Util.toArray(document.head.querySelectorAll("style"))
         .filter((el: HTMLStyleElement) => /\.blocklySvg/.test(el.innerText))[0] as HTMLStyleElement;
     // Custom CSS injected directly into the DOM by Blockly
-    customCss.unshift((document.getElementById(`blockly-common-style`) as HTMLLinkElement)?.innerText || "");
-    customCss.unshift((document.getElementById(`blockly-renderer-style-pxt-classic`) as HTMLLinkElement)?.innerText || "");
+    customCss.unshift((document.getElementById(`blockly-common-style`) as HTMLStyleElement)?.innerText || "");
+    // Blockly injects renderer styles with className="blockly-renderer-style", not an id
+    const rendererStyle = document.querySelector(`style.blockly-renderer-style`) as HTMLStyleElement;
+    customCss.unshift(rendererStyle?.innerText || "");
     // CSS may contain <, > which need to be stored in CDATA section
     const cssString = (blocklySvg ? blocklySvg.innerText : "") + '\n\n' + customCss.map(el => el + '\n\n');
     cssLink.appendChild(xsg.createCDATASection(cssString));


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/6936

Via copilot, because I think it's a nice summary:
The code was looking up the renderer style element using `document.getElementById('blockly-renderer-style-pxt-classic')`, but Blockly (since the v11/v13 upgrades) creates this element with `className="blockly-renderer-style"`, not an id. So, the lookup returned null, and the critical CSS rules for text fill color and font-family were silently omitted from the rendered SVG.

Without these CSS rules:
Text defaults to fill: black (SVG default) instead of white
Font falls back to the browser default instead of the configured monospace font

I also looked at the other blocks-svg scenarios with this change and they all look good!

Upload target: https://makecode.microbit.org/app/e5b98b20f43e1b7a1f340e51bb8818e4f3b613d8-a84451c729--eval