### PR TITLE
Set keyboard navigation to active when using the keyboard help shortcut

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -338,6 +338,9 @@ export class ProjectView
                 return
             }
             case "togglekeyboardcontrolshelp": {
+                if (this.isBlocksActive()) {
+                    Blockly.keyboardNavigationController.setIsActive(true);
+                }
                 this.toggleBuiltInSideDoc("keyboardControls", false);
                 return
             }


### PR DESCRIPTION
This ensures that the keyboard navigation styling is applied to the blocks workspace if the first thing the user does is toggle the keyboard help docs.