### PR TITLE
fixes for offline app doc serving issues

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3064,7 +3064,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
 
                     html = pxt.docs.renderMarkdown({
                         template: docsTemplate,
-                        markdown: patchedMd,
+                        markdown: pxt.docs.normalizeStaticMarkdown(patchedMd),
                         theme: pxt.appTarget.appTheme,
                         filepath: path.join("docs", pathUnderDocs),
                     });

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -56,6 +56,7 @@ pxt.docs.requireDOMSanitizer = () => {
             code: mergeClassAttribute("code"),
             pre: mergeClassAttribute("pre"),
             div: mergeClassAttribute("div", "data-youtube", "title"),
+            img: mergeClassAttribute("img"),
         },
     };
 

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -91,6 +91,39 @@ namespace pxt.docs {
         return s;
     }
 
+    export function normalizeStaticMarkdown(markdown: string): string {
+        const lines = markdown.split(/\r?\n/)
+        let codeFenceMarker = ""
+
+        for (let i = 0; i < lines.length; i++) {
+            const fenceMatch = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(lines[i])
+            if (fenceMatch) {
+                const marker = fenceMatch[1]
+                const trailingText = fenceMatch[2]
+                const closesCodeFence = !!codeFenceMarker
+                    && marker[0] === codeFenceMarker[0]
+                    && marker.length >= codeFenceMarker.length
+                    && !trailingText.trim()
+
+                if (closesCodeFence) {
+                    codeFenceMarker = ""
+                } else if (!codeFenceMarker) {
+                    codeFenceMarker = marker
+                }
+
+                continue
+            }
+
+            if (!codeFenceMarker && /^ {0,3}<br\s*\/?>\s*$/i.test(lines[i])) {
+                // Marked treats a standalone break as inline content, which can extend a
+                // preceding table or keep the following Markdown in the same paragraph.
+                lines[i] = "\n<p><br/></p>\n"
+            }
+        }
+
+        return lines.join("\n")
+    }
+
     // the input already should be HTML-quoted but we want to make sure, and also quote quotes
     export function html2Quote(s: string) {
         if (!s) return s;

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -316,7 +316,7 @@ function loadPackageAsync(id: string, code?: string, dependencies?: string[]) {
                     epkg.files[pxt.MAIN_TS] = code;
                     //set the custom doc name from the URL.
                     let cfg = JSON.parse(epkg.files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
-                    cfg.name = window.location.href.split('/').pop().split(/[?#]/)[0];;
+                    cfg.name = window.location.href.split('/').pop().split(/[?#]/)[0].replace(/\.html$/i, "");
                     if (cfg.files.indexOf(pxt.MAIN_BLOCKS) == -1) {
                         cfg.files.push(pxt.MAIN_BLOCKS);
                     }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -317,6 +317,9 @@ function loadPackageAsync(id: string, code?: string, dependencies?: string[]) {
                     //set the custom doc name from the URL.
                     let cfg = JSON.parse(epkg.files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
                     cfg.name = window.location.href.split('/').pop().split(/[?#]/)[0];;
+                    if (cfg.files.indexOf(pxt.MAIN_BLOCKS) == -1) {
+                        cfg.files.push(pxt.MAIN_BLOCKS);
+                    }
                     epkg.files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
 
                     //Propgate the change to main package


### PR DESCRIPTION
2 more things from marked
* it got upset a bit at `<br>` tags in some instances causing e.g. the extra rows in tables when ended in a br
* images were getting their classes stripped as part of sanitizer

fix https://github.com/microsoft/pxt-microbit/issues/7001
fix https://github.com/microsoft/pxt-microbit/issues/7004
fix https://github.com/microsoft/pxt-microbit/issues/7005
fix https://github.com/microsoft/pxt-microbit/issues/7006
fix https://github.com/microsoft/pxt-microbit/issues/7007