### PR TITLE
persist piano roll track ids more cleanly

### DIFF
--- a/webapp/src/components/pianoRoll/FieldEditor.tsx
+++ b/webapp/src/components/pianoRoll/FieldEditor.tsx
@@ -19,7 +19,7 @@ export const PianoRollFieldEditor = (props: Props) => {
     const [undoStack, setUndoStack] = useState<PianoRollState["undoStack"]>([]);
     const [redoStack, setRedoStack] = useState<PianoRollState["redoStack"]>([]);
     const [velocityEditorVisible, setVelocityEditorVisible] = useState<PianoRollState["velocityEditorVisible"]>(undefined);
-    const [selectedTrack, setSelectedTrack] = useState<PianoRollState["selectedTrack"]>(undefined);
+    const [selectedTrack, setSelectedTrack] = useState<PianoRollState["selectedTrackIndex"]>(undefined);
 
     const resultRef = useRef<PianoRollState>();
 
@@ -50,7 +50,7 @@ export const PianoRollFieldEditor = (props: Props) => {
                         undoStack: resultRef.current?.undoStack,
                         redoStack: resultRef.current?.redoStack,
                         velocityEditorVisible: resultRef.current?.velocityEditorVisible,
-                        selectedTrack: resultRef.current?.selectedTrack
+                        selectedTrack: resultRef.current?.selectedTrackIndex
                     }
                 },
                 restorePersistentData: (value: any) => {
@@ -75,7 +75,7 @@ export const PianoRollFieldEditor = (props: Props) => {
             undoStack={undoStack}
             redoStack={redoStack}
             onStateChanged={onStateChange}
-            selectedTrack={selectedTrack}
+            selectedTrackIndex={selectedTrack}
             velocityEditorVisible={velocityEditorVisible}
             showEditControls={true}
             onDoneClicked={onDoneClicked?.onDoneClicked}

--- a/webapp/src/components/pianoRoll/Header.tsx
+++ b/webapp/src/components/pianoRoll/Header.tsx
@@ -4,7 +4,7 @@ import { Song, lf, isDrumInstrument, NOTE_RANGES } from "./types";
 
 interface Props {
     song: Song;
-    selectedTrack: number;
+    selectedTrackId: number;
     velocityEditorVisible: boolean;
 
     onTrackSelected(trackId: number): void;
@@ -16,7 +16,7 @@ interface Props {
 }
 
 export const Header = (props: Props) => {
-    const { song, selectedTrack, velocityEditorVisible, onVelocityEditorToggle, onTrackSelected, onInstrumentSelected, onTrackCreated, onTrackDeleted, onOctavesChanged } = props;
+    const { song, selectedTrackId: selectedTrack, velocityEditorVisible, onVelocityEditorToggle, onTrackSelected, onInstrumentSelected, onTrackCreated, onTrackDeleted, onOctavesChanged } = props;
 
     const onTrackDropdownChange = (id: string) => {
         if (id === "new-track") {

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -18,7 +18,7 @@ interface PianoRollProps {
     asset?: pxt.assets.music.Song;
     undoStack?: StateSnapshot[];
     redoStack?: StateSnapshot[];
-    selectedTrack?: number;
+    selectedTrackIndex?: number;
     velocityEditorVisible?: boolean;
     showEditControls?: boolean;
     name?: string;
@@ -46,7 +46,7 @@ export interface PianoRollState {
     undoStack: StateSnapshot[];
     redoStack: StateSnapshot[];
     asset: pxt.assets.music.Song;
-    selectedTrack: number;
+    selectedTrackIndex: number;
     velocityEditorVisible: boolean;
     name?: string;
 }
@@ -61,7 +61,7 @@ export interface FieldEditorParams {
 
 interface StateSnapshot {
     song: Song;
-    selectedTrack: number;
+    selectedTrackIndex: number;
 }
 
 
@@ -69,7 +69,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
     const {
         onStateChanged,
         asset,
-        selectedTrack: initialSelectedTrack,
+        selectedTrackIndex: initialSelectedTrackIndex,
         velocityEditorVisible: initialVelocityEditorVisible,
         undoStack: initialUndoStack,
         redoStack: initialRedoStack,
@@ -83,12 +83,12 @@ const PianoRollInternal = (props: PianoRollProps) => {
     const lastFiredState = useRef<PianoRollState | null>(null);
 
     const [song, setSong] = useState<Song>(asset ? fromPXTSong(asset) : getEmptySong());
-    const [selectedTrack, setSelectedTrack] = useState(song.tracks[0].id);
+    const [selectedTrackIndex, setSelectedTrackIndex] = useState(0);
     const [modal, setModal] = useState<{ type: modalType, trackId?: number, instrumentId?: number } | null>(null);
 
     const [undoStack, setUndoStack] = useState<StateSnapshot[]>(initialUndoStack || []);
     const [redoStack, setRedoStack] = useState<StateSnapshot[]>(initialRedoStack || []);
-    const [name, setName] = useState(props.name || undefined);
+    const [name, setName] = useState(initialName || undefined);
 
     const [velocityEditorVisible, setVelocityEditorVisible] = useState(initialVelocityEditorVisible || false);
 
@@ -96,14 +96,13 @@ const PianoRollInternal = (props: PianoRollProps) => {
         if (asset) {
             const song = fromPXTSong(asset);
             setSong(song);
-            setSelectedTrack(song.tracks[0].id);
             setModal(null);
             setUndoStack(initialUndoStack || []);
             setRedoStack(initialRedoStack || []);
-            setSelectedTrack(initialSelectedTrack || song.tracks[0].id);
+            setSelectedTrackIndex(initialSelectedTrackIndex || 0);
             setVelocityEditorVisible(initialVelocityEditorVisible || false);
             stopPlayback();
-            fireStateChange({ asset, undoStack: initialUndoStack || [], redoStack: initialRedoStack || [], selectedTrack: initialSelectedTrack || song.tracks[0].id, velocityEditorVisible: initialVelocityEditorVisible || false })
+            fireStateChange({ asset, undoStack: initialUndoStack || [], redoStack: initialRedoStack || [], selectedTrackIndex: initialSelectedTrackIndex || 0, velocityEditorVisible: initialVelocityEditorVisible || false })
         }
     }, [asset, onStateChanged])
 
@@ -117,14 +116,14 @@ const PianoRollInternal = (props: PianoRollProps) => {
         if (initialRedoStack) {
             setRedoStack(initialRedoStack);
         }
-        if (initialSelectedTrack !== undefined) {
-            setSelectedTrack(initialSelectedTrack);
+        if (initialSelectedTrackIndex !== undefined) {
+            setSelectedTrackIndex(initialSelectedTrackIndex);
         }
         if (initialVelocityEditorVisible !== undefined) {
             setVelocityEditorVisible(initialVelocityEditorVisible);
         }
         setName(initialName);
-    }, [initialUndoStack, initialRedoStack, initialSelectedTrack, initialVelocityEditorVisible, initialName]);
+    }, [initialUndoStack, initialRedoStack, initialSelectedTrackIndex, initialVelocityEditorVisible, initialName]);
 
     useEffect(() => {
         if (onStateChanged) {
@@ -153,7 +152,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     asset: toPXTSong(song),
                     undoStack,
                     redoStack,
-                    selectedTrack,
+                    selectedTrackIndex,
                     velocityEditorVisible,
                     name
                 };
@@ -169,11 +168,11 @@ const PianoRollInternal = (props: PianoRollProps) => {
     }
 
     const updateSong = (newSong: Song) => {
-        setUndoStack([...undoStack, { song, selectedTrack }]);
+        setUndoStack([...undoStack, { song, selectedTrackIndex }]);
         setRedoStack([])
 
         setSong(newSong);
-        fireStateChange({ asset: toPXTSong(newSong), undoStack: [...undoStack, { song, selectedTrack }], redoStack: [] })
+        fireStateChange({ asset: toPXTSong(newSong), undoStack: [...undoStack, { song, selectedTrackIndex }], redoStack: [] })
 
         if (isPlaying()) {
             updatePlaybackSongAsync(toPXTSong(newSong));
@@ -185,17 +184,18 @@ const PianoRollInternal = (props: PianoRollProps) => {
     }
 
     const onTrackSelected = (trackId: number) => {
-        setSelectedTrack(trackId);
-        fireStateChange({ selectedTrack: trackId });
+        const index = song.tracks.findIndex(t => t.id === trackId);
+        setSelectedTrackIndex(index);
+        fireStateChange({ selectedTrackIndex: index });
     }
 
     const onTrackCreated = () => {
         const newSong = newTrack(song.instruments[0].id, song);
         updateSong(newSong);
 
-        const newTrackId = newSong.tracks[newSong.tracks.length - 1].id;
-        setSelectedTrack(newTrackId);
-        fireStateChange({ selectedTrack: newTrackId });
+        const newTrackIndex = newSong.tracks.length - 1;
+        setSelectedTrackIndex(newTrackIndex);
+        fireStateChange({ selectedTrackIndex: newTrackIndex });
     }
 
     const onTrackDeleted = (trackId: number) => {
@@ -205,7 +205,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
             setModal({ type: "delete-error" });
         }
         else if (!toDelete?.events.length) {
-            setSelectedTrack(song.tracks[0].id);
+            setSelectedTrackIndex(0);
             updateSong({
                 ...song,
                 tracks: song.tracks.filter(t => t.id !== trackId)
@@ -230,7 +230,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
     }
 
     const deleteTrack = (trackId: number) => {
-        setSelectedTrack(song.tracks[0].id);
+        setSelectedTrackIndex(0);
         updateSong({
             ...song,
             tracks: song.tracks.filter(t => t.id !== trackId)
@@ -242,7 +242,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
     }
 
     const playNote = (note: number) => {
-        const track = song.tracks.find(t => t.id === selectedTrack)!;
+        const track = song.tracks[selectedTrackIndex]!;
         const instrument = song.instruments.find(i => i.id === track.instrumentId)!;
 
         if (isDrumInstrument(instrument)) {
@@ -280,7 +280,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
     }
 
     const onOctavesChanged = (minOctave: number, maxOctave: number) => {
-        const track = song.tracks.find(t => t.id === selectedTrack)!;
+        const track = song.tracks[selectedTrackIndex]!;
 
         if (track.minOctave === minOctave && track.maxOctave === maxOctave) return;
 
@@ -289,11 +289,11 @@ const PianoRollInternal = (props: PianoRollProps) => {
         }
 
         updateTheme({ minOctave, maxOctave });
-        updateSong(changeOctaves(selectedTrack, minOctave, maxOctave, song));
+        updateSong(changeOctaves(track.id, minOctave, maxOctave, song));
     }
 
     const onVelocityChange = (notes: NoteEvent[]) => {
-        updateSong(updateNoteEvents(song, selectedTrack, notes));
+        updateSong(updateNoteEvents(song, song.tracks[selectedTrackIndex]!.id, notes));
     }
 
     const onVelocityEditorToggle = () => {
@@ -305,13 +305,13 @@ const PianoRollInternal = (props: PianoRollProps) => {
         if (!undoStack.length) return;
 
         const lastState = undoStack.pop()!;
-        redoStack.push({ song, selectedTrack });
+        redoStack.push({ song, selectedTrackIndex });
 
         setUndoStack([...undoStack]);
         setRedoStack([...redoStack]);
 
         setSong(lastState.song);
-        setSelectedTrack(lastState.selectedTrack);
+        setSelectedTrackIndex(lastState.selectedTrackIndex);
 
         fireStateChange({ asset: toPXTSong(lastState.song), undoStack: [...undoStack], redoStack: [...redoStack] });
 
@@ -328,13 +328,13 @@ const PianoRollInternal = (props: PianoRollProps) => {
         if (!redoStack.length) return;
 
         const nextState = redoStack.pop()!;
-        undoStack.push({ song, selectedTrack });
+        undoStack.push({ song, selectedTrackIndex });
 
         setUndoStack([...undoStack]);
         setRedoStack([...redoStack]);
 
         setSong(nextState.song);
-        setSelectedTrack(nextState.selectedTrack);
+        setSelectedTrackIndex(nextState.selectedTrackIndex);
 
         fireStateChange({ asset: toPXTSong(nextState.song), undoStack: [...undoStack], redoStack: [...redoStack] });
 
@@ -354,7 +354,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
 
     const closeModal = () => setModal(null);
 
-    const track = song.tracks.find(t => t.id === selectedTrack)!;
+    const track = song.tracks[selectedTrackIndex]!;
     const instrument = song.instruments.find(i => i.id === track.instrumentId)!;
 
     let minOctave: number;
@@ -397,7 +397,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                 <div className="header-container">
                     <Header
                         song={song}
-                        selectedTrack={selectedTrack}
+                        selectedTrackId={track.id}
                         velocityEditorVisible={velocityEditorVisible}
                         onVelocityEditorToggle={onVelocityEditorToggle}
                         onTrackSelected={onTrackSelected}
@@ -414,7 +414,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     <div className="sidebar-container">
                         <Sidebar
                             instrument={instrument}
-                            selectedTrack={selectedTrack}
+                            selectedTrackId={track.id}
                             minOctave={minOctave}
                             maxOctave={maxOctave}
                         />

--- a/webapp/src/components/pianoRoll/Sidebar.tsx
+++ b/webapp/src/components/pianoRoll/Sidebar.tsx
@@ -4,14 +4,14 @@ import { Instrument } from "./types";
 import { range } from "./utils";
 
 interface Props {
-    selectedTrack: number;
+    selectedTrackId: number;
     instrument: Instrument;
     minOctave: number;
     maxOctave: number;
 }
 
 export const Sidebar = (props: Props) => {
-    const { selectedTrack, instrument, minOctave, maxOctave } = props;
+    const { selectedTrackId: selectedTrack, instrument, minOctave, maxOctave } = props;
 
     const octaves = range(minOctave, maxOctave + 1);
     octaves.reverse();

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -21,7 +21,7 @@ export interface Song {
     tracks: Track[];
     measures: number;
     tempo: number;
-    nextId: number;
+    nextInstrumentId: number;
 }
 
 interface BaseInstrument {
@@ -65,7 +65,11 @@ export const NOTE_RANGES = [
 export function getEmptySong(): Song {
     const makecodeSong = pxt.assets.music.getEmptySong(4);
 
+    let nextInstrumentId = 0;
+
     const instruments: Instrument[] = makecodeSong.tracks.map(t => {
+        nextInstrumentId = Math.max(nextInstrumentId, t.id + 1);
+
         if (t.drums) {
             return {
                 id: t.id,
@@ -87,7 +91,7 @@ export function getEmptySong(): Song {
     });
 
     const song: Song = {
-        nextId: 1,
+        nextInstrumentId,
         instruments,
         tracks: [{
             instrumentId: 0,
@@ -196,12 +200,20 @@ function removeEventAtTimeIfNeeded(start: number, track: Track, maxPolyphony: nu
     }
 }
 
+function getNewTrackId(song: Song): number {
+    let id = 0;
+    while (song.tracks.some(t => t.id === id)) {
+        id++;
+    }
+    return id;
+}
+
 export function newTrack(instrumentId: number, song: Song): Song {
     const range = NOTE_RANGES.find(r => r.id === "treble")!;
     const newTrack: Track = {
         instrumentId,
         events: [],
-        id: song.nextId++,
+        id: getNewTrackId(song),
         nextId: 0,
         minOctave: range.minOctave,
         maxOctave: range.maxOctave
@@ -331,7 +343,7 @@ export function toPXTSong(song: Song): pxt.assets.music.Song {
             const instrument = song.instruments.find(i => i.id === track.instrumentId)!;
 
             const pxtTrack: pxt.assets.music.Track = {
-                id: track.instrumentId,
+                id: track.id,
                 name: instrument.name,
                 notes: track.events.map(e => ({
                     startTick: e.start,
@@ -357,7 +369,6 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
     result.tempo = pxtSong.beatsPerMinute;
 
     result.tracks = [];
-    result.nextId += 1000;
 
     const ticksPerSixteenth = pxtSong.ticksPerBeat / 4;
 
@@ -397,7 +408,7 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
             if (instrument) newTrack.instrumentId = instrument.id;
             else {
                 const newInstrument: MelodicInstrument = {
-                    id: result.nextId++,
+                    id: result.nextInstrumentId++,
                     name: lf("Instrument {0}", instrumentIdCounter++),
                     instrument: track.instrument,
                 };


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6899

cleans up the admittedly hacky handling of track ids:
* track ids are now saved to the PXT song. this is going to be weird if a piano roll song is opened in the regular song editor, but i think i'll probably have to do something to prevent that scenario anyhow since there are a few things not supported in the other editor
* track ids are now allocated by looking for the first available id instead of using an ever increasing number
* modified the piano roll component to use track index instead of track id in its state