### PR TITLE
fix icons on project view area

### DIFF
--- a/theme/scriptsearch.less
+++ b/theme/scriptsearch.less
@@ -85,6 +85,13 @@
     }
 
     .ui.card.file .content {
+        margin-left: 4rem;
         margin-right: 3rem;
+    }
+}
+
+@media only screen and (max-width: @largestMobileScreen) {
+    .ui.modal.scriptmanager .ui.card.file .content {
+        margin-left: 3rem;
     }
 }


### PR DESCRIPTION
quick build https://arcade.makecode.com/app/2b69048394e81a0822eee4161e3f392d226308a6-262172c267

basically same as https://github.com/microsoft/pxt-arcade/pull/7652, but that fix belonged in pxt not target less 

fix https://github.com/microsoft/pxt-arcade/issues/7634