### PR TITLE
sim: pass the editor's origin as a simulator extension's parentOrigin

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -422,10 +422,16 @@ namespace pxsim {
                             // not found, spin a new one
                             if (!messageFrame) {
                                 const url = new URL(simulatorExtension.url);
-                                if (this.options.parentOrigin)
-                                    url.searchParams.set("parentOrigin", encodeURIComponent(this.options.parentOrigin));
+                                // The extension's parent window is this editor, so the origin it
+                                // should trust is the editor's own. options.parentOrigin is the
+                                // editor's *embedder* origin (controller mode) - the extension's
+                                // grandparent - so an extension that validates messages against
+                                // it rejects everything the editor sends when the editor is
+                                // embedded cross-origin.
+                                // searchParams.set() encodes, so don't encode the values here.
+                                url.searchParams.set("parentOrigin", window.location.origin);
                                 if (this.options.userLanguage)
-                                    url.searchParams.set("language", encodeURIComponent(this.options.userLanguage));
+                                    url.searchParams.set("language", this.options.userLanguage);
                                 startSimulatorExtension(url.toString(), simulatorExtension.permanent, simulatorExtension.aspectRatio);
                             }
                             // not running the current run, restart


### PR DESCRIPTION
Fixes #11446


### Problem

When the editor spawns a simulator extension (simx) iframe it sets the extension's `parentOrigin` query param. A simx that validates the origin of incoming `postMessage`s -- as [jacdac-docs does](https://github.com/jacdac/jacdac-docs/blob/69cf764a42b1c321d64eb6416a71acd98d4ba97b/src/jacdac/providerbus.ts#L85) -- uses that value to decide which sender to trust.

The editor was forwarding `options.parentOrigin`, but that is the *editor's* embedder origin, set only when the editor is itself hosted inside another page (controller mode). For the simx that origin is its **grandparent**, not its parent: the simx's parent window is the editor, and every simulator message the editor posts into the simx arrives with the editor's origin. So an origin-validating simx rejects all of them whenever the editor is embedded on an origin different from its own.

Repro: embed the micro:bit/Calliope editor cross-origin, use a jacdac block. The simx iframe loads but no message ever passes its origin check, so the jacdac dashboard stays dead.


### Fix

Pass `window.location.origin` -- the origin the simx actually receives messages from -- and set it unconditionally.

Also drops the `encodeURIComponent` calls: `URLSearchParams.set` percent-encodes internally, so the values were encoded twice and a simx reading `params.get("parentOrigin")` saw `https%3A%2F%2F...`, which never matches a real message origin. The same double encoding applied to `language` (harmless in practice, since language codes contain nothing that needs escaping). The `$PARENT_ORIGIN$` substitution on the legacy `messageSimulator` path just below builds its query string by hand, so its `encodeURIComponent` is correct and is left alone.


### Why this is safe

| Case | Before | After |
| --- | --- | --- |
| Editor embedded same-origin | works | unchanged (values are equal) |
| Editor not embedded | param unset, simx accepts any origin | param set to editor origin -- still validates, and tightens the check |
| Editor embedded cross-origin | **broken** | fixed |