### PR TITLE
fix toolbox shadow block generation for builtin blocks

### DIFF
--- a/pxtblocks/toolbox.ts
+++ b/pxtblocks/toolbox.ts
@@ -220,6 +220,9 @@ export function createShadowValue(info: pxtc.BlocksInfo, p: pxt.blocks.BlockPara
                         shadow.appendChild(shadowXml.firstChild.cloneNode(true));
                         shadowXml.firstChild.remove();
                     }
+                    if (shadowSymbol.attributes.builtinBlockId) {
+                        shadow.setAttribute("type", shadowSymbol.attributes.builtinBlockId);
+                    }
                 }
             }
         }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -2499,8 +2499,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     const shadowType = info?.attributes?.builtinBlockId || type;
                     let b = this.getBlockXml(builtin ? builtin : { name: type, type: type, attributes: { blockId: type } }, ignoregap, true);
                     // Note: we're setting one innerHTML to another
-                    // eslint-disable-next-line @microsoft/sdl/no-inner-html
                     if (b && b.length > 0 && b[0] && b[0].getAttribute("type") === shadowType) {
+                        // eslint-disable-next-line @microsoft/sdl/no-inner-html
                         shadow.innerHTML = b[0].innerHTML;
                         shadow.setAttribute("type", shadowType);
                     }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -711,7 +711,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             preconditionFn: (workspace, scope) => {
                 const focused = scope.focusedNode;
                 // duplicate-on-drag blocks (including allowlisted shadows) have special
-                // casing below so allow them through. 
+                // casing below so allow them through.
                 if (focused instanceof Blockly.BlockSvg && shouldDuplicateOnDrag(focused)) {
                     return !workspace.isReadOnly() && !workspace.isDragging();
                 }
@@ -2494,10 +2494,16 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     let type = shadow.getAttribute('type');
                     if (type === block.type) return;
                     const builtin = snippets.allBuiltinBlocks()[type];
+                    const info = this.blockInfo.blocksById[type];
+
+                    const shadowType = info?.attributes?.builtinBlockId || type;
                     let b = this.getBlockXml(builtin ? builtin : { name: type, type: type, attributes: { blockId: type } }, ignoregap, true);
                     // Note: we're setting one innerHTML to another
                     // eslint-disable-next-line @microsoft/sdl/no-inner-html
-                    if (b && b.length > 0 && b[0] && b[0].getAttribute("type") === type) shadow.innerHTML = b[0].innerHTML;
+                    if (b && b.length > 0 && b[0] && b[0].getAttribute("type") === shadowType) {
+                        shadow.innerHTML = b[0].innerHTML;
+                        shadow.setAttribute("type", shadowType);
+                    }
                 })
         }
         return [blockXml];


### PR DESCRIPTION
fixing the toolbox xml generation when a shadow block is one of the builtin blocks (currently just the new color picker)