### PR TITLE
Use theme from compiled script if available

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1186,6 +1186,7 @@ declare namespace ts.pxtc {
         usedBuiltinParts?: string[];
         allParts?: string[];
         breakpoints?: number[];
+        theme?: pxt.Map<string>;
     }
 
     interface UpgradePolicy {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1186,7 +1186,7 @@ declare namespace ts.pxtc {
         usedBuiltinParts?: string[];
         allParts?: string[];
         breakpoints?: number[];
-        theme?: pxt.Map<string>;
+        theme?: string | pxt.Map<string>;
     }
 
     interface UpgradePolicy {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -431,6 +431,7 @@ function initDriverAndOptions(
     } = compileInfo || {};
     let board = pxt.appTarget.simulator.boardDefinition;
     let storedState: pxt.Map<string> = getStoredState(simOptions.id)
+    let theme: string | pxt.Map<string> = mainPkg.config?.theme ?? compileInfo?.theme;
     let runOptions: pxsim.SimulatorRunOptions = {
         debug: simOptions.debug,
         mute: simOptions.mute,
@@ -449,7 +450,7 @@ function initDriverAndOptions(
         autofocus: simOptions.autofocus,
         queryParameters: simOptions.additionalQueryParameters,
         mpRole: simOptions.mpRole,
-        theme: mainPkg.config?.theme,
+        theme,
     };
     if (pxt.appTarget.simulator && !simOptions.fullScreen)
         runOptions.aspectRatio = parts.length && pxt.appTarget.simulator.partsAspectRatio


### PR DESCRIPTION
The code to load the theme only runs when a script is compiled locally. In the cloud-compile case, that information is lost. The plan is to start sending the theme-info along with the compiled JS in the future. Once that happens, this code will load that theme instead of falling-back to the default theme.

I tested this locally and confirmed that the theme from the JS response is used as expected:
<img width="1315" height="1307" alt="image" src="https://github.com/user-attachments/assets/139a05f2-f05f-46de-87ae-bc38b97af517" />

And here is an example with the single word theme "zune" instead of a map of properties: 
<img width="1168" height="1314" alt="image" src="https://github.com/user-attachments/assets/1723a519-741d-4ce4-a8a2-9ae3fe6f1721" />


Will fix https://github.com/microsoft/pxt-arcade/issues/6488
