### PR TITLE
Fix unreliable Duplicate button in My Assets

### DIFF
--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -755,7 +755,7 @@ namespace pxt {
             }
         }
 
-        public pushUndo() {
+        public pushUndo(protectedAssetId?: string) {
             if (this.undoStack.length && this.committedState.revision === this.state.revision) return;
             this.redoStack = [];
             this.undoStack.push({
@@ -770,7 +770,7 @@ namespace pxt {
             }
 
             this.committedState = this.cloneState();
-            this.cleanupTemporaryAssets();
+            this.cleanupTemporaryAssets(protectedAssetId);
         }
 
         public revision() {
@@ -1477,9 +1477,10 @@ namespace pxt {
             return assets;
         }
 
-        protected cleanupTemporaryAssets() {
+        protected cleanupTemporaryAssets(protectedAssetId?: string) {
             const images = this.getAssetCollection(AssetType.Image);
-            const orphaned = images.getSnapshot(image => !image.meta.displayName && !(image.meta.blockIDs?.length));
+            const orphaned = images.getSnapshot(image =>
+                image.id !== protectedAssetId && !image.meta.displayName && !(image.meta.blockIDs?.length));
             for (const image of orphaned) {
                 images.removeByID(image.id);
             }
@@ -1842,9 +1843,9 @@ namespace pxt {
     }
 
     export function cloneAsset<U extends Asset>(asset: U, includeEditorData = false): U {
-        asset.meta = Object.assign({}, asset.meta);
-        if (asset.meta.temporaryInfo) {
-            asset.meta.temporaryInfo = Object.assign({}, asset.meta.temporaryInfo);
+        const meta = Object.assign({}, asset.meta);
+        if (meta.temporaryInfo) {
+            meta.temporaryInfo = Object.assign({}, meta.temporaryInfo);
         }
 
         switch (asset.type) {
@@ -1852,26 +1853,31 @@ namespace pxt {
             case AssetType.Image:
                 return {
                     ...asset,
+                    meta,
                     bitmap: cloneBitmap((asset as ProjectImage | Tile).bitmap)
                 };
             case AssetType.Animation:
                 return {
                     ...asset,
+                    meta,
                     frames: (asset as Animation).frames.map(frame => cloneBitmap(frame))
                 };
             case AssetType.Tilemap:
                 return {
                     ...asset,
+                    meta,
                     data: (asset as ProjectTilemap).data.cloneData(includeEditorData)
                 };
             case AssetType.Song:
                 return {
                     ...asset,
+                    meta,
                     song: pxt.assets.music.cloneSong(asset.song)
                 }
             case AssetType.Json:
                 return {
                     ...asset,
+                    meta,
                     data: U.clone((asset as JsonAsset).data),
                 }
         }

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as core from "../../core";
 import * as pkg from "../../package";
 import { connect } from 'react-redux';
 
@@ -7,7 +8,7 @@ import { Button } from "../../../../react-common/components/controls/Button";
 import { Modal, ModalAction } from "../../../../react-common/components/controls/Modal";
 
 import { AssetEditorState, GalleryView } from './store/assetEditorReducerState';
-import { dispatchUpdateUserAssets } from './actions/dispatch';
+import { dispatchChangeSelectedAsset, dispatchUpdateUserAssets } from './actions/dispatch';
 
 import { AssetCardList } from "./assetCardList";
 import { AssetTopbar } from "./assetTopbar";
@@ -18,6 +19,7 @@ interface AssetGalleryProps {
     userAssets: pxt.Asset[];
     disableCreateButton?: boolean;
     showAssetFieldView?: (asset: pxt.Asset, cb: (result: any) => void) => void;
+    dispatchChangeSelectedAsset?: (assetType?: pxt.AssetType, assetId?: string) => void;
     dispatchUpdateUserAssets?: () => void;
 }
 
@@ -94,22 +96,32 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
             this.props.showAssetFieldView(asset, (result: any) => {
                 project.pushUndo();
                 const name = result.meta?.displayName;
+                let newAsset: pxt.Asset;
                 switch (type) {
                     case pxt.AssetType.Image:
-                        project.createNewProjectImage(result.bitmap, name); break;
+                        newAsset = project.createNewProjectImage(result.bitmap, name); break;
                     case pxt.AssetType.Tile:
-                        project.createNewTile(result.bitmap, null, name); break;
+                        newAsset = project.createNewTile(result.bitmap, null, name); break;
                     case pxt.AssetType.Tilemap:
-                        project.createNewTilemapFromData(result.data, name); break;
+                        const [id] = project.createNewTilemapFromData(result.data, name);
+                        newAsset = project.getTilemap(id);
+                        break;
                     case pxt.AssetType.Animation:
-                        project.createNewAnimationFromData(result.frames, result.interval, name); break;
+                        newAsset = project.createNewAnimationFromData(result.frames, result.interval, name); break;
                     case pxt.AssetType.Song:
-                        project.createNewSong(result.song, name); break;
+                        newAsset = project.createNewSong(result.song, name); break;
                     case pxt.AssetType.Json:
-                        project.createNewJsonAsset(result.data, result.fileName, name); break;
+                        newAsset = project.createNewJsonAsset(result.data, result.fileName, name); break;
                 }
                 pkg.mainEditorPkg().buildAssetsAsync()
-                    .then(() => this.props.dispatchUpdateUserAssets());
+                    .then(() => {
+                        this.props.dispatchUpdateUserAssets();
+                        if (newAsset) this.props.dispatchChangeSelectedAsset(newAsset.type, newAsset.id);
+                    })
+                    .catch(e => {
+                        pxt.reportException(e);
+                        core.errorNotification(lf("Something went wrong while trying to create this asset."));
+                    });
             });
         }
     }
@@ -195,6 +207,7 @@ function mapStateToProps(state: AssetEditorState, ownProps: any) {
 }
 
 const mapDispatchToProps = {
+    dispatchChangeSelectedAsset,
     dispatchUpdateUserAssets
 };
 

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -96,7 +96,7 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
             this.props.showAssetFieldView(asset, (result: any) => {
                 project.pushUndo();
                 const name = result.meta?.displayName;
-                let newAsset: pxt.Asset;
+                let newAsset: pxt.Asset | undefined;
                 switch (type) {
                     case pxt.AssetType.Image:
                         newAsset = project.createNewProjectImage(result.bitmap, name); break;

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as core from "../../core";
 import * as pkg from "../../package";
 import * as simulator from "../../simulator";
 import { connect } from 'react-redux';
@@ -94,11 +95,16 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         this.props.showAssetFieldView(this.props.asset, this.editAssetDoneHandler);
     }
 
+    protected handleAssetOpError = (action: string) => (e: any) => {
+        pxt.reportException(e);
+        core.errorNotification(lf("Something went wrong while trying to {0} this asset.", action));
+    }
+
     protected editAssetDoneHandler = (result: pxt.Asset) => {
         pxt.tickEvent("assets.edit", { type: result.type.toString() });
 
         const project = pxt.react.getTilemapProject();
-        project.pushUndo();
+        project.pushUndo(this.props.asset?.id);
         result = pxt.patchTemporaryAsset(this.props.asset, result, project);
 
         if (result.meta.displayName && (result.type !== pxt.AssetType.Json || result.data)) {
@@ -111,7 +117,10 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         }
 
         this.props.dispatchChangeGalleryView(GalleryView.User);
-        this.updateAssets().then(() => simulator.setDirty());
+        this.updateAssets().then(() => {
+            simulator.setDirty();
+            this.props.dispatchChangeSelectedAsset(result.type, result.id);
+        }).catch(this.handleAssetOpError(lf("edit")));
     }
 
     protected duplicateAssetHandler = () => {
@@ -124,11 +133,12 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
             || pxt.getDefaultAssetDisplayName(asset.type);
 
         const project = pxt.react.getTilemapProject();
-        project.pushUndo();
+        project.pushUndo(asset.id);
         const { type, id } = project.duplicateAsset(asset, displayName);
         this.updateAssets().then(() => {
+            this.props.dispatchChangeSelectedAsset(type, id);
             if (isGalleryAsset) this.props.dispatchChangeGalleryView(GalleryView.User, type, id);
-        });
+        }).catch(this.handleAssetOpError(lf("duplicate")));
     }
 
     protected copyAssetHandler = () => {
@@ -176,10 +186,10 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
 
         this.setState({ showDeleteModal: false });
         const project = pxt.react.getTilemapProject();
-        project.pushUndo();
+        project.pushUndo(this.props.asset?.id);
         project.removeAsset(this.props.asset);
         this.props.dispatchChangeSelectedAsset();
-        this.updateAssets();
+        this.updateAssets().catch(this.handleAssetOpError(lf("delete")));
     }
 
     render() {

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -95,9 +95,9 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         this.props.showAssetFieldView(this.props.asset, this.editAssetDoneHandler);
     }
 
-    protected handleAssetOpError = (action: string) => (e: any) => {
+    protected handleAssetOpError = (message: string) => (e: any) => {
         pxt.reportException(e);
-        core.errorNotification(lf("Something went wrong while trying to {0} this asset.", action));
+        core.errorNotification(message);
     }
 
     protected editAssetDoneHandler = (result: pxt.Asset) => {
@@ -120,7 +120,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         this.updateAssets().then(() => {
             simulator.setDirty();
             this.props.dispatchChangeSelectedAsset(result.type, result.id);
-        }).catch(this.handleAssetOpError(lf("edit")));
+        }).catch(this.handleAssetOpError(lf("Something went wrong while trying to edit this asset.")));
     }
 
     protected duplicateAssetHandler = () => {
@@ -138,7 +138,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         this.updateAssets().then(() => {
             this.props.dispatchChangeSelectedAsset(type, id);
             if (isGalleryAsset) this.props.dispatchChangeGalleryView(GalleryView.User, type, id);
-        }).catch(this.handleAssetOpError(lf("duplicate")));
+        }).catch(this.handleAssetOpError(lf("Something went wrong while trying to duplicate this asset.")));
     }
 
     protected copyAssetHandler = () => {
@@ -189,7 +189,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         project.pushUndo(this.props.asset?.id);
         project.removeAsset(this.props.asset);
         this.props.dispatchChangeSelectedAsset();
-        this.updateAssets().catch(this.handleAssetOpError(lf("delete")));
+        this.updateAssets().catch(this.handleAssetOpError(lf("Something went wrong while trying to delete this asset.")));
     }
 
     render() {

--- a/webapp/src/components/assetEditor/store/assetEditorReducer.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducer.ts
@@ -35,7 +35,9 @@ const topReducer = (state: AssetEditorState = initialState, action: any): AssetE
 
             return {
                 ...state,
-                selectedAsset: state.selectedAsset ? assets.find(el => el.id == state.selectedAsset.id) : undefined,
+                selectedAsset: state.selectedAsset
+                    ? (assets.find(el => el.type == state.selectedAsset.type && el.id == state.selectedAsset.id) ?? state.selectedAsset)
+                    : undefined,
                 assets
             }
         case actions.UPDATE_GALLERY_ASSETS:

--- a/webapp/src/components/assetEditor/store/assetEditorReducerState.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducerState.ts
@@ -11,5 +11,5 @@ export interface AssetEditorState {
 }
 
 export function isGalleryAsset(asset?: pxt.Asset) {
-    return asset?.id.startsWith("sprites.") || (asset?.meta?.package && asset.meta.package !== "this");
+    return !!(asset?.id.startsWith("sprites.") || (asset?.meta?.package && asset.meta.package !== "this"));
 }

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -505,8 +505,13 @@ export class EditorPackage {
         if (!this.tilemapProject?.needsRebuild) return;
         this.tilemapProject.needsRebuild = false;
 
-        await this.buildTilemapsAsync();
-        await this.buildImagesAsync();
+        try {
+            await this.buildTilemapsAsync();
+            await this.buildImagesAsync();
+        } catch (e) {
+            this.tilemapProject.needsRebuild = true;
+            throw e;
+        }
     }
 
     buildTilemapsAsync() {


### PR DESCRIPTION
Fixes microsoft/pxt-arcade#7589

## Problem

The Duplicate button in the My Assets panel would silently do nothing for:
- Unnamed assets
- An asset that was just renamed (unnamed -> named) in the same session
- A brand-new asset with an auto-generated default name (e.g. a new tile named `myTile24`)
- A sprite embedded directly in a block

In all cases, reloading the project made duplication work again.

## Root causes

1. `isGalleryAsset()` could return `undefined` instead of `false` for any asset whose id doesn't start with `"sprites."` and has no `meta.package`  (tiles, temporary block-embedded assets, and others). `duplicateAssetHandler`/`copyAssetHandler` then called `.toString()` on that `undefined`, throwing synchronously before the duplicate/copy logic ever ran. This was the primary cause: a silent, uncaught exception in the click handler.
2. Stale/type-unsafe reselection after any asset-list refresh re-selected the current asset by `id` only, with no `type` check, and no fallback when a promoted (newly-named) asset's id changed.
3. `buildAssetsAsync()` cleared its rebuild flag before attempting work and had no `try/catch`, so any failure silently wedged asset syncing for the rest of the session with no user-visible error.
4. `pushUndo()` could delete the asset being duplicated via its unconditional `cleanupTemporaryAssets()` call, and `cloneAsset()` mutated its input object in place instead of producing an independent copy.

## Fix

- `isGalleryAsset()` now always returns a real boolean.
- Duplicate/edit/create now explicitly reselect the resulting asset instead of relying on implicit state carry-through.
- `buildAssetsAsync()` self-heals its rebuild flag on failure, and failures now surface as a visible error notification instead of failing silently.
- The in-flight selected asset is protected from `cleanupTemporaryAssets()`.
- `cloneAsset()` no longer mutates its input.

## API notes

Two `pxt.TilemapProject` methods gained a new optional trailing parameter, which is non-breaking for all existing callers (all current call sites across `pxtlib`/`webapp`/`pxtblocks`/`pxteditor` already pass zero args):
- `pushUndo()` -> `pushUndo(protectedAssetId?: string)`
- `cleanupTemporaryAssets()` (protected) -> `cleanupTemporaryAssets(protectedAssetId?: string)`

`cloneAsset()`'s signature is unchanged, but its behavior changed: it previously mutated the `meta` object on its input `asset` as a side effect before returning the clone; it no longer does. Any code relying on that mutation (none found in this repo) would need to be updated, but this was an unintentional side effect of what's documented/named as a pure clone function.

Fix was manually verified from a
```bash
cd ../pxt-arcade
pxt link ../pxt
pxt serve
```
