### PR TITLE
Expose Screen Reader Mode over the iframe API

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -85,6 +85,7 @@ declare namespace pxt.editor {
         | "sethighcontrast" // EditorMessageSetHighContrastRequest
         | "togglegreenscreen"
         | "togglekeyboardcontrols"
+        | "togglescreenreadermode"
         | "settracestate" //
         | "setsimulatorfullscreen" // EditorMessageSimulatorFullScreenRequest
 
@@ -425,6 +426,7 @@ declare namespace pxt.editor {
         locale: string;
         availableLocales?: string[];
         keyboardControls: boolean;
+        screenReaderMode: boolean;
     }
 
     export interface PackageExtensionData {
@@ -1048,7 +1050,8 @@ declare namespace pxt.editor {
 
         toggleHighContrast(): void;
         setHighContrast(on: boolean): void;
-        toggleScreenReaderMode(eventSource: string): void;
+        toggleScreenReaderModeAsync(eventSource: string): Promise<void>;
+        isScreenReaderModeEnabled(): boolean;
         toggleGreenScreen(): void;
         launchFullEditor(): void;
         resetWorkspace(): void;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -261,6 +261,9 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                 // Keyboard controls are always on; message kept for API compatibility.
                                 return Promise.resolve();
                             }
+                            case "togglescreenreadermode": {
+                                return projectView.toggleScreenReaderModeAsync("settings");
+                            }
                             case "print": {
                                 return Promise.resolve()
                                     .then(() => projectView.printCode());
@@ -275,7 +278,8 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                             versions: pxt.appTarget.versions,
                                             locale: ts.pxtc.Util.userLanguage(),
                                             availableLocales: pxt.appTarget.appTheme.availableLocales,
-                                            keyboardControls: true
+                                            keyboardControls: true,
+                                            screenReaderMode: projectView.isScreenReaderModeEnabled()
                                         } as pxt.editor.InfoMessage;
                                     });
                             }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -223,7 +223,7 @@ export class ProjectView
         this.openDeviceSerial = this.openDeviceSerial.bind(this);
         this.openSerial = this.openSerial.bind(this);
         this.toggleGreenScreen = this.toggleGreenScreen.bind(this);
-        this.toggleScreenReaderMode = this.toggleScreenReaderMode.bind(this);
+        this.toggleScreenReaderModeAsync = this.toggleScreenReaderModeAsync.bind(this);
         this.toggleSimulatorFullscreen = this.toggleSimulatorFullscreen.bind(this);
         this.toggleSimulatorCollapse = this.toggleSimulatorCollapse.bind(this);
         this.showKeymap = this.showKeymap.bind(this);
@@ -5324,12 +5324,16 @@ export class ProjectView
         this.setColorThemeById(on ? pxt.appTarget.appTheme.highContrastColorTheme : pxt.appTarget.appTheme.defaultColorTheme, true);
     }
 
-    async toggleScreenReaderMode(eventSource: string) {
+    async toggleScreenReaderModeAsync(eventSource: string) {
         const nextEnabled = !this.getData<boolean>(auth.SCREEN_READER_MODE);
         await core.setScreenReaderMode(nextEnabled, eventSource);
         if (this.blocksEditor) {
             this.blocksEditor.setScreenReaderMode(nextEnabled, eventSource === "shortcut" ? "shortcut" : "menu");
         }
+    }
+
+    isScreenReaderModeEnabled(): boolean {
+        return !!this.getData<boolean>(auth.SCREEN_READER_MODE);
     }
 
     toggleGreenScreen() {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -742,7 +742,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             Blockly.ShortcutRegistry.registry.register({
                 ...toggleScreenreader,
                 callback: (workspace, e) => {
-                    this.parent.toggleScreenReaderMode("shortcut");
+                    this.parent.toggleScreenReaderModeAsync("shortcut");
                     e.preventDefault();
                     return true;
                 }

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -254,7 +254,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
     toggleScreenReaderMode() {
         pxt.tickEvent("menu.togglescreenreadermode", undefined, { interactiveConsent: true });
-        this.props.parent.toggleScreenReaderMode("settings");
+        this.props.parent.toggleScreenReaderModeAsync("settings");
     }
 
     toggleGreenScreen() {


### PR DESCRIPTION
Adds a "togglescreenreadermode" editor message that behaves like the settings menu toggle (including the "settings" telemetry event source), and reports the current state via a new screenReaderMode field on the "info" response.

As part of this change I realised that toggleScreenReaderMode was async in implementation but not interface so I've aligned both to be async.

Needed for micro:bit classroom to expose the same setting.

I'm hopeful that this is our last change!