### PR TITLE
don't duplicate block aliases in monaco toolbox

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -2075,7 +2075,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private filterBlocks(subns: string, blocks: toolbox.BlockDefinition[]) {
         return blocks.filter((block => !(block.attributes.blockHidden)
             && !(block.attributes.deprecated && !this.parent.isTutorial())
-            && (block.name.indexOf('_') != 0 || block.attributes.blockAliasFor)
+            && (block.name.indexOf('_') != 0 || block.attributes.blockAliasFor && !blocks.some(b => b.qName === block.attributes.blockAliasFor))
             && ((!subns && !block.attributes.subcategory && !block.attributes.advanced)
                 || (subns && ((block.attributes.advanced && subns == lf("more"))
                     || (block.attributes.subcategory && subns == block.attributes.subcategory))))));


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7577

sprites create has a [block alias](https://github.com/microsoft/pxt-common-packages/blob/master/libs/game/sprites.ts#L60) that we use to make it show up twice in the blocks toolbox, once with the set variable and once without. in monaco, snippets for both versions of the block are the same so we can dedupe them.