### PR TITLE
modify init project tsconfig to work with latest typescript compiler

### DIFF
--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -4,7 +4,10 @@ namespace pxt.template {
         "target": "ES5",
         "noImplicitAny": true,
         "outDir": "built",
-        "rootDir": "."
+        "rootDir": ".",
+        "ignoreDeprecations": "6.0",
+        "strictPropertyInitialization": false,
+        "strictNullChecks": false
     },
     "exclude": ["pxt_modules/**/*test.ts"]
 }


### PR DESCRIPTION
updating the tsconfig we generate for github projects so that it works with the latest typescript compiler version.

see the corresponding mkc pr here: https://github.com/microsoft/pxt-mkc/pull/175