### PR TITLE
prevent auth from running inside time machine

### DIFF
--- a/pxtlib/auth.ts
+++ b/pxtlib/auth.ts
@@ -759,7 +759,7 @@ namespace pxt.auth {
     }
 
     export function hasIdentity(): boolean {
-        return !authDisabled && !pxt.BrowserUtils.isPxtElectron() && identityProviders().length > 0;
+        return !authDisabled && !pxt.BrowserUtils.isPxtElectron() && identityProviders().length > 0 && !pxt.shell.isTimeMachineEmbed();
     }
 
     function idpEnabled(idp: pxt.IdentityProviderId): boolean {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7585

this should hopefully fix the issue where we were getting lots of duplicate projects when messing with time machine. turns out, the time machine iframe was attempting to sync projects to the cloud which was probably causing all sorts of shenanigans.

this PR just disables auth entirely when the url contains `timeMachine=1`