### PR TITLE
fix high contrast css for music gallery items

### DIFF
--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -272,3 +272,12 @@ input[type=range].blocklyFieldSlider::-moz-range-track {
 .song-gallery-item .common-button.play-button i.fas {
     color: var(--pxt-neutral-foreground1) !important;
 }
+
+.song-gallery-item .common-button.play-button:focus, .song-gallery-item .common-button.play-button:focus-visible {
+    outline: none !important;
+}
+
+.song-gallery-item .common-button.play-button:focus::after, .song-gallery-item .common-button.play-button:focus-visible::after {
+    border-radius: 50% !important;
+    outline-offset: 10px !important;
+}

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -259,3 +259,16 @@ input[type=range].blocklyFieldSlider::-moz-range-track {
 .blocklyFieldSliderDropdown input[type=range].blocklyFieldSlider:hover::-moz-range-track, .blocklyFieldSliderDropdown input[type=range].blocklyFieldSlider:focus-visible::-moz-range-track {
     outline: solid 3px var(--pxt-focus-border) !important;
 }
+
+/*
+ * Music editor gallery
+ */
+.song-gallery-item .common-button.play-button {
+    background-color: var(--pxt-neutral-background1) !important;
+    color: var(--pxt-neutral-foreground1) !important;
+    border: solid 2px var(--pxt-neutral-foreground1) !important;
+}
+
+.song-gallery-item .common-button.play-button i.fas {
+    color: var(--pxt-neutral-foreground1) !important;
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7663

as the title says, fixes the high contrast css for music gallery items

<img width="619" height="658" alt="image" src="https://github.com/user-attachments/assets/964ee1e7-0680-4921-92dc-cc8e9676c51b" />
