### PR TITLE
Update to Blockly 13.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@zip.js/zip.js": "2.4.20",
     "adm-zip": "^0.5.12",
     "axios": "^1.12.2",
-    "blockly": "13.1.0",
+    "blockly": "13.1.1",
     "browserify": "17.0.0",
     "chai": "^3.5.0",
     "chalk": "^4.1.2",
@@ -151,10 +151,10 @@
   },
   "overrides": {
     "@blockly/field-grid-dropdown": {
-      "blockly": "13.1.0"
+      "blockly": "13.1.1"
     },
     "@blockly/plugin-workspace-search": {
-      "blockly": "13.1.0"
+      "blockly": "13.1.1"
     },
     "combine-source-map": {
       "source-map": "0.4.4"


### PR DESCRIPTION
This fixes an issue dragging blocks over the toolbox to delete them at non-1.0 zoom levels, which includes pxt's default.

That fix is the only material change in the release.

Fixes https://github.com/microsoft/pxt-microbit/issues/6997