### PR TITLE
fix rendering of diffs for files that exceed our max diff size

### DIFF
--- a/pxtlib/diff.ts
+++ b/pxtlib/diff.ts
@@ -182,6 +182,10 @@ namespace pxt.diff {
     export function computeFormattedDiff(fileA: string, fileB: string, options: DiffOptions = {}): string[] {
         const diff = compute(fileA, fileB, options);
 
+        if (!diff) {
+            return null;
+        }
+
         if (options.context == Infinity || options.full) {
             return diff.map(formatEdit);
         }


### PR DESCRIPTION
reported on the forum here:

https://forum.makecode.com/t/help-github-project-opens-to-a-white-screen-but-the-extension-imports-correctly/45031/3

if a diff in a github repo is bigger than our maximum allowed diff size, `computeFormattedDiff()` will throw an exception since `compute()` returns null

the places where `computeFormattedDiff()` is called all had handling for if it returns null/undefined, so clearly i must have broken this at some point in all the version history refactors. this PR fixes it by making sure we propagate any null return values up