### PR TITLE
Add parameter labels for input names

### DIFF
--- a/libs/bare/basic.ts
+++ b/libs/bare/basic.ts
@@ -18,6 +18,7 @@ namespace control {
      * @param ms how long to pause for, eg: 100, 200, 500, 1000, 2000
      */
     //% async block="pause (ms) %pause"
+    //% ms.label="value"
     //% blockId=device_pause icon="\uf110" shim=basic::pause
     export function pause(ms: number): void {
     }
@@ -42,6 +43,7 @@ namespace console {
     //% weight=90
     //% help=console/log blockGap=8 text.shadowOptions.toString=true
     //% blockId=console_log block="console|log %text"
+    //% value.label="value"
     export function log(value: any): void {
         let s: string = value + ""
         control.__log(s)

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -15,6 +15,7 @@ interface Array<T> {
     //% help=arrays/push
     //% shim=Array_::push weight=50
     //% blockId="array_push" block="%list| add value %value| to end" blockNamespace="arrays"
+    //% list.label="list to change" item.label="value to add"
     //% group="Modify"
     push(item: T): void;
 
@@ -31,6 +32,7 @@ interface Array<T> {
     //% help=arrays/pop
     //% shim=Array_::pop weight=45
     //% blockId="array_pop" block="get and remove last value from %list" blockNamespace="arrays"
+    //% list.label="list to change"
     //% group="Read"
     pop(): T;
 
@@ -40,6 +42,7 @@ interface Array<T> {
     //% help=arrays/reverse
     //% helper=arrayReverse weight=10
     //% blockId="array_reverse" block="reverse %list" blockNamespace="arrays"
+    //% list.label="list to change"
     //% group="Operations"
     reverse(): void;
 
@@ -49,6 +52,7 @@ interface Array<T> {
     //% help=arrays/shift
     //% helper=arrayShift weight=30
     //% blockId="array_shift" block="get and remove first value from %list" blockNamespace="arrays"
+    //% list.label="list to change"
     //% group="Read"
     shift(): T;
 
@@ -59,6 +63,7 @@ interface Array<T> {
     //% help=arrays/unshift
     //% helper=arrayUnshift weight=25
     //% blockId="array_unshift" block="%list| insert %value| at beginning" blockNamespace="arrays"
+    //% list.label="list to change" value.label="value to add"
     //% group="Modify"
     //unshift(...values:T[]): number; //rest is not supported in our compiler yet.
     unshift(value: T): number;
@@ -159,6 +164,7 @@ interface Array<T> {
     //% help=arrays/remove-at
     //% shim=Array_::removeAt weight=47
     //% blockId="array_removeat" block="%list| get and remove value at %index" blockNamespace="arrays"
+    //% list.label="list to change" index.label="position within list"
     //% group="Read"
     removeAt(index: number): T;
 
@@ -170,6 +176,7 @@ interface Array<T> {
     //% help=arrays/insert-at
     //% shim=Array_::insertAt weight=20
     //% blockId="array_insertAt" block="%list| insert at %index| value %value" blockNamespace="arrays"
+    //% list.label="list to change" index.label="position within list" value.label="value to add"
     //% group="Modify"
     insertAt(index: number, value: T): void;
 
@@ -181,6 +188,7 @@ interface Array<T> {
     //% help=arrays/index-of
     //% shim=Array_::indexOf weight=40
     //% blockId="array_indexof" block="%list| find index of %value" blockNamespace="arrays"
+    //% list.label="list to check" item.label="value to find"
     //% group="Operations"
     indexOf(item: T, fromIndex?: number): number;
 
@@ -207,6 +215,7 @@ interface Array<T> {
     //% help=arrays/pick-random
     //% helper=arrayPickRandom weight=25
     //% blockId="array_pickRandom" block="get random value from %list"
+    //% list.label="list to check"
     //% blockNamespace="arrays"
     //% group="Read"
     _pickRandom(): T;
@@ -220,6 +229,7 @@ interface Array<T> {
     //% help=arrays/unshift
     //% helper=arrayUnshift weight=24
     //% blockId="array_unshift_statement" block="%list| insert %value| at beginning" blockNamespace="arrays"
+    //% list.label="list to change" value.label="value to add"
     //% blockAliasFor="Array.unshift"
     //% group="Modify"
     _unshiftStatement(value: T): void;
@@ -230,6 +240,7 @@ interface Array<T> {
     //% help=arrays/pop
     //% shim=Array_::pop weight=44
     //% blockId="array_pop_statement" block="remove last value from %list" blockNamespace="arrays"
+    //% list.label="list to change"
     //% blockAliasFor="Array.pop"
     //% group="Modify"
     _popStatement(): void;
@@ -240,6 +251,7 @@ interface Array<T> {
     //% help=arrays/shift
     //% helper=arrayShift weight=29
     //% blockId="array_shift_statement" block="remove first value from %list" blockNamespace="arrays"
+    //% list.label="list to change"
     //% blockAliasFor="Array.shift"
     //% group="Modify"
     _shiftStatement(): void;
@@ -248,6 +260,7 @@ interface Array<T> {
     //% help=arrays/remove-at-statement
     //% shim=Array_::removeAt weight=14
     //% blockId="array_removeat_statement" block="%list| remove value at %index" blockNamespace="arrays"
+    //% list.label="list to change" index.label="position within list"
     //% blockAliasFor="Array.removeAt"
     //% group="Modify"
     _removeAtStatement(index: number): void;
@@ -272,6 +285,7 @@ declare interface String {
     //% shim=String_::charAt weight=48
     //% help=text/char-at
     //% blockId="string_get" block="char from %this=text|at %pos" blockNamespace="text"
+    //% this.label="value" index.label="position within text"
     //% this.defl="this"
     charAt(index: number): string;
 
@@ -287,6 +301,7 @@ declare interface String {
     //% shim=String_::charCodeAt weight=46
     //% help=text/char-code-at
     //% blockId="string_charcode_at" block="char code from $this=text|at $index" blockNamespace="text"
+    //% this.label="value" index.label="position within text"
     //% this.defl="this"
     charCodeAt(index: number): number;
 
@@ -297,6 +312,7 @@ declare interface String {
     //% shim=String_::compare
     //% help=text/compare
     //% blockId="string_compare" block="compare %this=text| to %that" blockNamespace="text"
+    //% this.label="value" that.label="other value"
     //% this.defl="this"
     compare(that: string): number;
 
@@ -309,6 +325,7 @@ declare interface String {
     //% help=text/substr
     //% blockId=string_substr_new
     //% block="substring of $this|from $start||of length $length"
+    //% this.label="value" start.label="start position" length.label="length"
     //% this.shadow="text"
     //% this.defl="this"
     //% blockNamespace="text"
@@ -348,6 +365,7 @@ declare interface String {
     //% help=text/is-empty
     //% blockId="string_isempty" blockNamespace="text"
     //% block="%this=text| is empty"
+    //% this.label="value"
     //% this.defl="this"
     isEmpty(): boolean;
 
@@ -360,6 +378,7 @@ declare interface String {
     //% help=text/index-of
     //% blockId="string_indexof" blockNamespace="text"
     //% block="%this=text|find index of %searchValue"
+    //% this.label="value" searchValue.label="text to find"
     //% this.defl="this"
     indexOf(searchValue: string, start?: number): number;
 
@@ -372,6 +391,7 @@ declare interface String {
     //% help=text/includes
     //% blockId="string_includes" blockNamespace="text"
     //% block="%this=text|includes %searchValue"
+    //% this.label="value" searchValue.label="text to find"
     //% this.defl="this"
     includes(searchValue: string, start?: number): boolean;
 
@@ -384,6 +404,7 @@ declare interface String {
     //% help=text/split
     //% blockId="string_split" blockNamespace="text"
     //% block="split %this=text|at %separator"
+    //% this.label="value" separator.label="separator"
     //% this.defl="this"
     split(separator?: string, limit?: number): string[];
 
@@ -415,6 +436,7 @@ declare interface String {
     //% helper=stringSubstr
     //% help=text/substr
     //% blockId="string_substr" block="substring of %this=text|from %start|of length %length" blockNamespace="text"
+    //% this.label="value" start.label="start position" length.label="length"
     //% this.defl="this"
     //% blockAliasFor="String.substr"
     //% deprecated
@@ -430,6 +452,7 @@ declare interface String {
 //% shim=String_::toNumber
 //% help=text/parse-float
 //% blockId="string_parsefloat" block="parse to number %text" blockNamespace="text"
+//% text.label="value"
 //% text.defl="123"
 declare function parseFloat(text: string): number;
 
@@ -440,6 +463,7 @@ declare function parseFloat(text: string): number;
  * @param max the upper inclusive bound, eg: 10
  */
 //% blockId="device_random" block="pick random %min|to %limit"
+//% min.label="minimum" max.label="maximum"
 //% blockNamespace="Math"
 //% help=math/randint
 //% shim=Math_::randomRange
@@ -485,6 +509,7 @@ declare namespace String {
     //% help=math/from-char-code
     //% shim=String_::fromCharCode weight=1
     //% blockNamespace="text" blockId="stringFromCharCode" block="text from char code %code"
+    //% code.label="value"
     function fromCharCode(code: number): string;
 }
 
@@ -542,6 +567,7 @@ declare namespace Math {
      * @param max the upper inclusive bound, eg: 10
      */
     //% blockId="device_random_deprecated" block="pick random %min|to %limit"
+    //% min.label="minimum" max.label="maximum"
     //% help=math/random-range deprecated
     //% shim=Math_::randomRange
     function randomRange(min: number, max: number): number;

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -40,6 +40,7 @@ interface StringMap {
   */
 //% help=text/parse-int
 //% blockId="string_parseint" block="parse to integer %text" blockNamespace="text"
+//% text.label="value"
 //% text.defl="123"
 //% blockHidden=1
 function parseInt(text: string, radix?: number): number {

--- a/pxtblocks/builtins/math.ts
+++ b/pxtblocks/builtins/math.ts
@@ -30,13 +30,13 @@ export function initMath(blockInfo: pxtc.BlocksInfo) {
                         "type": "input_value",
                         "name": "x",
                         "check": "Number",
-                        "ariaLabelText": lf("first number")
+                        "ariaLabelText": lf("first value")
                     },
                     {
                         "type": "input_value",
                         "name": "y",
                         "check": "Number",
-                        "ariaLabelText": lf("second number")
+                        "ariaLabelText": lf("second value")
                     }
                 ],
                 "inputsInline": true,
@@ -72,7 +72,7 @@ export function initMath(blockInfo: pxtc.BlocksInfo) {
                         "type": "input_value",
                         "name": "x",
                         "check": "Number",
-                        "ariaLabelText": lf("number")
+                        "ariaLabelText": lf("value")
                     }
                 ],
                 "inputsInline": true,
@@ -219,8 +219,8 @@ export function initMathOpBlock() {
         i.setCheck("Number");
         i.setAriaLabelProvider(input =>
             b.getInput("ARG1")
-                ? (input.name === "ARG0" ? lf("first number") : lf("second number"))
-                : lf("number"));
+                ? (input.name === "ARG0" ? lf("first value") : lf("second value"))
+                : lf("value"));
         if (second) {
             (i.connection as any).setShadowDom(numberShadowDom());
             (i.connection as any).respawnShadow_();
@@ -304,6 +304,6 @@ export function initMathRoundBlock() {
     function addArgInput(b: Blockly.Block) {
         const i = b.appendValueInput("ARG0");
         i.setCheck("Number");
-        i.setAriaLabelProvider(lf("number"));
+        i.setAriaLabelProvider(lf("value"));
     }
 }

--- a/pxtblocks/builtins/text.ts
+++ b/pxtblocks/builtins/text.ts
@@ -31,7 +31,7 @@ export function initText() {
                     "type": "input_value",
                     "name": "VALUE",
                     "check": ['String'],
-                    "ariaLabelText": lf("text to check")
+                    "ariaLabelText": lf("value")
                 }
             ],
             "output": 'Number',

--- a/pxtblocks/composableMutations.ts
+++ b/pxtblocks/composableMutations.ts
@@ -458,6 +458,10 @@ export function initVariableReporterArgs(b: Blockly.Block, handlerArgs: pxt.bloc
                     inputToFocus = b.appendValueInput(DRAGGABLE_PARAM_INPUT_PREFIX + arg.name);
                     inputToFocus.setCheck(getBlocklyCheckForType(arg.type, info));
 
+                    // Use zero width space character. Empty strings and null are falsey
+                    // which results in the default value being used by Blockly "input i".
+                    inputToFocus.setAriaLabelProvider("\u200b");
+
                     setDuplicateOnDrag(b.type, inputToFocus.name);
 
                     if (buttonExists) {

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -280,7 +280,9 @@ function initBlock(block: Blockly.Block, info: pxtc.BlocksInfo, fn: pxtc.SymbolI
                 } else {
                     i.setCheck("Variable");
                 }
-
+                // Use zero width space character. Empty strings and null are falsey
+                // which results in the default value being used by Blockly "input i".
+                i.setAriaLabelProvider("\u200b");
             });
 
             comp.handlerArgs.forEach(arg => {
@@ -863,8 +865,8 @@ function initAccessibilityMessages() {
         INPUT_LABEL_VALUE_B: lf("second value"),                 // logic_compare
         INPUT_LABEL_CONDITION_A: lf("first condition"),          // logic_operation
         INPUT_LABEL_CONDITION_B: lf("second condition"),         // logic_operation
-        INPUT_LABEL_NUMBER_A: lf("first number"),                // math_arithmetic
-        INPUT_LABEL_NUMBER_B: lf("second number"),               // math_arithmetic
+        INPUT_LABEL_NUMBER_A: lf("first value"),                // math_arithmetic
+        INPUT_LABEL_NUMBER_B: lf("second value"),               // math_arithmetic
         INPUT_LABEL_MATH_DIVIDEND: lf("dividend"),               // math_modulo
         INPUT_LABEL_MATH_DIVISOR: lf("divisor"),                 // math_modulo
         INPUT_LABEL_LOOP_TIMES: lf("number of times to repeat"), // controls_repeat_ext

--- a/pxtblocks/plugins/math/numberBlocks.ts
+++ b/pxtblocks/plugins/math/numberBlocks.ts
@@ -11,7 +11,8 @@ Blockly.defineBlocksWithJsonArray([
         "args0": [{
             "type": "field_number",
             "name": "NUM",
-            "precision": 1
+            "precision": 1,
+            "ariaTypeName": lf("value")
         }],
         "output": "Number",
         "outputShape": provider.SHAPES.ROUND,
@@ -29,7 +30,8 @@ Blockly.defineBlocksWithJsonArray([
             "type": "field_number",
             "name": "NUM",
             "min": 0,
-            "precision": 1
+            "precision": 1,
+            "ariaTypeName": lf("value")
         }],
         "output": "Number",
         "outputShape": provider.SHAPES.ROUND,
@@ -46,7 +48,8 @@ Blockly.defineBlocksWithJsonArray([
         "args0": [{
             "type": "field_number",
             "name": "NUM",
-            "min": 0
+            "min": 0,
+            "ariaTypeName": lf("value")
         }],
         "output": "Number",
         "outputShape": provider.SHAPES.ROUND,

--- a/pxtblocks/plugins/text/join.ts
+++ b/pxtblocks/plugins/text/join.ts
@@ -143,7 +143,9 @@ const TEXT_JOIN_MUTATOR_MIXIN = {
             if (!this.getInput('ADD' + i)) {
                 const input = this.appendValueInput('ADD' + i)
                     // pxt-blockly: pxt-blockly/pull/112
-                    .setAlign(Blockly.inputs.Align.LEFT);
+                    .setAlign(Blockly.inputs.Align.LEFT)
+                    .setAriaLabelProvider(
+                        Blockly.Msg['INPUT_LABEL_TEXT_JOIN_ITEM'].replace('%1', (i + 1).toString()));
                 // if (i == 0) {
                 //   input.appendField(Blockly.Msg['TEXT_JOIN_TITLE_CREATEWITH']);
                 // }


### PR DESCRIPTION
This PR uses the mechanism added in https://github.com/microsoft/pxt/pull/11334 to create sensible input names for block inputs for screen reader users. The impact of these changes is currently limited to move mode where the block has more than one input. However, in the next Blockly release, these names will be surfaced when screen reader users focus an input via keyboard navigation. As such, I've opened this PR as a draft to provide visibility of these changes ahead of time for review and feedback.

Example of how this will work:
<img width="480" height="282" alt="Screenshot 2026-06-24 at 15 52 18" src="https://github.com/user-attachments/assets/3b270cd8-fcfd-4ebc-a32f-5c3ec0cddcb2" />

Current output on beta:
<img width="400" height="291" alt="Screenshot 2026-06-24 at 15 52 34" src="https://github.com/user-attachments/assets/db01dcbc-d259-437c-989e-a8a19cc0dada" />


The parameter label creation was AI-assisted and manually reviewed.