### PR TITLE
use npm v11 in workflow

### DIFF
--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -43,7 +43,10 @@ jobs:
         uses: actions/setup-node@main
         with:
           node-version: 20.x
-          
+
+      - name: Update npm
+        run: npm install -g npm@11
+
       - name: npm install
         run: |
           sudo apt-get install xvfb
@@ -75,6 +78,9 @@ jobs:
         uses: actions/setup-node@main
         with:
           node-version: 20.x
+
+      - name: Update npm
+        run: npm install -g npm@11
 
       - name: npm install
         run: |


### PR DESCRIPTION
npm v12 was published yesterday and the node version we use is incompatible. we should probably update node at some point, but for now we can just make sure we stick to using v11.x.x