### PR TITLE
[stable13.0] fix incorrect 'could not filter tutorial blocks, displaying full tool…

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1897,7 +1897,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     colour: c.color,
                     contents: [] as Blockly.utils.toolbox.ToolboxItemInfo[]
                 }));
-                (Blockly.getMainWorkspace() as Blockly.WorkspaceSvg).getToolbox().render({contents: allCategoriesToToolboxItemInfo});
+                this.editor.getToolbox().render({contents: allCategoriesToToolboxItemInfo});
             } else {
                 this.showFlyoutOnlyToolbox();
             }


### PR DESCRIPTION
…box' warning (#11528)

porting https://github.com/microsoft/pxt/pull/11528 since the code that can potentially hit https://github.com/microsoft/pxt-arcade/issues/7659 is present