### PR TITLE
Make custom field init() idempotent to fix stuck touch drags

### DIFF
--- a/pxtblocks/fields/field_base.ts
+++ b/pxtblocks/fields/field_base.ts
@@ -44,6 +44,7 @@ export abstract class FieldBase<U> extends Blockly.Field implements FieldCustom 
     }
 
     init() {
+        if (this.fieldGroup_) return;
         super.init();
         this.onInit();
 

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -73,6 +73,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
     }
 
     init() {
+        if (this.fieldGroup_) return;
         super.init();
         this.onInit();
     }


### PR DESCRIPTION
pxt's renderer re-runs field.init() on every render (the input.init() in RenderInfo.measure, added in #9865 to replace the fork-era re-runnable BlockSvg.initSvg). Blockly.Field.init() is idempotent, but FieldBase and FieldCustomMelody ran onInit() unconditionally, rebuilding the field's DOM on every render.

On touch, the pointerdown target implicitly captures the pointer, so destroying that element mid-drag breaks event delivery. Dragging a melody_editor shadow by its preview triggers exactly this: duplicate- on-drag forces a render at drag start, updateFieldLabel() removes the captured element, and in an iframe embed Chrome then routes the rest of the touch's events (including pointerup) to the top-level document. The gesture never ends, Blockly's touchIdentifier_ stays pinned to the dead pointer, and every subsequent touch moves the block with no way to drop it.

Top-level documents seem to recover from this so we can only reproduce issues in an iframe (e.g. with controller.html).

Guard init() so onInit() runs once per field, matching the Blockly.Field.init behavior.

Fixes https://github.com/microsoft/pxt-microbit/issues/7045