### PR TITLE
Upgrade to Blockly v13.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@zip.js/zip.js": "2.4.20",
     "adm-zip": "^0.5.12",
     "axios": "^1.12.2",
-    "blockly": "13.0.0",
+    "blockly": "13.1.0",
     "browserify": "17.0.0",
     "chai": "^3.5.0",
     "chalk": "^4.1.2",
@@ -151,10 +151,10 @@
   },
   "overrides": {
     "@blockly/field-grid-dropdown": {
-      "blockly": "13.0.0"
+      "blockly": "13.1.0"
     },
     "@blockly/plugin-workspace-search": {
-      "blockly": "13.0.0"
+      "blockly": "13.1.0"
     },
     "combine-source-map": {
       "source-map": "0.4.4"

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -828,8 +828,9 @@ function initAccessibilityMessages() {
         SCREENREADER_HINT: lf("Use the arrow keys to navigate. Press %1 to toggle screenreader accessibility mode."),
         // Aria labels for the workspace tree.
         WORKSPACE_LABEL_PLAIN: lf("Blocks workspace."),
-        WORKSPACE_LABEL_1_STACK: lf("Blocks workspace. 1 stack of blocks"),
-        WORKSPACE_LABEL_MANY_STACKS: lf("Blocks workspace. %1 stacks of blocks"),
+        WORKSPACE_ROLEDESCRIPTION: lf("workspace"),
+        WORKSPACE_LABEL_1_STACK: lf("1 stack of blocks"),
+        WORKSPACE_LABEL_MANY_STACKS: lf("%1 stacks of blocks"),
         WORKSPACE_LABEL_MUTATOR_WORKSPACE: lf("Block editor workspace"),
         WORKSPACE_LABEL_FLYOUT_WORKSPACE: lf("%1 blocks"),
         // Workspace contents announcement (the 'I' announce-info shortcut).
@@ -915,7 +916,7 @@ function initAccessibilityMessages() {
         CURRENT_BLOCK_ANNOUNCEMENT: lf("Current block: %1"),
         PARENT_BLOCKS_ANNOUNCEMENT: lf("Parent blocks: %1"),
         NO_PARENT_ANNOUNCEMENT: lf("Current block has no parent"),
-        // Screenreader mode toggle (Cmd/Ctrl+Alt+Z).
+        // Screenreader mode toggle (Alt/Option+Shift+A).
         SCREENREADER_MODE_ENABLED: lf("Screenreader mode is on, press %1 to turn it off"),
         SCREENREADER_MODE_DISABLED: lf("Screenreader mode is off, press %1 to turn it on"),
         // Used for Blockly's toast close aria label.

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -733,7 +733,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             }
         });
 
-        // Route Blockly's built-in screenreader toggle (Ctrl/Cmd+Alt+Z) through
+        // Route Blockly's built-in screenreader toggle (Alt/Option+Shift+A) through
         // MakeCode's persistent setting so the keyboard shortcut, the Settings
         // menu checkbox, and the stored preference all stay in sync.
         const toggleScreenreader = Blockly.ShortcutRegistry.registry.getRegistry()[Blockly.ShortcutItems.names.TOGGLE_SCREENREADER];


### PR DESCRIPTION
This PR upgrades Blockly the v13.1.0. This upgrade fixes a number of issues. Additional information is now attached to full block fields for the zelos renderer which also provides support for custom input names for these inputs.

[Blockly release notes](https://github.com/RaspberryPiFoundation/blockly/releases/tag/blockly-v13.1.0)

Closes https://github.com/microsoft/pxt-microbit/issues/6951