### PR TITLE
Detach recycled flyout blocks from the canvas

### DIFF
--- a/pxtblocks/plugins/flyout/blockInflater.ts
+++ b/pxtblocks/plugins/flyout/blockInflater.ts
@@ -37,6 +37,9 @@ export class MultiFlyoutRecyclableBlockInflater extends Blockly.BlockFlyoutInfla
         if (this.keyToBlock.has(key)) {
             block = this.keyToBlock.get(key);
             this.keyToBlock.delete(key);
+            // Re-attach the SVG we detached in recycleBlock(). The flyout positions
+            // the block during layout, after createBlock() returns.
+            workspace.getCanvas().appendChild(block.getSvgRoot());
         }
 
         block = block ?? super.createBlock(blockDefinition, workspace);
@@ -76,6 +79,11 @@ export class MultiFlyoutRecyclableBlockInflater extends Blockly.BlockFlyoutInfla
         block.addClass(HIDDEN_CLASS_NAME);
         block.getFocusableElement().ariaHidden = "true";
         block.setDisabledReason(true, HIDDEN_CLASS_NAME);
+        // Detach the SVG from the flyout canvas while the block sits in the pool.
+        // Leaving recycled blocks in place interacts poorly with the flyout's use
+        // of aria-owns with VoiceOver/Safari. Reopening a closed flyout can then
+        // take 10s of seconds. See microsoft/pxt-microbit#6946.
+        block.getSvgRoot().remove();
         const key = this.blockToKey.get(block);
         this.keyToBlock.set(key, block);
         this.removeListeners(block.id);


### PR DESCRIPTION
The flyout block recycler kept recycled blocks parented to the flyout canvas (hidden), so the canvas accumulated every block shown as the user moved between categories. That interacts poorly with the flyout's use of aria-owns on the canvas under VoiceOver/Safari: reopening a closed flyout gets progressively slower and can hang for tens of seconds once a screen reader has activated accessibility for the page.

Detach the block's SVG from the canvas while it sits in the recycle pool and re-attach it on reuse. The BlockSvg stays alive, so recycling still avoids re-rendering; only the parent changes.

@riknoll I think this will leave the benefit of the caching in place but appreciate a sanity check.

An alternative is to remove the use of aria-owns in Blockly. All typical flyout contents are in the right DOM hierarchy but Blockly doesn't require this so has used aria-owns just in case. See https://github.com/RaspberryPiFoundation/blockly/blob/a233ac19fd6b6471694fb41b056a3bf5a42f678a/packages/blockly/core/flyout_base.ts#L668-L679

Fixes microsoft/pxt-microbit#6946

Demo: https://fix-flyout-recycle-voiceover.review-pxt.pages.dev/