### PR TITLE
fixing a few piano roll bugs

### DIFF
--- a/pxtblocks/fields/field_musiceditor.ts
+++ b/pxtblocks/fields/field_musiceditor.ts
@@ -56,7 +56,9 @@ export class FieldMusicEditor extends FieldAssetEditor<FieldMusicEditorOptions, 
         }
         else {
             // Restore all of the unused tracks
-            pxt.assets.music.inflateSong(song);
+            if (this.shouldInflateAsset()) {
+                pxt.assets.music.inflateSong(song);
+            }
         }
 
         const newAsset: pxt.Song = {
@@ -131,5 +133,9 @@ export class FieldMusicEditor extends FieldAssetEditor<FieldMusicEditorOptions, 
     protected previewWidth() {
         const measures = this.asset ? (this.asset as pxt.Song).song.measures : 2;
         return measures * PREVIEW_HEIGHT;
+    }
+
+    protected shouldInflateAsset(): boolean {
+        return true;
     }
 }

--- a/pxtblocks/fields/field_piano_roll.ts
+++ b/pxtblocks/fields/field_piano_roll.ts
@@ -199,6 +199,10 @@ export class FieldPianoRoll extends FieldMusicEditor {
         }
         return null;
     }
+
+    protected override shouldInflateAsset(): boolean {
+        return false;
+    }
 }
 
 function melodyInstrument(): pxt.assets.music.Instrument {

--- a/webapp/src/components/pianoRoll/PianoOctave.tsx
+++ b/webapp/src/components/pianoRoll/PianoOctave.tsx
@@ -14,6 +14,7 @@ export const PianoOctave = (props: Props) => {
     const { octave, selectedTrack, instrument } = props;
 
     const containerRef = useRef<HTMLDivElement>(null);
+    const isDrum = isDrumInstrument(instrument);
 
     useEffect(() => {
         const container = containerRef.current;
@@ -21,6 +22,12 @@ export const PianoOctave = (props: Props) => {
 
         const handleNoteChange = (track: number, note: number, on: boolean) => {
             if (track !== selectedTrack) return;
+
+            if (!isDrum) {
+                // the pxt format for melodic instruments is 1-based, but the piano roll is 0 based
+                note--;
+            }
+
             if (note < octave * 12 || note >= (octave + 1) * 12) return;
 
             const key = container.querySelector(`#key-${note}`) as HTMLDivElement | null;
@@ -42,7 +49,7 @@ export const PianoOctave = (props: Props) => {
         return () => {
             removeNoteChangeListener(handleNoteChange);
         };
-    }, [octave, selectedTrack]);
+    }, [octave, selectedTrack, isDrum]);
 
     const playNote = useCallback(async (note: number) => {
         const ref = containerRef.current?.querySelector(`#key-${note}`) as HTMLDivElement | null;
@@ -65,7 +72,6 @@ export const PianoOctave = (props: Props) => {
         }
     }, [instrument]);
 
-    const isDrum = isDrumInstrument(instrument);
 
     return (
         <div className="octave-sidebar" ref={containerRef}>

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -193,21 +193,23 @@ export const Workspace = (props: Props) => {
             lastTime = Date.now();
             if (!isPlaying) {
                 isPlaying = true;
-                playheadRef.current.style.left = `${playbackHeadPosition}px`;
-                playheadRef.current.style.display = "unset";
+                if (playheadRef.current) {
+                    playheadRef.current.style.left = `${playbackHeadPosition}px`;
+                    playheadRef.current.style.display = "unset";
+                }
                 animationFrameRef = requestAnimationFrame(onAnimationFrame);
             }
         }
 
         const onStop = () => {
             isPlaying = false;
-            playheadRef.current.style.display = "none";
+            if (playheadRef.current) playheadRef.current.style.display = "none";
             if (animationFrameRef) cancelAnimationFrame(animationFrameRef);
         }
 
         const onAnimationFrame = () => {
             const position = playbackHeadPosition + tickDistance * (Date.now() - lastTime) / tickTime;
-            playheadRef.current.style.left = `${position}px`;
+            if (playheadRef.current) playheadRef.current.style.left = `${position}px`;
             if (isPlaying) animationFrameRef = requestAnimationFrame(onAnimationFrame);
         }
 

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -451,7 +451,15 @@ function instrumentsEqual(a: pxt.assets.music.Instrument, b: pxt.assets.music.In
 
 function envelopesEqual(a: pxt.assets.music.Envelope | undefined, b: pxt.assets.music.Envelope | undefined) {
     if (a === b) return true;
-    if (!a || !b) return false;
+    if (!a) {
+        if (!b) return true;
+        if (b.amplitude === 0) return true;
+        return false;
+    }
+    else if (!b) {
+        if (a.amplitude === 0) return true;
+        return false;
+    }
 
     if (a.attack !== b.attack) return false;
     if (a.decay !== b.decay) return false;
@@ -464,7 +472,15 @@ function envelopesEqual(a: pxt.assets.music.Envelope | undefined, b: pxt.assets.
 
 function lfosEqual(a: pxt.assets.music.LFO | undefined, b: pxt.assets.music.LFO | undefined) {
     if (a === b) return true;
-    if (!a || !b) return false;
+        if (!a) {
+        if (!b) return true;
+        if (b.amplitude === 0) return true;
+        return false;
+    }
+    else if (!b) {
+        if (a.amplitude === 0) return true;
+        return false;
+    }
 
     if (a.frequency !== b.frequency) return false;
     if (a.amplitude !== b.amplitude) return false;

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -341,6 +341,7 @@ export function toPXTSong(song: Song): pxt.assets.music.Song {
         measures: song.measures,
         tracks: song.tracks.map(track => {
             const instrument = song.instruments.find(i => i.id === track.instrumentId)!;
+            const isDrums = isDrumInstrument(instrument);
 
             const pxtTrack: pxt.assets.music.Track = {
                 id: track.id,
@@ -349,13 +350,13 @@ export function toPXTSong(song: Song): pxt.assets.music.Song {
                     startTick: e.start,
                     endTick: (e.start + e.duration),
                     notes: [{
-                        note: e.note + 1,
+                        note: isDrums ? e.note : e.note + 1,
                         enharmonicSpelling: "normal"
                     }],
                     velocity: e.velocity
                 })),
-                instrument: isDrumInstrument(instrument) ? undefined : (instrument as MelodicInstrument).instrument,
-                drums: isDrumInstrument(instrument) ? (instrument as DrumInstrument).drums : undefined
+                instrument: isDrums ? undefined : (instrument as MelodicInstrument).instrument,
+                drums: isDrums ? (instrument as DrumInstrument).drums : undefined
             }
 
             return pxtTrack;
@@ -386,7 +387,7 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
         const newNoteEvent = (note: number, startTick: number, endTick: number, velocity: number): void => {
             const newEvent: NoteEvent = {
                 id: newTrack.nextId++,
-                note: note - 1,
+                note: track.drums?.length ? note : note - 1,
                 start: Math.round(startTick / ticksPerSixteenth),
                 duration: Math.max(1, Math.round((endTick - startTick) / ticksPerSixteenth)),
                 velocity: velocity ?? 128


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7612

fixes a few bugs reported by beta testers:
* an off by one error in drum instruments where they were playing back one higher than they should
* the lit up keys in the sidebar were off by one for melodic tracks
* the instrument matching when reopening a song was broken for melodic tracks
* an exception that occurred when you dismissed the piano roll editor while it is still playing