### PR TITLE
Remove menu attribute from field slider content div

### DIFF
--- a/pxtblocks/plugins/math/fieldSlider.ts
+++ b/pxtblocks/plugins/math/fieldSlider.ts
@@ -200,10 +200,6 @@ export class FieldSlider extends Blockly.FieldNumber {
         // Used for high contrast styling
         contentDiv.parentElement.classList.add("blocklyFieldSliderDropdown");
 
-        // Accessibility properties
-        contentDiv.setAttribute('role', 'menu');
-        contentDiv.setAttribute('aria-haspopup', 'true');
-
         this.addSlider_(contentDiv);
 
         // Set colour and size of drop-down


### PR DESCRIPTION
After the latest Chrome / Edge update, this "menu subMenu" is output instead of the text input aria-label. This PR fixes this by removing markup that was otherwise unused.