### PR TITLE
restore the import file button to the extensions dialog

### DIFF
--- a/react-common/components/controls/Modal.tsx
+++ b/react-common/components/controls/Modal.tsx
@@ -23,13 +23,13 @@ export interface ModalAction {
 export interface ModalProps extends ContainerProps {
     title: string;
     leftIcon?: string;
-    helpUrl?: string
     ariaDescribedBy?: string;
     actions?: ModalAction[];
     onClose?: () => void;
     fullscreen?: boolean;
     parentElement?: Element;
     hideDismissButton?: boolean;
+    rightHeader?: React.ReactNode;
 }
 
 export const Modal = (props: ModalProps) => {
@@ -43,12 +43,12 @@ export const Modal = (props: ModalProps) => {
         role,
         title,
         leftIcon,
-        helpUrl,
         actions,
         onClose,
         parentElement,
         fullscreen,
         hideDismissButton,
+        rightHeader
     } = props;
 
     const closeClickHandler = (e?: React.MouseEvent<HTMLButtonElement>) => {
@@ -110,18 +110,9 @@ export const Modal = (props: ModalProps) => {
                     {leftIcon && <i className={leftIcon} aria-hidden={true}/>}
                     {title}
                 </div>
-                {fullscreen && helpUrl &&
-                    <div className="common-modal-help">
-                        <Link
-                            className="common-button menu-button"
-                            title={lf("Help on {0} dialog", title)}
-                            href={props.helpUrl}
-                            target="_blank"
-                        >
-                            <span className="common-button-flex">
-                                <i className="fas fa-question" aria-hidden={true}/>
-                            </span>
-                        </Link>
+                {fullscreen && rightHeader &&
+                    <div className="common-modal-right-menu">
+                        {rightHeader}
                     </div>
                 }
                 {!fullscreen && !hideDismissButton &&

--- a/react-common/styles/controls/Modal.less
+++ b/react-common/styles/controls/Modal.less
@@ -112,14 +112,16 @@
         align-items: center;
         font-size: 1.2rem;
         font-weight: 600;
-
-        .common-button.men .fas {
-
-        }
     }
 
     .common-modal-back:focus-within {
         border: 1px, solid var(--pxt-focus-border);
+    }
+
+    .common-modal-right-menu {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
     }
 
     .common-modal-help {
@@ -127,6 +129,11 @@
         align-items: center;
         font-size: 1.2rem;
         font-weight: 600;
+        height: 100%;
+
+        a:hover {
+            color: var(--pxt-primary-foreground);
+        }
     }
 
     .common-modal-title {

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -625,7 +625,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
                         className="menu-button"
                         title={lf("Import extension from file")}
                         label={lf("Import File")}
-                        labelClassName="mobile-hide"
+                        labelClassName="mobile-hidden"
                         onClick={importExtension}
                         leftIcon="fas fa-upload"
                     />

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -12,6 +12,7 @@ import { ExtensionCard } from "../../react-common/components/extensions/Extensio
 import { Modal } from "../../react-common/components/controls/Modal";
 import { classList } from "../../react-common/components/util";
 import { TabList, TabListProps } from "../../react-common/components/controls/TabList";
+import { Link } from "../../react-common/components/controls/Link";
 
 type ExtensionMeta = pxtc.service.ExtensionMeta & { installed?: boolean };
 const ExtensionType = pxtc.service.ExtensionType;
@@ -618,7 +619,30 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
             fullscreen={true}
             className={"extensions-browser"}
             onClose={props.hideExtensions}
-            helpUrl={"/extensions"}
+            rightHeader={
+                <>
+                    <Button
+                        className="menu-button"
+                        title={lf("Import extension from file")}
+                        label={lf("Import File")}
+                        labelClassName="mobile-hide"
+                        onClick={importExtension}
+                        leftIcon="fas fa-upload"
+                    />
+                    <div className="common-modal-help">
+                        <Link
+                            className="common-button menu-button"
+                            title={lf("Help on {0} dialog", lf("Extensions"))}
+                            href="/extensions"
+                            target="_blank"
+                        >
+                            <span className="common-button-flex">
+                                <i className="fas fa-question" aria-hidden={true}/>
+                            </span>
+                        </Link>
+                    </div>
+                </>
+            }
         >
             <div className="ui">
                 {showImportExtensionDialog &&


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/7027

restores the "import file" button in the extensions dialog. now it's in the top bar next to the help icon:

<img width="1309" height="636" alt="image" src="https://github.com/user-attachments/assets/ab55a123-cc6d-4122-bad8-ae6aacc2ec7e" />


on mobile the button collapses down to just an icon

@ganicke this will require updating the images in the markdown docs linked in the above issue