### PR TITLE
fix: work around blockly delete-area hit test at non-default zoom

### DIFF
--- a/pxtblocks/monkeyPatches/deleteArea.ts
+++ b/pxtblocks/monkeyPatches/deleteArea.ts
@@ -1,0 +1,46 @@
+import * as Blockly from "blockly";
+import { assertMethod } from "./util";
+
+/**
+ * Fixes delete-area hit testing at non-default zoom. Fixed upstream in
+ * commit 9f4f1c1, which is not in the blockly 13.1.0.
+ *   Issue: https://github.com/RaspberryPiFoundation/blockly/issues/10095
+ *   PR:    https://github.com/RaspberryPiFoundation/blockly/pull/10096
+ *
+ * Dragger.onDrag/onDragEnd compute the hit-test coordinate once and pass that
+ * same Coordinate object to several getDragTarget calls. getDragTarget runs it
+ * through wsToScreenCoordinates, whose `coordinate.scale(ws.scale)` mutates the
+ * coordinate in place. So the first call scales the shared coordinate by the
+ * zoom factor, the next call scales the already-scaled value again, and it
+ * lands outside the delete area. At scale 1 the mutation is a no-op, which is
+ * why blocks only fail to delete when the workspace is zoomed (pxt zooms by
+ * default). The error grows with distance from the workspace origin.
+ *
+ * Fix: clone the coordinate before the round-trip so successive calls can't
+ * corrupt each other. Drop this once we upgrade past blockly 9f4f1c1.
+ */
+export function monkeyPatchDeleteArea() {
+    const proto = Blockly.WorkspaceSvg.prototype as any;
+    assertMethod(proto, "getDragTarget");
+
+    proto.getDragTarget = function (
+        this: Blockly.WorkspaceSvg,
+        point: PointerEvent | Blockly.utils.Coordinate,
+    ): Blockly.IDragTarget | null {
+        const coordinate =
+            point instanceof Blockly.utils.Coordinate
+                ? Blockly.utils.svgMath.wsToScreenCoordinates(this, point.clone())
+                : new Blockly.utils.Coordinate(point.clientX, point.clientY);
+        // dragTargetAreas is private in the .d.ts.
+        const areas = (this as any).dragTargetAreas as Array<{
+            component: Blockly.IDragTarget;
+            clientRect: Blockly.utils.Rect;
+        }>;
+        for (const area of areas) {
+            if (area.clientRect.contains(coordinate.x, coordinate.y)) {
+                return area.component;
+            }
+        }
+        return null;
+    };
+}

--- a/pxtblocks/monkeyPatches/index.ts
+++ b/pxtblocks/monkeyPatches/index.ts
@@ -1,5 +1,6 @@
 import { monkeyPatchBlockSvg } from "./blockSvg";
 import { monkeyPatchConnection } from "./connection";
+import { monkeyPatchDeleteArea } from "./deleteArea";
 import { monkeyPatchFullBlockField } from "./fullBlockField";
 import { monkeyPatchGesture, monkeyPatchShadowDragTargetBlock } from "./gesture";
 import { monkeyPatchGrid } from "./grid";
@@ -13,4 +14,5 @@ export function applyMonkeyPatches() {
     monkeyPatchAddKeyMapping();
     monkeyPatchConnection();
     monkeyPatchFullBlockField();
+    monkeyPatchDeleteArea();
 }


### PR DESCRIPTION
Monkey patch WorkspaceSvg.getDragTarget to clone the coordinate before the screen round-trip, so successive getDragTarget calls during a drag no longer double-scale a shared, in-place-mutated Coordinate and miss the delete area.

Fixed upstream in blockly 9f4f1c1 (not in the 13.1.0 we're using). https://github.com/RaspberryPiFoundation/blockly/issues/10095

Draft for the moment as I'm hoping we'll get a point release instead.

Closes https://github.com/microsoft/pxt-microbit/issues/6997

Demo: https://monkeypatch-coords-issue.review-pxt.pages.dev/#editor