### PR TITLE
fix incorrect 'could not filter tutorial blocks, displaying full toolbox' warning

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1897,7 +1897,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     colour: c.color,
                     contents: [] as Blockly.utils.toolbox.ToolboxItemInfo[]
                 }));
-                (Blockly.getMainWorkspace() as Blockly.WorkspaceSvg).getToolbox().render({contents: allCategoriesToToolboxItemInfo});
+                this.editor.getToolbox().render({contents: allCategoriesToToolboxItemInfo});
             } else {
                 this.showFlyoutOnlyToolbox();
             }


### PR DESCRIPTION
`Blockly.getMainWorkspace()` appears to have been returning the workspace used for rendering hint snippets due to the timing (which makes sense / is why the warning on this fn exists https://docs.blockly.com/reference/blockly.getmainworkspace_variable/)

build https://arcade.makecode.com/app/3e79cd40503b0f19c49c993370455c414bceefbf-045180f67d