### PR TITLE
Jacdac radio conflict (proxy mode)

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -362,13 +362,13 @@ namespace pxsim {
             if (frameID) frames = frames.filter(f => f.id === frameID);
 
             let isDeferrableBroadcastMessage = false;
-
             const broadcastmsg = msg as pxsim.SimulatorBroadcastMessage;
             if (source && broadcastmsg?.broadcast) {
-                // include index of the source iframe
-                broadcastmsg.srcFrameIndex = this.simFrames().findIndex((item) => item.contentWindow === source)
+                const mkcdFrames = frames.filter(frame => !frame.dataset[FRAME_DATA_MESSAGE_CHANNEL]);
                 const messageChannel = msg.type === "messagepacket" && (msg as SimulatorControlMessage).channel;
-                if (broadcastmsg.srcFrameIndex > 0 && messageChannel === "jacdac")
+                // include index of the source iframe
+                broadcastmsg.srcFrameIndex = this.simFrames().findIndex((item) => item.contentWindow === source);   
+                if (mkcdFrames.indexOf(frames[broadcastmsg.srcFrameIndex]) >= 0 && broadcastmsg.srcFrameIndex > 0 && messageChannel === "jacdac")
                     return; // only first frame should handle jacdac messages
                 // if the editor is hosted in a multi-editor setting
                 // don't start extra frames
@@ -392,7 +392,6 @@ namespace pxsim {
                         })
                         // start second simulator
                     } else if (!single) {
-                        const messageChannel = msg.type === "messagepacket" && (msg as SimulatorControlMessage).channel;
                         const messageSimulator = messageChannel &&
                             this.options.messageSimulators &&
                             this.options.messageSimulators[messageChannel];
@@ -451,7 +450,6 @@ namespace pxsim {
                         } else {
                             isDeferrableBroadcastMessage = true;
                             // start secondary frame if needed
-                            const mkcdFrames = frames.filter(frame => !frame.dataset[FRAME_DATA_MESSAGE_CHANNEL]);
                             if (!messageChannel &&
                                     (mkcdFrames.length == 0 || mkcdFrames.length == 1 && !this.singleSimulator)) {
                                 // messageChannel is set to false whenever msg.type !== "messagepacket"

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -368,8 +368,9 @@ namespace pxsim {
                 const messageChannel = msg.type === "messagepacket" && (msg as SimulatorControlMessage).channel;
                 // include index of the source iframe
                 broadcastmsg.srcFrameIndex = this.simFrames().findIndex((item) => item.contentWindow === source);
-                // only first frame should handle jacdac messages
-                if (mkcdFrames.indexOf(frames[broadcastmsg.srcFrameIndex]) >= 0 && broadcastmsg.srcFrameIndex > 0 && messageChannel === "jacdac")
+                const sourceFrame = broadcastmsg.srcFrameIndex >= 0 ? this.simFrames()[broadcastmsg.srcFrameIndex] : undefined;
+                // jacdac messages from a board sim other than first should be dropped
+                if (broadcastmsg.srcFrameIndex > 0 && mkcdFrames.find(f => f === sourceFrame) && messageChannel === "jacdac")
                     return;
                 // if the editor is hosted in a multi-editor setting
                 // don't start extra frames
@@ -474,7 +475,7 @@ namespace pxsim {
                 const frame = frames[i] as HTMLIFrameElement
                 // same frame as source
                 if (source && frame.contentWindow == source) continue;
-                // if jacdac message, don't send to other frames, only the first frame should handle it
+                // if jacdac message, don't send to other (board) simulator frames
                 if (i > 0 && !frame.dataset[FRAME_DATA_MESSAGE_CHANNEL] &&
                     msg.type === "messagepacket" && (msg as pxsim.SimulatorControlMessage).channel === "jacdac") continue;
                 // frame not in DOM

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -350,9 +350,6 @@ namespace pxsim {
             this.singleSimulator = true
         }
 
-        // BEGIN TEMPORARY: jacdac simulator
-        newJacdacSimulator: boolean = false;
-        // END TEMPORARY: jacdac simulator
         public postMessage(msg: pxsim.SimulatorMessage, source?: Window, frameID?: string) {
             if (this.hwdbg) {
                 this.hwdbg.postMessage(msg)
@@ -418,10 +415,6 @@ namespace pxsim {
                         if (simulatorExtension) {
                             // find a frame already running that simulator
                             let messageFrame = frames.find(frame => frame.dataset[FRAME_DATA_MESSAGE_CHANNEL] === messageChannel);
-                            // BEGIN TEMPORARY: jacdac simulator
-                            if (messageChannel === "jacdac/pxt-jacdac")
-                                this.newJacdacSimulator = true;
-                            // END TEMPORARY: jacdac simulator
                             // not found, spin a new one
                             if (!messageFrame) {
                                 const url = new URL(simulatorExtension.url);
@@ -442,13 +435,11 @@ namespace pxsim {
                             let messageFrame = frames.find(frame => frame.dataset[FRAME_DATA_MESSAGE_CHANNEL] === messageChannel);
                             // not found, spin a new one
                             if (!messageFrame) {
-                                if (messageChannel !== "jacdac" || !this.newJacdacSimulator) { // TEMPORARY: jacdac simulator
-                                    const useLocalHost = U.isLocalHost() && /localhostmessagesims=1/i.test(window.location.href)
-                                    const url = ((useLocalHost && messageSimulator.localHostUrl) || messageSimulator.url)
-                                        .replace("$PARENT_ORIGIN$", encodeURIComponent(this.options.parentOrigin || ""))
-                                        .replace("$LANGUAGE$", encodeURIComponent(this.options.userLanguage))
-                                    startSimulatorExtension(url, messageSimulator.permanent, messageSimulator.aspectRatio);
-                                }
+                                const useLocalHost = U.isLocalHost() && /localhostmessagesims=1/i.test(window.location.href)
+                                const url = ((useLocalHost && messageSimulator.localHostUrl) || messageSimulator.url)
+                                    .replace("$PARENT_ORIGIN$", encodeURIComponent(this.options.parentOrigin || ""))
+                                    .replace("$LANGUAGE$", encodeURIComponent(this.options.userLanguage))
+                                startSimulatorExtension(url, messageSimulator.permanent, messageSimulator.aspectRatio);
                             }
                             // not running the curren run, restart
                             else if (messageFrame.dataset['runid'] != this.runId) {
@@ -481,6 +472,8 @@ namespace pxsim {
                 const frame = frames[i] as HTMLIFrameElement
                 // same frame as source
                 if (source && frame.contentWindow == source) continue;
+                // if jacdac message, don't send to other frames, only the first frame should handle it
+                if (i > 0 && msg.type === "messagepacket" && (msg as pxsim.SimulatorControlMessage).channel === "jacdac") continue;
                 // frame not in DOM
                 if (!frame.contentWindow) continue;
 

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -367,6 +367,9 @@ namespace pxsim {
             if (source && broadcastmsg?.broadcast) {
                 // include index of the source iframe
                 broadcastmsg.srcFrameIndex = this.simFrames().findIndex((item) => item.contentWindow === source)
+                const messageChannel = msg.type === "messagepacket" && (msg as SimulatorControlMessage).channel;
+                if (broadcastmsg.srcFrameIndex > 0 && messageChannel === "jacdac")
+                    return; // only first frame should handle jacdac messages
                 // if the editor is hosted in a multi-editor setting
                 // don't start extra frames
                 const single = !!this._currentRuntime?.single;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -367,9 +367,10 @@ namespace pxsim {
                 const mkcdFrames = frames.filter(frame => !frame.dataset[FRAME_DATA_MESSAGE_CHANNEL]);
                 const messageChannel = msg.type === "messagepacket" && (msg as SimulatorControlMessage).channel;
                 // include index of the source iframe
-                broadcastmsg.srcFrameIndex = this.simFrames().findIndex((item) => item.contentWindow === source);   
+                broadcastmsg.srcFrameIndex = this.simFrames().findIndex((item) => item.contentWindow === source);
+                // only first frame should handle jacdac messages
                 if (mkcdFrames.indexOf(frames[broadcastmsg.srcFrameIndex]) >= 0 && broadcastmsg.srcFrameIndex > 0 && messageChannel === "jacdac")
-                    return; // only first frame should handle jacdac messages
+                    return;
                 // if the editor is hosted in a multi-editor setting
                 // don't start extra frames
                 const single = !!this._currentRuntime?.single;
@@ -474,7 +475,8 @@ namespace pxsim {
                 // same frame as source
                 if (source && frame.contentWindow == source) continue;
                 // if jacdac message, don't send to other frames, only the first frame should handle it
-                if (i > 0 && msg.type === "messagepacket" && (msg as pxsim.SimulatorControlMessage).channel === "jacdac") continue;
+                if (i > 0 && !frame.dataset[FRAME_DATA_MESSAGE_CHANNEL] &&
+                    msg.type === "messagepacket" && (msg as pxsim.SimulatorControlMessage).channel === "jacdac") continue;
                 // frame not in DOM
                 if (!frame.contentWindow) continue;
 


### PR DESCRIPTION
this PR fixes the issue https://github.com/jacdac/jacdac/issues/68. The fix is to allow only the first microbit sim to send and receive Jacdac messages. This prevents the proxy mode from engaging when a radio message is sent creating a second microbit sim, which will neither receive/send jacdac messages.