### PR TITLE
if null or undef in union take other type, and fix audio node muting

### DIFF
--- a/pxtblocks/compiler/typeChecker.ts
+++ b/pxtblocks/compiler/typeChecker.ts
@@ -353,7 +353,7 @@ export function returnType(e: Environment, b: Blockly.Block): Point {
         return find(b.p);
     }
 
-    if (b.type == "variables_get")
+    if (b.type == "variables_get" || b.type == "variables_get_reporter")
         return find(lookup(e, b, b.getField("VAR").getText()).type);
 
     if (b.type == "function_call_output")  {
@@ -493,14 +493,18 @@ function getReturnTypeOfFunctionCall(e: Environment, call: Blockly.Block) {
 // Basic type unification routine; easy, because there's no structural types.
 // FIXME: Generics are not supported
 function unify(t1: string, t2: string) {
-    if (t1 == null || t1 === "Array" && isArrayType(t2))
+    if (t1 == null || isNullishType(t1) || t1 === "Array" && isArrayType(t2))
         return t2;
-    else if (t2 == null || t2 === "Array" && isArrayType(t1))
+    else if (t2 == null || isNullishType(t2) || t2 === "Array" && isArrayType(t1))
         return t1;
     else if (t1 == t2)
         return t1;
     else
         throw new Error("cannot mix " + t1 + " with " + t2);
+}
+
+function isNullishType(type: string) {
+    return type === "null" || type === "undefined";
 }
 
 function isArrayType(type: string) {

--- a/pxtsim/sound/audioSource.ts
+++ b/pxtsim/sound/audioSource.ts
@@ -3,10 +3,11 @@ namespace pxsim.AudioContextManager {
         static activeSources: AudioSource[] = [];
 
         static stopAll() {
-            for (const source of AudioSource.activeSources) {
+            const activeSources = AudioSource.activeSources;
+            AudioSource.activeSources = [];
+            for (const source of activeSources) {
                 source.dispose();
             }
-            AudioSource.activeSources = [];
         }
 
         protected vca: GainNode;

--- a/tests/blocklycompiler-test/baselines/function_nullish_return.ts
+++ b/tests/blocklycompiler-test/baselines/function_nullish_return.ts
@@ -1,0 +1,26 @@
+function sprite_first () {
+    for (let localSprite1 of testTypes.allSprites()) {
+        localSprite1.setPosition(0, 0)
+        return localSprite1
+    }
+    return testTypes.undefinedValue()
+}
+function undefined_first () {
+    if (true) {
+        return testTypes.undefinedValue()
+    }
+    for (let localSprite2 of testTypes.allSprites()) {
+        localSprite2.setPosition(0, 0)
+        return localSprite2
+    }
+}
+let undefinedFirst: Sprite = null
+let spriteFirst: Sprite = null
+let spriteFirstReferenced = spriteFirst == spriteFirst
+let undefinedFirstReferenced = undefinedFirst == undefinedFirst
+spriteFirst = sprite_first()
+undefinedFirst = undefined_first()
+game.onUpdate(function () {
+    spriteFirst = sprite_first()
+    undefinedFirst = undefined_first()
+})

--- a/tests/blocklycompiler-test/cases/function_nullish_return.blocks
+++ b/tests/blocklycompiler-test/cases/function_nullish_return.blocks
@@ -1,0 +1,209 @@
+<xml xmlns="https://developers.google.com/blockly/xml">
+    <variables>
+        <variable id="spriteFirst">spriteFirst</variable>
+        <variable id="undefinedFirst">undefinedFirst</variable>
+        <variable id="spriteFirstReferenced">spriteFirstReferenced</variable>
+        <variable id="undefinedFirstReferenced">undefinedFirstReferenced</variable>
+        <variable id="localSprite1">localSprite1</variable>
+        <variable id="localSprite2">localSprite2</variable>
+    </variables>
+    <block type="pxt-on-start" x="0" y="0">
+        <statement name="HANDLER">
+            <block type="variables_set">
+                <field name="VAR" id="spriteFirstReferenced">spriteFirstReferenced</field>
+                <value name="VALUE">
+                    <block type="logic_compare">
+                        <field name="OP">EQ</field>
+                        <value name="A">
+                            <block type="variables_get">
+                                <field name="VAR" id="spriteFirst">spriteFirst</field>
+                            </block>
+                        </value>
+                        <value name="B">
+                            <block type="variables_get">
+                                <field name="VAR" id="spriteFirst">spriteFirst</field>
+                            </block>
+                        </value>
+                    </block>
+                </value>
+                <next>
+                    <block type="variables_set">
+                        <field name="VAR" id="undefinedFirstReferenced">undefinedFirstReferenced</field>
+                        <value name="VALUE">
+                            <block type="logic_compare">
+                                <field name="OP">EQ</field>
+                                <value name="A">
+                                    <block type="variables_get">
+                                        <field name="VAR" id="undefinedFirst">undefinedFirst</field>
+                                    </block>
+                                </value>
+                                <value name="B">
+                                    <block type="variables_get">
+                                        <field name="VAR" id="undefinedFirst">undefinedFirst</field>
+                                    </block>
+                                </value>
+                            </block>
+                        </value>
+                        <next>
+                            <block type="variables_set">
+                                <field name="VAR" id="spriteFirst">spriteFirst</field>
+                                <value name="VALUE">
+                                    <block type="function_call_output">
+                                        <mutation name="sprite_first" functionid="sprite-first-function" />
+                                    </block>
+                                </value>
+                                <next>
+                                    <block type="variables_set">
+                                        <field name="VAR" id="undefinedFirst">undefinedFirst</field>
+                                        <value name="VALUE">
+                                            <block type="function_call_output">
+                                                <mutation name="undefined_first" functionid="undefined-first-function" />
+                                            </block>
+                                        </value>
+                                    </block>
+                                </next>
+                            </block>
+                        </next>
+                    </block>
+                </next>
+            </block>
+        </statement>
+    </block>
+    <block type="gameupdate" x="0" y="180">
+        <statement name="HANDLER">
+            <block type="variables_set">
+                <field name="VAR" id="spriteFirst">spriteFirst</field>
+                <value name="VALUE">
+                    <block type="function_call_output">
+                        <mutation name="sprite_first" functionid="sprite-first-function" />
+                    </block>
+                </value>
+                <next>
+                    <block type="variables_set">
+                        <field name="VAR" id="undefinedFirst">undefinedFirst</field>
+                        <value name="VALUE">
+                            <block type="function_call_output">
+                                <mutation name="undefined_first" functionid="undefined-first-function" />
+                            </block>
+                        </value>
+                    </block>
+                </next>
+            </block>
+        </statement>
+    </block>
+    <block type="function_definition" x="400" y="0">
+        <mutation name="sprite_first" functionid="sprite-first-function" />
+        <field name="function_name">sprite_first</field>
+        <statement name="STACK">
+            <block type="pxt_controls_for_of">
+                <value name="VAR">
+                    <block type="variables_get_reporter" deletable="false">
+                        <field name="VAR" id="localSprite1">localSprite1</field>
+                    </block>
+                </value>
+                <value name="LIST">
+                    <block type="test_all_sprites" />
+                </value>
+                <statement name="DO">
+                    <block type="spritesetpos">
+                        <value name="sprite">
+                            <block type="variables_get_reporter">
+                                <field name="VAR" id="localSprite1">localSprite1</field>
+                            </block>
+                        </value>
+                        <value name="x">
+                            <shadow type="math_number">
+                                <field name="NUM">0</field>
+                            </shadow>
+                        </value>
+                        <value name="y">
+                            <shadow type="math_number">
+                                <field name="NUM">0</field>
+                            </shadow>
+                        </value>
+                        <next>
+                            <block type="function_return">
+                                <mutation xmlns="http://www.w3.org/1999/xhtml" no_return_value="false" />
+                                <value name="RETURN_VALUE">
+                                    <block type="variables_get_reporter">
+                                        <field name="VAR" id="localSprite1">localSprite1</field>
+                                    </block>
+                                </value>
+                            </block>
+                        </next>
+                    </block>
+                </statement>
+                <next>
+                    <block type="function_return">
+                        <mutation xmlns="http://www.w3.org/1999/xhtml" no_return_value="false" />
+                        <value name="RETURN_VALUE">
+                            <block type="test_undefined_value" />
+                        </value>
+                    </block>
+                </next>
+            </block>
+        </statement>
+    </block>
+    <block type="function_definition" x="400" y="300">
+        <mutation name="undefined_first" functionid="undefined-first-function" />
+        <field name="function_name">undefined_first</field>
+        <statement name="STACK">
+            <block type="controls_if">
+                <value name="IF0">
+                    <shadow type="logic_boolean">
+                        <field name="BOOL">TRUE</field>
+                    </shadow>
+                </value>
+                <statement name="DO0">
+                    <block type="function_return">
+                        <mutation xmlns="http://www.w3.org/1999/xhtml" no_return_value="false" />
+                        <value name="RETURN_VALUE">
+                            <block type="test_undefined_value" />
+                        </value>
+                    </block>
+                </statement>
+                <next>
+                    <block type="pxt_controls_for_of">
+                        <value name="VAR">
+                            <block type="variables_get_reporter" deletable="false">
+                                <field name="VAR" id="localSprite2">localSprite2</field>
+                            </block>
+                        </value>
+                        <value name="LIST">
+                            <block type="test_all_sprites" />
+                        </value>
+                        <statement name="DO">
+                            <block type="spritesetpos">
+                                <value name="sprite">
+                                    <block type="variables_get_reporter">
+                                        <field name="VAR" id="localSprite2">localSprite2</field>
+                                    </block>
+                                </value>
+                                <value name="x">
+                                    <shadow type="math_number">
+                                        <field name="NUM">0</field>
+                                    </shadow>
+                                </value>
+                                <value name="y">
+                                    <shadow type="math_number">
+                                        <field name="NUM">0</field>
+                                    </shadow>
+                                </value>
+                                <next>
+                                    <block type="function_return">
+                                        <mutation xmlns="http://www.w3.org/1999/xhtml" no_return_value="false" />
+                                        <value name="RETURN_VALUE">
+                                            <block type="variables_get_reporter">
+                                                <field name="VAR" id="localSprite2">localSprite2</field>
+                                            </block>
+                                        </value>
+                                    </block>
+                                </next>
+                            </block>
+                        </statement>
+                    </block>
+                </next>
+            </block>
+        </statement>
+    </block>
+</xml>

--- a/tests/blocklycompiler-test/test-library/spritekind.ts
+++ b/tests/blocklycompiler-test/test-library/spritekind.ts
@@ -60,6 +60,18 @@ class Sprite {
     }
 }
 
+namespace testTypes {
+    //% blockId=test_all_sprites block="all sprites"
+    export function allSprites(): Sprite[] {
+        return [];
+    }
+
+    //% blockId=test_undefined_value block="undefined"
+    export function undefinedValue(): undefined {
+        return undefined;
+    }
+}
+
 //% blockNamespace="statusbars"
 //% blockGap=8
 class StatusBarSprite extends Sprite {

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -505,6 +505,10 @@ describe("blockly compiler", function () {
             blockTestAsync("function_output").then(done, done);
         });
 
+        it("should ignore nullish types when inferring function return types", (done: () => void) => {
+            blockTestAsync("function_nullish_return").then(done, done);
+        });
+
         it("should output a return type for recursive functions", (done: () => void) => {
             blockTestAsync("function_recursion").then(done, done);
         });


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/7639. I don't see anything we did differently that caused this, so i'm leaning towards it just being blockly update changing compile order or something along those lines?

also fix mentioned in https://github.com/microsoft/pxt-common-packages/pull/1637 on the side; the pr that introduced that 'fixed' it by causing it to go over the node again, but the actual issue is that source.dispose() removed from the array while it was being iterated over / caused skipping

build with both fixes for testing https://arcade.makecode.com/app/8e5645847349dcf098d8aa44805a713fe9b16890-0854ddbdaf