### PR TITLE
piano roll editor bug fixes and improvements

### DIFF
--- a/pxtblocks/fields/field_piano_roll.ts
+++ b/pxtblocks/fields/field_piano_roll.ts
@@ -10,6 +10,7 @@ interface FieldPianoRollOptions extends FieldMusicEditorOptions {
     encodeAsMelody?: boolean;
     minOctave?: number;
     maxOctave?: number;
+    showTimeSignature?: boolean;
 }
 
 export class FieldPianoRoll extends FieldMusicEditor {
@@ -158,6 +159,10 @@ export class FieldPianoRoll extends FieldMusicEditor {
             if (result.encodeAsMelody) {
                 result.maxPolyphony = 1;
             }
+        }
+
+        if (opts.showTimeSignature) {
+            result.showTimeSignature = isTrue(opts.showTimeSignature);
         }
 
 

--- a/pxtblocks/fields/field_piano_roll.ts
+++ b/pxtblocks/fields/field_piano_roll.ts
@@ -11,6 +11,7 @@ interface FieldPianoRollOptions extends FieldMusicEditorOptions {
     minOctave?: number;
     maxOctave?: number;
     showTimeSignature?: boolean;
+    showSnapControls?: boolean;
 }
 
 export class FieldPianoRoll extends FieldMusicEditor {
@@ -165,6 +166,9 @@ export class FieldPianoRoll extends FieldMusicEditor {
             result.showTimeSignature = isTrue(opts.showTimeSignature);
         }
 
+        if (opts.showSnapControls) {
+            result.showSnapControls = isTrue(opts.showSnapControls);
+        }
 
         return result;
     }

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -202,7 +202,7 @@
     top: 0;
     height: 100%;
     background-color: var(--selected-note-event-color);
-    opacity: 0.3;
+    opacity: 0.25;
     pointer-events: none;
 }
 

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -224,21 +224,29 @@
     position: relative;
 }
 
-.piano-roll .workspace .note-event {
-    height: calc(var(--grid-cell-height) + 1px);
-    position: absolute;
-    display: flex;
-    align-items: center;
-    user-select: none;
+.piano-roll .workspace {
+    .note-event, .cursor {
+        height: calc(var(--grid-cell-height) + 1px);
+        position: absolute;
+        display: flex;
+        align-items: center;
+        user-select: none;
 
-    padding-left: 0.25rem;
+        padding-left: 0.25rem;
 
-    font-size: calc(var(--grid-cell-height) * 0.6);
-    background-color: var(--note-event-color);
-    border: var(--note-event-border);
-    color: var(--note-event-text-color);
+        font-size: calc(var(--grid-cell-height) * 0.6);
+        cursor: pointer;
+    }
 
-    cursor: pointer;
+    .note-event {
+        border: var(--note-event-border);
+        background-color: var(--note-event-color);
+        color: var(--note-event-text-color);
+    }
+
+    .cursor {
+        border: var(--note-event-border-hover);
+    }
 }
 
 .piano-roll .workspace {

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -38,7 +38,7 @@
     --octave-height: calc(var(--white-key-height) * 7);
 
     --grid-cell-height: calc(var(--octave-height) / 12);
-    --grid-cell-width: calc(var(--octave-width) / 16);
+    --tick-width: 30px;
 
     --header-height: 2.5rem;
     --timeline-height: 1.5rem;
@@ -94,6 +94,16 @@
             }
         }
     }
+
+    & > .common-dropdown {
+        .common-button {
+            min-width: 4.75rem;
+        }
+
+        .common-menu-dropdown-pane {
+            bottom: 2.25rem
+        }
+    }
 }
 
 .piano-roll .header {
@@ -130,7 +140,6 @@
     }
 
     .measure {
-        width: var(--octave-width);
         flex-shrink: 0;
         padding-left: 0.25rem;
         user-select: none;
@@ -207,7 +216,6 @@
 }
 
 .piano-roll .workspace {
-    background-size: var(--octave-width) var(--octave-height);
     background-repeat: repeat;
     position: relative;
 }
@@ -283,14 +291,14 @@
 
     .velocity-slider {
         height: var(--velocity-editor-height);
-        width: var(--grid-cell-width);
+        width: var(--tick-width);
         position: absolute;
         cursor: grab;
 
         .velocity-slider-inner {
             position: relative;
             height: var(--velocity-editor-height);
-            width: var(--grid-cell-width);
+            width: var(--tick-width);
         }
 
         input[type="range"] {

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -5,6 +5,10 @@
     --note-event-border: 2px solid darken(#03adfc, 20%);
     --note-event-text-color: darken(#03adfc, 30%);
 
+    --selected-note-event-color: #03fca9;
+    --selected-note-event-border: 2px solid darken(#03fca9, 20%);
+    --selected-note-event-text-color: darken(#03fca9, 30%);
+
     --note-event-text-color-hover: #ffffff;
     --note-event-border-hover: 2px solid #ffffff;
 
@@ -80,6 +84,7 @@
 
     .music-playback-controls {
         padding: 0;
+
         .common-button {
             height: calc(var(--header-height) - 0.3rem)
         }
@@ -95,7 +100,7 @@
         }
     }
 
-    & > .common-dropdown {
+    &>.common-dropdown {
         .common-button {
             min-width: 4.75rem;
         }
@@ -120,7 +125,7 @@
         }
     }
 
-    & > .common-dropdown #snap-select {
+    &>.common-dropdown #snap-select {
         min-width: 4.75rem;
     }
 }
@@ -167,6 +172,7 @@
 }
 
 .measure-header {
+    position: relative;
     height: var(--timeline-height);
     display: flex;
     flex-direction: row;
@@ -189,6 +195,15 @@
         padding-left: 0.25rem;
         user-select: none;
     }
+}
+
+.selection {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    background-color: var(--selected-note-event-color);
+    opacity: 0.3;
+    pointer-events: none;
 }
 
 .piano-roll .sidebar-container {
@@ -267,7 +282,9 @@
 }
 
 .piano-roll .workspace {
-    .note-event, .cursor {
+
+    .note-event,
+    .cursor {
         height: calc(var(--grid-cell-height) + 1px);
         position: absolute;
         display: flex;
@@ -286,13 +303,21 @@
         color: var(--note-event-text-color);
     }
 
+    .note-event.selected, .note-event.floating {
+        border: var(--selected-note-event-border);
+        background-color: var(--selected-note-event-color);
+        color: var(--selected-note-event-text-color);
+    }
+
     .cursor {
         border: var(--note-event-border-hover);
     }
 }
 
 .piano-roll .workspace {
-    .note-event:hover, .note-event.highlighted {
+
+    .note-event:hover,
+    .note-event.highlighted {
         border: var(--note-event-border-hover);
         color: var(--note-event-text-color-hover);
     }
@@ -378,7 +403,9 @@
             background-color: var(--note-event-color);
         }
 
-        &:focus-within, &:hover, &.highlighted {
+        &:focus-within,
+        &:hover,
+        &.highlighted {
             .velocity-slider-view {
                 border: var(--note-event-border-hover);
             }

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -119,6 +119,10 @@
             max-width: 2rem;
         }
     }
+
+    & > .common-dropdown #snap-select {
+        min-width: 4.75rem;
+    }
 }
 
 .measure-header {

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -125,6 +125,47 @@
     }
 }
 
+.scrollbar.horizontal {
+    height: 0.75rem;
+    width: 100%;
+    position: absolute;
+    bottom: var(--header-height);
+    left: var(--sidebar-width);
+    right: 0;
+
+    .scrollbar-thumb {
+        height: 100%;
+    }
+}
+
+.scrollbar.vertical {
+    width: 0.75rem;
+    height: 100%;
+    position: absolute;
+    top: var(--timeline-height);
+    bottom: 0;
+    right: 0;
+
+    .scrollbar-thumb {
+        width: 100%;
+    }
+}
+
+.piano-roll.show-header .scrollbar.vertical {
+    top: calc(var(--header-height) + var(--timeline-height));
+}
+
+.scrollbar .scrollbar-thumb {
+    position: absolute;
+    background-color: black;
+    border-radius: 0.375rem;
+    opacity: 0.5;
+
+    &:hover {
+        opacity: 0.75;
+    }
+}
+
 .measure-header {
     height: var(--timeline-height);
     display: flex;
@@ -214,9 +255,10 @@
 
 .piano-roll .workspace-container {
     flex: 1;
-    overflow-x: hidden;
+    overflow-x: auto;
     overflow-y: hidden;
     touch-action: none;
+    scrollbar-width: none;
 }
 
 .piano-roll .workspace {
@@ -260,6 +302,7 @@
     max-height: 100%;
     width: 100%;
     overflow-y: auto;
+    scrollbar-width: none;
     flex-grow: 1;
 }
 

--- a/webapp/src/components/pianoRoll/Header.tsx
+++ b/webapp/src/components/pianoRoll/Header.tsx
@@ -1,11 +1,13 @@
 import { Checkbox } from "../../../../react-common/components/controls/Checkbox";
 import { Dropdown, DropdownItem } from "../../../../react-common/components/controls/Dropdown";
-import { Song, lf, isDrumInstrument, NOTE_RANGES } from "./types";
+import { Song, lf, isDrumInstrument, NOTE_RANGES, SNAP_OPTIONS } from "./types";
 
 interface Props {
     song: Song;
     selectedTrackId: number;
     velocityEditorVisible: boolean;
+    snapTicks: number;
+    showSnapControls: boolean;
 
     onTrackSelected(trackId: number): void;
     onTrackCreated(): void;
@@ -13,10 +15,24 @@ interface Props {
     onInstrumentSelected(trackId: number, instrumentId: number): void;
     onOctavesChanged(minOctave: number, maxOctave: number): void;
     onVelocityEditorToggle(): void;
+    onSnapChanged(snapTicks: number): void;
 }
 
 export const Header = (props: Props) => {
-    const { song, selectedTrackId: selectedTrack, velocityEditorVisible, onVelocityEditorToggle, onTrackSelected, onInstrumentSelected, onTrackCreated, onTrackDeleted, onOctavesChanged } = props;
+    const {
+        song,
+        selectedTrackId: selectedTrack,
+        velocityEditorVisible,
+        snapTicks,
+        showSnapControls,
+        onVelocityEditorToggle,
+        onTrackSelected,
+        onInstrumentSelected,
+        onTrackCreated,
+        onTrackDeleted,
+        onOctavesChanged,
+        onSnapChanged
+    } = props;
 
     const onTrackDropdownChange = (id: string) => {
         if (id === "new-track") {
@@ -87,6 +103,12 @@ export const Header = (props: Props) => {
         selectedRangeId = range.id;
     }
 
+    const snapOptions: DropdownItem[] = SNAP_OPTIONS.map(option => ({
+        label: option.name,
+        title: option.name,
+        id: option.id
+    }));
+
 
     return (
         <div className="header">
@@ -127,6 +149,20 @@ export const Header = (props: Props) => {
                 isChecked={velocityEditorVisible}
                 onChange={onVelocityEditorToggle}
             />
+            <div className="spacer" />
+            {showSnapControls &&
+                <>
+                    <div className="music-editor-label">
+                        {lf("Snap:")}
+                    </div>
+                    <Dropdown
+                        id="snap-select"
+                        items={snapOptions}
+                        selectedId={snapTicksToId(snapTicks)}
+                        onItemSelected={(id) => onSnapChanged(snapIdToTicks(id))}
+                    />
+                </>
+            }
         </div>
     );
 }
@@ -147,3 +183,12 @@ function parseInstrumentId(id: string) {
     return parseInt(id.replace("instrument-", ""));
 }
 
+function snapIdToTicks(id: string) {
+    const option = SNAP_OPTIONS.find(option => option.id === id);
+    return option?.ticksPerSnap ?? 1;
+}
+
+function snapTicksToId(ticks: number) {
+    const option = SNAP_OPTIONS.find(option => option.ticksPerSnap === ticks);
+    return option?.id ?? "sixteenth";
+}

--- a/webapp/src/components/pianoRoll/MeasureHeader.tsx
+++ b/webapp/src/components/pianoRoll/MeasureHeader.tsx
@@ -1,16 +1,13 @@
 import { range } from "./utils";
+import { usePianoRollTheme } from "./context";
 
-interface Props {
-    measures: number;
-}
-
-export const MeasureHeader = (props: Props) => {
-    const { measures } = props;
+export const MeasureHeader = () => {
+    const { measures, tickWidth, ticksPerBeat, beatsPerMeasure } = usePianoRollTheme();
 
     return (
         <div className="measure-header" id="measure-header">
             {range(0, measures).map(m =>
-                <div key={m + 1} className="measure">{m + 1}</div>
+                <div key={m + 1} className="measure" style={{ width: tickWidth * ticksPerBeat * beatsPerMeasure }}>{m + 1}</div>
             )}
         </div>
     );

--- a/webapp/src/components/pianoRoll/MeasureHeader.tsx
+++ b/webapp/src/components/pianoRoll/MeasureHeader.tsx
@@ -1,14 +1,92 @@
-import { range } from "./utils";
+import * as React from "react";
+import { noteLeft, noteWidth, range, xToTick } from "./utils";
 import { usePianoRollTheme } from "./context";
+import { WorkspaceSelection } from "./types";
 
-export const MeasureHeader = () => {
+interface Props {
+    selection?: WorkspaceSelection;
+    onSelectionChange: (selection: WorkspaceSelection) => void;
+}
+
+export const MeasureHeader = ({ selection, onSelectionChange }: Props) => {
     const { measures, tickWidth, ticksPerBeat, beatsPerMeasure } = usePianoRollTheme();
 
+    const ref = React.useRef<HTMLDivElement>(null);
+    const theme = usePianoRollTheme();
+
+    React.useEffect(() => {
+        if (!ref.current) return undefined;
+
+        const header = ref.current;
+
+        let selectionStartTick: number = undefined;
+        let selectionEndTick: number = undefined;
+        let dragging = false;
+
+        const clientToTick = (clientX: number) => {
+            const bounds = header.getBoundingClientRect();
+            return xToTick(theme, clientX - bounds.left + header.scrollLeft);
+        }
+
+        const onPointerMove = (e: PointerEvent) => {
+            if (!dragging) return;
+
+            const tick = clientToTick(e.clientX);
+            selectionEndTick = tick;
+        };
+
+        const onPointerUp = (e: PointerEvent) => {
+            dragging = false;
+
+            const startTick = Math.min(selectionStartTick, selectionEndTick);
+            const endTick = Math.max(selectionStartTick, selectionEndTick);
+
+            if (startTick === endTick || endTick === undefined) {
+                onSelectionChange(undefined);
+            }
+            else {
+                onSelectionChange({ startTick, endTick });
+            }
+
+            selectionStartTick = undefined;
+            selectionEndTick = undefined;
+            document.removeEventListener("pointermove", onPointerMove);
+            document.removeEventListener("pointerup", onPointerUp);
+        };
+
+        const onPointerDown = (e: PointerEvent) => {
+            e.preventDefault();
+            selectionStartTick = clientToTick(e.clientX);
+            dragging = true;
+            document.addEventListener("pointermove", onPointerMove);
+            document.addEventListener("pointerup", onPointerUp);
+        };
+
+
+        header.addEventListener("pointerdown", onPointerDown);
+
+        return () => {
+            header.removeEventListener("pointerdown", onPointerDown);
+            document.removeEventListener("pointermove", onPointerMove);
+            document.removeEventListener("pointerup", onPointerUp);
+        };
+    }, [onSelectionChange, theme]);
+
     return (
-        <div className="measure-header" id="measure-header">
+        <div className="measure-header" id="measure-header" ref={ref}>
             {range(0, measures).map(m =>
                 <div key={m + 1} className="measure" style={{ width: tickWidth * ticksPerBeat * beatsPerMeasure }}>{m + 1}</div>
             )}
+            {selection &&
+                <div
+                    id="measure-header-selection"
+                    className="selection"
+                    style={{
+                        left: noteLeft(theme, selection.startTick),
+                        width: noteWidth(theme, selection.endTick - selection.startTick)
+                    }}
+                ></div>
+            }
         </div>
     );
 }

--- a/webapp/src/components/pianoRoll/MeasureHeader.tsx
+++ b/webapp/src/components/pianoRoll/MeasureHeader.tsx
@@ -52,7 +52,7 @@ export const MeasureHeader = ({ selection, onSelectionChange, addEventListeners,
             const startTick = Math.min(selectionStartTick, selectionEndTick);
             const endTick = Math.max(selectionStartTick, selectionEndTick);
 
-            if (startTick === endTick || endTick === undefined) {
+            if (startTick === endTick || endTick === undefined || Number.isNaN(startTick) || Number.isNaN(endTick)) {
                 onSelectionChange(undefined);
             }
             else {

--- a/webapp/src/components/pianoRoll/MeasureHeader.tsx
+++ b/webapp/src/components/pianoRoll/MeasureHeader.tsx
@@ -1,23 +1,23 @@
-import * as React from "react";
 import { noteLeft, noteWidth, range, xToTick } from "./utils";
 import { usePianoRollTheme } from "./context";
 import { WorkspaceSelection } from "./types";
+import { useEffect, useRef, useState } from "react";
 
 interface Props {
     selection?: WorkspaceSelection;
-    onKeyDown(e: React.KeyboardEvent<HTMLDivElement>): void;
     snapTicks: number;
     onSelectionChange: (selection: WorkspaceSelection) => void;
+    addEventListeners: (el: HTMLElement) => void;
 }
 
-export const MeasureHeader = ({ selection, onSelectionChange, onKeyDown, snapTicks }: Props) => {
+export const MeasureHeader = ({ selection, onSelectionChange, addEventListeners, snapTicks }: Props) => {
     const { measures, tickWidth, ticksPerBeat, beatsPerMeasure } = usePianoRollTheme();
 
-    const ref = React.useRef<HTMLDivElement>(null);
+    const ref = useRef<HTMLDivElement>(null);
     const theme = usePianoRollTheme();
-    const [pendingSelection, setPendingSelection] = React.useState<WorkspaceSelection>(undefined);
+    const [pendingSelection, setPendingSelection] = useState<WorkspaceSelection>(undefined);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (!ref.current) return undefined;
 
         const header = ref.current;
@@ -25,6 +25,13 @@ export const MeasureHeader = ({ selection, onSelectionChange, onKeyDown, snapTic
         let selectionStartTick: number = undefined;
         let selectionEndTick: number = undefined;
         let dragging = false;
+
+        const updateSelection = (startTick: number, endTick: number) => {
+            setPendingSelection({
+                startTick: Math.floor(Math.min(startTick, endTick) / snapTicks) * snapTicks,
+                endTick: Math.ceil(Math.max(startTick, endTick) / snapTicks) * snapTicks
+            });
+        };
 
         const clientToTick = (clientX: number) => {
             const bounds = header.getBoundingClientRect();
@@ -36,10 +43,7 @@ export const MeasureHeader = ({ selection, onSelectionChange, onKeyDown, snapTic
 
             const tick = clientToTick(e.clientX);
             selectionEndTick = tick;
-            setPendingSelection({
-                startTick: Math.min(selectionStartTick, selectionEndTick),
-                endTick: Math.max(selectionStartTick, selectionEndTick)
-            });
+            updateSelection(selectionStartTick, selectionEndTick);
         };
 
         const onPointerUp = (e: PointerEvent) => {
@@ -69,10 +73,9 @@ export const MeasureHeader = ({ selection, onSelectionChange, onKeyDown, snapTic
             dragging = true;
             document.addEventListener("pointermove", onPointerMove);
             document.addEventListener("pointerup", onPointerUp);
-            setPendingSelection({
-                startTick: selectionStartTick,
-                endTick: selectionStartTick
-            });
+            updateSelection(selectionStartTick, selectionStartTick);
+
+            document.getElementById("piano-roll-workspace")?.focus();
         };
 
 
@@ -85,10 +88,16 @@ export const MeasureHeader = ({ selection, onSelectionChange, onKeyDown, snapTic
         };
     }, [onSelectionChange, theme]);
 
+
+    useEffect(() => {
+        if (!ref.current) return undefined;
+
+        return addEventListeners(ref.current);
+    }, [addEventListeners]);
     const displaySelection = pendingSelection || selection;
 
     return (
-        <div className="measure-header" id="measure-header" ref={ref} tabIndex={0} onKeyDown={onKeyDown}>
+        <div className="measure-header" id="measure-header" ref={ref}>
             {range(0, measures).map(m =>
                 <div key={m + 1} className="measure" style={{ width: tickWidth * ticksPerBeat * beatsPerMeasure }}>{m + 1}</div>
             )}

--- a/webapp/src/components/pianoRoll/MeasureHeader.tsx
+++ b/webapp/src/components/pianoRoll/MeasureHeader.tsx
@@ -5,14 +5,17 @@ import { WorkspaceSelection } from "./types";
 
 interface Props {
     selection?: WorkspaceSelection;
+    onKeyDown(e: React.KeyboardEvent<HTMLDivElement>): void;
+    snapTicks: number;
     onSelectionChange: (selection: WorkspaceSelection) => void;
 }
 
-export const MeasureHeader = ({ selection, onSelectionChange }: Props) => {
+export const MeasureHeader = ({ selection, onSelectionChange, onKeyDown, snapTicks }: Props) => {
     const { measures, tickWidth, ticksPerBeat, beatsPerMeasure } = usePianoRollTheme();
 
     const ref = React.useRef<HTMLDivElement>(null);
     const theme = usePianoRollTheme();
+    const [pendingSelection, setPendingSelection] = React.useState<WorkspaceSelection>(undefined);
 
     React.useEffect(() => {
         if (!ref.current) return undefined;
@@ -33,6 +36,10 @@ export const MeasureHeader = ({ selection, onSelectionChange }: Props) => {
 
             const tick = clientToTick(e.clientX);
             selectionEndTick = tick;
+            setPendingSelection({
+                startTick: Math.min(selectionStartTick, selectionEndTick),
+                endTick: Math.max(selectionStartTick, selectionEndTick)
+            });
         };
 
         const onPointerUp = (e: PointerEvent) => {
@@ -48,6 +55,8 @@ export const MeasureHeader = ({ selection, onSelectionChange }: Props) => {
                 onSelectionChange({ startTick, endTick });
             }
 
+            setPendingSelection(undefined);
+
             selectionStartTick = undefined;
             selectionEndTick = undefined;
             document.removeEventListener("pointermove", onPointerMove);
@@ -60,6 +69,10 @@ export const MeasureHeader = ({ selection, onSelectionChange }: Props) => {
             dragging = true;
             document.addEventListener("pointermove", onPointerMove);
             document.addEventListener("pointerup", onPointerUp);
+            setPendingSelection({
+                startTick: selectionStartTick,
+                endTick: selectionStartTick
+            });
         };
 
 
@@ -72,18 +85,20 @@ export const MeasureHeader = ({ selection, onSelectionChange }: Props) => {
         };
     }, [onSelectionChange, theme]);
 
+    const displaySelection = pendingSelection || selection;
+
     return (
-        <div className="measure-header" id="measure-header" ref={ref}>
+        <div className="measure-header" id="measure-header" ref={ref} tabIndex={0} onKeyDown={onKeyDown}>
             {range(0, measures).map(m =>
                 <div key={m + 1} className="measure" style={{ width: tickWidth * ticksPerBeat * beatsPerMeasure }}>{m + 1}</div>
             )}
-            {selection &&
+            {displaySelection &&
                 <div
                     id="measure-header-selection"
                     className="selection"
                     style={{
-                        left: noteLeft(theme, selection.startTick),
-                        width: noteWidth(theme, selection.endTick - selection.startTick)
+                        left: noteLeft(theme, displaySelection.startTick),
+                        width: noteWidth(theme, displaySelection.endTick - displaySelection.startTick)
                     }}
                 ></div>
             }

--- a/webapp/src/components/pianoRoll/NoteEvent.tsx
+++ b/webapp/src/components/pianoRoll/NoteEvent.tsx
@@ -1,3 +1,4 @@
+import { classList } from "../../../../react-common/components/util";
 import { usePianoRollTheme } from "./context";
 import { NoteEvent } from "./types";
 import { getNoteName, noteLeft, noteTop, noteWidth } from "./utils";
@@ -5,10 +6,11 @@ import { getNoteName, noteLeft, noteTop, noteWidth } from "./utils";
 interface Props {
     event: NoteEvent;
     isDrumTrack?: boolean;
+    type?: "floating" | "selected"
 }
 
 export const NoteEventView = (props: Props) => {
-    const { event, isDrumTrack } = props;
+    const { event, isDrumTrack, type } = props;
     const { duration, note, start, id } = event;
 
     const theme = usePianoRollTheme();
@@ -16,12 +18,14 @@ export const NoteEventView = (props: Props) => {
     return (
         <div
             id={`note-${id}`}
-            className="note-event"
+            className={classList("note-event", type)}
             style={{
                 width: `${noteWidth(theme, duration)}px`,
                 left: `${noteLeft(theme, start)}px`,
                 top: `${noteTop(theme, note)}px`
             }}
+            data-tick={start}
+            data-note={note}
         >
             {isDrumTrack ? undefined : getNoteName(note)}
         </div>

--- a/webapp/src/components/pianoRoll/OctaveWarningModal.tsx
+++ b/webapp/src/components/pianoRoll/OctaveWarningModal.tsx
@@ -1,0 +1,38 @@
+import { Modal } from "../../../../react-common/components/controls/Modal";
+import { lf } from "./types";
+
+interface Props {
+    trackId: number;
+    onClose(): void;
+    onPaste(trackId: number): void;
+}
+
+export const OctaveWarningModal = (props: Props) => {
+    const { trackId, onClose, onPaste } = props;
+
+    const handlePaste = () => {
+        onPaste(trackId);
+        onClose();
+    };
+
+    return (
+        <Modal
+            title={lf("Octave Warning")}
+            onClose={onClose}
+            actions={[
+                {
+                    label: lf("Cancel"),
+                    className: "neutral",
+                    onClick: onClose
+                },
+                {
+                    label: lf("Paste Anyway"),
+                    className: "red",
+                    onClick: handlePaste
+                }
+            ]}
+        >
+            <p>{lf("The copied notes are outside the current track's octave range. If you paste, it will change the octave range of this track.")}</p>
+        </Modal>
+    )
+}

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -190,7 +190,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
         }
     }
 
-    useEffect(() => {
+    const addEventListeners = useCallback((el: HTMLElement) => {
         const onKeydown = (e: KeyboardEvent) => {
             if (e.key === "Escape") {
                 if (song.floatingLayer) {
@@ -221,7 +221,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     e.stopPropagation();
                 }
             }
-        }
+        };
 
         const onCopy = (e: ClipboardEvent) => {
             if (song.floatingLayer) {
@@ -238,7 +238,25 @@ const PianoRollInternal = (props: PianoRollProps) => {
                 e.preventDefault();
                 e.stopPropagation();
             }
-        }
+        };
+
+        const onCut = (e: ClipboardEvent) => {
+            if (song.floatingLayer) {
+                const floatingLayer = song.floatingLayer;
+                const track = song.tracks.find(t => t.id === song.floatingLayer!.trackId)!;
+                setCopiedData({
+                    events: floatingLayer.events,
+                    startTick: floatingLayer.startTick,
+                    endTick: floatingLayer.endTick,
+                    isDrumTrack: isDrumInstrument(song.instruments.find(i => i.id === track.instrumentId)!),
+                    minOctave: track.minOctave,
+                    maxOctave: track.maxOctave
+                });
+                e.preventDefault();
+                e.stopPropagation();
+                updateSong(deleteFloatingLayer(song));
+            }
+        };
 
         const onPaste = (e: ClipboardEvent) => {
             const track = song.tracks[selectedTrackIndex]!;
@@ -312,15 +330,17 @@ const PianoRollInternal = (props: PianoRollProps) => {
             let newSong = applyFloatingLayer(song);
             newSong.floatingLayer = newFloatingLayer;
             updateSong(newSong);
-        }
+        };
 
-        window.addEventListener("keydown", onKeydown);
-        window.addEventListener("copy", onCopy);
-        window.addEventListener("paste", onPaste);
+        el.addEventListener("keydown", onKeydown);
+        el.addEventListener("copy", onCopy);
+        el.addEventListener("paste", onPaste);
+        el.addEventListener("cut", onCut);
         return () => {
-            window.removeEventListener("keydown", onKeydown);
-            window.removeEventListener("copy", onCopy);
-            window.removeEventListener("paste", onPaste);
+            el.removeEventListener("keydown", onKeydown);
+            el.removeEventListener("copy", onCopy);
+            el.removeEventListener("paste", onPaste);
+            el.removeEventListener("cut", onCut);
         };
     }, [updateSong, song, selectedTrackIndex]);
 
@@ -669,7 +689,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                 selection={song.floatingLayer}
                 onSelectionChange={onSelectionChange}
                 snapTicks={fieldEditorParams?.showSnapControls ? snapTicks : 1}
-                onKeyDown={() => {}}
+                addEventListeners={addEventListeners}
             />
             <div className="scroll-container">
                 <div className="content-container">
@@ -694,6 +714,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                             floatingLayer={song.floatingLayer}
                             updateFloatingLayer={updateFloatingLayerCB}
                             applyFloatingLayer={applyFloatingLayerCB}
+                            addEventListeners={addEventListeners}
                         />
                         <Scrollbar horizontal />
                     </div>

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -2,7 +2,7 @@ import { PianoRollTheme, PianoRollThemeProvider, usePianoRollThemeContext } from
 import { Workspace } from "./Workspace"
 import { Sidebar } from "./Sidebar"
 import { useEffect, useRef, useState, useCallback, useMemo } from "react"
-import { applyFloatingLayer, changeMeasures, changeOctaves, changeTimeSignature, changeTrackInstrument, deleteFloatingLayer, deleteSelection, fromPXTSong, getEmptySong, isDrumInstrument, moveFloatingLayer, moveSelection, newTrack, NoteEvent, selectionToFloatingLayer, Song, TIME_SIGNATURES, toPXTSong, Track, transposeFloatingLayer, transposeSelection, updateNoteEvent, updateNoteEvents, updateTrack, WorkspaceSelection } from "./types"
+import { applyFloatingLayer, changeMeasures, changeOctaves, changeTimeSignature, changeTrackInstrument, deleteFloatingLayer, deleteSelection, fromPXTSong, getEmptySong, isDrumInstrument, moveFloatingLayer, moveSelection, newTrack, NoteEvent, NOTE_RANGES, selectionToFloatingLayer, Song, TIME_SIGNATURES, toPXTSong, Track, transposeFloatingLayer, transposeSelection, updateNoteEvent, updateNoteEvents, updateTrack, WorkspaceSelection } from "./types"
 import { Header } from "./Header"
 import { DeleteTrackModal } from "./DeleteTrackModal"
 import { DeleteErrorModal } from "./DeleteErrorModal"
@@ -15,6 +15,9 @@ import { EditControls } from "../musicEditor/EditControls"
 import { Dropdown, DropdownItem } from "../../../../react-common/components/controls/Dropdown"
 import { Scrollbar } from "./Scrollbar"
 import { classList } from "../../../../react-common/components/util"
+import { getCopiedData, setCopiedData } from "./clipboard"
+import { xToTick } from "./utils"
+import { OctaveWarningModal } from "./OctaveWarningModal"
 
 interface PianoRollProps {
     onStateChanged?: (state: PianoRollState) => void;
@@ -29,7 +32,7 @@ interface PianoRollProps {
     fieldEditorParams?: FieldEditorParams;
 }
 
-type modalType = "delete-track" | "delete-error" | "drum-warning";
+type modalType = "delete-track" | "delete-error" | "drum-warning" | "octave-paste-warning";
 
 export const PianoRoll = (props: PianoRollProps) => {
     useEffect(() => {
@@ -97,6 +100,8 @@ const PianoRollInternal = (props: PianoRollProps) => {
 
     const [snapTicks, setSnapTicks] = useState(4);
     const [velocityEditorVisible, setVelocityEditorVisible] = useState(initialVelocityEditorVisible || false);
+
+    const workspaceContainerRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (asset) {
@@ -217,11 +222,107 @@ const PianoRollInternal = (props: PianoRollProps) => {
                 }
             }
         }
+
+        const onCopy = (e: ClipboardEvent) => {
+            if (song.floatingLayer) {
+                const floatingLayer = song.floatingLayer;
+                const track = song.tracks.find(t => t.id === song.floatingLayer!.trackId)!;
+                setCopiedData({
+                    events: floatingLayer.events,
+                    startTick: floatingLayer.startTick,
+                    endTick: floatingLayer.endTick,
+                    isDrumTrack: isDrumInstrument(song.instruments.find(i => i.id === track.instrumentId)!),
+                    minOctave: track.minOctave,
+                    maxOctave: track.maxOctave
+                });
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        }
+
+        const onPaste = (e: ClipboardEvent) => {
+            const track = song.tracks[selectedTrackIndex]!;
+            const instrument = song.instruments.find(i => i.id === track.instrumentId)!;
+
+            const copiedData = getCopiedData(track.instrumentId === undefined ? false : isDrumInstrument(instrument));
+            if (!copiedData) return;
+
+            // we want to paste the copied data at the closest measure to where we are scrolled
+            // in the workspace
+            const workspaceContainer = workspaceContainerRef.current;
+            if (!workspaceContainer) return;
+
+            const leftTick = xToTick(theme, workspaceContainer.scrollLeft);
+            const ticksPerMeasure = song.beatsPerMeasure * song.ticksPerBeat;
+            const measureStart = Math.ceil(leftTick / ticksPerMeasure) * ticksPerMeasure;
+
+            if (!copiedData.isDrumTrack) {
+                const copiedMinOctave = Math.floor(copiedData.events.reduce((min, e) => Math.min(min, e.note), Infinity) / 12);
+                const copiedMaxOctave = Math.floor(copiedData.events.reduce((max, e) => Math.max(max, e.note), -Infinity) / 12);
+
+                // if the copied data is outside of the current track's octave range, first try to transpose up
+                // or down three octaves (the difference between the treble and bass) ranges
+                if (copiedMinOctave < track.minOctave) {
+                    if (
+                        copiedMinOctave + 2 <= track.maxOctave  &&
+                        copiedMinOctave + 2 >= track.minOctave &&
+                        copiedMaxOctave + 2 <= track.maxOctave
+                    ) {
+                        for (const event of copiedData.events) {
+                            event.note += 24;
+                        }
+                    }
+                    else {
+                        setModal({ type: "octave-paste-warning", trackId: track.id });
+                        e.preventDefault();
+                        e.stopPropagation();
+                        return;
+                    }
+                }
+                else if (copiedMaxOctave > track.maxOctave) {
+                    if (
+                        copiedMaxOctave - 2 >= track.minOctave &&
+                        copiedMaxOctave - 2 <= track.maxOctave &&
+                        copiedMinOctave - 2 >= track.minOctave
+                    ) {
+                        for (const event of copiedData.events) {
+                            event.note -= 24;
+                        }
+                    }
+                    else {
+                        setModal({ type: "octave-paste-warning", trackId: track.id });
+                        e.preventDefault();
+                        e.stopPropagation();
+                        return;
+                    }
+                }
+            }
+
+            const newFloatingLayer: Song["floatingLayer"] = {
+                trackId: track.id,
+                startTick: measureStart,
+                endTick: measureStart + (copiedData.endTick - copiedData.startTick),
+                events: copiedData.events.map(e => ({
+                    ...e,
+                    id: track.nextId++,
+                    start: measureStart + (e.start - copiedData.startTick)
+                }))
+            };
+
+            let newSong = applyFloatingLayer(song);
+            newSong.floatingLayer = newFloatingLayer;
+            updateSong(newSong);
+        }
+
         window.addEventListener("keydown", onKeydown);
+        window.addEventListener("copy", onCopy);
+        window.addEventListener("paste", onPaste);
         return () => {
             window.removeEventListener("keydown", onKeydown);
+            window.removeEventListener("copy", onCopy);
+            window.removeEventListener("paste", onPaste);
         };
-    }, [updateSong, song]);
+    }, [updateSong, song, selectedTrackIndex]);
 
     const onTrackEdit = (updatedTrack: Track) => {
         updateSong(updateTrack(updatedTrack, applyFloatingLayer(song)));
@@ -440,6 +541,39 @@ const PianoRollInternal = (props: PianoRollProps) => {
         fireStateChange({ name: newName });
     }
 
+    const onForcePaste = (trackId: number) => {
+        const track = song.tracks.find(t => t.id === trackId)!;
+        const instrument = song.instruments.find(i => i.id === track.instrumentId)!;
+
+        const copiedData = getCopiedData(isDrumInstrument(instrument));
+        if (!copiedData || copiedData.isDrumTrack) return;
+
+        const workspaceContainer = workspaceContainerRef.current;
+        if (!workspaceContainer) return;
+
+
+        const leftTick = xToTick(theme, workspaceContainer.scrollLeft);
+        const ticksPerMeasure = song.beatsPerMeasure * song.ticksPerBeat;
+        const measureStart = Math.ceil(leftTick / ticksPerMeasure) * ticksPerMeasure;
+        const newRange = NOTE_RANGES.find(r => r.id === "full")!;
+
+        const newFloatingLayer: Song["floatingLayer"] = {
+            trackId,
+            startTick: measureStart,
+            endTick: measureStart + (copiedData.endTick - copiedData.startTick),
+            events: copiedData.events.map(e => ({
+                ...e,
+                id: track.nextId++,
+                start: measureStart + (e.start - copiedData.startTick)
+            }))
+        };
+
+        let newSong = applyFloatingLayer(song);
+        newSong = changeOctaves(trackId, newRange.minOctave, newRange.maxOctave, newSong);
+        newSong.floatingLayer = newFloatingLayer;
+        updateSong(newSong);
+    }
+
     const timeSignatures: DropdownItem[] = TIME_SIGNATURES.map(ts => ({
         label: ts.name,
         title: ts.name,
@@ -494,7 +628,13 @@ const PianoRollInternal = (props: PianoRollProps) => {
     const showHeader = !fieldEditorParams?.hideHeader;
 
     return (
-        <div className={classList("piano-roll", showHeader ? "show-header" : "hide-header", velocityEditorVisible ? "show-velocity-editor" : "hide-velocity-editor")}>
+        <div
+            className={classList(
+                "piano-roll",
+                showHeader ? "show-header" : "hide-header",
+                velocityEditorVisible ? "show-velocity-editor" : "hide-velocity-editor"
+            )}
+        >
             {modal?.type === "delete-track" &&
                 <DeleteTrackModal trackId={modal.trackId!} onClose={closeModal} onDelete={deleteTrack} />
             }
@@ -503,6 +643,9 @@ const PianoRollInternal = (props: PianoRollProps) => {
             }
             {modal?.type === "drum-warning" &&
                 <DrumWarningModal trackId={modal.trackId!} instrumentId={modal.instrumentId!} onClose={closeModal} onConfirm={setTrackInstrument} />
+            }
+            {modal?.type === "octave-paste-warning" &&
+                <OctaveWarningModal trackId={modal.trackId!} onClose={closeModal} onPaste={onForcePaste} />
             }
             {showHeader &&
                 <div className="header-container">
@@ -522,7 +665,12 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     />
                 </div>
             }
-            <MeasureHeader selection={song.floatingLayer} onSelectionChange={onSelectionChange} />
+            <MeasureHeader
+                selection={song.floatingLayer}
+                onSelectionChange={onSelectionChange}
+                snapTicks={fieldEditorParams?.showSnapControls ? snapTicks : 1}
+                onKeyDown={() => {}}
+            />
             <div className="scroll-container">
                 <div className="content-container">
                     <div className="sidebar-container">
@@ -533,7 +681,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                             maxOctave={maxOctave}
                         />
                     </div>
-                    <div className="workspace-container">
+                    <div ref={workspaceContainerRef} className="workspace-container">
                         <Workspace
                             track={track}
                             onEdit={onTrackEdit}

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -2,7 +2,7 @@ import { PianoRollTheme, PianoRollThemeProvider, usePianoRollThemeContext } from
 import { Workspace } from "./Workspace"
 import { Sidebar } from "./Sidebar"
 import { useEffect, useRef, useState } from "react"
-import { changeMeasures, changeOctaves, changeTrackInstrument, fromPXTSong, getEmptySong, isDrumInstrument, newTrack, NoteEvent, Song, toPXTSong, Track, updateNoteEvent, updateNoteEvents, updateTrack } from "./types"
+import { changeMeasures, changeOctaves, changeTimeSignature, changeTrackInstrument, fromPXTSong, getEmptySong, isDrumInstrument, newTrack, NoteEvent, Song, TIME_SIGNATURES, toPXTSong, Track, updateNoteEvent, updateNoteEvents, updateTrack } from "./types"
 import { Header } from "./Header"
 import { DeleteTrackModal } from "./DeleteTrackModal"
 import { DeleteErrorModal } from "./DeleteErrorModal"
@@ -12,6 +12,7 @@ import { PlaybackControls } from "../musicEditor/PlaybackControls"
 import { MeasureHeader } from "./MeasureHeader"
 import { VelocityEditor } from "./VelocityEditor"
 import { EditControls } from "../musicEditor/EditControls"
+import { Dropdown, DropdownItem } from "../../../../react-common/components/controls/Dropdown"
 
 interface PianoRollProps {
     onStateChanged?: (state: PianoRollState) => void;
@@ -57,6 +58,7 @@ export interface FieldEditorParams {
     borderColor?: string;
     minOctave?: number;
     maxOctave?: number;
+    showTimeSignature?: boolean;
 }
 
 interface StateSnapshot {
@@ -272,6 +274,16 @@ const PianoRollInternal = (props: PianoRollProps) => {
         updateTheme({ measures: newMeasures });
     }
 
+    const onTimeSignatureChanged = (id: string) => {
+        const signature = TIME_SIGNATURES.find(ts => ts.id === id);
+        if (!signature) return;
+
+        const { beatsPerMeasure, ticksPerBeat } = signature;
+        updateSong(changeTimeSignature(beatsPerMeasure, ticksPerBeat, song));
+
+        updateTheme({ beatsPerMeasure, ticksPerBeat });
+    }
+
     const onTempoChange = (newTempo: number) => {
         updateSong({
             ...song,
@@ -318,6 +330,9 @@ const PianoRollInternal = (props: PianoRollProps) => {
         if (lastState.song.measures !== song.measures) {
             updateTheme({ measures: lastState.song.measures });
         }
+        if (lastState.song.beatsPerMeasure !== song.beatsPerMeasure || lastState.song.ticksPerBeat !== song.ticksPerBeat) {
+            updateTheme({ beatsPerMeasure: lastState.song.beatsPerMeasure, ticksPerBeat: lastState.song.ticksPerBeat });
+        }
 
         if (isPlaying()) {
             updatePlaybackSongAsync(toPXTSong(lastState.song));
@@ -341,6 +356,9 @@ const PianoRollInternal = (props: PianoRollProps) => {
         if (nextState.song.measures !== song.measures) {
             updateTheme({ measures: nextState.song.measures });
         }
+        if (nextState.song.beatsPerMeasure !== song.beatsPerMeasure || nextState.song.ticksPerBeat !== song.ticksPerBeat) {
+            updateTheme({ beatsPerMeasure: nextState.song.beatsPerMeasure, ticksPerBeat: nextState.song.ticksPerBeat });
+        }
 
         if (isPlaying()) {
             updatePlaybackSongAsync(toPXTSong(nextState.song));
@@ -351,6 +369,13 @@ const PianoRollInternal = (props: PianoRollProps) => {
         setName(newName);
         fireStateChange({ name: newName });
     }
+
+    const timeSignatures: DropdownItem[] = TIME_SIGNATURES.map(ts => ({
+        label: ts.name,
+        title: ts.name,
+        id: ts.id
+    }));
+    const selectedTimeSignature = TIME_SIGNATURES.find(ts => ts.beatsPerMeasure === song.beatsPerMeasure && ts.ticksPerBeat === song.ticksPerBeat);
 
     const closeModal = () => setModal(null);
 
@@ -375,10 +400,16 @@ const PianoRollInternal = (props: PianoRollProps) => {
     }
 
     useEffect(() => {
-        if (theme.minOctave !== minOctave || theme.maxOctave !== maxOctave || theme.measures !== song.measures) {
-            updateTheme({ minOctave, maxOctave, measures: song.measures });
+        if (
+            theme.minOctave !== minOctave ||
+            theme.maxOctave !== maxOctave ||
+            theme.measures !== song.measures ||
+            theme.beatsPerMeasure !== song.beatsPerMeasure ||
+            theme.ticksPerBeat !== song.ticksPerBeat
+        ) {
+            updateTheme({ minOctave, maxOctave, measures: song.measures, beatsPerMeasure: song.beatsPerMeasure, ticksPerBeat: song.ticksPerBeat });
         }
-    }, [minOctave, maxOctave, theme.minOctave, theme.maxOctave, updateTheme, song.measures])
+    }, [minOctave, maxOctave, theme.minOctave, theme.maxOctave, updateTheme, song.measures, song.beatsPerMeasure, song.ticksPerBeat])
 
     const showHeader = !fieldEditorParams?.hideHeader;
 
@@ -408,7 +439,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     />
                 </div>
             }
-            <MeasureHeader measures={song.measures} />
+            <MeasureHeader />
             <div className="scroll-container">
                 <div className="content-container">
                     <div className="sidebar-container">
@@ -425,7 +456,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                             onEdit={onTrackEdit}
                             isDrumTrack={isDrumInstrument(instrument)}
                             playNote={playNote}
-                            measures={song.measures}
+                            maxTicks={song.measures * song.beatsPerMeasure * song.ticksPerBeat}
                             bpm={song.tempo}
                         />
                     </div>
@@ -448,6 +479,14 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     hideBassClefOption={true}
                     singlePlayButton={true}
                 />
+                {fieldEditorParams?.showTimeSignature &&
+                    <Dropdown
+                        id="time-signature-dropdown"
+                        items={timeSignatures}
+                        selectedId={selectedTimeSignature?.id}
+                        onItemSelected={onTimeSignatureChanged}
+                    />
+                }
                 <div className="spacer" />
                 { showEditControls &&
                     <EditControls

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -13,6 +13,8 @@ import { MeasureHeader } from "./MeasureHeader"
 import { VelocityEditor } from "./VelocityEditor"
 import { EditControls } from "../musicEditor/EditControls"
 import { Dropdown, DropdownItem } from "../../../../react-common/components/controls/Dropdown"
+import { Scrollbar } from "./Scrollbar"
+import { classList } from "../../../../react-common/components/util"
 
 interface PianoRollProps {
     onStateChanged?: (state: PianoRollState) => void;
@@ -417,7 +419,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
     const showHeader = !fieldEditorParams?.hideHeader;
 
     return (
-        <div className="piano-roll">
+        <div className={classList("piano-roll", showHeader ? "show-header" : "hide-header", velocityEditorVisible ? "show-velocity-editor" : "hide-velocity-editor")}>
             {modal?.type === "delete-track" &&
                 <DeleteTrackModal trackId={modal.trackId!} onClose={closeModal} onDelete={deleteTrack} />
             }
@@ -467,8 +469,10 @@ const PianoRollInternal = (props: PianoRollProps) => {
                             newNoteDuration={fieldEditorParams?.showSnapControls ? snapTicks : 1}
                             bpm={song.tempo}
                         />
+                        <Scrollbar horizontal />
                     </div>
                 </div>
+                <Scrollbar />
             </div>
             {velocityEditorVisible &&
                 <VelocityEditor notes={track.events} onNotesChange={onVelocityChange} />

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -59,6 +59,7 @@ export interface FieldEditorParams {
     minOctave?: number;
     maxOctave?: number;
     showTimeSignature?: boolean;
+    showSnapControls?: boolean;
 }
 
 interface StateSnapshot {
@@ -91,6 +92,8 @@ const PianoRollInternal = (props: PianoRollProps) => {
     const [undoStack, setUndoStack] = useState<StateSnapshot[]>(initialUndoStack || []);
     const [redoStack, setRedoStack] = useState<StateSnapshot[]>(initialRedoStack || []);
     const [name, setName] = useState(initialName || undefined);
+
+    const [snapTicks, setSnapTicks] = useState(4);
 
     const [velocityEditorVisible, setVelocityEditorVisible] = useState(initialVelocityEditorVisible || false);
 
@@ -430,12 +433,15 @@ const PianoRollInternal = (props: PianoRollProps) => {
                         song={song}
                         selectedTrackId={track.id}
                         velocityEditorVisible={velocityEditorVisible}
+                        snapTicks={snapTicks}
+                        showSnapControls={fieldEditorParams?.showSnapControls}
                         onVelocityEditorToggle={onVelocityEditorToggle}
                         onTrackSelected={onTrackSelected}
                         onInstrumentSelected={onInstrumentSelected}
                         onTrackCreated={onTrackCreated}
                         onTrackDeleted={onTrackDeleted}
                         onOctavesChanged={onOctavesChanged}
+                        onSnapChanged={setSnapTicks}
                     />
                 </div>
             }
@@ -457,6 +463,8 @@ const PianoRollInternal = (props: PianoRollProps) => {
                             isDrumTrack={isDrumInstrument(instrument)}
                             playNote={playNote}
                             maxTicks={song.measures * song.beatsPerMeasure * song.ticksPerBeat}
+                            snapTicks={fieldEditorParams?.showSnapControls ? snapTicks : 1}
+                            newNoteDuration={fieldEditorParams?.showSnapControls ? snapTicks : 1}
                             bpm={song.tempo}
                         />
                     </div>

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -1,8 +1,8 @@
 import { PianoRollTheme, PianoRollThemeProvider, usePianoRollThemeContext } from "./context"
 import { Workspace } from "./Workspace"
 import { Sidebar } from "./Sidebar"
-import { useEffect, useRef, useState } from "react"
-import { changeMeasures, changeOctaves, changeTimeSignature, changeTrackInstrument, fromPXTSong, getEmptySong, isDrumInstrument, newTrack, NoteEvent, Song, TIME_SIGNATURES, toPXTSong, Track, updateNoteEvent, updateNoteEvents, updateTrack } from "./types"
+import { useEffect, useRef, useState, useCallback, useMemo } from "react"
+import { applyFloatingLayer, changeMeasures, changeOctaves, changeTimeSignature, changeTrackInstrument, deleteFloatingLayer, deleteSelection, fromPXTSong, getEmptySong, isDrumInstrument, moveFloatingLayer, moveSelection, newTrack, NoteEvent, selectionToFloatingLayer, Song, TIME_SIGNATURES, toPXTSong, Track, transposeFloatingLayer, transposeSelection, updateNoteEvent, updateNoteEvents, updateTrack, WorkspaceSelection } from "./types"
 import { Header } from "./Header"
 import { DeleteTrackModal } from "./DeleteTrackModal"
 import { DeleteErrorModal } from "./DeleteErrorModal"
@@ -96,7 +96,6 @@ const PianoRollInternal = (props: PianoRollProps) => {
     const [name, setName] = useState(initialName || undefined);
 
     const [snapTicks, setSnapTicks] = useState(4);
-
     const [velocityEditorVisible, setVelocityEditorVisible] = useState(initialVelocityEditorVisible || false);
 
     useEffect(() => {
@@ -150,7 +149,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
         }
 
         updateTheme(newTheme);
-    }, [fieldEditorParams, updateTheme])
+    }, [fieldEditorParams, updateTheme]);
 
     const fireStateChange = (newState: Partial<PianoRollState>) => {
         if (onStateChanged) {
@@ -186,18 +185,57 @@ const PianoRollInternal = (props: PianoRollProps) => {
         }
     }
 
+    useEffect(() => {
+        const onKeydown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                if (song.floatingLayer) {
+                    updateSong(applyFloatingLayer(song));
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            }
+            else if (e.key === "Delete" || e.key === "Backspace") {
+                if (song.floatingLayer) {
+                    updateSong(deleteFloatingLayer(song));
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            }
+            else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+                if (song.floatingLayer) {
+                    updateSong(transposeFloatingLayer(song, e.key === "ArrowUp" ? 1 : -1));
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            }
+            else if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+                if (song.floatingLayer) {
+                    const deltaTicks = e.key === "ArrowLeft" ? -1 : 1;
+                    updateSong(moveFloatingLayer(song, deltaTicks));
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            }
+        }
+        window.addEventListener("keydown", onKeydown);
+        return () => {
+            window.removeEventListener("keydown", onKeydown);
+        };
+    }, [updateSong, song]);
+
     const onTrackEdit = (updatedTrack: Track) => {
-        updateSong(updateTrack(updatedTrack, song));
+        updateSong(updateTrack(updatedTrack, applyFloatingLayer(song)));
     }
 
     const onTrackSelected = (trackId: number) => {
+        updateSong(applyFloatingLayer(song));
         const index = song.tracks.findIndex(t => t.id === trackId);
         setSelectedTrackIndex(index);
         fireStateChange({ selectedTrackIndex: index });
     }
 
     const onTrackCreated = () => {
-        const newSong = newTrack(song.instruments[0].id, song);
+        const newSong = newTrack(song.instruments[0].id, applyFloatingLayer(song));
         updateSong(newSong);
 
         const newTrackIndex = newSong.tracks.length - 1;
@@ -238,14 +276,16 @@ const PianoRollInternal = (props: PianoRollProps) => {
 
     const deleteTrack = (trackId: number) => {
         setSelectedTrackIndex(0);
+        let newSong = applyFloatingLayer(song);
         updateSong({
-            ...song,
-            tracks: song.tracks.filter(t => t.id !== trackId)
+            ...newSong,
+            tracks: newSong.tracks.filter(t => t.id !== trackId)
         });
     }
 
     const setTrackInstrument = (trackId: number, instrumentId: number) => {
-        updateSong(changeTrackInstrument(trackId, instrumentId, song));
+        let newSong = applyFloatingLayer(song);
+        updateSong(changeTrackInstrument(trackId, instrumentId, newSong));
     }
 
     const playNote = (note: number) => {
@@ -274,7 +314,8 @@ const PianoRollInternal = (props: PianoRollProps) => {
     }
 
     const onMeasuresChanged = (newMeasures: number) => {
-        updateSong(changeMeasures(newMeasures, song));
+        let newSong = applyFloatingLayer(song);
+        updateSong(changeMeasures(newMeasures, newSong));
 
         updateTheme({ measures: newMeasures });
     }
@@ -284,7 +325,8 @@ const PianoRollInternal = (props: PianoRollProps) => {
         if (!signature) return;
 
         const { beatsPerMeasure, ticksPerBeat } = signature;
-        updateSong(changeTimeSignature(beatsPerMeasure, ticksPerBeat, song));
+        let newSong = applyFloatingLayer(song);
+        updateSong(changeTimeSignature(beatsPerMeasure, ticksPerBeat, newSong));
 
         updateTheme({ beatsPerMeasure, ticksPerBeat });
     }
@@ -297,26 +339,49 @@ const PianoRollInternal = (props: PianoRollProps) => {
     }
 
     const onOctavesChanged = (minOctave: number, maxOctave: number) => {
-        const track = song.tracks[selectedTrackIndex]!;
+        let newSong = applyFloatingLayer(song);
+        const track = newSong.tracks[selectedTrackIndex]!;
 
         if (track.minOctave === minOctave && track.maxOctave === maxOctave) return;
 
-        if (isDrumInstrument(song.instruments.find(i => i.id === track.instrumentId)!)) {
+        if (isDrumInstrument(newSong.instruments.find(i => i.id === track.instrumentId)!)) {
             return;
         }
 
         updateTheme({ minOctave, maxOctave });
-        updateSong(changeOctaves(track.id, minOctave, maxOctave, song));
+        updateSong(changeOctaves(track.id, minOctave, maxOctave, newSong));
     }
 
     const onVelocityChange = (notes: NoteEvent[]) => {
-        updateSong(updateNoteEvents(song, song.tracks[selectedTrackIndex]!.id, notes));
+        let newSong = applyFloatingLayer(song);
+        updateSong(updateNoteEvents(newSong, newSong.tracks[selectedTrackIndex]!.id, notes));
     }
 
     const onVelocityEditorToggle = () => {
         setVelocityEditorVisible(!velocityEditorVisible);
         fireStateChange({ velocityEditorVisible: !velocityEditorVisible });
     }
+
+    const onSelectionChange = useCallback((selection: WorkspaceSelection | undefined) => {
+        let newSong = song;
+        if (song.floatingLayer) {
+            newSong = applyFloatingLayer(song);
+        }
+
+        if (!selection) {
+            setSong(newSong);
+            return;
+        }
+
+        const newSelection = { ...selection };
+
+        if (fieldEditorParams?.showSnapControls) {
+            newSelection.startTick = Math.floor(selection.startTick / snapTicks) * snapTicks;
+            newSelection.endTick = Math.ceil(selection.endTick / snapTicks) * snapTicks;
+        }
+
+        setSong(selectionToFloatingLayer(newSong, selectedTrackIndex, newSelection));
+    }, [snapTicks, fieldEditorParams?.showSnapControls, song]);
 
     const undo = () => {
         if (!undoStack.length) return;
@@ -416,6 +481,16 @@ const PianoRollInternal = (props: PianoRollProps) => {
         }
     }, [minOctave, maxOctave, theme.minOctave, theme.maxOctave, updateTheme, song.measures, song.beatsPerMeasure, song.ticksPerBeat])
 
+    const applyFloatingLayerCB = useCallback(() => {
+        updateSong(applyFloatingLayer(song));
+    }, [song, updateSong]);
+
+    const updateFloatingLayerCB = useCallback((deltaTicks: number, deltaNotes: number) => {
+        if (song.floatingLayer) {
+            updateSong(moveFloatingLayer(transposeFloatingLayer(song, deltaNotes), deltaTicks));
+        }
+    }, [song, updateSong]);
+
     const showHeader = !fieldEditorParams?.hideHeader;
 
     return (
@@ -447,7 +522,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     />
                 </div>
             }
-            <MeasureHeader />
+            <MeasureHeader selection={song.floatingLayer} onSelectionChange={onSelectionChange} />
             <div className="scroll-container">
                 <div className="content-container">
                     <div className="sidebar-container">
@@ -468,6 +543,9 @@ const PianoRollInternal = (props: PianoRollProps) => {
                             snapTicks={fieldEditorParams?.showSnapControls ? snapTicks : 1}
                             newNoteDuration={fieldEditorParams?.showSnapControls ? snapTicks : 1}
                             bpm={song.tempo}
+                            floatingLayer={song.floatingLayer}
+                            updateFloatingLayer={updateFloatingLayerCB}
+                            applyFloatingLayer={applyFloatingLayerCB}
                         />
                         <Scrollbar horizontal />
                     </div>
@@ -500,7 +578,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                     />
                 }
                 <div className="spacer" />
-                { showEditControls &&
+                {showEditControls &&
                     <EditControls
                         assetName={name}
                         onAssetNameChanged={onNameChange}

--- a/webapp/src/components/pianoRoll/Scrollbar.tsx
+++ b/webapp/src/components/pianoRoll/Scrollbar.tsx
@@ -1,0 +1,140 @@
+import * as React from "react";
+
+interface Props {
+    horizontal?: boolean;
+}
+
+export const Scrollbar = (props: Props) => {
+    const { horizontal } = props;
+    const scrollbarRef = React.useRef<HTMLDivElement>(null);
+    const thumbRef = React.useRef<HTMLDivElement>(null);
+
+    React.useEffect(() => {
+        const scrollbar = scrollbarRef.current;
+        const container = scrollbar.parentElement;
+        const thumb = thumbRef.current;
+
+        if (!scrollbar || !container || !thumb) return () => {};
+
+        let updateThumb = () => {
+            const containerSize = horizontal ? container.clientWidth : container.clientHeight;
+            const contentSize = horizontal ? container.scrollWidth : container.scrollHeight;
+
+            if (contentSize <= containerSize) {
+                scrollbar.style.display = "none";
+                return;
+            }
+            else {
+                scrollbar.style.display = "block";
+            }
+
+            const thumbSize = Math.max((containerSize / contentSize) * containerSize, 20);
+            const thumbPosition = (horizontal ? container.scrollLeft : container.scrollTop) / (contentSize - containerSize) * (containerSize - thumbSize - 16) + 8;
+            if (horizontal) {
+                thumb.style.width = `${thumbSize}px`;
+                thumb.style.transform = `translateX(${thumbPosition}px)`;
+            } else {
+                thumb.style.height = `${thumbSize}px`;
+                thumb.style.transform = `translateY(${thumbPosition}px)`;
+            }
+        };
+
+        updateThumb();
+        requestAnimationFrame(updateThumb);
+        container.addEventListener("scroll", updateThumb);
+        window.addEventListener("resize", updateThumb);
+
+        let dragging = false;
+        let dragStart = 0;
+        let scrollStart = 0;
+
+        const onPointerDownThumb = (e: PointerEvent) => {
+            e.preventDefault();
+            dragging = true;
+            dragStart = horizontal ? e.clientX : e.clientY;
+            scrollStart = horizontal ? container.scrollLeft : container.scrollTop;
+            document.addEventListener("pointermove", onPointerMoveThumb);
+            document.addEventListener("pointerup", onPointerUpThumb);
+        }
+
+        const onPointerMoveThumb = (e: PointerEvent) => {
+            if (!dragging) return;
+            e.preventDefault();
+
+            const delta = (horizontal ? e.clientX : e.clientY) - dragStart;
+            const containerSize = horizontal ? container.clientWidth : container.clientHeight;
+            const contentSize = horizontal ? container.scrollWidth : container.scrollHeight;
+            const thumbSize = horizontal ? thumb.offsetWidth : thumb.offsetHeight;
+            const scrollDelta = delta * (contentSize - containerSize) / (containerSize - thumbSize - 16);
+            if (horizontal) {
+                container.scrollLeft = scrollStart + scrollDelta;
+            } else {
+                container.scrollTop = scrollStart + scrollDelta;
+            }
+        }
+
+        const onPointerUpThumb = (e: PointerEvent) => {
+            dragging = false;
+            document.removeEventListener("pointermove", onPointerMoveThumb);
+            document.removeEventListener("pointerup", onPointerUpThumb);
+        }
+
+        thumb.addEventListener("pointerdown", onPointerDownThumb);
+
+        const onPointerDown = (e: PointerEvent) => {
+            e.preventDefault();
+            const rect = scrollbar.getBoundingClientRect();
+            const clickPosition = horizontal ? e.clientX - rect.left : e.clientY - rect.top;
+            const containerSize = horizontal ? container.clientWidth : container.clientHeight;
+            const contentSize = horizontal ? container.scrollWidth : container.scrollHeight;
+            const thumbSize = horizontal ? thumb.offsetWidth : thumb.offsetHeight;
+            const thumbPosition = (horizontal ? container.scrollLeft : container.scrollTop) / (contentSize - containerSize) * (containerSize - thumbSize - 16) + 8;
+
+            if (clickPosition < thumbPosition) {
+                if (horizontal) {
+                    container.scrollLeft -= containerSize;
+                } else {
+                    container.scrollTop -= containerSize;
+                }
+            }
+            else if (clickPosition > thumbPosition + thumbSize) {
+                if (horizontal) {
+                    container.scrollLeft += containerSize;
+                } else {
+                    container.scrollTop += containerSize;
+                }
+            }
+
+            onPointerDownThumb(e);
+        }
+
+        scrollbar.addEventListener("pointerdown", onPointerDown);
+
+        const mutationObserver = new MutationObserver(updateThumb);
+        mutationObserver.observe(container, { childList: true, subtree: true });
+
+        const resizeObserver = new ResizeObserver(updateThumb);
+        resizeObserver.observe(container);
+
+        return () => {
+            scrollbar.removeEventListener("pointerdown", onPointerDown);
+            thumb.removeEventListener("pointerdown", onPointerDownThumb);
+            document.removeEventListener("pointermove", onPointerMoveThumb);
+            document.removeEventListener("pointerup", onPointerUpThumb);
+            container.removeEventListener("scroll", updateThumb);
+            window.removeEventListener("resize", updateThumb);
+            mutationObserver.disconnect();
+            resizeObserver.disconnect();
+        };
+    }, [horizontal]);
+
+    const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
+
+    };
+
+    return (
+        <div ref={scrollbarRef} className={`scrollbar ${horizontal ? "horizontal" : "vertical"}`}>
+            <div ref={thumbRef} className="scrollbar-thumb" />
+        </div>
+    );
+}

--- a/webapp/src/components/pianoRoll/VelocityEditor.tsx
+++ b/webapp/src/components/pianoRoll/VelocityEditor.tsx
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 import { useEffect, useRef, useState } from "react";
 import { classList } from "../../../../react-common/components/util";
 import { usePianoRollTheme } from "./context";
@@ -25,6 +27,17 @@ export const VelocityEditor = (props: Props) => {
     const width = tickWidth * ticksPerBeat * beatsPerMeasure * measures;
 
     const offsets: NoteOffset[] = [];
+
+    const ref = useRef<HTMLDivElement>(null);
+
+    React.useEffect(() => {
+        if (!ref.current) return;
+
+        const workspace = document.getElementById("piano-roll-workspace");
+        if (!workspace) return;
+
+        ref.current.scrollLeft = workspace.parentElement.scrollLeft;
+    }, []);
 
     for (const note of notes) {
         const offset = offsets.find(o => o.start === note.start);
@@ -78,7 +91,7 @@ export const VelocityEditor = (props: Props) => {
     }
 
     return (
-        <div id="velocity-editor" className="velocity-editor">
+        <div id="velocity-editor" className="velocity-editor" ref={ref}>
             <div className="velocity-editor-sidebar" />
             <div className="velocity-sliders" style={{ width: `${width}px` }}>
                 {offsets.map((notes, i) => (

--- a/webapp/src/components/pianoRoll/VelocityEditor.tsx
+++ b/webapp/src/components/pianoRoll/VelocityEditor.tsx
@@ -18,11 +18,11 @@ interface NoteOffset {
 export const VelocityEditor = (props: Props) => {
     const { notes, onNotesChange } = props;
     const theme = usePianoRollTheme();
-    const { octaveWidth, measures } = theme;
+    const { tickWidth, ticksPerBeat, beatsPerMeasure, measures } = theme;
 
-    const [highlightedTick, setHighlightedTick] = useState<Number>(undefined);
+    const [highlightedTick, setHighlightedTick] = useState<number | undefined>(undefined);
 
-    const width = octaveWidth * measures;
+    const width = tickWidth * ticksPerBeat * beatsPerMeasure * measures;
 
     const offsets: NoteOffset[] = [];
 

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -181,7 +181,7 @@ export const Workspace = (props: Props) => {
 
 
     useEffect(() => {
-        const tickTime = pxsim.music.tickToMs(bpm, 4, 1);
+        const tickTime = pxsim.music.tickToMs(bpm, theme.ticksPerBeat, 1);
         const tickDistance = noteWidth(theme, 1);
         let playbackHeadPosition = 0;
         let isPlaying = false;

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -12,6 +12,8 @@ interface Props {
     playNote: (note: number) => void;
     onEdit: (track: Track) => void;
     maxTicks: number;
+    snapTicks: number;
+    newNoteDuration: number;
     bpm: number;
 }
 
@@ -22,11 +24,10 @@ interface GestureState {
     startScrollY: number;
     noteEvent?: NoteEvent;
     isScrolling?: boolean
-    noteElement?: HTMLDivElement;
-}
+    noteElement?: HTMLDivElement;}
 
 export const Workspace = (props: Props) => {
-    const { track, onEdit, isDrumTrack, playNote, maxTicks, bpm } = props;
+    const { track, onEdit, isDrumTrack, playNote, maxTicks, bpm, snapTicks, newNoteDuration } = props;
 
     const bg = useWorkspaceBackground();
     const theme = usePianoRollTheme();
@@ -79,9 +80,11 @@ export const Workspace = (props: Props) => {
             const coords = clientToNoteCoordinates(clientX, clientY);
             if (!coords) return 1;
 
+            const snappedTime = Math.ceil((coords.time + 1) / snapTicks) * snapTicks;
+
             const max = getMaxDuration(editing.note, editing.start, track, maxTicks, theme.maxPolyphony);
 
-            return Math.max(1, Math.min(max, coords.time - editing.start + 1));
+            return Math.max(1, Math.min(max, snappedTime - editing.start));
         }
 
         const getNoteEventAtPosition = (x: number, y: number): NoteEvent | undefined => {
@@ -152,7 +155,9 @@ export const Workspace = (props: Props) => {
                     const coords = clientToNoteCoordinates(gestureState.current.startX, gestureState.current.startY);
 
                     if (coords) {
-                        onEdit(newNoteEvent(coords.note, coords.time, track, isDrumTrack, maxTicks, theme.maxPolyphony));
+                        const snappedTime = snapTicks > 1 ? Math.floor(coords.time / snapTicks) * snapTicks : coords.time;
+                        coords.time = snappedTime;
+                        onEdit(newNoteEvent(coords.note, coords.time, newNoteDuration, track, isDrumTrack, maxTicks, theme.maxPolyphony));
                         playNote(coords.note);
                     }
                 }
@@ -177,7 +182,7 @@ export const Workspace = (props: Props) => {
             workspaceRef.current?.removeEventListener("pointercancel", onPointerUp);
             workspaceRef.current?.removeEventListener("pointerleave", onPointerUp);
         }
-    }, [track, onEdit, theme.minOctave, theme.maxOctave, isDrumTrack])
+    }, [track, onEdit, theme.minOctave, theme.maxOctave, isDrumTrack, snapTicks, maxTicks])
 
 
     useEffect(() => {

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -11,7 +11,7 @@ interface Props {
     isDrumTrack: boolean;
     playNote: (note: number) => void;
     onEdit: (track: Track) => void;
-    measures: number;
+    maxTicks: number;
     bpm: number;
 }
 
@@ -26,7 +26,7 @@ interface GestureState {
 }
 
 export const Workspace = (props: Props) => {
-    const { track, onEdit, isDrumTrack, playNote, measures, bpm } = props;
+    const { track, onEdit, isDrumTrack, playNote, maxTicks, bpm } = props;
 
     const bg = useWorkspaceBackground();
     const theme = usePianoRollTheme();
@@ -79,7 +79,7 @@ export const Workspace = (props: Props) => {
             const coords = clientToNoteCoordinates(clientX, clientY);
             if (!coords) return 1;
 
-            const max = getMaxDuration(editing.note, editing.start, track, measures, theme.maxPolyphony);
+            const max = getMaxDuration(editing.note, editing.start, track, maxTicks, theme.maxPolyphony);
 
             return Math.max(1, Math.min(max, coords.time - editing.start + 1));
         }
@@ -152,13 +152,13 @@ export const Workspace = (props: Props) => {
                     const coords = clientToNoteCoordinates(gestureState.current.startX, gestureState.current.startY);
 
                     if (coords) {
-                        onEdit(newNoteEvent(coords.note, coords.time, track, isDrumTrack, measures, theme.maxPolyphony));
+                        onEdit(newNoteEvent(coords.note, coords.time, track, isDrumTrack, maxTicks, theme.maxPolyphony));
                         playNote(coords.note);
                     }
                 }
             }
             else if (gestureState.current.noteEvent && !isDrumTrack) {
-                onEdit(changeNoteEventDuration(gestureState.current.noteEvent.id, getNewNoteDuration(e.clientX, e.clientY), track, measures, theme.maxPolyphony));
+                onEdit(changeNoteEventDuration(gestureState.current.noteEvent.id, getNewNoteDuration(e.clientX, e.clientY), track, maxTicks, theme.maxPolyphony));
             }
 
             gestureState.current = null;
@@ -226,6 +226,7 @@ export const Workspace = (props: Props) => {
     return (
         <div className="workspace" style={{
             backgroundImage: bg,
+            backgroundSize: `${theme.tickWidth * theme.ticksPerBeat}px ${7 * theme.whiteKeyHeight}px`,
             width: workspaceWidth(theme),
             height: workspaceHeight(theme)
         }} ref={workspaceRef}>

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -2,8 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import { addPlaybackStateListener, addTickListener, removePlaybackStateListener, removeTickListener } from "../musicEditor/playback";
 import { usePianoRollTheme } from "./context";
 import { NoteEventView } from "./NoteEvent"
-import { changeNoteEventDuration, getMaxDuration, isInSelection, newNoteEvent, NoteEvent, Song, Track, WorkspaceSelection } from "./types";
-import { noteLeft, noteTop, noteWidth, range, workspaceHeight, workspaceWidth, xToTick, yToNote } from "./utils";
+import { changeNoteEventDuration, getMaxDuration, newNoteEvent, NoteEvent, Song, Track } from "./types";
+import { noteLeft, noteTop, noteWidth, workspaceHeight, workspaceWidth, xToTick, yToNote } from "./utils";
 import { useWorkspaceBackground } from "./workspaceBackground";
 
 interface Props {
@@ -19,6 +19,7 @@ interface Props {
 
     updateFloatingLayer: (deltaTicks: number, deltaNotes: number) => void;
     applyFloatingLayer: () => void;
+    addEventListeners: (el: HTMLElement) => void;
 }
 
 interface GestureState {
@@ -44,7 +45,8 @@ export const Workspace = (props: Props) => {
         newNoteDuration,
         floatingLayer,
         updateFloatingLayer,
-        applyFloatingLayer
+        applyFloatingLayer,
+        addEventListeners
     } = props;
 
     const bg = useWorkspaceBackground();
@@ -324,6 +326,11 @@ export const Workspace = (props: Props) => {
         setDeltaTicks(0);
     }, [floatingLayer])
 
+    useEffect(() => {
+        if (!workspaceRef.current) return;
+        return addEventListeners(workspaceRef.current!)
+    }, [addEventListeners])
+
     return (
         <div
             className="workspace"
@@ -335,6 +342,7 @@ export const Workspace = (props: Props) => {
                 height: workspaceHeight(theme)
             }}
             ref={workspaceRef}
+            tabIndex={0}
         >
             <div className="playhead" ref={playheadRef}></div>
             {track.events.map((e, i) =>

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -48,16 +48,23 @@ export const Workspace = (props: Props) => {
         cursor.style.display = "none";
         workspaceRef.current?.appendChild(cursor);
 
+        const onSroll = () => {
+            const scrollLeft = horizontalScroller?.scrollLeft || 0;
+
+            if (measureScroller) {
+                measureScroller.scrollLeft = scrollLeft;
+            }
+            if (velocityEditor) {
+                velocityEditor.scrollLeft = scrollLeft;
+            }
+        }
+
+        horizontalScroller?.addEventListener("scroll", onSroll);
+
         const changeHorizontalScroll = (delta: number) => {
             const scroll = gestureState.current.startScrollX - delta;
             if (horizontalScroller) {
                 horizontalScroller.scrollLeft = scroll;
-            }
-            if (measureScroller) {
-                measureScroller.scrollLeft = scroll;
-            }
-            if (velocityEditor) {
-                velocityEditor.scrollLeft = scroll;
             }
         }
 
@@ -215,6 +222,7 @@ export const Workspace = (props: Props) => {
             workspaceRef.current?.removeEventListener("pointercancel", onPointerUp);
             workspaceRef.current?.removeEventListener("pointerleave", onPointerUp);
             workspaceRef.current?.removeChild(cursor);
+            horizontalScroller?.removeEventListener("scroll", onSroll);
         }
     }, [track, onEdit, theme.minOctave, theme.maxOctave, isDrumTrack, snapTicks, maxTicks])
 
@@ -263,12 +271,16 @@ export const Workspace = (props: Props) => {
     }, [theme, bpm])
 
     return (
-        <div className="workspace" style={{
-            backgroundImage: bg,
-            backgroundSize: `${theme.tickWidth * theme.ticksPerBeat}px ${7 * theme.whiteKeyHeight}px`,
-            width: workspaceWidth(theme),
-            height: workspaceHeight(theme)
-        }} ref={workspaceRef}>
+        <div
+            className="workspace"
+            id="piano-roll-workspace"
+            style={{
+                backgroundImage: bg,
+                backgroundSize: `${theme.tickWidth * theme.ticksPerBeat}px ${7 * theme.whiteKeyHeight}px`,
+                width: workspaceWidth(theme),
+                height: workspaceHeight(theme)
+            }}
+            ref={workspaceRef}>
             <div className="playhead" ref={playheadRef}></div>
             {track.events.map((e, i) => <NoteEventView key={i} event={e} isDrumTrack={isDrumTrack} />)}
         </div>

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -3,7 +3,7 @@ import { addPlaybackStateListener, addTickListener, removePlaybackStateListener,
 import { usePianoRollTheme } from "./context";
 import { NoteEventView } from "./NoteEvent"
 import { changeNoteEventDuration, getMaxDuration, newNoteEvent, NoteEvent, Track } from "./types";
-import { noteWidth, range, workspaceHeight, workspaceWidth, xToTick, yToNote } from "./utils";
+import { noteLeft, noteTop, noteWidth, range, workspaceHeight, workspaceWidth, xToTick, yToNote } from "./utils";
 import { useWorkspaceBackground } from "./workspaceBackground";
 
 interface Props {
@@ -41,6 +41,12 @@ export const Workspace = (props: Props) => {
         const verticalScroller = horizontalScroller?.parentElement?.parentElement;
         const measureScroller = document.getElementById("measure-header");
         const velocityEditor = document.getElementById("velocity-editor");
+
+        const cursor = document.createElement("div");
+        cursor.className = "cursor";
+        cursor.style.position = "absolute";
+        cursor.style.display = "none";
+        workspaceRef.current?.appendChild(cursor);
 
         const changeHorizontalScroll = (delta: number) => {
             const scroll = gestureState.current.startScrollX - delta;
@@ -95,7 +101,31 @@ export const Workspace = (props: Props) => {
         }
 
         const updateGesture = (e: PointerEvent) => {
-            if (!gestureState.current) return;
+            if (!gestureState.current) {
+                const event = getNoteEventAtPosition(e.clientX, e.clientY);
+
+                if (!event) {
+                    cursor.style.display = "block";
+                    const coords = clientToNoteCoordinates(e.clientX, e.clientY);
+
+                    if (coords) {
+                        const snappedTime = snapTicks > 1 ? Math.floor(coords.time / snapTicks) * snapTicks : coords.time;
+                        coords.time = snappedTime;
+
+                        const maxDuration = isDrumTrack ? 1 : Math.min(getMaxDuration(coords.note, coords.time, track, maxTicks, theme.maxPolyphony), newNoteDuration);
+                        cursor.style.left = `${noteLeft(theme, coords.time)}px`;
+                        cursor.style.top = `${noteTop(theme, coords.note)}px`;
+                        cursor.style.width = `${noteWidth(theme, maxDuration)}px`;
+                    }
+
+                }
+                else {
+                    cursor.style.display = "none";
+                }
+                return;
+            }
+
+            cursor.style.display = "none";
 
             const deltaX = e.clientX - gestureState.current.startX;
             const deltaY = e.clientY - gestureState.current.startY;
@@ -141,7 +171,10 @@ export const Workspace = (props: Props) => {
         }
 
         const onPointerUp = (e: PointerEvent) => {
-            if (!gestureState.current) return;
+            if (!gestureState.current) {
+                cursor.style.display = "none";
+                return;
+            }
             updateGesture(e);
 
             if (!gestureState.current.isScrolling) {
@@ -181,6 +214,7 @@ export const Workspace = (props: Props) => {
             workspaceRef.current?.removeEventListener("pointerup", onPointerUp);
             workspaceRef.current?.removeEventListener("pointercancel", onPointerUp);
             workspaceRef.current?.removeEventListener("pointerleave", onPointerUp);
+            workspaceRef.current?.removeChild(cursor);
         }
     }, [track, onEdit, theme.minOctave, theme.maxOctave, isDrumTrack, snapTicks, maxTicks])
 

--- a/webapp/src/components/pianoRoll/Workspace.tsx
+++ b/webapp/src/components/pianoRoll/Workspace.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { addPlaybackStateListener, addTickListener, removePlaybackStateListener, removeTickListener } from "../musicEditor/playback";
 import { usePianoRollTheme } from "./context";
 import { NoteEventView } from "./NoteEvent"
-import { changeNoteEventDuration, getMaxDuration, newNoteEvent, NoteEvent, Track } from "./types";
+import { changeNoteEventDuration, getMaxDuration, isInSelection, newNoteEvent, NoteEvent, Song, Track, WorkspaceSelection } from "./types";
 import { noteLeft, noteTop, noteWidth, range, workspaceHeight, workspaceWidth, xToTick, yToNote } from "./utils";
 import { useWorkspaceBackground } from "./workspaceBackground";
 
@@ -15,6 +15,10 @@ interface Props {
     snapTicks: number;
     newNoteDuration: number;
     bpm: number;
+    floatingLayer?: Song["floatingLayer"];
+
+    updateFloatingLayer: (deltaTicks: number, deltaNotes: number) => void;
+    applyFloatingLayer: () => void;
 }
 
 interface GestureState {
@@ -24,10 +28,24 @@ interface GestureState {
     startScrollY: number;
     noteEvent?: NoteEvent;
     isScrolling?: boolean
-    noteElement?: HTMLDivElement;}
+    isMove?: boolean;
+    noteElement?: HTMLDivElement;
+}
 
 export const Workspace = (props: Props) => {
-    const { track, onEdit, isDrumTrack, playNote, maxTicks, bpm, snapTicks, newNoteDuration } = props;
+    const {
+        track,
+        onEdit,
+        isDrumTrack,
+        playNote,
+        maxTicks,
+        bpm,
+        snapTicks,
+        newNoteDuration,
+        floatingLayer,
+        updateFloatingLayer,
+        applyFloatingLayer
+    } = props;
 
     const bg = useWorkspaceBackground();
     const theme = usePianoRollTheme();
@@ -35,6 +53,8 @@ export const Workspace = (props: Props) => {
     const workspaceRef = useRef<HTMLDivElement>(null);
     const playheadRef = useRef<HTMLDivElement>(null);
     const gestureState = useRef<GestureState | null>(null);
+
+    const [deltaTicks, setDeltaTicks] = useState(0);
 
     useEffect(() => {
         const horizontalScroller = workspaceRef.current?.parentElement;
@@ -48,7 +68,20 @@ export const Workspace = (props: Props) => {
         cursor.style.display = "none";
         workspaceRef.current?.appendChild(cursor);
 
-        const onSroll = () => {
+        const moveSelection = (deltaTicks: number) => {
+            if (!floatingLayer) return;
+
+            const headerSelection = document.getElementById("measure-header-selection");
+            const newStart = floatingLayer.startTick + deltaTicks;
+
+            if (headerSelection) {
+                headerSelection.style.left = `${noteLeft(theme, newStart)}px`;
+            }
+
+            setDeltaTicks(deltaTicks);
+        }
+
+        const onScroll = () => {
             const scrollLeft = horizontalScroller?.scrollLeft || 0;
 
             if (measureScroller) {
@@ -59,7 +92,7 @@ export const Workspace = (props: Props) => {
             }
         }
 
-        horizontalScroller?.addEventListener("scroll", onSroll);
+        horizontalScroller?.addEventListener("scroll", onScroll);
 
         const changeHorizontalScroll = (delta: number) => {
             const scroll = gestureState.current.startScrollX - delta;
@@ -143,7 +176,11 @@ export const Workspace = (props: Props) => {
             }
 
             if (gestureState.current.isScrolling) {
-                if (!gestureState.current.noteEvent || isDrumTrack) {
+                if (gestureState.current.isMove) {
+                    const deltaTicks = Math.round(deltaX / noteWidth(theme, 1));
+                    moveSelection(deltaTicks);
+                }
+                else if (!gestureState.current.noteEvent || isDrumTrack) {
                     changeHorizontalScroll(deltaX);
                     changeVerticalScroll(deltaY);
                 }
@@ -162,13 +199,19 @@ export const Workspace = (props: Props) => {
         }
 
         const onPointerDown = (e: PointerEvent) => {
+            const { time } = clientToNoteCoordinates(e.clientX, e.clientY) || {};
             gestureState.current = {
                 startX: e.clientX,
                 startY: e.clientY,
                 startScrollX: horizontalScroller?.scrollLeft || 0,
                 startScrollY: verticalScroller?.scrollTop || 0,
-                noteEvent: getNoteEventAtPosition(e.clientX, e.clientY)
+                noteEvent: getNoteEventAtPosition(e.clientX, e.clientY),
+                isMove: floatingLayer && time > floatingLayer.startTick && time < floatingLayer.endTick
             };
+
+            if (floatingLayer && !gestureState.current.isMove) {
+                applyFloatingLayer();
+            }
 
             updateGesture(e);
         }
@@ -178,6 +221,7 @@ export const Workspace = (props: Props) => {
         }
 
         const onPointerUp = (e: PointerEvent) => {
+            setDeltaTicks(0);
             if (!gestureState.current) {
                 cursor.style.display = "none";
                 return;
@@ -185,7 +229,10 @@ export const Workspace = (props: Props) => {
             updateGesture(e);
 
             if (!gestureState.current.isScrolling) {
-                if (gestureState.current.noteEvent) {
+                if (gestureState.current.isMove) {
+                    applyFloatingLayer();
+                }
+                else if (gestureState.current.noteEvent) {
                     onEdit({
                         ...track,
                         events: track.events.filter(e => e !== gestureState.current?.noteEvent)
@@ -201,6 +248,9 @@ export const Workspace = (props: Props) => {
                         playNote(coords.note);
                     }
                 }
+            }
+            else if (gestureState.current.isMove) {
+                updateFloatingLayer(Math.round((e.clientX - gestureState.current.startX) / noteWidth(theme, 1)), 0);
             }
             else if (gestureState.current.noteEvent && !isDrumTrack) {
                 onEdit(changeNoteEventDuration(gestureState.current.noteEvent.id, getNewNoteDuration(e.clientX, e.clientY), track, maxTicks, theme.maxPolyphony));
@@ -222,9 +272,9 @@ export const Workspace = (props: Props) => {
             workspaceRef.current?.removeEventListener("pointercancel", onPointerUp);
             workspaceRef.current?.removeEventListener("pointerleave", onPointerUp);
             workspaceRef.current?.removeChild(cursor);
-            horizontalScroller?.removeEventListener("scroll", onSroll);
+            horizontalScroller?.removeEventListener("scroll", onScroll);
         }
-    }, [track, onEdit, theme.minOctave, theme.maxOctave, isDrumTrack, snapTicks, maxTicks])
+    }, [track, onEdit, theme.minOctave, theme.maxOctave, isDrumTrack, snapTicks, maxTicks, floatingLayer, updateFloatingLayer, applyFloatingLayer])
 
 
     useEffect(() => {
@@ -270,6 +320,10 @@ export const Workspace = (props: Props) => {
         }
     }, [theme, bpm])
 
+    useEffect(() => {
+        setDeltaTicks(0);
+    }, [floatingLayer])
+
     return (
         <div
             className="workspace"
@@ -280,9 +334,34 @@ export const Workspace = (props: Props) => {
                 width: workspaceWidth(theme),
                 height: workspaceHeight(theme)
             }}
-            ref={workspaceRef}>
+            ref={workspaceRef}
+        >
             <div className="playhead" ref={playheadRef}></div>
-            {track.events.map((e, i) => <NoteEventView key={i} event={e} isDrumTrack={isDrumTrack} />)}
+            {track.events.map((e, i) =>
+                <NoteEventView
+                    key={i}
+                    event={e}
+                    isDrumTrack={isDrumTrack}
+                />
+            )}
+            {floatingLayer?.events?.map((e, i) =>
+                <NoteEventView
+                    key={`floating-${i}`}
+                    event={{ ...e, start: e.start + deltaTicks }}
+                    isDrumTrack={isDrumTrack}
+                    type="floating"
+                />
+            )}
+            {floatingLayer &&
+                <div
+                    id="workspace-selection"
+                    className="selection"
+                    style={{
+                        left: noteLeft(theme, floatingLayer.startTick + deltaTicks),
+                        width: noteWidth(theme, floatingLayer.endTick - floatingLayer.startTick)
+                    }}
+                ></div>
+            }
         </div>
     );
 }

--- a/webapp/src/components/pianoRoll/clipboard.ts
+++ b/webapp/src/components/pianoRoll/clipboard.ts
@@ -1,0 +1,25 @@
+import { CopyData } from "./types";
+
+export function setCopiedData(data: CopyData) {
+    const json = JSON.stringify(data);
+    if (data.isDrumTrack) {
+        localStorage.setItem("piano-roll-drum-copy", json);
+    }
+    else {
+        localStorage.setItem("piano-roll-copy", json);
+    }
+}
+
+export function getCopiedData(isDrumTrack: boolean): CopyData | undefined {
+    const json = isDrumTrack ? localStorage.getItem("piano-roll-drum-copy") : localStorage.getItem("piano-roll-copy");
+    if (!json) return undefined;
+
+    try {
+        const data = JSON.parse(json);
+        return data;
+    }
+    catch (e) {
+        console.error("Failed to parse copied data", e);
+        return undefined;
+    }
+}

--- a/webapp/src/components/pianoRoll/context.tsx
+++ b/webapp/src/components/pianoRoll/context.tsx
@@ -1,8 +1,10 @@
 import { createContext, useContext, useEffect, useReducer, useRef } from "react";
 
 export interface PianoRollTheme {
-    octaveWidth: number;
+    tickWidth: number;
     whiteKeyHeight: number;
+    ticksPerBeat: number;
+    beatsPerMeasure: number;
     measures: number;
     minOctave: number;
     maxOctave: number;
@@ -14,8 +16,10 @@ export interface PianoRollTheme {
 }
 
 const defaultTheme: PianoRollTheme = {
-    octaveWidth: 500,
+    tickWidth: 30,
     whiteKeyHeight: 40,
+    ticksPerBeat: 4,
+    beatsPerMeasure: 4,
     measures: 4,
     minOctave: 3,
     maxOctave: 5,
@@ -70,7 +74,7 @@ export function PianoRollThemeProvider(
 
     useEffect(() => {
         const styleParts = [
-            `--octave-width: ${value.state.octaveWidth}px`,
+            `--tick-width: ${value.state.tickWidth}px`,
             `--white-key-height: ${value.state.whiteKeyHeight}px`,
         ];
 
@@ -79,7 +83,7 @@ export function PianoRollThemeProvider(
         }
 
         rootRef.current!.setAttribute("style", styleParts.join("; "));
-    }, [value.state.octaveWidth, value.state.whiteKeyHeight, value.state.borderColor])
+    }, [value.state.tickWidth, value.state.whiteKeyHeight, value.state.borderColor])
 
     return (
         <PianoRollContext.Provider

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -83,6 +83,24 @@ export const TIME_SIGNATURES = [
     }
 ]
 
+export const SNAP_OPTIONS = [
+    {
+        name: lf("1/4"),
+        id: "quarter",
+        ticksPerSnap: 4
+    },
+    {
+        name: lf("1/8"),
+        id: "eighth",
+        ticksPerSnap: 2
+    },
+    {
+        name: lf("1/16"),
+        id: "sixteenth",
+        ticksPerSnap: 1
+    }
+];
+
 export const NOTE_RANGES = [
     {
         name: lf("Treble"),
@@ -174,14 +192,14 @@ export function getMaxDuration(note: number, start: number, track: Track, maxTic
     return maxTicks - start;
 }
 
-export function newNoteEvent(note: number, start: number, track: Track, isDrumTrack: boolean, maxTicks: number, maxPolyphony: number): Track {
+export function newNoteEvent(note: number, start: number, duration: number, track: Track, isDrumTrack: boolean, maxTicks: number, maxPolyphony: number): Track {
     track = removeEventAtTimeIfNeeded(start, track, maxPolyphony);
 
     const newEvent: NoteEvent = {
         id: track.nextId++,
         note,
         start,
-        duration: isDrumTrack ? 1 : Math.min(4, getMaxDuration(note, start, track, maxTicks, maxPolyphony)),
+        duration: isDrumTrack ? 1 : Math.min(duration, getMaxDuration(note, start, track, maxTicks, maxPolyphony)),
         velocity: 128
     };
 

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -59,6 +59,8 @@ export interface CopyData {
     endTick: number;
     events: NoteEvent[];
     isDrumTrack: boolean;
+    minOctave?: number;
+    maxOctave?: number;
 }
 
 export const lf = pxt.U.lf;
@@ -719,7 +721,9 @@ export function getCopyData(song: Song, trackId: number, selection: WorkspaceSel
         startTick: selection.startTick,
         endTick: selection.endTick,
         events,
-        isDrumTrack: isDrumInstrument(song.instruments.find(i => i.id === track.instrumentId))
+        isDrumTrack: isDrumInstrument(song.instruments.find(i => i.id === track.instrumentId)),
+        minOctave: track.minOctave,
+        maxOctave: track.maxOctave,
     };
 }
 

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -25,6 +25,13 @@ export interface Song {
 
     beatsPerMeasure: number;
     ticksPerBeat: number;
+
+    floatingLayer?: {
+        events: NoteEvent[];
+        startTick: number;
+        endTick: number;
+        trackId: number;
+    }
 }
 
 interface BaseInstrument {
@@ -41,6 +48,18 @@ export interface DrumInstrument extends BaseInstrument {
 }
 
 export type Instrument = MelodicInstrument | DrumInstrument;
+
+export interface WorkspaceSelection {
+    startTick: number;
+    endTick: number;
+}
+
+export interface CopyData {
+    startTick: number;
+    endTick: number;
+    events: NoteEvent[];
+    isDrumTrack: boolean;
+}
 
 export const lf = pxt.U.lf;
 
@@ -355,14 +374,15 @@ export function changeTrackInstrument(trackId: number, instrumentId: number, son
 }
 
 export function changeMeasures(measures: number, song: Song): Song {
+    const maxTicks = measures * song.beatsPerMeasure * song.ticksPerBeat;
     return {
         ...song,
         measures,
         tracks: song.tracks.map(track => ({
             ...track,
-            events: track.events.filter(e => e.start < measures * 4 * 4).map(e => ({
+            events: track.events.filter(e => e.start < maxTicks).map(e => ({
                 ...e,
-                duration: Math.min(e.duration, measures * 4 * 4 - e.start)
+                duration: Math.min(e.duration, maxTicks - e.start)
             }))
         }))
     }
@@ -396,6 +416,8 @@ export function isMelodicInstrument(instrument: Instrument): instrument is Melod
 }
 
 export function toPXTSong(song: Song): pxt.assets.music.Song {
+    song = applyFloatingLayer(song);
+
     return {
         ticksPerBeat: song.ticksPerBeat,
         beatsPerMeasure: song.beatsPerMeasure,
@@ -500,6 +522,17 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
         }
     }
 
+    if (result.tracks.length === 0) {
+        result.tracks.push({
+            id: 0,
+            instrumentId: result.instruments[0].id,
+            events: [],
+            nextId: 0,
+            minOctave: NOTE_RANGES[0].minOctave,
+            maxOctave: NOTE_RANGES[0].maxOctave
+        })
+    }
+
     return result;
 }
 
@@ -564,4 +597,210 @@ function lfosEqual(a: pxt.assets.music.LFO | undefined, b: pxt.assets.music.LFO 
     if (a.amplitude !== b.amplitude) return false;
 
     return true;
+}
+
+export function applyFloatingLayer(song: Song): Song {
+    if (!song.floatingLayer) return song;
+
+    const track = song.tracks.find(t => t.id === song.floatingLayer!.trackId);
+    if (!track) return song;
+
+    const copyData: CopyData = {
+        startTick: song.floatingLayer.startTick,
+        endTick: song.floatingLayer.endTick,
+        events: song.floatingLayer.events,
+        isDrumTrack: isDrumInstrument(song.instruments.find(i => i.id === track.instrumentId)!)
+    };
+
+    const result = pasteCopyData(song, song.floatingLayer.trackId, copyData, song.floatingLayer.startTick);
+    result.floatingLayer = undefined;
+
+    return result;
+}
+
+export function deleteFloatingLayer(song: Song): Song {
+    if (!song.floatingLayer) return song;
+
+    const result = cloneSong(song);
+    result.floatingLayer = undefined;
+
+    return result;
+}
+
+export function selectionToFloatingLayer(song: Song, trackId: number, selection: WorkspaceSelection): Song {
+    const result = applyFloatingLayer(song);
+    const copyData = getCopyData(result, trackId, selection);
+
+    result.floatingLayer = {
+        events: copyData.events,
+        startTick: copyData.startTick,
+        endTick: copyData.endTick,
+        trackId
+    };
+
+    return deleteSelection(result, trackId, selection);
+}
+
+export function transposeFloatingLayer(song: Song, deltaNotes: number): Song {
+    if (!song.floatingLayer || !deltaNotes) return song;
+
+    const result = cloneSong(song);
+    result.floatingLayer.events = result.floatingLayer.events.map(e => ({ ...e, note: e.note + deltaNotes }));
+
+    return result;
+}
+
+export function moveFloatingLayer(song: Song, deltaTicks: number): Song {
+    if (!song.floatingLayer || !deltaTicks) return song;
+
+    const result = cloneSong(song);
+    result.floatingLayer.startTick += deltaTicks;
+    result.floatingLayer.endTick += deltaTicks;
+    result.floatingLayer.events = result.floatingLayer.events.map(e => ({ ...e, start: e.start + deltaTicks }));
+
+    return result;
+}
+
+export function isInSelection(event: NoteEvent, selection: WorkspaceSelection): boolean {
+    return event.start >= selection.startTick && event.start + event.duration <= selection.endTick;
+}
+
+export function deleteSelection(song: Song, trackId: number, selection: WorkspaceSelection): Song {
+    const trackIndex = song.tracks.findIndex(t => t.id === trackId);
+    if (trackIndex === -1) return song;
+
+    const track = song.tracks[trackIndex];
+
+    const updatedTrack: Track = {
+        ...track,
+        events: track.events.filter(e => !isInSelection(e, selection))
+    };
+
+    return updateTrack(updatedTrack, song);
+}
+
+export function transposeSelection(song: Song, trackId: number, selection: WorkspaceSelection, deltaNotes: number): Song {
+    const trackIndex = song.tracks.findIndex(t => t.id === trackId);
+    if (trackIndex === -1) return song;
+
+    const track = song.tracks[trackIndex];
+
+    const updatedTrack: Track = {
+        ...track,
+        events: track.events.map(e => {
+            if (isInSelection(e, selection)) {
+                return { ...e, note: e.note + deltaNotes };
+            }
+            else {
+                return e;
+            }
+        })
+    };
+
+    return updateTrack(updatedTrack, song);
+}
+
+export function moveSelection(song: Song, trackId: number, selection: WorkspaceSelection, deltaTicks: number): Song {
+    const trackIndex = song.tracks.findIndex(t => t.id === trackId);
+    if (trackIndex === -1) return song;
+
+    const copyData = getCopyData(song, trackId, selection);
+    const newSong = deleteSelection(song, trackId, selection);
+    return pasteCopyData(newSong, trackId, copyData, selection.startTick + deltaTicks);
+}
+
+export function getCopyData(song: Song, trackId: number, selection: WorkspaceSelection): CopyData {
+    const track = song.tracks.find(t => t.id === trackId);
+    if (!track) return undefined;
+
+    const events = track.events.filter(e => isInSelection(e, selection)).map(e => ({ ...e }));
+
+    return {
+        startTick: selection.startTick,
+        endTick: selection.endTick,
+        events,
+        isDrumTrack: isDrumInstrument(song.instruments.find(i => i.id === track.instrumentId))
+    };
+}
+
+export function pasteCopyData(song: Song, trackId: number, copyData: CopyData, pasteStartTick: number): Song {
+    const trackIndex = song.tracks.findIndex(t => t.id === trackId);
+    if (trackIndex === -1) return song;
+
+    const track = song.tracks[trackIndex];
+
+    const maxTicks = song.measures * song.beatsPerMeasure * song.ticksPerBeat;
+    const deltaTicks = pasteStartTick - copyData.startTick;
+    let selectedEvents = copyData.events.map(e => ({ ...e, start: e.start + deltaTicks, id: track.nextId++ }));
+    for (const event of selectedEvents) {
+        event.duration = Math.min(event.duration, maxTicks - event.start);
+        event.start = Math.max(0, event.start);
+    }
+
+    selectedEvents = selectedEvents.filter(e => e.start < maxTicks && e.start + e.duration > 0);
+
+    const resultTrack = { ...song.tracks[trackIndex], events: track.events.map(e => ({ ...e })) };
+
+    for (const selectedEvent of selectedEvents) {
+        for (const event of resultTrack.events) {
+            if (event.note !== selectedEvent.note) continue;
+            if (event.start + event.duration <= selectedEvent.start) continue;
+            if (event.start >= selectedEvent.start + selectedEvent.duration) break;
+
+            if (event.start <= selectedEvent.start && event.start + event.duration > selectedEvent.start) {
+                event.duration = selectedEvent.start - event.start;
+            }
+            else if (event.start > selectedEvent.start) {
+                event.duration = event.start + event.duration - (selectedEvent.start + selectedEvent.duration);
+                event.start = selectedEvent.start + selectedEvent.duration;
+            }
+        }
+    }
+
+    resultTrack.events = resultTrack.events.filter(e => e.duration > 0);
+
+    let pasteIndex = 0;
+    for (let i = 0; i < resultTrack.events.length; i++) {
+        const toPaste = selectedEvents[pasteIndex];
+        if (!toPaste) break;
+
+        if (toPaste.start < resultTrack.events[i].start) {
+            resultTrack.events.splice(i, 0, toPaste);
+            pasteIndex++;
+            i++;
+        }
+    }
+
+    if (pasteIndex < selectedEvents.length) {
+        resultTrack.events.push(...selectedEvents.slice(pasteIndex));
+    }
+
+    return updateTrack(resultTrack, song);
+}
+
+export function pasteToFloatingLayer(song: Song, trackId: number, copyData: CopyData, pasteStartTick: number): Song {
+    const result = cloneSong(song);
+
+    const deltaTicks = pasteStartTick - copyData.startTick;
+    const selectedEvents = copyData.events.map(e => ({ ...e, start: e.start + deltaTicks }));
+
+    result.floatingLayer = {
+        events: selectedEvents,
+        startTick: pasteStartTick,
+        endTick: pasteStartTick + (copyData.endTick - copyData.startTick),
+        trackId
+    };
+
+    return result;
+}
+
+function cloneSong(song: Song): Song {
+    return {
+        ...song,
+        tracks: song.tracks.map(t => ({
+            ...t,
+            events: t.events.map(e => ({ ...e }))
+        })),
+        floatingLayer: song.floatingLayer ? { ...song.floatingLayer, events: song.floatingLayer.events.map(e => ({ ...e })) } : undefined
+    };
 }

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -22,6 +22,9 @@ export interface Song {
     measures: number;
     tempo: number;
     nextInstrumentId: number;
+
+    beatsPerMeasure: number;
+    ticksPerBeat: number;
 }
 
 interface BaseInstrument {
@@ -40,6 +43,45 @@ export interface DrumInstrument extends BaseInstrument {
 export type Instrument = MelodicInstrument | DrumInstrument;
 
 export const lf = pxt.U.lf;
+
+export const TIME_SIGNATURES = [
+    {
+        name: lf("4/4"),
+        id: "ts4-4",
+        beatsPerMeasure: 4,
+        ticksPerBeat: 4
+    },
+    {
+        name: lf("3/4"),
+        id: "ts3-4",
+        beatsPerMeasure: 3,
+        ticksPerBeat: 4
+    },
+    {
+        name: lf("2/4"),
+        id: "ts2-4",
+        beatsPerMeasure: 2,
+        ticksPerBeat: 4
+    },
+    {
+        name: lf("3/8"),
+        id: "ts3-8",
+        beatsPerMeasure: 3,
+        ticksPerBeat: 2
+    },
+    {
+        name: lf("6/8"),
+        id: "ts6-8",
+        beatsPerMeasure: 6,
+        ticksPerBeat: 2
+    },
+    {
+        name: lf("12/8"),
+        id: "ts12-8",
+        beatsPerMeasure: 12,
+        ticksPerBeat: 2
+    }
+]
 
 export const NOTE_RANGES = [
     {
@@ -93,6 +135,8 @@ export function getEmptySong(): Song {
     const song: Song = {
         nextInstrumentId,
         instruments,
+        beatsPerMeasure: 4,
+        ticksPerBeat: 4,
         tracks: [{
             instrumentId: 0,
             events: [],
@@ -112,7 +156,7 @@ export function getNextNoteEvent(note: number, start: number, track: Track, maxP
     return track.events.find(e => e.note === note && e.start > start);
 }
 
-export function getMaxDuration(note: number, start: number, track: Track, measures: number, maxPolyphony: number): number {
+export function getMaxDuration(note: number, start: number, track: Track, maxTicks: number, maxPolyphony: number): number {
     let activeNotes: NoteEvent[] = [];
 
     for (const event of track.events) {
@@ -127,29 +171,29 @@ export function getMaxDuration(note: number, start: number, track: Track, measur
         activeNotes = activeNotes.filter(e => e.start + e.duration < event.start);
     }
 
-    return measures * 4 * 4 - start;
+    return maxTicks - start;
 }
 
-export function newNoteEvent(note: number, start: number, track: Track, isDrumTrack: boolean, measures: number, maxPolyphony: number): Track {
+export function newNoteEvent(note: number, start: number, track: Track, isDrumTrack: boolean, maxTicks: number, maxPolyphony: number): Track {
     track = removeEventAtTimeIfNeeded(start, track, maxPolyphony);
 
     const newEvent: NoteEvent = {
         id: track.nextId++,
         note,
         start,
-        duration: isDrumTrack ? 1 : Math.min(4, getMaxDuration(note, start, track, measures, maxPolyphony)),
+        duration: isDrumTrack ? 1 : Math.min(4, getMaxDuration(note, start, track, maxTicks, maxPolyphony)),
         velocity: 128
     };
 
     return insertNoteEvent(newEvent, track);
 }
 
-export function changeNoteEventDuration(id: number, duration: number, track: Track, measures: number, maxPolyphony: number): Track {
+export function changeNoteEventDuration(id: number, duration: number, track: Track, maxTicks: number, maxPolyphony: number): Track {
     const eventIndex = track.events.findIndex(e => e.id === id);
     if (eventIndex === -1) return track;
 
     const event = track.events[eventIndex];
-    const maxDuration = getMaxDuration(event.note, event.start, track, measures, maxPolyphony);
+    const maxDuration = getMaxDuration(event.note, event.start, track, maxTicks, maxPolyphony);
 
     const updatedEvent = {
         ...event,
@@ -335,8 +379,8 @@ export function isMelodicInstrument(instrument: Instrument): instrument is Melod
 
 export function toPXTSong(song: Song): pxt.assets.music.Song {
     return {
-        ticksPerBeat: 4,
-        beatsPerMeasure: 4,
+        ticksPerBeat: song.ticksPerBeat,
+        beatsPerMeasure: song.beatsPerMeasure,
         beatsPerMinute: song.tempo,
         measures: song.measures,
         tracks: song.tracks.map(track => {
@@ -371,7 +415,10 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
 
     result.tracks = [];
 
-    const ticksPerSixteenth = pxtSong.ticksPerBeat / 4;
+    const ticksPerSixteenth = pxtSong.ticksPerBeat === 8 ? 2 : 1;
+
+    result.beatsPerMeasure = pxtSong.beatsPerMeasure;
+    result.ticksPerBeat = pxtSong.ticksPerBeat === 8 ? 4 : pxtSong.ticksPerBeat;
 
     let instrumentIdCounter = 0;
     for (const track of pxtSong.tracks) {
@@ -436,6 +483,18 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
     }
 
     return result;
+}
+
+export function changeTimeSignature(beatsPerMeasure: number, ticksPerBeat: number, song: Song): Song {
+    const prevTotalTicks = song.measures * song.beatsPerMeasure * song.ticksPerBeat;
+    const newMeasures = Math.ceil(prevTotalTicks / (beatsPerMeasure * ticksPerBeat));
+
+    return {
+        ...song,
+        measures: newMeasures,
+        beatsPerMeasure,
+        ticksPerBeat
+    };
 }
 
 function instrumentsEqual(a: pxt.assets.music.Instrument, b: pxt.assets.music.Instrument) {

--- a/webapp/src/components/pianoRoll/types.ts
+++ b/webapp/src/components/pianoRoll/types.ts
@@ -425,29 +425,90 @@ export function toPXTSong(song: Song): pxt.assets.music.Song {
         beatsPerMeasure: song.beatsPerMeasure,
         beatsPerMinute: song.tempo,
         measures: song.measures,
-        tracks: song.tracks.map(track => {
+        tracks: song.tracks.reduce((acc, track) => {
             const instrument = song.instruments.find(i => i.id === track.instrumentId)!;
-            const isDrums = isDrumInstrument(instrument);
+            acc.push(...toPXTTrack(track, instrument));
 
-            const pxtTrack: pxt.assets.music.Track = {
+            return acc;
+        }, [] as pxt.assets.music.Track[])
+    }
+}
+
+function toPXTTrack(track: Track, instrument: Instrument): pxt.assets.music.Track[] {
+    if (isDrumInstrument(instrument)) {
+        return [
+            {
                 id: track.id,
                 name: instrument.name,
                 notes: track.events.map(e => ({
                     startTick: e.start,
                     endTick: (e.start + e.duration),
                     notes: [{
-                        note: isDrums ? e.note : e.note + 1,
+                        note: e.note,
                         enharmonicSpelling: "normal"
                     }],
                     velocity: e.velocity
                 })),
-                instrument: isDrums ? undefined : (instrument as MelodicInstrument).instrument,
-                drums: isDrums ? (instrument as DrumInstrument).drums : undefined
+                instrument: undefined,
+                drums: (instrument as DrumInstrument).drums
             }
-
-            return pxtTrack;
-        })
+        ];
     }
+
+    /**
+     * note encoding (1 byte)
+     *     lower six bits = note - (instrumentOctave - 2) * 12
+     *     upper two bits are the enharmonic spelling:
+     *          0 = normal
+     *          1 = flat
+     *          2 = sharp
+     *
+     * to ensure our notes are in range, we need to split the track into multiple tracks if
+     * the range of notes exceeds 64 (6 bits)
+     */
+
+    let minNote = track.events[0]?.note || 0;
+    let maxNote = track.events[0]?.note || 0;
+
+    for (const event of track.events) {
+        minNote = Math.min(minNote, event.note);
+        maxNote = Math.max(maxNote, event.note);
+    }
+
+    minNote++;
+    maxNote++;
+
+    const result: pxt.assets.music.Track[] = [];
+    const minOctave = Math.floor(minNote / 12);
+
+    if (maxNote - (minOctave * 12) >= 64) {
+        result.push(...toPXTTrack({ ...track, events: track.events.filter(e => e.note < 64) }, instrument));
+        result.push(...toPXTTrack({ ...track, events: track.events.filter(e => e.note >= 64) }, instrument));
+        return result;
+    }
+
+    const instrumentOctave = minOctave + 2;
+
+    const pxtTrack: pxt.assets.music.Track = {
+        id: track.id,
+        name: instrument.name,
+        notes: track.events.map(e => ({
+            startTick: e.start,
+            endTick: (e.start + e.duration),
+            notes: [{
+                note: e.note + 1,
+                enharmonicSpelling: "normal"
+            }],
+            velocity: e.velocity
+        })),
+        instrument: {
+            ...(instrument as MelodicInstrument).instrument,
+            octave: instrumentOctave
+        },
+        drums: undefined
+    }
+
+    return [pxtTrack];
 }
 
 export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
@@ -464,38 +525,39 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
 
     let instrumentIdCounter = 0;
     for (const track of pxtSong.tracks) {
-        const newTrack: Track = {
+        const existingTrack = result.tracks.find(t => t.id === track.id);
+        const resultTrack: Track = existingTrack || {
             id: track.id,
             instrumentId: 0,
             events: [],
             nextId: 0,
             minOctave: 7,
             maxOctave: 0
-        }
+        };
 
         const newNoteEvent = (note: number, startTick: number, endTick: number, velocity: number): void => {
             const newEvent: NoteEvent = {
-                id: newTrack.nextId++,
+                id: resultTrack.nextId++,
                 note: track.drums?.length ? note : note - 1,
                 start: Math.round(startTick / ticksPerSixteenth),
                 duration: Math.max(1, Math.round((endTick - startTick) / ticksPerSixteenth)),
                 velocity: velocity ?? 128
             };
 
-            newTrack.events.push(newEvent);
+            resultTrack.events.push(newEvent);
 
-            const octave = Math.floor(note / 12);
-            newTrack.minOctave = Math.min(newTrack.minOctave, octave);
-            newTrack.maxOctave = Math.max(newTrack.maxOctave, octave);
+            const octave = Math.floor(newEvent.note / 12);
+            resultTrack.minOctave = Math.min(resultTrack.minOctave, octave);
+            resultTrack.maxOctave = Math.max(resultTrack.maxOctave, octave);
         };
 
         if (track.drums?.length) {
-            newTrack.instrumentId = result.instruments.find(i => isDrumInstrument(i))!.id;
+            resultTrack.instrumentId = result.instruments.find(i => isDrumInstrument(i))!.id;
         }
         else {
             const instrument = result.instruments.find(i => !isDrumInstrument(i) && instrumentsEqual(i.instrument, track.instrument));
 
-            if (instrument) newTrack.instrumentId = instrument.id;
+            if (instrument) resultTrack.instrumentId = instrument.id;
             else {
                 const newInstrument: MelodicInstrument = {
                     id: result.nextInstrumentId++,
@@ -503,7 +565,7 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
                     instrument: track.instrument,
                 };
                 result.instruments.push(newInstrument);
-                newTrack.instrumentId = newInstrument.id;
+                resultTrack.instrumentId = newInstrument.id;
             }
         }
 
@@ -513,14 +575,14 @@ export function fromPXTSong(pxtSong: pxt.assets.music.Song): Song {
             }
         }
 
-        const range = NOTE_RANGES.find(r => r.minOctave <= newTrack.minOctave && r.maxOctave >= newTrack.maxOctave);
+        const range = NOTE_RANGES.find(r => r.minOctave <= resultTrack.minOctave && r.maxOctave >= resultTrack.maxOctave);
         if (range) {
-            newTrack.minOctave = range.minOctave;
-            newTrack.maxOctave = range.maxOctave;
+            resultTrack.minOctave = range.minOctave;
+            resultTrack.maxOctave = range.maxOctave;
         }
 
-        if (newTrack.events.length > 0 || result.tracks.length === 0) {
-            result.tracks.push(newTrack);
+        if (!existingTrack && resultTrack.events.length > 0 || result.tracks.length === 0) {
+            result.tracks.push(resultTrack);
         }
     }
 
@@ -552,7 +614,6 @@ export function changeTimeSignature(beatsPerMeasure: number, ticksPerBeat: numbe
 
 function instrumentsEqual(a: pxt.assets.music.Instrument, b: pxt.assets.music.Instrument) {
     if (a.waveform !== b.waveform) return false;
-    if (a.octave !== b.octave) return false;
 
     if (!envelopesEqual(a.ampEnvelope, b.ampEnvelope)) return false;
     if (!envelopesEqual(a.pitchEnvelope, b.pitchEnvelope)) return false;

--- a/webapp/src/components/pianoRoll/utils.ts
+++ b/webapp/src/components/pianoRoll/utils.ts
@@ -17,11 +17,11 @@ export function range(start: number, end: number) {
 }
 
 export function noteWidth(theme: PianoRollTheme, duration: number) {
-    return (theme.octaveWidth / 16) * duration + 1;
+    return theme.tickWidth * duration + 1;
 }
 
 export function noteLeft(theme: PianoRollTheme, start: number) {
-    return (theme.octaveWidth / 16) * start;
+    return theme.tickWidth * start;
 }
 
 export function noteTop(theme: PianoRollTheme, note: number) {
@@ -41,11 +41,11 @@ export function workspaceHeight(theme: PianoRollTheme) {
 }
 
 export function workspaceWidth(theme: PianoRollTheme) {
-    return theme.measures * theme.octaveWidth;
+    return theme.measures * theme.ticksPerBeat * theme.beatsPerMeasure * theme.tickWidth;
 }
 
 export function xToTick(theme: PianoRollTheme, x: number) {
-    return Math.floor(x / (theme.octaveWidth / 16));
+    return Math.floor(x / theme.tickWidth);
 }
 
 export function yToNote(theme: PianoRollTheme, y: number) {

--- a/webapp/src/components/pianoRoll/workspaceBackground.tsx
+++ b/webapp/src/components/pianoRoll/workspaceBackground.tsx
@@ -2,20 +2,21 @@ import { useEffect, useState } from "react";
 import { PianoRollTheme, usePianoRollTheme } from "./context"
 
 function createWorkspaceBackground(
-    octaveWidth: number,
+    tickWidth: number,
+    ticksPerBeat: number,
     octaveHeight: number,
     borderColor: string = "#1e343d",
     blackKeyColor: string = "#2e4c58",
     backgroundColor: string = "#36535f"
 ) {
     return `
-<svg xmlns="http://www.w3.org/2000/svg" width="${octaveWidth}" height="${octaveHeight}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${tickWidth * ticksPerBeat}" height="${octaveHeight}">
     <defs>
-        <pattern id="grid" width="${octaveWidth / 16}" height="${octaveHeight / 12}" patternUnits="userSpaceOnUse">
+        <pattern id="grid" width="${tickWidth}" height="${octaveHeight / 12}" patternUnits="userSpaceOnUse">
             <rect width="1" height="${octaveHeight / 12}" fill="${borderColor}" />
-            <rect width="${octaveWidth / 16}" height="1" fill="${borderColor}" />
+            <rect width="${tickWidth}" height="1" fill="${borderColor}" />
         </pattern>
-        <pattern id="grid2" width="${octaveWidth / 4}" height="${octaveHeight / 12}" patternUnits="userSpaceOnUse">
+        <pattern id="grid2" width="${tickWidth * ticksPerBeat}" height="${octaveHeight / 12}" patternUnits="userSpaceOnUse">
             <rect width="2" height="${octaveHeight / 12}" fill="${borderColor}" />
         </pattern>
     </defs>
@@ -31,7 +32,8 @@ function createWorkspaceBackground(
 function getBackgroundCss(theme: PianoRollTheme) {
     return `url("data:image/svg+xml,${encodeURIComponent(
         createWorkspaceBackground(
-            theme.octaveWidth,
+            theme.tickWidth,
+            theme.ticksPerBeat,
             7 * theme.whiteKeyHeight,
             theme.gridLineColor,
             theme.blackKeyWorkspaceColor,
@@ -46,7 +48,7 @@ export function useWorkspaceBackground() {
 
     useEffect(() => {
         setBg(getBackgroundCss(theme));
-    }, [theme.octaveWidth, theme.whiteKeyHeight, theme.gridLineColor, theme.blackKeyWorkspaceColor, theme.whiteKeyWorkspaceColor])
+    }, [theme.tickWidth, theme.ticksPerBeat, theme.whiteKeyHeight, theme.gridLineColor, theme.blackKeyWorkspaceColor, theme.whiteKeyWorkspaceColor])
 
     return bg;
 }


### PR DESCRIPTION
this PR makes a number of improvements to the piano roll editor:
* adds a cursor when you hover over the workspace, showing what note event will be created
* adds an optional "snap" setting that works similar to the grid in the other song editor; changes the created note length and snaps all edits to the selected note division
* adds an optional time signature (defaults to 4/4)
* adds the ability to select sections of a track by dragging on the measure header. selected notes can be moved by dragging with the mouse or using arrow keys
* adds copy/paste support
* adds transposing of selections using the up/down arrow keys
* adds custom horizontal/vertical scroll bars

the snap and time signature can be turned on/off using flags on the field editor declaration. copy/paste can be done between tracks and songs, but not between melodic and drum tracks (they have separate copy/paste entries)

also fixes a few bugs:
* fixes the creation of new songs
* fixes a bug where the velocity editor would sometimes be desynced from the scroll of the workspace
* fixes a bug where notes outside the range of the instrument octave would overflow. now tracks are split in two if they exceed the limit of note encoding and recombined when opening the editor