### PR TITLE
version history and reflow zoom accessibility fixes

### DIFF
--- a/react-common/components/controls/FocusList.tsx
+++ b/react-common/components/controls/FocusList.tsx
@@ -6,6 +6,7 @@ export interface FocusListProps extends ContainerProps {
     childTabStopId?: string;
     focusSelectsItem?: boolean;
     useUpAndDownArrowKeys?: boolean;
+    title?: string;
     onItemReceivedFocus?: (item: HTMLElement) => void;
     onClose?: () => void;
 }
@@ -30,6 +31,7 @@ export const FocusList = (props: FocusListProps) => {
         focusSelectsItem,
         onItemReceivedFocus,
         useUpAndDownArrowKeys,
+        title,
         onClose
     } = props;
 
@@ -159,7 +161,8 @@ export const FocusList = (props: FocusListProps) => {
             onKeyDown={onKeyDown}
             ref={handleRef}
             aria-hidden={ariaHidden}
-            aria-label={ariaLabel}>
+            aria-label={ariaLabel}
+            title={title}>
             {children}
         </div>
     );

--- a/react-common/components/controls/Tree.tsx
+++ b/react-common/components/controls/Tree.tsx
@@ -5,6 +5,7 @@ import { FocusList } from "./FocusList";
 
 export interface TreeProps extends ContainerProps {
     role?: "tree" | "group";
+    title?: string;
 }
 
 export interface TreeItemProps extends ContainerProps {
@@ -26,6 +27,7 @@ export const Tree = (props: TreeProps) => {
         ariaHidden,
         ariaDescribedBy,
         role,
+        title
     } = props;
 
     if (!role || role === "tree") {
@@ -37,6 +39,7 @@ export const Tree = (props: TreeProps) => {
                 aria-hidden={ariaHidden}
                 aria-describedby={ariaDescribedBy}
                 role={role || "tree"}
+                title={title}
             >
                 {children}
             </FocusList>
@@ -51,6 +54,7 @@ export const Tree = (props: TreeProps) => {
             aria-hidden={ariaHidden}
             aria-describedby={ariaDescribedBy}
             role={role || "tree"}
+            title={title}
         >
             {children}
         </div>

--- a/theme/common.less
+++ b/theme/common.less
@@ -408,13 +408,15 @@ div.simframe > iframe {
 .menubar {
     .left.menu, .right.menu, .center.menu {
         display: flex;
-        flex: 1;
+        flex-grow: 1;
     }
     .right.menu {
         justify-content: flex-end;
+        flex-shrink: 0;
     }
     .center.menu {
         justify-content: center;
+        flex-shrink: 0;
     }
 
     .ui.item {

--- a/theme/timeMachine.less
+++ b/theme/timeMachine.less
@@ -153,4 +153,11 @@
     .time-machine-header {
         height: @mobileMenuHeight;
     }
+
+    button.common-button.square-on-mobile {
+        width: 3rem;
+        height: 3rem;
+        padding: 0;
+        min-width: 0;
+    }
 }

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -110,9 +110,19 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
 
         return <div className="ui item logo organization" aria-hidden="true">
             {targetTheme.organizationWideLogo || targetTheme.organizationLogo
-                ? <img className={`ui logo ${view !== "home" ? "mobile hide" : ""}`} src={targetTheme.organizationWideLogo || targetTheme.organizationLogo} alt={lf("{0} Logo", targetTheme.organization)} />
+                ? <img
+                    className="ui logo mobile hide"
+                    src={targetTheme.organizationWideLogo || targetTheme.organizationLogo}
+                    alt={lf("{0} Logo", targetTheme.organization)}
+                />
                 : <span className="name">{targetTheme.organization}</span>}
-            {targetTheme.organizationLogo && view !== "home" && (<img className={`ui image mobile only`} src={targetTheme.organizationLogo} alt={lf("{0} Logo", targetTheme.organization)} />)}
+            {targetTheme.organizationLogo &&
+                <img
+                    className="ui image mobile only"
+                    src={targetTheme.organizationLogo}
+                    alt={lf("{0} Logo", targetTheme.organization)}
+                />
+            }
         </div>
     }
 
@@ -124,7 +134,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
         const shouldLinkHome = pxt.shell.hasHomeScreen() && view !== "home";
 
         // TODO: "sandbox" view components are temporary share page layout
-        return <div aria-hidden={!shouldLinkHome} className={`ui item logo brand ${view !== "sandbox" && view !== "home" ? "mobile hide" : ""}`}>
+        return <div aria-hidden={!shouldLinkHome} className={`ui item logo brand ${view !== "sandbox" ? "mobile hide" : ""}`}>
             {targetTheme.useTextLogo
             ? (shouldLinkHome
                 ? [<Button className="name menu-button" key="org-name"

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -2016,7 +2016,7 @@ function cardActionButton(props: Partial<ProjectsDetailProps>, className: string
 
     // todo: Left these two specifically with the ui class from semantic
     // because messing with them too much had too many side effects
-    // for a side fix (detail card buttons, etc) 
+    // for a side fix (detail card buttons, etc)
     return asLink ? // TODO (shakao)  migrate forumurl to otherAction json in md
         <Link
             ref={autoFocus ? linkRef : undefined}
@@ -2177,7 +2177,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                 closeIcon={true} header={lf("Import")}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
             >
-                <div className={`ui ${cardClass} cards`}>
+                <div className={`ui ${cardClass} stackable cards`}>
                     {showOpenFiles &&
                         <codecard.CodeCardView
                             ariaLabel={lf("Open files from your computer")}

--- a/webapp/src/timeMachine.tsx
+++ b/webapp/src/timeMachine.tsx
@@ -308,13 +308,13 @@ export const TimeMachine = (props: TimeMachineProps) => {
                         {lf("Version History")}
                     </h3>
                     <div className="time-machine-tree-container">
-                        <Tree>
+                        <Tree title={lf("Version History Timeline")}>
                             {entries.map((e, i) =>
                                 <TreeItem key={i} initiallyExpanded={i === 0}>
                                     <TreeItemBody>
                                         {e.label}
                                     </TreeItemBody>
-                                    <Tree role="group">
+                                    <Tree role="group" title={lf("Versions from {0}", e.label)}>
                                         {e.entries.map((entry, index) => {
                                             const isSelected = (!selected && entry.timestamp === -1) ||
                                                 (selected?.kind === entry.kind && selected?.timestamp === entry.timestamp);

--- a/webapp/src/timeMachine.tsx
+++ b/webapp/src/timeMachine.tsx
@@ -269,11 +269,17 @@ export const TimeMachine = (props: TimeMachineProps) => {
                             {selected ? formatFullDate(selected.timestamp) : lf("Now")}
                         </div>
                         <Button
+                            className="square-on-mobile"
+                            labelClassName="mobile-hidden"
+                            leftIcon="fas fa-save mobile-only"
                             label={lf("Save a copy")}
                             title={lf("Save a copy")}
                             onClick={onSaveCopySelect}
                         />
                         <Button
+                            className="square-on-mobile"
+                            labelClassName="mobile-hidden"
+                            leftIcon="fas fa-undo mobile-only"
                             label={lf("Restore")}
                             title={lf("Restore")}
                             onClick={onGoPressed}


### PR DESCRIPTION
contains a fix for https://github.com/microsoft/pxt-microbit/issues/6866

we had a number of bleeding issues at extreme zooms in small screens. this PR makes the following changes to fix 'em:
* changes the save-a-copy and restore buttons in the version history dialog to icons at mobile widths
* changes the organization and microsoft logos on the homescreen to collapse on mobile, just like they do in the editor
* changes the cards in the import dialog to vertically stack on mobile instead of getting squished
* tweaks the flex box on the header bar to make sure that the right and center portions of the header don't shrink when zoomed. this prevents the editor toggle and settings cogwheel from overlapping

fixed version history:
<img width="578" height="458" alt="image" src="https://github.com/user-attachments/assets/ebad5fbd-ab45-4471-a488-51e11190d1d1" />

fixed editor toggle: 

<img width="533" height="413" alt="image" src="https://github.com/user-attachments/assets/88f7c7f2-af27-44e3-bf74-17619ee2219c" />

fixed home:

<img width="562" height="851" alt="image" src="https://github.com/user-attachments/assets/5b3ba5b1-96df-4b56-bd4b-9278a0a6660f" />


also contains a fix for https://github.com/microsoft/pxt-microbit/issues/6837

adds a title to both the parent version history tree and subtrees