### PR TITLE
check to make sure tutorial dependencies are defined

### DIFF
--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -622,6 +622,9 @@ ${code}
 
     export function mergeTutorialDependencies(projectDependencies: pxt.Map<string>, tutorialDependencies: pxt.Map<string>): pxt.Map<string> {
         const merged: pxt.Map<string> = { ...projectDependencies };
+
+        if (!tutorialDependencies) return merged;
+
         for (const dep of Object.keys(tutorialDependencies)) {
             const ver = tutorialDependencies[dep];
             if (ver.toLowerCase() === "remove") {


### PR DESCRIPTION
fixing the maker build with latest pxt: https://github.com/microsoft/pxt-maker/actions/runs/29273006669/job/86897154935?pr=395

if a snippet references no packages, the dependencies object will be undefined