### PR TITLE
fix focus indicator for codecardview and close icon in ui modal

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -154,7 +154,7 @@
         background: var(--pxt-target-background1);
         color: var(--pxt-target-foreground1);
     }
-    
+
     .button.large {
         font-weight: 700;
     }

--- a/theme/semantic-ui-overrides.less
+++ b/theme/semantic-ui-overrides.less
@@ -26,10 +26,10 @@ This file overrides the default semantic ui theming with our own theme variables
         &:hover, &:focus {
             // Semantic UI darkens background using a filter, which isn't necessary when we have a hover color.
             filter: none;
-    
+
             background-color: @hoverBg;
             color: @hoverFg;
-    
+
             &.inverted {
                 background-color: @hoverFg;
                 color: @hoverBg;
@@ -84,9 +84,14 @@ body.pxt-theme-root {
         color: var(--pxt-neutral-foreground1);
         border-color: var(--pxt-neutral-stencil1);
 
-        &:hover, &:focus {
+        &:hover {
             background-color: var(--pxt-neutral-background1-hover);
             color: var(--pxt-neutral-foreground1-hover);
+        }
+
+        &:focus-visible {
+            outline: 4px solid var(--pxt-focus-border);
+            outline-offset: 2px;
         }
 
         .extra.content a.learnmore {
@@ -101,7 +106,7 @@ body.pxt-theme-root {
             .header {
                 color: var(--pxt-neutral-foreground1);
             }
-    
+
             .description {
                 color: var(--pxt-neutral-alpha80);
             }
@@ -125,7 +130,6 @@ body.pxt-theme-root {
         > .content,
         > .header,
         > .actions,
-        > .closeIcon,
         > .closeIcon .close,
         > .content > .ui.items > .item > .content > .description {
             background-color: var(--pxt-neutral-background1);
@@ -268,7 +272,7 @@ body.pxt-theme-root {
         input {
             border: 1px solid var(--pxt-neutral-stencil1);
 
-            & ~ .box:before, 
+            & ~ .box:before,
             & ~ label:before {
                 border: 1px solid var(--pxt-neutral-stencil1);
             }
@@ -281,7 +285,7 @@ body.pxt-theme-root {
                 color: var(--pxt-neutral-foreground1) !important;
             }
 
-            & ~ .box:before, 
+            & ~ .box:before,
             & ~ label:before {
                 border: 1px solid var(--pxt-neutral-stencil1);
                 background-color: var(--pxt-primary-background) !important;
@@ -296,7 +300,7 @@ body.pxt-theme-root {
     // Colors
     .blue {
         color: var(--pxt-colors-blue-background);
-        
+
         &.inverted {
             color: var(--pxt-colors-blue-background) !important;
             background-color: var(--pxt-colors-blue-foreground) !important;

--- a/theme/themes/pxt/modules/modal.overrides
+++ b/theme/themes/pxt/modules/modal.overrides
@@ -262,16 +262,18 @@
     border-radius: 50%;
     font-size: 2.15rem;
     line-height: 2.15rem;
-    transition: all .15s ease-out;
     height: 2.15rem;
     width: 2.15rem;
     padding: 0;
 }
-.ui.modal > .closeIcon:focus .close,
-.ui.modal > .closeIcon:hover  .close {
-    box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.50);
-    outline: none;
-    transform: scale(1.1);
+.ui.modal > .closeIcon:hover .close {
+    outline: solid 4px var(--pxt-neutral-alpha20);
+    outline-offset: 2px;
+}
+
+.ui.modal > .closeIcon:focus-visible .close {
+    outline: solid 4px var(--pxt-focus-border);
+    outline-offset: 2px;
 }
 
 .ui.button.icon.clear {

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -94,10 +94,6 @@ export class CodeCardView extends data.Component<CodeCardProps, CodeCardState> {
         // they won't update dynamically when headers change.
         const header = card.projectId ? this.getData<pxt.workspace.Header>(`header:${card.projectId}`) : null;
         const name = header ? header.name : card.name;
-        const cloudMd = card.projectId ? this.getData<cloud.CloudTempMetadata>(`${cloud.HEADER_CLOUDSTATE}:${card.projectId}`) : null;
-        const cloudStatus = cloudMd?.cloudStatus();
-        const lastCloudSave = cloudStatus ? Math.min(header.cloudLastSyncTime, header.modificationTime) : card.time;
-        const cloudShowTimestamp = cloudStatus && (cloudStatus.value === "synced" || cloudStatus.value === "justSynced" || cloudStatus.value === "localEdits");
 
         const ariaLabel = card.ariaLabel || card.title || card.shortName || name;
         const ariaExpanded = !card.directOpen && card.selected !== undefined ? card.selected : undefined;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -2016,7 +2016,7 @@ function cardActionButton(props: Partial<ProjectsDetailProps>, className: string
 
     // todo: Left these two specifically with the ui class from semantic
     // because messing with them too much had too many side effects
-    // for a side fix (detail card buttons, etc) 
+    // for a side fix (detail card buttons, etc)
     return asLink ? // TODO (shakao)  migrate forumurl to otherAction json in md
         <Link
             ref={autoFocus ? linkRef : undefined}
@@ -2182,35 +2182,35 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                         <codecard.CodeCardView
                             ariaLabel={lf("Open files from your computer")}
                             role="button"
-                            key={'import'}
                             icon="upload"
                             iconColor="secondary"
                             name={lf("Import File...")}
                             description={lf("Open files from your computer")}
                             onClick={this.importHex}
-                        />}
+                        />
+                    }
                     {showImport &&
                         <codecard.CodeCardView
                             ariaLabel={lf("Open a shared project URL or GitHub repo")}
                             role="button"
-                            key={'importurl'}
                             icon="cloud download"
                             iconColor="secondary"
                             name={lf("Import URL...")}
                             description={lf("Open a shared project URL or GitHub repo")}
                             onClick={this.importUrl}
-                        />}
+                        />
+                    }
                     {showCreateGithubRepo &&
                         <codecard.CodeCardView
                             ariaLabel={lf("Clone or create your own GitHub repository")}
                             role="button"
-                            key={'importgithub'}
                             icon="github"
                             iconColor="secondary"
                             name={lf("Your GitHub Repo...")}
                             description={lf("Clone or create your own GitHub repository")}
                             onClick={this.cloneGithub}
-                        />}
+                        />
+                    }
                 </div>
             </sui.Modal>
         )


### PR DESCRIPTION
contains a fix for https://github.com/microsoft/pxt-microbit/issues/6838

fixes the focus indicator for codecard views in the import dialog, language dialog, script search dialog, and experiments dialog as well the close icon in the semantic ui modals

<img width="1182" height="556" alt="focus-indic" src="https://github.com/user-attachments/assets/bae775ae-ebb4-4908-baab-f082d84e159a" />

also removes the background on that close button which was covering up some borders and the corner radius. here's what it looked like with the background, note the missing bottom border and the non-rounded corner:

<img width="140" height="122" alt="image" src="https://github.com/user-attachments/assets/55fa7fbb-a50a-46d2-be6f-c050c575a414" />

finally, also deletes some random unused code i noticed while debugging