### PR TITLE
add validation to piano roll text inputs

### DIFF
--- a/react-common/components/controls/Input.tsx
+++ b/react-common/components/controls/Input.tsx
@@ -25,6 +25,7 @@ export interface InputProps extends ControlProps {
     options?: pxt.Map<string>;
     filter?: string;
 
+    validator?: (value: string, prevValue: string) => string;
     onChange?: (newValue: string) => void;
     onEnterKey?: (value: string) => void;
     onIconClick?: (value: string) => void;
@@ -71,7 +72,8 @@ export const Input = (props: InputProps) => {
         onOptionSelected,
         handleInputRef,
         preserveValueOnBlur = true,
-        options
+        options,
+        validator,
     } = props;
 
     const [value, setValue] = React.useState(initialValue || "");
@@ -116,9 +118,14 @@ export const Input = (props: InputProps) => {
     const keyDownHandler = (e: React.KeyboardEvent) => {
         const charCode = (typeof e.which == "number") ? e.which : e.keyCode;
         if (charCode === /*enter*/13 || props.treatSpaceAsEnter && charCode === /*space*/32) {
+            let validatedValue = value;
+            if (validator) {
+                validatedValue = validator(value, initialValue || "");
+                setValue(validatedValue);
+            }
             if (onEnterKey) {
                 e.preventDefault();
-                onEnterKey(value);
+                onEnterKey(validatedValue);
             }
         } else if (options && e.key === "ArrowDown") {
             if (expanded) {
@@ -164,8 +171,13 @@ export const Input = (props: InputProps) => {
     }
 
     const blurHandler = () => {
+        let validatedValue = value;
+        if (validator) {
+            validatedValue = validator(value, initialValue || "");
+            setValue(validatedValue);
+        }
         if (onBlur) {
-            onBlur(value);
+            onBlur(validatedValue);
         }
         if (!preserveValueOnBlur) {
             setValue("");

--- a/webapp/src/components/musicEditor/PlaybackControls.tsx
+++ b/webapp/src/components/musicEditor/PlaybackControls.tsx
@@ -139,7 +139,8 @@ export const PlaybackControls = (props: PlaybackControlsProps) => {
             label={lf("Tempo:")}
             initialValue={beatsPerMinute.toString()}
             onBlur={handleTempoChange}
-            onEnterKey={handleTempoChange} />
+            onEnterKey={handleTempoChange}
+            validator={validateTempo} />
         <div className="spacer" />
         {!hideBassClefOption &&
             <Checkbox
@@ -177,6 +178,7 @@ export const PlaybackControls = (props: PlaybackControlsProps) => {
                 initialValue={measures.toString()}
                 onBlur={handleMeasureChange}
                 onEnterKey={handleMeasureChange}
+                validator={validateMeasures}
             />
             <Button
                 className="menu-button"
@@ -185,4 +187,24 @@ export const PlaybackControls = (props: PlaybackControlsProps) => {
                 onClick={handleMeasurePlusClick} />
         </div>
     </div>
+}
+
+function validateTempo(value: string, prevValue: string): string {
+    if (!value) return value;
+
+    const numValue = parseFloat(value);
+    if (isNaN(numValue)) {
+        return prevValue;
+    }
+    return Math.min(500, Math.max(20, Math.floor(numValue))).toString();
+}
+
+function validateMeasures(value: string, prevValue: string): string {
+    if (!value) return value;
+
+    const numValue = parseInt(value);
+    if (isNaN(numValue)) {
+        return prevValue;
+    }
+    return Math.max(1, Math.min(numValue, 50)).toString();
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6922

adds a validator to the tempo and measures inputs to prevent invalid values from being input. the validators only take effect on enter or blur so as not to interrupt typing.