### PR TITLE
fix visibility of subcategories when advanced is collapsed

### DIFF
--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -811,7 +811,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                                         {treeRow.subcategories?.map(subTreeRow =>
                                             <CategoryItem
                                                 key={subTreeRow.nameid + subTreeRow.subns}
-                                                className={classList(expandedItem != treeRow.nameid && "sr-only")}
+                                                className={classList((!showAdvanced || expandedItem != treeRow.nameid) && "sr-only")}
                                                 toolbox={this}
                                                 index={index++}
                                                 editorname={editorname}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/7057

pretty self explanatory! just an error in the logic for subcategories of advanced categories. `sr-only` here refers to "screenreader only" and hides the category when set.