### PR TITLE
remove hex info packaging

### DIFF
--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -1102,9 +1102,8 @@ _stored_program: .hex ${res}
 
         res += U.uint8ArrayToString([
             metablob.length & 0xff, metablob.length >> 8,
-            binstring.length & 0xff, (binstring.length >> 8) & 0xff,
-            (binstring.length >> 16) & 0xff, (binstring.length >> 24) & 0xff,
-            0, 0
+            binstring.length & 0xff, binstring.length >> 8,
+            0, 0, 0, 0
         ])
 
         res += metablob

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -1102,8 +1102,9 @@ _stored_program: .hex ${res}
 
         res += U.uint8ArrayToString([
             metablob.length & 0xff, metablob.length >> 8,
-            binstring.length & 0xff, binstring.length >> 8,
-            0, 0, 0, 0
+            binstring.length & 0xff, (binstring.length >> 8) & 0xff,
+            (binstring.length >> 16) & 0xff, (binstring.length >> 24) & 0xff,
+            0, 0
         ])
 
         res += metablob

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1222,7 +1222,7 @@ int main() {
             let m = /^:10....0[0E]41140E2FB82FA2BB(....)(....)(....)(....)(..)/.exec(ln)
             if (m) {
                 metaLen = parseInt(swapBytes(m[1]), 16)
-                textLen = parseInt(swapBytes(m[2]), 16) + parseInt(swapBytes(m[3]), 16) * 0x10000
+                textLen = parseInt(swapBytes(m[2]), 16)
                 toGo = metaLen + textLen
                 buf = <any>new Uint8Array(toGo)
             } else if (toGo > 0) {

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1222,7 +1222,7 @@ int main() {
             let m = /^:10....0[0E]41140E2FB82FA2BB(....)(....)(....)(....)(..)/.exec(ln)
             if (m) {
                 metaLen = parseInt(swapBytes(m[1]), 16)
-                textLen = parseInt(swapBytes(m[2]), 16)
+                textLen = parseInt(swapBytes(m[2]), 16) + parseInt(swapBytes(m[3]), 16) * 0x10000
                 toGo = metaLen + textLen
                 buf = <any>new Uint8Array(toGo)
             } else if (toGo > 0) {

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1526,11 +1526,6 @@ namespace pxt.hexloader {
         return JSON.stringify(cachedMeta);
     }
 
-    export function storeHexInfoCacheEntryAsync(host: Host, sha: string, cachedHexInfo: string) {
-        if (!sha || !cachedHexInfo) return Promise.resolve();
-        return storeWithLimitAsync(host, "hex-keys", "hex-" + sha, cachedHexInfo);
-    }
-
     export function getHexInfoAsync(host: Host, extInfo: pxtc.ExtensionInfo, cloudModule?: any): Promise<pxtc.HexInfo> {
         if (!extInfo.sha)
             return Promise.resolve<any>(null)

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -542,7 +542,6 @@ namespace pxt {
     export const TUTORIAL_INFO_FILE = "tutorial-info-cache.json";
     export const TUTORIAL_CUSTOM_TS = "tutorial.custom.ts";
     export const PACKAGED_EXTENSIONS = "_packaged-extensions.json";
-    export const PACKAGED_EXT_INFO = "_packaged-ext-info.json";
     export const BREAKPOINT_TABLET = 991; // TODO (shakao) revisit when tutorial stuff is more settled
     export const PALETTES_FILE = "_palettes.json";
     export const HISTORY_FILE = "_history";

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -1282,9 +1282,6 @@ namespace pxt {
 
             if (!noFileEmbed) {
                 const files = await this.filesToBePublishedAsync(true, !appTarget.compile.useUF2)
-                const packagedExtInfo = this.packagedExtensionHexInfo(opts);
-                if (Object.keys(packagedExtInfo).length)
-                    files[pxt.PACKAGED_EXT_INFO] = JSON.stringify(packagedExtInfo);
                 const headerString = JSON.stringify({
                     name: this.config.name,
                     comment: this.config.description,
@@ -1419,21 +1416,6 @@ namespace pxt {
             }
 
             packDeps(this);
-            return packaged;
-        }
-
-        private packagedExtensionHexInfo(opts: pxtc.CompileOptions): pxt.Map<string> {
-            const packaged: pxt.Map<string> = {};
-            const targets = [opts, ...(opts.otherMultiVariants || [])];
-
-            for (const target of targets) {
-                const extInfo = target.extinfo;
-                if (!extInfo?.sha || !extInfo.hexinfo?.hex) continue;
-
-                const serialized = pxt.hexloader.stringifyHexInfoForCache(extInfo.hexinfo);
-                if (serialized) packaged[extInfo.sha] = serialized;
-            }
-
             return packaged;
         }
 

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -775,13 +775,7 @@ export async function installAsync(h0: InstallHeader, text: ScriptText, dontOver
         packagedExtensionFiles = pxt.Util.jsonTryParse(text[pxt.PACKAGED_EXTENSIONS]);
         delete text[pxt.PACKAGED_EXTENSIONS];
     }
-    let packagedExtInfo: pxt.Map<string>;
-    if (text[pxt.PACKAGED_EXT_INFO]) {
-        packagedExtInfo = pxt.Util.jsonTryParse(text[pxt.PACKAGED_EXT_INFO]);
-        delete text[pxt.PACKAGED_EXT_INFO];
-    }
 
-    await cachePackagedExtInfoAsync(packagedExtInfo);
     await cachePackagedScriptExtensionsAsync(packagedExtensionFiles);
     await pxt.github.cacheProjectDependenciesAsync(cfg, packagedExtensionFiles)
     await importAsync(h, text);
@@ -811,34 +805,6 @@ async function cachePackagedScriptExtensionsAsync(packagedExtensionFiles?: pxt.M
         }
         catch (e) {
             pxt.log("Unable to cache packaged extension in DB");
-        }
-    }));
-}
-
-async function cachePackagedExtInfoAsync(packagedExtInfo?: pxt.Map<string>) {
-    if (!packagedExtInfo) return;
-
-    const hostCache = await indexedDBWorkspace.getObjectStoreAsync<{ id: string, val: string }>(indexedDBWorkspace.HOSTCACHE_TABLE);
-    const cacheHost = {
-        cacheStoreAsync: async (id: string, val: string) => {
-            await hostCache.setAsync({ id, val });
-        },
-        cacheGetAsync: async (id: string) => {
-            try {
-                return (await hostCache.getAsync(id)).val;
-            }
-            catch (e) {
-                return null;
-            }
-        }
-    } as pxt.Host;
-
-    await Promise.all(Object.keys(packagedExtInfo).map(async sha => {
-        try {
-            await pxt.hexloader.storeHexInfoCacheEntryAsync(cacheHost, sha, packagedExtInfo[sha]);
-        }
-        catch (e) {
-            pxt.log("Unable to cache packaged extension hex info in DB");
         }
     }));
 }


### PR DESCRIPTION
ran into an issue where in some cases this failed to load back in hex file to app because the hex file writer was only writing bottom 16 bits instead of all 32; it was already a side feature so just removing, packaged extensions should still load just fine but won't be able to download until internet for full hex info. hex file was also noticeably increasing size of full hex, so just doesn't feel worth it -- it would have already been a bit of a stretch as would have required exact cpp match (e.g. if there was a 1 character change on live site vs latest offline app would have failed), so fine to cut, rather than dealing with weird stuff here.

The part that i committed & reverted does work, and should be fine, but is not necessary with the hexfile portion culled / don't see a reason to actually merge it and have to think about it. put it in here just in case so can have the exact change if it does need to be updated, for any reason

(this pr is purely deleting code added in https://github.com/microsoft/pxt/pull/11342)