### PR TITLE
fix pxt checkdocs for snippets with core packages

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -6278,6 +6278,23 @@ function readBlocksprjConfig(): pxt.PackageConfig {
     return config;
 }
 
+function mergeCorePackage(corePackage: pxt.PackageConfig, dependencies = {} as pxt.Map<string>): pxt.Map<string> {
+    for (const dep of Object.keys(dependencies)) {
+        const verSpec = dependencies[dep];
+
+        if (pxt.appTarget.bundledpkgs[dep] && (verSpec === "*" || verSpec.startsWith("file:"))) {
+            const bundled = pxt.appTarget.bundledpkgs[dep];
+            const config = pxt.U.jsonTryParse(bundled[pxt.CONFIG_NAME]);
+
+            if (config?.core) {
+                return dependencies;
+            }
+        }
+    }
+
+    return pxt.tutorial.mergeTutorialDependencies(corePackage.dependencies, dependencies);
+}
+
 function checkFileSize(files: string[]): number {
     if (!pxt.appTarget.cloud)
         return 0;
@@ -6536,7 +6553,7 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
                                     continue;
                                 }
                                 const tutorial = pxt.tutorial.parseTutorial(tutorialMd);
-                                const pkgs = pxt.tutorial.mergeTutorialDependencies(blocksprjConfig.dependencies, pxt.gallery.parsePackagesFromMarkdown(tutorialMd) || {});
+                                const pkgs = mergeCorePackage(blocksprjConfig, pxt.gallery.parsePackagesFromMarkdown(tutorialMd) || {});
 
                                 let extraFiles: Map<string> = null;
 
@@ -6595,7 +6612,7 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
                                     continue;
                                 }
                                 const prj = pxt.gallery.parseExampleMarkdown(card.name, exMd);
-                                const pkgs = pxt.tutorial.mergeTutorialDependencies(blocksprjConfig.dependencies, prj.dependencies);
+                                const pkgs = mergeCorePackage(blocksprjConfig, prj.dependencies);
 
                                 let extraFiles: Map<string> = undefined;
 
@@ -6691,7 +6708,7 @@ function internalCacheUsedBlocksAsync(): Promise<Map<pxt.BuiltTutorialInfo>> {
         }
         const tutorial = pxt.tutorial.parseTutorial(md) as TutorialInfo;
         const tutorialDeps = pxt.gallery.parsePackagesFromMarkdown(md) || {};
-        const pkgs: pxt.Map<string> = pxt.tutorial.mergeTutorialDependencies(blocksprjConfig.dependencies, tutorialDeps);
+        const pkgs: pxt.Map<string> = mergeCorePackage(blocksprjConfig, tutorialDeps);
 
         tutorial.pkgs = pkgs;
         tutorial.path = path;
@@ -6849,7 +6866,7 @@ export function getCodeSnippets(fileName: string, md: string, baseConfig: pxt.Pa
             return acc;
         }, {} as pxt.Map<string>);
 
-    const pkgs = pxt.tutorial.mergeTutorialDependencies(baseConfig.dependencies, tutorialDeps);
+    const pkgs = mergeCorePackage(baseConfig, tutorialDeps);
 
     const pkgName = fileName.replace(/\\/g, '-').replace(/.md$/i, '');
     return codeSnippets.map((snip, i) => {


### PR DESCRIPTION
back in https://github.com/microsoft/pxt/pull/11397 i removed a hack from our cli where we would add blocksprj as a dependency to all of our snippets when compiling them in pxt checkdocs.

this ended up breaking checkdocs in pxt-maker, because in maker we have a lot of snippets that rely on different "core" packages (one for each of the individual boards). the blocksprj in pxt-maker has a dependency on a core package, and each project can only have a dependency on a single core package or you get compile errors. merging the two configs caused their to be two core packages: the one from blocksprj and the one referenced by the markdown file that the snippet lived in.

it took me *forever* to figure out how my earlier change broke things; before we were always adding blocksprj as a dependency so theoretically that should be the same as merging the two configs. turns out, we have some delightfully hacky code in [pxtlib/package.ts](https://github.com/microsoft/pxt/blob/c446bd0aac2e2a19f06817c7117ac473b383c25f/pxtlib/package.ts#L610) that i'm guessing was added to workaround this exact problem. to fix it here, i've basically replicated the logic: the configs are only merged if the markdown file's dependencies do not include a core package.