### PR TITLE
prevent simulator from running in background when switching view

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -831,6 +831,7 @@ declare namespace pxt.editor {
         feedback?: FeedbackState;
         themePickerOpen?: boolean;
         errorListNote?: string;
+        timeMachine?: boolean;
     }
 
     export interface EditorState {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1170,7 +1170,17 @@ export class ProjectView
             restartSimulator: () => this.restartSimulator(),
             singleSimulator: () => this.singleSimulator(),
             onStateChanged: (state) => {
-                const simStateChanged = () => this.allEditors.forEach((editor) => editor.simStateChanged());
+                const simStateChanged = () => {
+                    // If the simulator was pending a run when the user switched to
+                    // a different view, stop the simulator to avoid running in the background
+                    if (
+                        state === pxsim.SimulatorState.Running &&
+                        this.isSimulatorInaccessible()
+                    ) {
+                        this.stopSimulator();
+                    }
+                    this.allEditors.forEach((editor) => editor.simStateChanged())
+                };
                 switch (state) {
                     case pxsim.SimulatorState.Paused:
                     case pxsim.SimulatorState.Unloaded:
@@ -4174,6 +4184,14 @@ export class ProjectView
         })();
     }
 
+    protected isSimulatorInaccessible() {
+        return this.state.home ||
+            this.state.extensionsVisible ||
+            this.profileDialog?.state?.visible ||
+            this.scriptSearch?.state.visible ||
+            this.state.timeMachine
+    }
+
     openNewTab(hd: pxt.workspace.Header, dependent: boolean) {
         if (!hd
             || pxt.BrowserUtils.isElectron()
@@ -4710,10 +4728,14 @@ export class ProjectView
             this.stopSimulator();
         }
 
+        this.setState({ timeMachine: true });
+
         await dialogs.showTurnBackTimeDialogAsync(this.state.header, () => {
             this.reloadHeaderAsync();
             simWasRunning = false;
         });
+
+        this.setState({ timeMachine: false });
 
         if (simWasRunning) {
             this.startSimulator();


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7613

if the simulator has a pending compile and you switch views, the simulator will still start running when the compile finishes regardless of if you're still in the editor or have swapped to a another view without the sim (e.g. the home page, the user profile, etc).

this PR is a non ideal fix because while it does stop the simulator from running, the simulator won't resume when you switch back. instead you'll have to click the play button. this problem only shows up if you happen to switch while the compile is in progress, so it's a pretty slim window depending on your processor speed.

obviously it would be better if this weren't the case (and i started to make a fix to that effect) but i realized as i was attempting to wrangle the control flow spaghetti that is app.tsx that this probably isn't a good thing to mess with so close to release. so instead, here's a non-ideal but very safe fix.