### PR TITLE
fix rows on ipad

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -867,6 +867,10 @@
     touch-action: pan-y;
 }
 
+.projectsdialog .carouselbody {
+    min-width: max-content;
+}
+
 .carouselitem {
     float: left;
 }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/7677

i can't get this to repro consistently on beta -- it's like ~1/5 times i try ish. but with this fix i haven't seen it

Effectively what's happening is that the carousel calcs out the size and at that exact dimension, there's a small timing issue when swapping back and forth where it can grab the smaller card width (what you would see in portrait view) instead of the wider one (what you would see in landscape view), and in that case the width it assigns to carouselbody is off because that's calculated from size of first element in row. This basically says 'make this row big enough for all the stuff in it'. 

for ref this line is the one setting the width https://github.com/microsoft/pxt/blob/dev/jwunderl/sim-theming-editor/webapp/src/carousel.tsx#L175. I think, looking at it, that this new line would basically remove need for that one? but I'm not super into just deleting an 8 year old line i've never thought about till now just before release.