### PR TITLE
[stable13.1] sim theming editor (#11554)

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1994,6 +1994,15 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
     if (theme.title) targetStrings[theme.title] = theme.title;
     if (theme.name) targetStrings[theme.name] = theme.name;
     if (theme.description) targetStrings[theme.description] = theme.description;
+    for (const preset of cfg.simulator?.themePresets ?? []) {
+        targetStrings[`{id:simulator-theme-name}${preset.name}`] = preset.name;
+    }
+    for (const layout of cfg.simulator?.themeLayouts ?? []) {
+        targetStrings[`{id:simulator-layout-name}${layout.name}`] = layout.name;
+        for (const field of layout.colorFields ?? []) {
+            targetStrings[`{id:simulator-theme-field}${field.label}`] = field.label;
+        }
+    }
     if (theme.homeScreenHero && typeof theme.homeScreenHero != "string") {
         const heroBannerCard = theme.homeScreenHero;
         if (heroBannerCard.title) targetStrings[heroBannerCard.title] = heroBannerCard.title;
@@ -2520,6 +2529,7 @@ function updateColorThemes(cfg: pxt.TargetBundle) {
             id: themeData.id,
             name: themeData.name,
             weight: themeData.weight,
+            defaultSimulatorTheme: themeData.defaultSimulatorTheme,
             monacoBaseTheme: themeData.monacoBaseTheme,
             colors: themeData.colors
         };

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -262,6 +262,28 @@ declare namespace pxt {
         order?: number;     // Sort order
     }
 
+    interface SimulatorTheme extends Map<string> {
+        layout: string;
+    }
+
+    interface SimulatorThemePreset {
+        id: string;
+        name: string;
+        theme: SimulatorTheme;
+    }
+
+    interface SimulatorThemeColorField {
+        property: string;
+        label: string;
+        defaultValue: string;
+    }
+
+    interface SimulatorThemeLayout {
+        id: string;
+        name: string;
+        colorFields?: SimulatorThemeColorField[]; // replaces the standard color fields for this layout
+    }
+
     interface AppSimulator {
         autoRun?: boolean; // enable autoRun in regular mode, not light mode
         autoRunLight?: boolean; // force autorun in light mode
@@ -286,6 +308,8 @@ declare namespace pxt {
         invalidatedClass?: string; // CSS class to be applied to the sim iFrame when it needs to be updated (defaults to sepia filter)
         stoppedClass?: string; // CSS class to be applied to the sim iFrame when it isn't running (defaults to grayscale filter)
         keymap?: boolean; // when non-empty and autoRun is disabled, this code is run upon simulator first start
+        themePresets?: SimulatorThemePreset[]; // customizable simulator themes offered by the editor
+        themeLayouts?: SimulatorThemeLayout[]; // additional simulator layouts offered by the theme editor; Default is always included
 
         // a map of allowed simulator channel to URL to handle specific control messages
         // DEPRECATED. Use `simx` in targetconfig.json approvedRepoLib instead.
@@ -641,6 +665,7 @@ declare namespace pxt {
         id: string; // Unique identifier
         name: string; // Human-readable name
         weight?: number; // Lower weights appear first in theme list, no value = go to end
+        defaultSimulatorTheme?: string | Partial<SimulatorTheme>; // Simulator preset id or partial inline theme used by Default
         overrideCss?: string; // Special css to apply for the theme
         monacoBaseTheme?: string; // Theme for monaco editor, see https://code.visualstudio.com/docs/getstarted/themes
         colors: { [key: string]: string }; // Values for theme variables

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -83,6 +83,7 @@ declare namespace pxt.editor {
         | "showthemepicker"
         | "togglehighcontrast"
         | "sethighcontrast" // EditorMessageSetHighContrastRequest
+        | "setsimulatortheme" // EditorMessageSetSimulatorThemeRequest
         | "togglegreenscreen"
         | "togglekeyboardcontrols"
         | "togglescreenreadermode"
@@ -404,6 +405,12 @@ declare namespace pxt.editor {
     export interface EditorMessageSetHighContrastRequest extends EditorMessageRequest {
         action: "sethighcontrast";
         on: boolean;
+    }
+
+    export interface EditorMessageSetSimulatorThemeRequest extends EditorMessageRequest {
+        action: "setsimulatortheme";
+        preference: pxt.auth.SimulatorThemePreference;
+        savePreference?: boolean;
     }
 
     export interface EditorMessageStartActivity extends EditorMessageRequest {
@@ -830,6 +837,7 @@ declare namespace pxt.editor {
         areaMenuOpen?: boolean;
         feedback?: FeedbackState;
         themePickerOpen?: boolean;
+        simulatorThemePickerOpen?: boolean;
         errorListNote?: string;
         timeMachine?: boolean;
     }
@@ -992,8 +1000,8 @@ declare namespace pxt.editor {
         setEditorOffset(): void;
 
         anonymousPublishHeaderByIdAsync(headerId: string, projectName?: string): Promise<ShareData>;
-        publishCurrentHeaderAsync(persistent: boolean, screenshotUri?: string): Promise<string>;
-        publishAsync (name: string, description?: string,screenshotUri?: string, forceAnonymous?: boolean): Promise<ShareData>;
+        publishCurrentHeaderAsync(persistent: boolean, screenshotUri?: string, simulatorTheme?: pxt.SimulatorTheme): Promise<string>;
+        publishAsync (name: string, description?: string,screenshotUri?: string, forceAnonymous?: boolean, simulatorTheme?: pxt.SimulatorTheme): Promise<ShareData>;
 
         startStopSimulator(opts?: SimulatorStartOptions): void;
         stopSimulator(unload?: boolean, opts?: SimulatorStartOptions): void;
@@ -1123,6 +1131,7 @@ declare namespace pxt.editor {
         getSharePreferenceForHeader(): boolean;
         saveSharePreferenceForHeaderAsync(anonymousByDefault: boolean): Promise<void>;
         setColorThemeById(colorThemeId: string, savePreference: boolean): void;
+        setSimulatorThemePreference(preference: pxt.auth.SimulatorThemePreference, savePreference?: boolean): Promise<void>;
     }
 
     export interface IHexFileImporter {

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -253,6 +253,10 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                 return Promise.resolve()
                                     .then(() => projectView.setHighContrast(hcmsg.on));
                             }
+                            case "setsimulatortheme": {
+                                const themeMsg = data as pxt.editor.EditorMessageSetSimulatorThemeRequest;
+                                return projectView.setSimulatorThemePreference(themeMsg.preference, themeMsg.savePreference);
+                            }
                             case "togglegreenscreen": {
                                 return Promise.resolve()
                                     .then(() => projectView.toggleGreenScreen());

--- a/pxtlib/auth.ts
+++ b/pxtlib/auth.ts
@@ -51,6 +51,67 @@ namespace pxt.auth {
         [targetId: string]: string;
     }
 
+    export const DEFAULT_SIMULATOR_THEME_COLOR_PROPERTIES = [
+        "background-color",
+        "button-stroke",
+        "text-color",
+        "button-fill",
+        "dpad-fill",
+        "joystick-handle-stroke",
+    ] as const;
+
+    export const DEFAULT_SIMULATOR_LAYOUT = "default";
+
+    export type SimulatorTheme = Map<string> & { layout: string };
+
+    export type SimulatorThemePreference = {
+        presetId: string;
+        theme: SimulatorTheme;
+    }
+
+    export type SimulatorThemesState = {
+        [targetId: string]: SimulatorThemePreference;
+    }
+
+    export const SIMULATOR_THEMES_LOCAL_STORAGE_KEY = "user-pref:simulatorThemes";
+
+    export function isSimulatorThemeColorProperty(property: string): boolean {
+        return property !== "layout"
+            && property !== "skin"
+            && /^[a-z][a-z0-9-]*$/.test(property);
+    }
+
+    export function isSimulatorThemeColor(value: unknown): value is string {
+        return typeof value === "string" && /^#[0-9a-f]{6}$/i.test(value);
+    }
+
+    export function isValidSimulatorTheme(theme: unknown): theme is SimulatorTheme {
+        if (!theme || typeof theme !== "object") return false;
+        const candidate = theme as Map<unknown>;
+        const colorProperties = Object.keys(candidate).filter(property => property !== "layout");
+        return colorProperties.length > 0
+            && colorProperties.every(property =>
+                isSimulatorThemeColorProperty(property)
+                && isSimulatorThemeColor(candidate[property]))
+            && typeof candidate.layout === "string"
+            && !!candidate.layout;
+    }
+
+    export function simulatorThemeColorsEqual(left: Map<string>, right: Map<string>): boolean {
+        const leftProperties = Object.keys(left).filter(isSimulatorThemeColorProperty);
+        const rightProperties = Object.keys(right).filter(isSimulatorThemeColorProperty);
+        return leftProperties.length === rightProperties.length
+            && leftProperties.every(property => left[property] === right[property]);
+    }
+
+    export function isValidSimulatorThemePreference(preference: unknown): preference is SimulatorThemePreference {
+        if (!preference || typeof preference !== "object") return false;
+        const candidate = preference as Partial<SimulatorThemePreference>;
+        return typeof candidate.presetId === "string"
+            && !!candidate.presetId
+            && isValidSimulatorTheme(candidate.theme);
+    }
+
     export type SetPrefResult = {
         success: boolean;
         res: UserPreferences;
@@ -64,6 +125,7 @@ namespace pxt.auth {
         highContrast?: boolean;
         screenReaderMode?: boolean;
         colorThemeIds?: ColorThemeIdsState;
+        simulatorThemes?: SimulatorThemesState;
         reader?: string;
         skillmap?: UserSkillmapState;
         badges?: UserBadgeState;
@@ -75,6 +137,7 @@ namespace pxt.auth {
         highContrast: false,
         screenReaderMode: false,
         colorThemeIds: {}, // Will lookup pxt.appTarget.appTheme.defaultColorTheme for active target
+        simulatorThemes: {},
         reader: "",
         skillmap: { mapProgress: {}, completedTags: {} },
         email: false

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1414,7 +1414,11 @@ namespace ts.pxtc.Util {
                 stringFiles = [{ staticName: "bundled-strings.json", path: targetId + "/bundled-strings.json" }];
                 break;
             case TranslationsKind.SkillMap:
-                stringFiles = [{ staticName: "skillmap-strings.json", path: "/skillmap-strings.json" }];
+                stringFiles = [
+                    { staticName: "strings.json", path: "strings.json" },
+                    { staticName: "target-strings.json", path: targetId + "/target-strings.json" },
+                    { staticName: "skillmap-strings.json", path: "/skillmap-strings.json" },
+                ];
                 break;
         }
         let translations: pxt.Map<string>;

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -275,13 +275,13 @@ namespace pxsim {
 
     export interface SetSimThemeMessage extends SimulatorMessage {
         type: "setsimthemecolor";
-        part:
-            | "background-color"
-            | "button-stroke"
-            | "text-color"
-            | "button-fill"
-            | "dpad-fill";
+        part: string;
         color: string;
+    }
+
+    export interface SetSimulatorThemeMessage extends SimulatorMessage {
+        type: "setsimtheme";
+        theme: string | pxt.Map<string>;
     }
 
     export interface SetMuteButtonStateMessage extends SimulatorMessage {

--- a/react-common/components/controls/Card.tsx
+++ b/react-common/components/controls/Card.tsx
@@ -5,6 +5,7 @@ export interface CardProps extends ContainerProps {
     onClick?: () => void;
     tabIndex?: number;
     ariaLabelledBy?: string;
+    ariaPressed?: boolean;
     label?: React.ReactNode;
     labelClass?: string;
 }
@@ -17,6 +18,7 @@ export const Card = (props: CardProps) => {
         children,
         ariaDescribedBy,
         ariaLabelledBy,
+        ariaPressed,
         ariaHidden,
         ariaLabel,
         onClick,
@@ -38,6 +40,7 @@ export const Card = (props: CardProps) => {
                         tabIndex={tabIndex}
                         aria-describedby={ariaDescribedBy}
                         aria-labelledby={ariaLabelledBy}
+                        aria-pressed={ariaPressed}
                         onClick={onClick}
                     />
                 }

--- a/react-common/components/controls/Modal.tsx
+++ b/react-common/components/controls/Modal.tsx
@@ -22,6 +22,7 @@ export interface ModalAction {
 
 export interface ModalProps extends ContainerProps {
     title: string;
+    hideTitle?: boolean;
     leftIcon?: string;
     ariaDescribedBy?: string;
     actions?: ModalAction[];
@@ -42,6 +43,7 @@ export const Modal = (props: ModalProps) => {
         ariaDescribedBy,
         role,
         title,
+        hideTitle,
         leftIcon,
         actions,
         onClose,
@@ -106,11 +108,11 @@ export const Modal = (props: ModalProps) => {
                         />
                     </div>
                 }
-                <div id="modal-title" className="common-modal-title">
+                <div id="modal-title" className={classList("common-modal-title", hideTitle && "sr-only")}>
                     {leftIcon && <i className={leftIcon} aria-hidden={true}/>}
                     {title}
                 </div>
-                {fullscreen && rightHeader &&
+                {rightHeader &&
                     <div className="common-modal-right-menu">
                         {rightHeader}
                     </div>

--- a/react-common/components/share/Share.tsx
+++ b/react-common/components/share/Share.tsx
@@ -24,10 +24,11 @@ export interface ShareProps {
     hasProjectBeenPersistentShared?: boolean;
     anonymousShareByDefault?: boolean;
     isMultiplayerGame?: boolean; // Arcade: Does the game being shared have multiplayer enabled?
+    simulatorTheme?: pxt.SimulatorTheme;
     kind?: "multiplayer" | "vscode" | "share"; // Arcade: Was the share dialog opened specifically for hosting a multiplayer game?
     setAnonymousSharePreference?: (anonymousByDefault: boolean) => void;
     simRecorder: SimRecorder;
-    publishAsync: (name: string, description?: string, screenshotUri?: string, forceAnonymous?: boolean) => Promise<ShareData>;
+    publishAsync: (name: string, description?: string, screenshotUri?: string, forceAnonymous?: boolean, simulatorTheme?: pxt.SimulatorTheme) => Promise<ShareData>;
     onClose: () => void;
 }
 
@@ -43,6 +44,7 @@ export const Share = (props: ShareProps) => {
         anonymousShareByDefault,
         setAnonymousSharePreference,
         isMultiplayerGame,
+        simulatorTheme,
         kind,
         onClose
     } = props;
@@ -55,6 +57,7 @@ export const Share = (props: ShareProps) => {
             simRecorder={simRecorder}
             publishAsync={publishAsync}
             isMultiplayerGame={isMultiplayerGame}
+            simulatorTheme={simulatorTheme}
             kind={kind}
             hasProjectBeenPersistentShared={hasProjectBeenPersistentShared}
             anonymousShareByDefault={anonymousShareByDefault}

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -25,8 +25,9 @@ export interface ShareInfoProps {
     isLoggedIn?: boolean;
     hasProjectBeenPersistentShared?: boolean;
     simRecorder: SimRecorder;
-    publishAsync: (name: string, description?: string, screenshotUri?: string, forceAnonymous?: boolean) => Promise<ShareData>;
+    publishAsync: (name: string, description?: string, screenshotUri?: string, forceAnonymous?: boolean, simulatorTheme?: pxt.SimulatorTheme) => Promise<ShareData>;
     isMultiplayerGame?: boolean; // Arcade: Does the game being shared have multiplayer enabled?
+    simulatorTheme?: pxt.SimulatorTheme;
     kind?: "multiplayer" | "vscode" | "share"; // Arcade: Was the share dialog opened specifically for hosting a multiplayer game?
     anonymousShareByDefault?: boolean;
     setAnonymousSharePreference?: (anonymousByDefault: boolean) => void;
@@ -46,6 +47,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
         anonymousShareByDefault,
         setAnonymousSharePreference,
         isMultiplayerGame,
+        simulatorTheme,
         kind = "share",
         onClose,
     } = props;
@@ -62,6 +64,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
     const [ kioskState, setKioskState ] = React.useState(false);
     const [ isAnonymous, setIsAnonymous ] = React.useState(!isLoggedIn || anonymousShareByDefault);
     const [ isShowingMultiConfirmation, setIsShowingMultiConfirmation ] = React.useState(false);
+    const [ shareWithSimulatorTheme, setShareWithSimulatorTheme ] = React.useState(false);
 
     const { simScreenshot, simGif } = pxt.appTarget.appTheme;
     const showSimulator = (simScreenshot || simGif) && !!simRecorder;
@@ -96,7 +99,8 @@ export const ShareInfo = (props: ShareInfoProps) => {
     const handlePublishClick = async () => {
         setShareState("publishing");
         setLastShareWasAnonymous(isAnonymous);
-        let publishedShareData = await publishAsync(name, description, thumbnailUri, isAnonymous);
+        let publishedShareData = await publishAsync(name, description, thumbnailUri, isAnonymous,
+            shareWithSimulatorTheme ? simulatorTheme : undefined);
         setShareData(publishedShareData);
         if (!publishedShareData?.error) setShareState("publish");
         else setShareState("share")
@@ -105,7 +109,8 @@ export const ShareInfo = (props: ShareInfoProps) => {
     const handlePublishInVscodeClick = async () => {
         setShareState("publishing");
         setLastShareWasAnonymous(isAnonymous);
-        let publishedShareData = await publishAsync(name, description, thumbnailUri, isAnonymous);
+        let publishedShareData = await publishAsync(name, description, thumbnailUri, isAnonymous,
+            shareWithSimulatorTheme ? simulatorTheme : undefined);
         setShareData(publishedShareData);
         if (!publishedShareData?.error) {
             setShareState("publish-vscode");
@@ -241,7 +246,8 @@ export const ShareInfo = (props: ShareInfoProps) => {
         setIsShowingMultiConfirmation(false);
         setLastShareWasAnonymous(isAnonymous);
 
-        const publishedShareData = await publishAsync(name, description, thumbnailUri, isAnonymous);
+        const publishedShareData = await publishAsync(name, description, thumbnailUri, isAnonymous,
+            shareWithSimulatorTheme ? simulatorTheme : undefined);
 
         // TODO multiplayer: This won't work on staging (parseScriptId domains check doesn't include staging urls)
         // but those wouldn't load anyways (as staging multiplayer is currently fetching games from prod links)
@@ -323,6 +329,11 @@ export const ShareInfo = (props: ShareInfoProps) => {
         if (setAnonymousSharePreference) setAnonymousSharePreference(!newValue);
     }
 
+    const handleShareWithSimulatorThemeClick = (newValue: boolean) => {
+        pxt.tickEvent("share.simulatorTheme", { checked: newValue.toString() });
+        setShareWithSimulatorTheme(newValue);
+    }
+
     const inputTitle = prePublish ? lf("Project Name") :
         (shareState === "publish-vscode" ? lf("Share Successful") : lf("Project Link"));
 
@@ -399,6 +410,12 @@ export const ShareInfo = (props: ShareInfoProps) => {
                             label={lf("Update existing share link for this project")}
                             isChecked={!isAnonymous}
                             onChange={handleAnonymousShareClick}
+                            />}
+                        {simulatorTheme && <Checkbox
+                            id="share-simulator-theme-checkbox"
+                            label={lf("Share with your simulator theme")}
+                            isChecked={shareWithSimulatorTheme}
+                            onChange={handleShareWithSimulatorThemeClick}
                             />}
                         </>
                     }

--- a/react-common/components/theming/SimulatorThemePickerModal.tsx
+++ b/react-common/components/theming/SimulatorThemePickerModal.tsx
@@ -1,0 +1,207 @@
+import * as React from "react";
+
+import { Input } from "../controls/Input";
+import { Modal } from "../controls/Modal";
+import { copySimulatorTheme, getSimulatorThemeForLayout } from "./simulatorThemeDefaults";
+import { ThemePickerToggle } from "./ThemePickerModal";
+
+export interface SimulatorThemePickerModalProps {
+    presets: pxt.SimulatorThemePreset[];
+    layouts?: pxt.SimulatorThemeLayout[];
+    initialPreference?: pxt.auth.SimulatorThemePreference;
+    defaultTheme?: pxt.SimulatorTheme;
+    accountTheme?: pxt.SimulatorTheme;
+    renderPreview: (theme: pxt.SimulatorTheme) => React.ReactNode;
+    onEditorThemeClicked?: () => void;
+    onUseAccountTheme?: () => void | Promise<void>;
+    onThemeChanged?: (preference: pxt.auth.SimulatorThemePreference) => void;
+    onSave: (preference: pxt.auth.SimulatorThemePreference) => void | Promise<void>;
+    onClose: () => void;
+}
+
+const CUSTOM_PRESET_ID = "custom";
+const ACCOUNT_PRESET_ID = "account";
+
+function getDefaultColorFields(theme: pxt.SimulatorTheme): pxt.SimulatorThemeColorField[] {
+    const labels: pxt.Map<string> = {
+        "background-color": lf("Console"),
+        "button-stroke": lf("Button outline"),
+        "text-color": lf("Button labels"),
+        "button-fill": lf("Buttons"),
+        "dpad-fill": lf("D-pad"),
+        "joystick-handle-stroke": lf("Joystick handle outline"),
+    };
+    return pxt.auth.DEFAULT_SIMULATOR_THEME_COLOR_PROPERTIES.map(property => ({
+        property,
+        label: labels[property],
+        defaultValue: theme[property],
+    }));
+}
+
+function getPresetId(theme: pxt.SimulatorTheme, presets: pxt.SimulatorThemePreset[]): string | undefined {
+    return presets.find(preset => pxt.auth.simulatorThemeColorsEqual(preset.theme, theme))?.id;
+}
+
+function normalizeColor(value: string): string | undefined {
+    const normalized = value.startsWith("#") ? value : `#${value}`;
+    return /^#[0-9a-f]{6}$/i.test(normalized) ? normalized.toUpperCase() : undefined;
+}
+
+export const SimulatorThemePickerModal = (props: SimulatorThemePickerModalProps) => {
+    const {
+        presets,
+        layouts,
+        initialPreference,
+        defaultTheme,
+        accountTheme,
+        renderPreview,
+        onEditorThemeClicked,
+        onUseAccountTheme,
+        onThemeChanged,
+        onSave,
+        onClose,
+    } = props;
+    const defaultColorFields = getDefaultColorFields(presets[0].theme);
+    const getColorFields = (layoutId: string) => {
+        const fields = layouts?.find(layout => layout.id === layoutId)?.colorFields;
+        return fields?.map(field => ({
+            ...field,
+            label: pxt.Util.rlf(`{id:simulator-theme-field}${field.label}`),
+        })) || defaultColorFields;
+    };
+    const savedPreset = presets.find(preset => preset.id === initialPreference?.presetId);
+    const initialPresetId = savedPreset
+        ? savedPreset.id
+        : initialPreference
+            ? getPresetId(initialPreference.theme, presets) || CUSTOM_PRESET_ID
+        : onUseAccountTheme
+            ? ACCOUNT_PRESET_ID
+            : presets[0].id;
+    const initialThemeSource = initialPresetId === "default"
+        ? defaultTheme || initialPreference?.theme || savedPreset?.theme || presets[0].theme
+        : initialPreference?.theme || savedPreset?.theme || accountTheme || presets[0].theme;
+    const initialLayoutId = initialPreference?.theme.layout
+        || initialThemeSource.layout
+        || pxt.auth.DEFAULT_SIMULATOR_LAYOUT;
+    const initialTheme = getSimulatorThemeForLayout(
+        initialThemeSource,
+        initialLayoutId,
+        getColorFields(initialLayoutId)
+    );
+    const [presetId, setPresetId] = React.useState(initialPresetId);
+    const [theme, setTheme] = React.useState<pxt.SimulatorTheme>(initialTheme);
+    const layoutId = theme.layout;
+    const layoutIsKnown = layoutId === pxt.auth.DEFAULT_SIMULATOR_LAYOUT || layouts?.some(layout => layout.id === layoutId);
+    const colorFields = getColorFields(layoutId);
+
+    const selectPreset = (id: string) => {
+        if (id === ACCOUNT_PRESET_ID && onUseAccountTheme) {
+            setPresetId(id);
+            const nextTheme = copySimulatorTheme(accountTheme || presets[0].theme);
+            setTheme(getSimulatorThemeForLayout(nextTheme, nextTheme.layout, getColorFields(nextTheme.layout)));
+            return;
+        }
+        const preset = presets.find(candidate => candidate.id === id);
+        if (!preset) return;
+        const presetTheme = copySimulatorTheme(id === "default" ? defaultTheme || preset.theme : preset.theme);
+        const nextTheme = getSimulatorThemeForLayout(
+            presetTheme,
+            presetTheme.layout,
+            getColorFields(presetTheme.layout)
+        );
+        setPresetId(id);
+        setTheme(nextTheme);
+        onThemeChanged?.({ presetId: id, theme: nextTheme });
+    };
+
+    const updateColor = (property: string, color: string) => {
+        const normalized = normalizeColor(color);
+        if (!normalized) return;
+        const nextTheme = {
+            ...theme,
+            [property]: normalized,
+        };
+        setPresetId(CUSTOM_PRESET_ID);
+        setTheme(nextTheme);
+        onThemeChanged?.({ presetId: CUSTOM_PRESET_ID, theme: nextTheme });
+    };
+
+    const selectLayout = (id: string) => {
+        const nextTheme = getSimulatorThemeForLayout(theme, id, getColorFields(id));
+        setPresetId(CUSTOM_PRESET_ID);
+        setTheme(nextTheme);
+        onThemeChanged?.({ presetId: CUSTOM_PRESET_ID, theme: nextTheme });
+    };
+
+    return <Modal
+        id="simulator-theme-picker-modal"
+        title={lf("Simulator Theme")}
+        hideTitle={!!onEditorThemeClicked}
+        className={`simulator-theme-picker-modal${onEditorThemeClicked ? "" : " standalone"}`}
+        onClose={onClose}
+        rightHeader={onEditorThemeClicked && <ThemePickerToggle
+            selected="simulator"
+            onModeChanged={onEditorThemeClicked} />}
+        actions={[
+            {
+                label: lf("Apply"),
+                className: "primary",
+                onClick: () => presetId === ACCOUNT_PRESET_ID
+                    ? onUseAccountTheme?.()
+                    : onSave({ presetId, theme }),
+            },
+        ]}>
+        <div className="simulator-theme-picker">
+            {renderPreview(theme)}
+            <div className="simulator-theme-controls">
+                <div className="simulator-theme-select-field">
+                    <label htmlFor="simulator-theme-preset">
+                        {onUseAccountTheme ? lf("Theme") : lf("Built-in theme")}
+                    </label>
+                    <select
+                        id="simulator-theme-preset"
+                        aria-label={onUseAccountTheme ? lf("Project simulator theme") : lf("Built-in simulator theme")}
+                        className="simulator-theme-select"
+                        value={presetId}
+                        onChange={event => selectPreset(event.target.value)}>
+                        {onUseAccountTheme && <option value={ACCOUNT_PRESET_ID}>{lf("Use account theme")}</option>}
+                        {presetId === CUSTOM_PRESET_ID && <option value={CUSTOM_PRESET_ID} disabled>{lf("Custom")}</option>}
+                        {presets.map(preset => <option key={preset.id} value={preset.id}>
+                            {pxt.Util.rlf(`{id:simulator-theme-name}${preset.name}`)}
+                        </option>)}
+                    </select>
+                </div>
+                {!!layouts?.length && <div className="simulator-theme-select-field">
+                    <label htmlFor="simulator-theme-layout">{lf("Layout")}</label>
+                    <select
+                        id="simulator-theme-layout"
+                        aria-label={lf("Simulator layout")}
+                        className="simulator-theme-select"
+                        value={layoutId}
+                        onChange={event => selectLayout(event.target.value)}>
+                        <option value={pxt.auth.DEFAULT_SIMULATOR_LAYOUT}>{lf("Default")}</option>
+                        {!layoutIsKnown && <option value={layoutId} disabled>{lf("Custom ({0})", layoutId)}</option>}
+                        {layouts.map(layout => <option key={layout.id} value={layout.id}>
+                            {pxt.Util.rlf(`{id:simulator-layout-name}${layout.name}`)}
+                        </option>)}
+                    </select>
+                </div>}
+                <div className="simulator-theme-color-list">
+                    {colorFields.map(field => <div className="simulator-theme-color" key={field.property}>
+                        <span>{field.label}</span>
+                        <input
+                            type="color"
+                            aria-label={lf("{0} color", field.label)}
+                            value={theme[field.property]}
+                            onChange={event => updateColor(field.property, event.target.value)} />
+                        <Input
+                            ariaLabel={lf("{0} hex color", field.label)}
+                            initialValue={theme[field.property]}
+                            onChange={value => updateColor(field.property, value)}
+                            validator={(value, previousValue) => normalizeColor(value) || previousValue} />
+                    </div>)}
+                </div>
+            </div>
+        </div>
+    </Modal>;
+};

--- a/react-common/components/theming/ThemeCard.tsx
+++ b/react-common/components/theming/ThemeCard.tsx
@@ -3,22 +3,24 @@ import { Card } from "../controls/Card";
 
 interface ThemeCardProps {
     theme: pxt.ColorThemeInfo;
-    onClick?: (theme: pxt.ColorThemeInfo) => void;
+    selected: boolean;
+    onClick: (theme: pxt.ColorThemeInfo) => void;
 }
 
 export const ThemeCard = (props: ThemeCardProps) => {
-    const { onClick, theme } = props;
+    const { onClick, selected, theme } = props;
 
     const themeName = pxt.Util.rlf(`{id:color-theme-name}${theme.name}`);
 
     return (
         <Card
-            className="theme-card"
+            className={`theme-card${selected ? " selected" : ""}`}
             role="listitem"
             ariaLabelledBy={theme.id + "-title"}
+            ariaPressed={selected}
             key={theme.id}
             onClick={() => onClick(theme)}
-            tabIndex={onClick && 0}
+            tabIndex={0}
         >
             <div className="theme-info-box">
                 <ThemePreview theme={theme} />

--- a/react-common/components/theming/ThemePickerModal.tsx
+++ b/react-common/components/theming/ThemePickerModal.tsx
@@ -1,29 +1,90 @@
+import * as React from "react";
 import { Modal } from "../controls/Modal";
+import { EditorToggle } from "../controls/EditorToggle";
 import { ThemeCard } from "./ThemeCard";
+
+export type ThemePickerMode = "editor" | "simulator";
+
+export interface ThemePickerToggleProps {
+    selected: ThemePickerMode;
+    onModeChanged: (mode: ThemePickerMode) => void;
+}
+
+export const ThemePickerToggle = (props: ThemePickerToggleProps) => {
+    const { selected, onModeChanged } = props;
+    const selectMode = (mode: ThemePickerMode) => {
+        if (mode !== selected) onModeChanged(mode);
+    };
+
+    return <div className="theme-picker-toggle">
+        <EditorToggle
+            id="theme-picker-toggle"
+            ariaLabel={lf("Theme type")}
+            selected={selected === "editor" ? 0 : 1}
+            items={[
+                {
+                    label: lf("Editor"),
+                    title: lf("Editor theme"),
+                    icon: "fas fa-paint-brush",
+                    focusable: true,
+                    onClick: () => selectMode("editor"),
+                },
+                {
+                    label: lf("Simulator"),
+                    title: lf("Simulator theme"),
+                    icon: "fas fa-gamepad",
+                    focusable: true,
+                    onClick: () => selectMode("simulator"),
+                },
+            ]} />
+    </div>;
+};
 
 export interface ThemePickerModalProps {
     themes: pxt.ColorThemeInfo[];
-    onThemeClicked(them: pxt.ColorThemeInfo): void;
+    selectedThemeId?: string;
+    onThemeChanged: (theme: pxt.ColorThemeInfo) => void;
+    onSave: (theme: pxt.ColorThemeInfo) => void;
+    onSimulatorThemeClicked?: () => void;
     onClose(): void;
 }
 export const ThemePickerModal = (props: ThemePickerModalProps) => {
+    const [selectedThemeId, setSelectedThemeId] = React.useState(
+        props.selectedThemeId || props.themes[0]?.id
+    );
+    const selectedTheme = props.themes.find(theme => theme.id === selectedThemeId);
+
     return (
         <Modal
-            id="theme-picker-modal" 
+            id="theme-picker-modal"
             title={lf("Choose a Theme")}
+            hideTitle={!!props.onSimulatorThemeClicked}
             onClose={props.onClose}
             className="theme-picker-modal"
+            rightHeader={props.onSimulatorThemeClicked && <ThemePickerToggle
+                selected="editor"
+                onModeChanged={props.onSimulatorThemeClicked} />}
+            actions={[{
+                label: lf("Apply"),
+                className: "primary",
+                disabled: !selectedTheme,
+                onClick: () => selectedTheme && props.onSave(selectedTheme),
+            }]}
         >
             <div
                 className="theme-picker"
                 role="list"
                 aria-label={lf("List of available themes")}
             >
-                {props.themes && props.themes.map(theme => 
+                {props.themes.map(theme =>
                     <ThemeCard
                         key={theme.id}
                         theme={theme}
-                        onClick={props.onThemeClicked}
+                        selected={theme.id === selectedThemeId}
+                        onClick={selected => {
+                            setSelectedThemeId(selected.id);
+                            props.onThemeChanged(selected);
+                        }}
                     />
                 )}
             </div>

--- a/react-common/components/theming/simulatorThemeDefaults.ts
+++ b/react-common/components/theming/simulatorThemeDefaults.ts
@@ -1,0 +1,77 @@
+export function getSimulatorThemePreferenceForColorThemeChange(
+    preference: pxt.auth.SimulatorThemePreference | undefined,
+    previousColorTheme: pxt.ColorThemeInfo | undefined,
+    nextColorTheme: pxt.ColorThemeInfo | undefined,
+    presets: pxt.SimulatorThemePreset[] | undefined
+): pxt.auth.SimulatorThemePreference | undefined {
+    if (!presets?.length || previousColorTheme?.id === nextColorTheme?.id) return preference;
+
+    const nextDefault = getDefaultSimulatorThemePreference(nextColorTheme, presets);
+    if (!nextDefault) return preference;
+
+    if (preference) {
+        if (preference.presetId !== nextDefault.presetId) return preference;
+        if (pxt.auth.simulatorThemeColorsEqual(preference.theme, nextDefault.theme)
+            && preference.theme.layout === nextDefault.theme.layout) return preference;
+    }
+    else if (!nextColorTheme?.defaultSimulatorTheme) {
+        return preference;
+    }
+
+    return nextDefault;
+}
+
+export function getDefaultSimulatorThemePreference(
+    colorTheme: pxt.ColorThemeInfo | undefined,
+    presets: pxt.SimulatorThemePreset[] | undefined
+): pxt.auth.SimulatorThemePreference | undefined {
+    const defaultPreset = presets?.find(candidate => candidate.id === "default") || presets?.[0];
+    if (!defaultPreset) return undefined;
+
+    const configuredDefault = colorTheme?.defaultSimulatorTheme;
+    const configuredPreset = typeof configuredDefault === "string"
+        ? presets?.find(candidate => candidate.id === configuredDefault)
+        : undefined;
+    const theme = typeof configuredDefault === "object"
+        ? { ...defaultPreset.theme, ...configuredDefault }
+        : configuredPreset?.theme || defaultPreset.theme;
+    return {
+        presetId: defaultPreset.id,
+        theme: copySimulatorTheme(theme as pxt.SimulatorTheme),
+    };
+}
+
+export function isImplicitSimulatorThemePreference(
+    preference: pxt.auth.SimulatorThemePreference,
+    presets: pxt.SimulatorThemePreset[] | undefined
+): boolean {
+    const defaultPreset = presets?.find(candidate => candidate.id === "default") || presets?.[0];
+    return preference.presetId === defaultPreset?.id
+        && preference.theme.layout === pxt.auth.DEFAULT_SIMULATOR_LAYOUT;
+}
+
+export function copySimulatorTheme(theme: pxt.SimulatorTheme): pxt.SimulatorTheme {
+    const result = { layout: theme.layout || pxt.auth.DEFAULT_SIMULATOR_LAYOUT } as pxt.SimulatorTheme;
+    for (const property of Object.keys(theme)) {
+        if (pxt.auth.isSimulatorThemeColorProperty(property)
+            && pxt.auth.isSimulatorThemeColor(theme[property])) {
+            result[property] = theme[property];
+        }
+    }
+    return result;
+}
+
+export function getSimulatorThemeForLayout(
+    theme: pxt.SimulatorTheme,
+    layoutId: string,
+    colorFields: pxt.SimulatorThemeColorField[] = []
+): pxt.SimulatorTheme {
+    const nextTheme = copySimulatorTheme(theme);
+    nextTheme.layout = layoutId;
+    for (const field of colorFields) {
+        if (!pxt.auth.isSimulatorThemeColor(nextTheme[field.property])) {
+            nextTheme[field.property] = field.defaultValue;
+        }
+    }
+    return nextTheme;
+}

--- a/react-common/styles/controls/Modal.less
+++ b/react-common/styles/controls/Modal.less
@@ -54,6 +54,12 @@
         padding-bottom: 1.25rem;
     }
 
+    .common-modal-right-menu {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
+
     .common-modal-close {
         border: 1px solid transparent;
     }
@@ -116,12 +122,6 @@
 
     .common-modal-back:focus-within {
         border: 1px, solid var(--pxt-focus-border);
-    }
-
-    .common-modal-right-menu {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
     }
 
     .common-modal-help {

--- a/react-common/styles/theming/ThemePickerModal.less
+++ b/react-common/styles/theming/ThemePickerModal.less
@@ -1,6 +1,190 @@
-.theme-picker-modal>.common-modal {
-    width: 80%;
-    max-width: 60rem;
+.theme-picker-modal,
+.simulator-theme-picker-modal {
+    >.common-modal {
+        width: 90%;
+        max-width: 64rem;
+    }
+
+    .common-modal-header {
+        padding-left: 0;
+
+        .common-modal-right-menu {
+            flex: 1;
+            justify-content: center;
+            min-width: 0;
+            margin-left: 4rem;
+        }
+    }
+
+    .common-modal-footer {
+        grid-template-columns: 1fr auto;
+
+        button:only-child {
+            justify-self: end;
+            min-width: 8rem;
+        }
+    }
+}
+
+.theme-picker-modal>.common-modal,
+.simulator-theme-picker-modal:not(.standalone)>.common-modal {
+    height: 90%;
+    max-height: 48rem;
+    display: flex;
+    flex-direction: column;
+
+    .common-modal-body {
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+    }
+}
+
+.theme-picker-toggle {
+    width: 20rem;
+    max-width: 40vw;
+    padding: 0.5rem 0;
+
+    .common-editor-toggle-outer {
+        width: 100%;
+    }
+
+    .common-editor-toggle {
+        overflow: hidden;
+    }
+
+    .common-editor-toggle .common-editor-toggle-item > .common-button {
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
+    }
+
+    .common-button-flex,
+    .common-button-label {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}
+
+.simulator-theme-picker-modal.standalone .common-modal-header {
+    padding-left: 1.5rem;
+}
+
+.simulator-theme-picker {
+    display: grid;
+    grid-template-columns: minmax(18rem, 1fr) minmax(18rem, 1fr);
+    gap: 2rem;
+    align-items: center;
+}
+
+.simulator-theme-preview {
+    min-width: 0;
+
+    .simframe {
+        margin: 0;
+    }
+
+    .simframe > .ui.loader {
+        display: none;
+    }
+}
+
+.simulator-theme-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-width: 0;
+}
+
+.simulator-theme-select-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.simulator-theme-select {
+    box-sizing: border-box;
+    width: 100%;
+    height: 2.5rem;
+    padding: 0 0.75rem;
+    border: 1px solid var(--pxt-neutral-stencil1);
+    border-radius: 2px;
+    background: var(--pxt-neutral-background1);
+    color: var(--pxt-neutral-foreground1);
+    font: inherit;
+    cursor: pointer;
+
+    &:focus-visible {
+        outline: 3px solid var(--pxt-focus-border);
+        outline-offset: 2px;
+    }
+}
+
+.simulator-theme-color-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.simulator-theme-color {
+    display: grid;
+    grid-template-columns: minmax(7rem, 1fr) 3rem minmax(8rem, 1fr);
+    gap: 0.5rem;
+    align-items: center;
+
+    .common-input-wrapper {
+        min-width: 0;
+    }
+
+    input[type="color"] {
+        width: 3rem;
+        height: 2.25rem;
+        padding: 0.125rem;
+        cursor: pointer;
+        border: 1px solid var(--pxt-neutral-stencil1);
+        background: var(--pxt-neutral-background1);
+    }
+}
+
+@media only screen and (max-width: 50rem) {
+    .theme-picker-modal>.common-modal {
+        width: 90%;
+    }
+
+    .theme-picker-modal,
+    .simulator-theme-picker-modal {
+        .common-modal-header .common-modal-right-menu {
+            margin-left: clamp(0rem, calc(90vw - 16rem), 4rem);
+        }
+    }
+
+    .theme-picker-toggle {
+        width: 10rem;
+        max-width: 100%;
+
+        .common-editor-toggle .common-editor-toggle-item > .common-button {
+            padding-left: 0.2rem;
+            padding-right: 0.2rem;
+
+            i {
+                display: none;
+            }
+        }
+    }
+
+    .simulator-theme-picker {
+        grid-template-columns: 1fr;
+    }
+
+    .simulator-theme-preview {
+        max-width: 28rem;
+        width: 100%;
+        justify-self: center;
+    }
+
+    .simulator-theme-color {
+        grid-template-columns: minmax(5.5rem, 1fr) 3rem minmax(6.5rem, 1fr);
+    }
 }
 
 .theme-picker {
@@ -18,10 +202,15 @@
 
     .theme-card {
         width: 18rem;
-        height: unset;
+        height: auto;
         background-color: var(--pxt-neutral-background1);
         color: var(--pxt-neutral-foreground1);
         border: 1px solid var(--pxt-neutral-stencil1);
+
+        &.selected {
+            border-color: var(--pxt-primary-background);
+            box-shadow: inset 0 0 0 2px var(--pxt-primary-background);
+        }
 
         &:hover {
             border: 1px solid var(--pxt-focus-border);

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -52,6 +52,12 @@ import './App.css';
 
 import { ThemeManager } from 'react-common/components/theming/themeManager';
 import { FeedbackModal } from 'react-common/components/controls/Feedback/Feedback';
+import { SimulatorThemePickerModal } from './components/SimulatorThemePickerModal';
+import {
+    getDefaultSimulatorThemePreference,
+    getSimulatorThemePreferenceForColorThemeChange,
+    isImplicitSimulatorThemePreference,
+} from '../../react-common/components/theming/simulatorThemeDefaults';
 
 /* eslint-enable import/no-unassigned-import */
 interface AppProps {
@@ -92,6 +98,9 @@ interface AppState {
     badgeSyncLock: boolean;
     showingSyncLoader?: boolean;
     forcelang?: string;
+    simulatorThemePickerOpen?: boolean;
+    editorThemeId?: string;
+    simulatorThemePreference?: pxt.auth.SimulatorThemePreference;
 }
 
 class AppImpl extends React.Component<AppProps, AppState> {
@@ -100,11 +109,17 @@ class AppImpl extends React.Component<AppProps, AppState> {
     protected loadedUser: UserState | undefined;
     protected readyPromise: ReadyPromise;
     protected themeManager: ThemeManager;
+    protected themePickerInitialColorThemeId?: string;
 
     constructor(props: any) {
         super(props);
         this.changeLanguage = this.changeLanguage.bind(this);
         this.changeTheme = this.changeTheme.bind(this);
+        this.previewColorTheme = this.previewColorTheme.bind(this);
+        this.showSimulatorThemePicker = this.showSimulatorThemePicker.bind(this);
+        this.showEditorThemePicker = this.showEditorThemePicker.bind(this);
+        this.closeThemePicker = this.closeThemePicker.bind(this);
+        this.saveSimulatorTheme = this.saveSimulatorTheme.bind(this);
 
         this.state = {
             cloudSyncCheckHasFinished: false,
@@ -390,6 +405,15 @@ class AppImpl extends React.Component<AppProps, AppState> {
 
     protected onMakeCodeFrameLoaded = async (sendMessageAsync: (message: any) => Promise<any>) => {
         this.readyPromise.setSendMessageAsync(sendMessageAsync);
+        const preference = await authClient.getSimulatorThemePreferenceAsync();
+        if (preference) {
+            await sendMessageAsync({
+                type: "pxteditor",
+                action: "setsimulatortheme",
+                preference,
+                savePreference: false,
+            } as pxt.editor.EditorMessageSetSimulatorThemeRequest);
+        }
     }
 
     async componentDidMount() {
@@ -432,6 +456,107 @@ class AppImpl extends React.Component<AppProps, AppState> {
     }
 
     async changeTheme(theme: pxt.ColorThemeInfo) {
+        await this.persistColorTheme(theme);
+
+        const simulatorThemePresets = pxt.appTarget.simulator?.themePresets;
+        if (simulatorThemePresets?.length) {
+            let simulatorThemePreference = this.state.simulatorThemePreference;
+            if (!simulatorThemePreference) {
+                const currentPreference = await authClient.getSimulatorThemePreferenceAsync();
+                const initialColorTheme = this.themePickerInitialColorThemeId
+                    ? pxt.appTarget.colorThemeMap?.[this.themePickerInitialColorThemeId]
+                    : undefined;
+                simulatorThemePreference = getSimulatorThemePreferenceForColorThemeChange(
+                    currentPreference,
+                    initialColorTheme,
+                    theme,
+                    simulatorThemePresets
+                );
+            }
+            if (simulatorThemePreference) {
+                await this.persistSimulatorTheme(simulatorThemePreference);
+            }
+        }
+        this.closeThemePicker(false);
+    }
+
+    previewColorTheme(theme: pxt.ColorThemeInfo) {
+        const previousColorTheme = pxt.appTarget.colorThemeMap?.[
+            this.state.editorThemeId || this.themeManager.getCurrentColorTheme()?.id
+        ];
+        if (!this.themePickerInitialColorThemeId) {
+            this.themePickerInitialColorThemeId = previousColorTheme?.id;
+        }
+        this.themeManager.switchColorTheme(theme.id);
+        const simulatorThemePresets = pxt.appTarget.simulator?.themePresets;
+        const simulatorThemePreference = simulatorThemePresets?.length && this.state.simulatorThemePreference
+            ? getSimulatorThemePreferenceForColorThemeChange(
+                this.state.simulatorThemePreference,
+                previousColorTheme,
+                theme,
+                simulatorThemePresets
+            )
+            : undefined;
+        this.setState({ editorThemeId: theme.id, simulatorThemePreference });
+    }
+
+    async showSimulatorThemePicker() {
+        const simulatorThemePresets = pxt.appTarget.simulator?.themePresets;
+        if (!simulatorThemePresets?.length) return;
+        const colorTheme = pxt.appTarget.colorThemeMap?.[
+            this.state.editorThemeId || this.themeManager.getCurrentColorTheme()?.id
+        ];
+        if (!this.themePickerInitialColorThemeId) {
+            this.themePickerInitialColorThemeId = this.themeManager.getCurrentColorTheme()?.id;
+        }
+        const savedSimulatorThemePreference = this.state.simulatorThemePreference
+            || await authClient.getSimulatorThemePreferenceAsync();
+        const initialColorTheme = this.themePickerInitialColorThemeId
+            ? pxt.appTarget.colorThemeMap?.[this.themePickerInitialColorThemeId]
+            : undefined;
+        const simulatorThemePreference = getSimulatorThemePreferenceForColorThemeChange(
+            savedSimulatorThemePreference,
+            initialColorTheme,
+            colorTheme,
+            simulatorThemePresets
+        )
+            || getDefaultSimulatorThemePreference(colorTheme, simulatorThemePresets);
+        this.setState({
+            simulatorThemePickerOpen: true,
+            editorThemeId: this.state.editorThemeId || this.themeManager.getCurrentColorTheme()?.id,
+            simulatorThemePreference,
+        });
+    }
+
+    showEditorThemePicker() {
+        this.setState({ simulatorThemePickerOpen: false });
+    }
+
+    closeThemePicker(restoreColorTheme = true) {
+        if (restoreColorTheme
+            && this.themePickerInitialColorThemeId
+            && this.themeManager.getCurrentColorTheme()?.id !== this.themePickerInitialColorThemeId) {
+            this.themeManager.switchColorTheme(this.themePickerInitialColorThemeId);
+        }
+        this.themePickerInitialColorThemeId = undefined;
+        this.setState({
+            simulatorThemePickerOpen: false,
+            editorThemeId: undefined,
+            simulatorThemePreference: undefined,
+        });
+        this.props.dispatchCloseSelectTheme();
+    }
+
+    async saveSimulatorTheme(preference: pxt.auth.SimulatorThemePreference) {
+        pxt.tickEvent("skillmap.simulator.theme.save", { preset: preference.presetId }, { interactiveConsent: true });
+        const editorThemeId = this.state.editorThemeId || this.themeManager.getCurrentColorTheme()?.id;
+        const editorTheme = this.themeManager.getAllColorThemes().find(theme => theme.id === editorThemeId);
+        if (editorTheme) await this.persistColorTheme(editorTheme);
+        await this.persistSimulatorTheme(preference);
+        this.closeThemePicker(false);
+    }
+
+    private async persistColorTheme(theme: pxt.ColorThemeInfo) {
         pxt.tickEvent(`skillmap.menu.theme.changetheme`, { theme: theme.id });
         this.themeManager.switchColorTheme(theme.id);
         await authClient.setColorThemeIdAsync(theme.id);
@@ -443,11 +568,30 @@ class AppImpl extends React.Component<AppProps, AppState> {
         }
     }
 
+    private async persistSimulatorTheme(preference: pxt.auth.SimulatorThemePreference) {
+        const persistedPreference = isImplicitSimulatorThemePreference(
+            preference,
+            pxt.appTarget.simulator?.themePresets
+        ) ? undefined : preference;
+        await authClient.setSimulatorThemePreferenceAsync(persistedPreference);
+        const resources = await this.ready();
+        await resources.sendMessageAsync?.({
+            type: "pxteditor",
+            action: "setsimulatortheme",
+            preference,
+            savePreference: false,
+        } as pxt.editor.EditorMessageSetSimulatorThemeRequest);
+    }
+
     render() {
         const { skillMaps, activityOpen, backgroundImageUrl, theme, pixelatedBackground } = this.props;
         const { error, showingSyncLoader, forcelang } = this.state;
         const maps = Object.keys(skillMaps).map((id: string) => skillMaps[id]);
         const feedbackEnabled = pxt.U.ocvEnabled();
+        const simulatorThemePresets = pxt.appTarget.simulator?.themePresets || [];
+        const selectedColorTheme = this.state.editorThemeId
+            ? pxt.appTarget.colorThemeMap?.[this.state.editorThemeId]
+            : this.themeManager?.getCurrentColorTheme();
 
         return (<div className={`app-container ${pxt.appTarget.id}`}>
                 <HeaderBar />
@@ -469,7 +613,27 @@ class AppImpl extends React.Component<AppProps, AppState> {
                     onLanguageChanged={this.changeLanguage}
                     onClose={this.props.dispatchCloseSelectLanguage}
                 />}
-                {this.props.showSelectTheme && this.themeManager && <ThemePickerModal themes={this.themeManager.getAllColorThemes()} onThemeClicked={this.changeTheme} onClose={this.props.dispatchCloseSelectTheme} />}
+                {this.props.showSelectTheme && this.themeManager && !this.state.simulatorThemePickerOpen && <ThemePickerModal
+                    themes={this.themeManager.getAllColorThemes()}
+                    selectedThemeId={this.state.editorThemeId || this.themeManager.getCurrentColorTheme()?.id}
+                    onThemeChanged={this.previewColorTheme}
+                    onSave={this.changeTheme}
+                    onSimulatorThemeClicked={simulatorThemePresets.length
+                        ? this.showSimulatorThemePicker
+                        : undefined}
+                    onClose={this.closeThemePicker} />}
+                {this.props.showSelectTheme && this.state.simulatorThemePickerOpen && !!simulatorThemePresets.length && <SimulatorThemePickerModal
+                    presets={simulatorThemePresets}
+                    layouts={pxt.appTarget.simulator?.themeLayouts}
+                    initialPreference={this.state.simulatorThemePreference}
+                    defaultTheme={getDefaultSimulatorThemePreference(
+                        selectedColorTheme,
+                        simulatorThemePresets
+                    )?.theme}
+                    onThemeChanged={simulatorThemePreference => this.setState({ simulatorThemePreference })}
+                    onEditorThemeClicked={this.showEditorThemePicker}
+                    onSave={this.saveSimulatorTheme}
+                    onClose={this.closeThemePicker} />}
                 { feedbackEnabled && this.props.showFeedback && <FeedbackModal kind="rating" onClose={this.props.dispatchCloseFeedback} />}
             </div>);
     }

--- a/skillmap/src/components/SimulatorThemePickerModal.tsx
+++ b/skillmap/src/components/SimulatorThemePickerModal.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+
+import {
+    SimulatorThemePickerModal as SharedSimulatorThemePickerModal,
+    SimulatorThemePickerModalProps as SharedSimulatorThemePickerModalProps,
+} from "../../../react-common/components/theming/SimulatorThemePickerModal";
+import { isLocal } from "../lib/browserUtils";
+
+export type SimulatorThemePickerModalProps = Omit<SharedSimulatorThemePickerModalProps, "renderPreview">;
+
+export const SimulatorThemePickerModal = (props: SimulatorThemePickerModalProps) => {
+    return <SharedSimulatorThemePickerModal
+        {...props}
+        renderPreview={theme => <SkillmapSimulatorThemePreview theme={theme} />} />;
+};
+
+interface SkillmapSimulatorThemePreviewProps {
+    theme: pxt.SimulatorTheme;
+}
+
+const SkillmapSimulatorThemePreview = (props: SkillmapSimulatorThemePreviewProps) => {
+    const { theme } = props;
+    const frame = React.useRef<HTMLIFrameElement>(null);
+    const simulatorUrl = getSimulatorUrl();
+    const loadedSimulatorUrl = React.useRef<string>();
+
+    const applyTheme = () => {
+        if (loadedSimulatorUrl.current !== simulatorUrl || !frame.current?.contentWindow) return;
+        const message = {
+            type: "setsimtheme",
+            theme,
+        };
+        frame.current.contentWindow.postMessage(message, new URL(simulatorUrl).origin);
+    };
+
+    React.useEffect(applyTheme, [theme, simulatorUrl]);
+
+    // The trusted target simulator requires both permissions for its script-driven UI.
+    /* eslint-disable @microsoft/sdl/react-iframe-missing-sandbox */
+    return <div className="simulator-theme-preview" role="group" aria-label={lf("Simulator theme preview")}>
+        <div className="simframe ui embed">
+            <iframe
+                ref={frame}
+                src={simulatorUrl}
+                title={lf("Simulator theme preview")}
+                sandbox="allow-same-origin allow-scripts"
+                onLoad={() => {
+                    loadedSimulatorUrl.current = simulatorUrl;
+                    applyTheme();
+                }} />
+        </div>
+    </div>;
+    /* eslint-enable @microsoft/sdl/react-iframe-missing-sandbox */
+};
+
+function getSimulatorUrl(): string {
+    if (isLocal()) return "http://localhost:3232/sim/simulator.html";
+    const configuredUrl = pxt.webConfig?.simUrl || (window as any).pxtConfig?.simUrl;
+    return new URL(configuredUrl || "/sim/simulator.html", window.location.origin).toString();
+}

--- a/skillmap/src/lib/authClient.ts
+++ b/skillmap/src/lib/authClient.ts
@@ -23,8 +23,11 @@ class AuthClient extends pxt.auth.AuthClient {
         }
         store.dispatch(dispatchSetUserProfile(state.profile));
     }
-    protected onUserPreferencesChanged(diff: ts.pxtc.jsonPatch.PatchOperation[]): Promise<void> {
-        // TODO: Dispatch individual preference fields individually (if changed): language, highContrast, etc.
+    protected async onUserPreferencesChanged(diff: ts.pxtc.jsonPatch.PatchOperation[]): Promise<void> {
+        if (diff.some(op => op.path[0] === "simulatorThemes")) {
+            const state = await pxt.auth.getUserStateAsync();
+            store.dispatch(dispatchSetUserPreferences(state.preferences));
+        }
         return Promise.resolve();
     }
     protected onStateCleared(): Promise<void> {
@@ -166,6 +169,44 @@ export async function setColorThemeIdAsync(themeId: string): Promise<void> {
             path: ['colorThemeIds'],
             value: newColorThemePref
         }, { immediate: true });
+    }
+}
+
+export async function getSimulatorThemePreferenceAsync(): Promise<pxt.auth.SimulatorThemePreference | undefined> {
+    const prefs = await userPreferencesAsync();
+    if (prefs) {
+        const cloudPreference = prefs.simulatorThemes?.[pxt.appTarget.id];
+        return pxt.auth.isValidSimulatorThemePreference(cloudPreference) ? cloudPreference : undefined;
+    }
+
+    const localPrefs = pxt.U.jsonTryParse(
+        pxt.storage.getLocal(pxt.auth.SIMULATOR_THEMES_LOCAL_STORAGE_KEY)
+    ) as pxt.auth.SimulatorThemesState;
+    const localPreference = localPrefs?.[pxt.appTarget.id];
+    return pxt.auth.isValidSimulatorThemePreference(localPreference) ? localPreference : undefined;
+}
+
+export async function setSimulatorThemePreferenceAsync(preference: pxt.auth.SimulatorThemePreference | undefined): Promise<void> {
+    if (preference && !pxt.auth.isValidSimulatorThemePreference(preference)) return;
+    const cli = await clientAsync();
+    const targetId = pxt.appTarget.id;
+    if (cli) {
+        const currentPrefs = await cli.userPreferencesAsync();
+        const newSimulatorThemePrefs = { ...currentPrefs?.simulatorThemes };
+        if (preference) newSimulatorThemePrefs[targetId] = preference;
+        else delete newSimulatorThemePrefs[targetId];
+        await cli.patchUserPreferencesAsync({
+            op: 'replace',
+            path: ['simulatorThemes'],
+            value: newSimulatorThemePrefs
+        }, { immediate: true });
+    } else {
+        const currentPrefs = pxt.U.jsonTryParse(
+            pxt.storage.getLocal(pxt.auth.SIMULATOR_THEMES_LOCAL_STORAGE_KEY)
+        ) as pxt.auth.SimulatorThemesState ?? {};
+        if (preference) currentPrefs[targetId] = preference;
+        else delete currentPrefs[targetId];
+        pxt.storage.setLocal(pxt.auth.SIMULATOR_THEMES_LOCAL_STORAGE_KEY, JSON.stringify(currentPrefs));
     }
 }
 

--- a/tests/pxt-editor-test/editorrunner.ts
+++ b/tests/pxt-editor-test/editorrunner.ts
@@ -6,10 +6,27 @@ import * as chai from "chai";
 import * as dmp from "diff-match-patch";
 import * as pxteditor from "../../pxteditor";
 import { getTextAtTime, HistoryFile, parseHistoryFile, updateHistory } from "../../pxteditor/history";
+import {
+    addSimulatorThemeToFiles,
+    getProjectSimulatorThemePreference,
+    getSimulatorThemePresetId,
+    removeSimulatorThemeFromFiles,
+    resolveSimulatorTheme,
+    serializeProjectSimulatorThemePreference,
+} from "../../webapp/src/simulatorTheme";
+import {
+    copySimulatorTheme,
+    getSimulatorThemeForLayout,
+    getSimulatorThemePreferenceForColorThemeChange,
+    isImplicitSimulatorThemePreference,
+} from "../../react-common/components/theming/simulatorThemeDefaults";
 
 pxt.appTarget = {
     versions: {
         target: "1"
+    },
+    appTheme: {
+        defaultLocale: "en"
     }
 } as any
 
@@ -24,6 +41,379 @@ function patchText(patch: unknown, a: string) {
 }
 
 const filename = "main.ts";
+
+const simulatorTheme: pxt.SimulatorTheme = {
+    "background-color": "#111111",
+    "button-stroke": "#222222",
+    "text-color": "#333333",
+    "button-fill": "#444444",
+    "dpad-fill": "#555555",
+    "joystick-handle-stroke": "#666666",
+    layout: "default",
+};
+
+describe("simulator themes", () => {
+    const defaultSimulatorTheme = simulatorTheme;
+    const purpleSimulatorTheme = { ...simulatorTheme, "background-color": "#660066" };
+    const redSimulatorTheme = { ...simulatorTheme, "background-color": "#660000" };
+    const tealSimulatorTheme = { ...simulatorTheme };
+    const retroSimulatorTheme = { ...simulatorTheme, "background-color": "#FCF7E4", layout: "retro" };
+    const presets: pxt.SimulatorThemePreset[] = [
+        {
+            id: "default",
+            name: "Default",
+            theme: defaultSimulatorTheme,
+        },
+        {
+            id: "purple",
+            name: "Purple",
+            theme: purpleSimulatorTheme,
+        },
+        {
+            id: "red",
+            name: "Red",
+            theme: redSimulatorTheme,
+        },
+        {
+            id: "teal",
+            name: "Teal",
+            theme: tealSimulatorTheme,
+        },
+        {
+            id: "retro",
+            name: "Retro",
+            theme: retroSimulatorTheme,
+        },
+    ];
+    const lightTheme = { id: "light", name: "Light", colors: {} };
+    const darkTheme = { id: "dark", name: "Dark", colors: {} };
+    const tokyoNightTheme = {
+        id: "tokyo-night",
+        name: "Tokyo Night",
+        defaultSimulatorTheme: "purple",
+        colors: {},
+    };
+    const inlineSimulatorTheme = {
+        id: "inline",
+        name: "Inline",
+        defaultSimulatorTheme: {
+            "background-color": "#123456",
+            layout: "inline",
+        },
+        colors: {},
+    };
+
+    it("loads shared and target translations for skillmaps", async () => {
+        const requestedUrls: string[] = [];
+        const originalHttpGetJsonAsync = pxt.Util.httpGetJsonAsync;
+        pxt.Util.httpGetJsonAsync = <T>(url: string) => {
+            requestedUrls.push(url);
+            return Promise.resolve({} as T);
+        };
+
+        try {
+            await pxt.Util.downloadTranslationsAsync(
+                "arcade",
+                "https://example.com/",
+                "fr",
+                false,
+                ts.pxtc.Util.TranslationsKind.SkillMap
+            );
+        } finally {
+            pxt.Util.httpGetJsonAsync = originalHttpGetJsonAsync;
+        }
+
+        chai.expect(requestedUrls).to.include.members([
+            "https://example.com/locales/fr/strings.json",
+            "https://example.com/locales/fr/target-strings.json",
+            "https://example.com/locales/fr/skillmap-strings.json",
+        ]);
+    });
+
+    it("initializes an empty cloud-synced simulator theme map", () => {
+        chai.expect(pxt.auth.DEFAULT_USER_PREFERENCES().simulatorThemes).deep.equals({});
+    });
+
+    it("uses the user theme only when project and device themes are absent", () => {
+        chai.expect(resolveSimulatorTheme(undefined, undefined, simulatorTheme, false)).equals(simulatorTheme);
+        chai.expect(resolveSimulatorTheme("project", undefined, simulatorTheme, false)).equals("project");
+        chai.expect(resolveSimulatorTheme(undefined, "device", simulatorTheme, false)).equals("device");
+    });
+
+    it("lets multiplayer override all other simulator themes", () => {
+        chai.expect(resolveSimulatorTheme("project", "device", simulatorTheme, true)).equals(undefined);
+    });
+
+    it("adds a simulator theme to a copied share config", () => {
+        const files: pxt.workspace.ScriptText = {
+            [pxt.CONFIG_NAME]: JSON.stringify({ name: "test", theme: "project" }),
+            [pxt.MAIN_TS]: "",
+        };
+        const sharedFiles = addSimulatorThemeToFiles(files, simulatorTheme);
+
+        chai.expect(JSON.parse(sharedFiles[pxt.CONFIG_NAME]).theme).deep.equals(simulatorTheme);
+        chai.expect(JSON.parse(files[pxt.CONFIG_NAME]).theme).equals("project");
+    });
+
+    it("matches project themes to built-in presets", () => {
+        chai.expect(getSimulatorThemePresetId("DEFAULT", presets)).equals("default");
+        chai.expect(getSimulatorThemePresetId({ ...simulatorTheme }, presets)).equals("default");
+        chai.expect(getSimulatorThemePresetId({ ...simulatorTheme, layout: "retro" }, presets)).equals("default");
+        chai.expect(getSimulatorThemePresetId({ ...simulatorTheme, "button-fill": "#666666" }, presets)).equals(undefined);
+        chai.expect(pxt.auth.simulatorThemeColorsEqual(simulatorTheme, { ...simulatorTheme, layout: "retro" })).equals(true);
+    });
+
+    it("resolves string project themes to their canonical presets", () => {
+        chai.expect(getProjectSimulatorThemePreference("RETRO", presets, defaultSimulatorTheme))
+            .deep.equals({ presetId: "retro", theme: retroSimulatorTheme });
+    });
+
+    it("preserves unknown string project themes as custom layouts", () => {
+        chai.expect(getProjectSimulatorThemePreference("target-layout", presets, defaultSimulatorTheme))
+            .deep.equals({
+                presetId: "custom",
+                theme: { ...defaultSimulatorTheme, layout: "target-layout" },
+            });
+    });
+
+    it("rejects malformed project theme overrides", () => {
+        chai.expect(getProjectSimulatorThemePreference({
+            "background-color": "invalid",
+        }, presets, defaultSimulatorTheme)).equals(undefined);
+    });
+
+    it("serializes canonical project themes by preset ID", () => {
+        chai.expect(serializeProjectSimulatorThemePreference({
+            presetId: "teal",
+            theme: tealSimulatorTheme,
+        }, presets)).equals("teal");
+    });
+
+    it("serializes independently customized layouts as full themes", () => {
+        const preference = {
+            presetId: "red",
+            theme: { ...redSimulatorTheme, layout: "retro" },
+        };
+        chai.expect(serializeProjectSimulatorThemePreference(preference, presets))
+            .deep.equals(preference.theme);
+    });
+
+    it("requires a layout in persisted themes", () => {
+        const themeWithoutLayout = { ...simulatorTheme } as Partial<pxt.SimulatorTheme>;
+        delete themeWithoutLayout.layout;
+
+        chai.expect(pxt.auth.isValidSimulatorTheme(simulatorTheme)).equals(true);
+        chai.expect(pxt.auth.isValidSimulatorTheme(themeWithoutLayout)).equals(false);
+    });
+
+    it("accepts sparse themes with target-defined colors", () => {
+        chai.expect(pxt.auth.isValidSimulatorTheme({
+            "background-color": "#123456",
+            "screen-border": "#ABCDEF",
+            layout: "target-layout",
+        })).equals(true);
+    });
+
+    it("rejects malformed simulator theme preferences", () => {
+        const invalidColors = ["", "#12345", "#1234567", "123456", "not-a-color"];
+        for (const color of invalidColors) {
+            chai.expect(pxt.auth.isValidSimulatorTheme({
+                ...simulatorTheme,
+                "background-color": color,
+            }), color).equals(false);
+        }
+
+        chai.expect(pxt.auth.isValidSimulatorThemePreference({
+            presetId: "default",
+            theme: simulatorTheme,
+        })).equals(true);
+        chai.expect(pxt.auth.isValidSimulatorThemePreference({
+            presetId: "",
+            theme: simulatorTheme,
+        })).equals(false);
+    });
+
+    it("uses a color theme's simulator default when no preference is set", () => {
+        const result = getSimulatorThemePreferenceForColorThemeChange(
+            undefined,
+            lightTheme,
+            tokyoNightTheme,
+            presets
+        );
+
+        chai.expect(result).deep.equals({ presetId: "default", theme: purpleSimulatorTheme });
+    });
+
+    it("merges an inline color theme simulator default over Default", () => {
+        const result = getSimulatorThemePreferenceForColorThemeChange(
+            undefined,
+            lightTheme,
+            inlineSimulatorTheme,
+            presets
+        );
+
+        chai.expect(result).deep.equals({
+            presetId: "default",
+            theme: {
+                ...defaultSimulatorTheme,
+                "background-color": "#123456",
+                layout: "inline",
+            },
+        });
+    });
+
+    it("moves between color theme simulator defaults", () => {
+        const defaultPreference = { presetId: "default", theme: defaultSimulatorTheme };
+        const purplePreference = getSimulatorThemePreferenceForColorThemeChange(
+            defaultPreference,
+            lightTheme,
+            tokyoNightTheme,
+            presets
+        );
+        const restoredPreference = getSimulatorThemePreferenceForColorThemeChange(
+            purplePreference,
+            tokyoNightTheme,
+            lightTheme,
+            presets
+        );
+
+        chai.expect(purplePreference).deep.equals({ presetId: "default", theme: purpleSimulatorTheme });
+        chai.expect(restoredPreference).deep.equals(defaultPreference);
+    });
+
+    it("uses the theme's layout while moving between color theme simulator defaults", () => {
+        const preference = { presetId: "default", theme: { ...defaultSimulatorTheme, layout: "retro" } };
+
+        chai.expect(getSimulatorThemePreferenceForColorThemeChange(
+            preference,
+            lightTheme,
+            tokyoNightTheme,
+            presets
+        )).deep.equals({ presetId: "default", theme: purpleSimulatorTheme });
+    });
+
+    it("preserves user-selected simulator themes when the color theme changes", () => {
+        const preferences = [
+            { presetId: "red", theme: redSimulatorTheme },
+            { presetId: "purple", theme: purpleSimulatorTheme },
+            { presetId: "teal", theme: tealSimulatorTheme },
+            { presetId: "custom", theme: { ...simulatorTheme } },
+        ];
+
+        for (const preference of preferences) {
+            chai.expect(getSimulatorThemePreferenceForColorThemeChange(
+                preference,
+                lightTheme,
+                tokyoNightTheme,
+                presets
+            )).equals(preference);
+        }
+    });
+
+    it("does not create a simulator preference between unpinned color themes", () => {
+        chai.expect(getSimulatorThemePreferenceForColorThemeChange(
+            undefined,
+            lightTheme,
+            darkTheme,
+            presets
+        )).equals(undefined);
+    });
+
+    it("keeps the existing default between unpinned color themes", () => {
+        const defaultPreference = { presetId: "default", theme: defaultSimulatorTheme };
+
+        chai.expect(getSimulatorThemePreferenceForColorThemeChange(
+            defaultPreference,
+            lightTheme,
+            darkTheme,
+            presets
+        )).equals(defaultPreference);
+    });
+
+    it("only treats the Default preset on the Default layout as implicit", () => {
+        chai.expect(isImplicitSimulatorThemePreference({
+            presetId: "default",
+            theme: purpleSimulatorTheme,
+        }, presets)).equals(true);
+        chai.expect(isImplicitSimulatorThemePreference({
+            presetId: "custom",
+            theme: defaultSimulatorTheme,
+        }, presets)).equals(false);
+        chai.expect(isImplicitSimulatorThemePreference({
+            presetId: "default",
+            theme: { ...defaultSimulatorTheme, layout: "retro" },
+        }, presets)).equals(false);
+    });
+
+    it("changes layout without changing custom colors", () => {
+        const customTheme = { ...simulatorTheme, "background-color": "#ABCDEF" };
+
+        chai.expect(getSimulatorThemeForLayout(customTheme, "retro"))
+            .deep.equals({ ...customTheme, layout: "retro" });
+    });
+
+    it("fills missing colors declared by a layout", () => {
+        const borderField: pxt.SimulatorThemeColorField = {
+            property: "screen-border",
+            label: "Screen border",
+            defaultValue: "#ABCDEF",
+        };
+        chai.expect(getSimulatorThemeForLayout(simulatorTheme, "retro", [borderField]))
+            .deep.equals({ ...simulatorTheme, layout: "retro", "screen-border": "#ABCDEF" });
+        chai.expect(getSimulatorThemeForLayout({
+            ...simulatorTheme,
+            "screen-border": "#123456",
+        }, "retro", [borderField])).deep.equals({
+            ...simulatorTheme,
+            layout: "retro",
+            "screen-border": "#123456",
+        });
+    });
+
+    it("selects the default layout without changing its colors", () => {
+        chai.expect(getSimulatorThemeForLayout(retroSimulatorTheme, "default"))
+            .deep.equals({ ...retroSimulatorTheme, layout: "default" });
+    });
+
+    it("preserves colors for a target-specific layout without a preset", () => {
+        chai.expect(getSimulatorThemeForLayout(simulatorTheme, "target-layout"))
+            .deep.equals({ ...simulatorTheme, layout: "target-layout" });
+    });
+
+    it("copies target-defined colors and ignores reserved or malformed properties", () => {
+        const themeWithMalformedProperty = {
+            ...simulatorTheme,
+            "screen-border": "#ABCDEF",
+            skin: "#123456",
+            extra: "ignored",
+        } as pxt.SimulatorTheme;
+        chai.expect(copySimulatorTheme(themeWithMalformedProperty)).deep.equals({
+            ...simulatorTheme,
+            "screen-border": "#ABCDEF",
+        });
+    });
+
+    it("removes a simulator theme from an editable shared-project copy", () => {
+        const files: pxt.workspace.ScriptText = {
+            [pxt.CONFIG_NAME]: JSON.stringify({ name: "test", theme: simulatorTheme }),
+            [pxt.MAIN_TS]: "",
+        };
+        const importedFiles = removeSimulatorThemeFromFiles(files);
+
+        chai.expect(JSON.parse(importedFiles[pxt.CONFIG_NAME]).theme).equals(undefined);
+        chai.expect(JSON.parse(files[pxt.CONFIG_NAME]).theme).deep.equals(simulatorTheme);
+        chai.expect(importedFiles).not.equals(files);
+    });
+
+    it("leaves shared-project files without a simulator theme unchanged", () => {
+        const files: pxt.workspace.ScriptText = {
+            [pxt.CONFIG_NAME]: JSON.stringify({ name: "test" }),
+            [pxt.MAIN_TS]: "",
+        };
+
+        chai.expect(removeSimulatorThemeFromFiles(files)).equals(files);
+    });
+});
 
 const versions = [
     "Here is some text",

--- a/theme/pxtjson.less
+++ b/theme/pxtjson.less
@@ -3,3 +3,15 @@
     flex-direction: column;
     gap: 0.5rem;
 }
+
+.pxt-json-simulator-theme {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.3rem;
+
+    label {
+        font-size: 14px;
+        font-weight: 600;
+    }
+}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -13,6 +13,8 @@ import * as pkg from "./package";
 import * as core from "./core";
 import * as sui from "./sui";
 import * as simulator from "./simulator";
+import * as simulatorTheme from "./simulatorTheme";
+import * as simulatorThemePreference from "./simulatorThemePreference";
 import * as srceditor from "./srceditor"
 import * as compiler from "./compiler"
 import * as cmds from "./cmds"
@@ -47,6 +49,7 @@ import * as headerbar from "./headerbar";
 import * as sidepanel from "./sidepanel";
 import * as qr from "./qr";
 import { ThemePickerModal } from "../../react-common/components/theming/ThemePickerModal";
+import { SimulatorThemePickerModal } from "./components/SimulatorThemePickerModal";
 
 import * as monaco from "./monaco"
 import * as toolboxHelpers from "./toolboxHelpers"
@@ -86,6 +89,11 @@ import { initGitHubDb } from "./idbworkspace";
 import { BlockDefinition, CategoryNameID } from "./toolbox";
 import { FeedbackModal } from "../../react-common/components/controls/Feedback/Feedback";
 import { ThemeManager } from "../../react-common/components/theming/themeManager";
+import {
+    getDefaultSimulatorThemePreference,
+    getSimulatorThemeForLayout,
+    getSimulatorThemePreferenceForColorThemeChange,
+} from "../../react-common/components/theming/simulatorThemeDefaults";
 import { applyPolyfills } from "./polyfills";
 import { sendUpdateFeedbackTheme } from "../../react-common/components/controls/Feedback/FeedbackEventListener";
 import { ariaAnnounce } from "./util";
@@ -163,6 +171,10 @@ export class ProjectView
     private firstRun: boolean;
 
     private runToken: pxt.Util.CancellationToken;
+    private simulatorWasRunningBeforeThemePicker?: boolean;
+    private themePickerInitialColorThemeId?: string;
+    private themePickerColorThemeId?: string;
+    private themePickerSimulatorThemePreference?: pxt.auth.SimulatorThemePreference;
     private updatingEditorFile: boolean;
     private loadingExample: boolean;
     private openingTypeScript: boolean;
@@ -239,6 +251,12 @@ export class ProjectView
         this.initSimulatorMessageHandlers();
         this.showThemePicker = this.showThemePicker.bind(this);
         this.hideThemePicker = this.hideThemePicker.bind(this);
+        this.showSimulatorThemePicker = this.showSimulatorThemePicker.bind(this);
+        this.showEditorThemePicker = this.showEditorThemePicker.bind(this);
+        this.hideSimulatorThemePicker = this.hideSimulatorThemePicker.bind(this);
+        this.previewColorTheme = this.previewColorTheme.bind(this);
+        this.saveEditorTheme = this.saveEditorTheme.bind(this);
+        this.saveSimulatorTheme = this.saveSimulatorTheme.bind(this);
         this.onThemeChanged = this.onThemeChanged.bind(this);
         this.setColorThemeById = this.setColorThemeById.bind(this);
         this.showLoginDialog = this.showLoginDialog.bind(this);
@@ -4504,7 +4522,7 @@ export class ProjectView
         return this.getShareUrl(script.shortid || script.id, false);
     }
 
-    async publishAsync (name: string, description?: string,screenshotUri?: string, forceAnonymous?: boolean): Promise<pxt.editor.ShareData> {
+    async publishAsync (name: string, description?: string,screenshotUri?: string, forceAnonymous?: boolean, sharedSimulatorTheme?: pxt.SimulatorTheme): Promise<pxt.editor.ShareData> {
         pxt.tickEvent("menu.embed.publish", undefined, { interactiveConsent: true });
         if ((name && this.state.projectName != name) || description !== undefined) {
             await this.updateHeaderNameAsync(name, description);
@@ -4514,7 +4532,7 @@ export class ProjectView
 
         try {
             const persistentPublish = hasIdentity && !forceAnonymous;
-            const id = await this.publishCurrentHeaderAsync(persistentPublish, screenshotUri);
+            const id = await this.publishCurrentHeaderAsync(persistentPublish, screenshotUri, sharedSimulatorTheme);
             return await this.getShareUrl(id, persistentPublish);
         } catch (e) {
             pxt.tickEvent("menu.embed.error", { code: (e as any).statusCode })
@@ -4565,7 +4583,7 @@ export class ProjectView
         return shareData;
     }
 
-    async publishCurrentHeaderAsync(persistent: boolean, screenshotUri?: string): Promise<string> {
+    async publishCurrentHeaderAsync(persistent: boolean, screenshotUri?: string, sharedSimulatorTheme?: pxt.SimulatorTheme): Promise<string> {
         pxt.tickEvent("publish");
         this.setState({ publishing: true })
         const mpkg = pkg.mainPkg
@@ -4574,8 +4592,14 @@ export class ProjectView
         try {
             await this.saveProjectNameAsync();
             await this.saveFileAsync();
-            const files = await mpkg.filesToBePublishedAsync(true);
-            if (epkg.header.pubCurrent && !screenshotUri) {
+            let files = await mpkg.filesToBePublishedAsync(true);
+            if (sharedSimulatorTheme) {
+                files = simulatorTheme.addSimulatorThemeToFiles(files, sharedSimulatorTheme);
+            }
+            const publishOptions: workspace.PublishOptions = {
+                projectFilesMatchPublishedFiles: !sharedSimulatorTheme,
+            };
+            if (epkg.header.pubCurrent && !screenshotUri && !sharedSimulatorTheme) {
                 return epkg.header.pubId;
             }
 
@@ -4589,11 +4613,11 @@ export class ProjectView
                 meta.blocksWidth = blocksSize.width;
             }
             if (persistent) {
-                const header = await workspace.persistentPublishAsync(epkg.header, files, meta, screenshotUri);
+                const header = await workspace.persistentPublishAsync(epkg.header, files, meta, screenshotUri, publishOptions);
                 return header.pubId
             }
             else {
-                const info = await workspace.anonymousPublishAsync(epkg.header, files, meta, screenshotUri);
+                const info = await workspace.anonymousPublishAsync(epkg.header, files, meta, screenshotUri, publishOptions);
                 return info.id;
             }
         }
@@ -4759,11 +4783,143 @@ export class ProjectView
     }
 
     showThemePicker() {
-        this.setState( { themePickerOpen: true });
+        const simulatorThemePresets = pxt.appTarget.simulator?.themePresets;
+        const currentColorTheme = this.themeManager.getCurrentColorTheme();
+        this.themePickerInitialColorThemeId = currentColorTheme?.id;
+        this.themePickerColorThemeId = currentColorTheme?.id;
+        if (simulatorThemePresets?.length) {
+            const simulatorPreference = simulatorThemePreference.getSimulatorThemePreference();
+            this.themePickerSimulatorThemePreference = simulatorPreference
+                ? { presetId: simulatorPreference.presetId, theme: { ...simulatorPreference.theme } }
+                : getDefaultSimulatorThemePreference(currentColorTheme, simulatorThemePresets);
+        }
+        else {
+            this.themePickerSimulatorThemePreference = undefined;
+        }
+        this.simulatorWasRunningBeforeThemePicker = simulatorThemePresets?.length
+            ? this.state.simState !== SimState.Stopped
+            : undefined;
+        this.setState({ themePickerOpen: true, simulatorThemePickerOpen: false });
     }
 
     hideThemePicker() {
-        this.setState( { themePickerOpen: false });
+        if (pxt.appTarget.simulator?.themePresets?.length) {
+            this.closeSimulatorThemePicker(false);
+            return;
+        }
+        this.resetThemePickerDrafts(true);
+        this.setState({ themePickerOpen: false });
+    }
+
+    showSimulatorThemePicker() {
+        const simulatorThemePresets = pxt.appTarget.simulator?.themePresets;
+        if (!simulatorThemePresets?.length) return;
+        pxt.tickEvent("simulator.theme.open", undefined, { interactiveConsent: true });
+        const defaultPreference = getDefaultSimulatorThemePreference(
+            pxt.appTarget.colorThemeMap?.[this.themePickerColorThemeId],
+            simulatorThemePresets
+        );
+        const preference = this.themePickerSimulatorThemePreference?.presetId === defaultPreference?.presetId
+            ? {
+                ...defaultPreference,
+                theme: getSimulatorThemeForLayout(
+                    defaultPreference.theme,
+                    this.themePickerSimulatorThemePreference.theme.layout
+                ),
+            }
+            : this.themePickerSimulatorThemePreference || defaultPreference;
+        if (!preference) return;
+        this.themePickerSimulatorThemePreference = preference;
+        simulator.setPreviewSimulatorTheme(preference.theme);
+        this.setState({ themePickerOpen: false, simulatorThemePickerOpen: true }, () => this.startSimulator());
+    }
+
+    hideSimulatorThemePicker() {
+        this.closeSimulatorThemePicker(false);
+    }
+
+    showEditorThemePicker() {
+        this.closeSimulatorThemePicker(true, false, false);
+    }
+
+    closeSimulatorThemePicker(showEditorThemePicker: boolean, resetDrafts = true, restoreColorTheme = true) {
+        const shouldRestartSimulator = this.simulatorWasRunningBeforeThemePicker;
+        if (resetDrafts) this.resetThemePickerDrafts(restoreColorTheme);
+        simulator.clearPreviewSimulatorTheme();
+        this.setState({
+            simulatorThemePickerOpen: false,
+            themePickerOpen: showEditorThemePicker,
+        }, () => {
+            this.stopSimulator(true).then(() => {
+                if (shouldRestartSimulator) this.startSimulator();
+            });
+        });
+    }
+
+    private resetThemePickerDrafts(restoreColorTheme: boolean) {
+        if (restoreColorTheme
+            && this.themePickerInitialColorThemeId
+            && this.themeManager.getCurrentColorTheme()?.id !== this.themePickerInitialColorThemeId) {
+            this.themeManager.switchColorTheme(this.themePickerInitialColorThemeId);
+        }
+        this.themePickerInitialColorThemeId = undefined;
+        this.themePickerColorThemeId = undefined;
+        this.themePickerSimulatorThemePreference = undefined;
+        this.simulatorWasRunningBeforeThemePicker = undefined;
+    }
+
+    private async saveThemePickerDrafts() {
+        const shouldRestartSimulator = !this.state.simulatorThemePickerOpen
+            && this.simulatorWasRunningBeforeThemePicker;
+        if (this.themePickerColorThemeId) {
+            await this.setColorThemeById(this.themePickerColorThemeId, true, false);
+        }
+        if (pxt.appTarget.simulator?.themePresets?.length) {
+            await simulatorThemePreference.setSimulatorThemePreference(this.themePickerSimulatorThemePreference);
+        }
+
+        if (this.state.simulatorThemePickerOpen) this.closeSimulatorThemePicker(false, true, false);
+        else {
+            simulator.clearPreviewSimulatorTheme();
+            this.resetThemePickerDrafts(false);
+            this.setState({ themePickerOpen: false });
+            if (shouldRestartSimulator) this.restartSimulator();
+        }
+    }
+
+    previewColorTheme(theme: pxt.ColorThemeInfo) {
+        const previousColorTheme = pxt.appTarget.colorThemeMap?.[this.themePickerColorThemeId];
+        this.themePickerSimulatorThemePreference = getSimulatorThemePreferenceForColorThemeChange(
+            this.themePickerSimulatorThemePreference,
+            previousColorTheme,
+            theme,
+            pxt.appTarget.simulator?.themePresets
+        );
+        this.themePickerColorThemeId = theme.id;
+        this.themeManager.switchColorTheme(theme.id);
+        if (this.themePickerSimulatorThemePreference) {
+            simulator.setPreviewSimulatorTheme(this.themePickerSimulatorThemePreference.theme);
+        }
+    }
+
+    async saveEditorTheme(theme: pxt.ColorThemeInfo) {
+        this.themePickerColorThemeId = theme.id;
+        await this.saveThemePickerDrafts();
+    }
+
+    async saveSimulatorTheme(preference: pxt.auth.SimulatorThemePreference) {
+        pxt.tickEvent("simulator.theme.save", { preset: preference.presetId }, { interactiveConsent: true });
+        this.themePickerSimulatorThemePreference = {
+            presetId: preference.presetId,
+            theme: { ...preference.theme },
+        };
+        await this.saveThemePickerDrafts();
+    }
+
+    async setSimulatorThemePreference(preference: pxt.auth.SimulatorThemePreference, savePreference = true) {
+        if (savePreference) await simulatorThemePreference.setSimulatorThemePreference(preference);
+        else simulatorThemePreference.setSessionSimulatorThemePreference(preference);
+        if (this.state.header) this.restartSimulator();
     }
 
     showImportUrlDialog() {
@@ -5417,8 +5573,10 @@ export class ProjectView
         this.setState({ bannerVisible: b });
     }
 
-    setColorThemeById(colorThemeId: string, savePreference: boolean) {
-        if (this.themeManager.getCurrentColorTheme()?.id === colorThemeId) {
+    async setColorThemeById(colorThemeId: string, savePreference: boolean, updateSimulatorDefault = true): Promise<void> {
+        const previousColorTheme = this.themeManager.getCurrentColorTheme();
+        if (previousColorTheme?.id === colorThemeId) {
+            if (savePreference) await this.updateThemePreference();
             return;
         }
 
@@ -5430,21 +5588,33 @@ export class ProjectView
         this.themeManager.switchColorTheme(colorThemeId);
 
         if (savePreference) {
-            this.updateThemePreference();
+            await this.updateThemePreference();
+            if (updateSimulatorDefault && pxt.appTarget.simulator?.themePresets?.length) {
+                const currentPreference = simulatorThemePreference.getSimulatorThemePreference();
+                const nextPreference = getSimulatorThemePreferenceForColorThemeChange(
+                    currentPreference,
+                    previousColorTheme,
+                    this.themeManager.getCurrentColorTheme(),
+                    pxt.appTarget.simulator?.themePresets
+                );
+                if (nextPreference && nextPreference !== currentPreference) {
+                    await this.setSimulatorThemePreference(nextPreference);
+                }
+            }
         }
     }
 
-    private updateThemePreference() {
+    private async updateThemePreference(): Promise<void> {
         const newThemeId = this.themeManager.getCurrentColorTheme()?.id;
 
         if (newThemeId) {
-            auth.setThemePrefAsync(newThemeId);
+            await auth.setThemePrefAsync(newThemeId);
 
             // Disable high contrast preference (separate from theme pref) if the new theme is not high contrast.
             // This is only needed while we transition from not having themes to having them. In time, the
             // auth.HIGHCONTRAST preference can be phased out in favor of the themeId preference.
             if (!this.themeManager.isHighContrast(newThemeId) && data.getData<boolean>(auth.HIGHCONTRAST)) {
-                auth.setHighContrastPrefAsync(false);
+                await auth.setHighContrastPrefAsync(false);
             }
         }
     }
@@ -5784,7 +5954,30 @@ export class ProjectView
                     shouldFocusAfterRender={false} closable={true} onClose={this.hideLightbox} /> : undefined}
                 {this.state.areaMenuOpen && <AreaMenuOverlay parent={this}/>}
                 {this.state.activeTourConfig && <Tour config={this.state.activeTourConfig} onClose={this.closeTour} />}
-                {this.state.themePickerOpen && <ThemePickerModal themes={this.themeManager.getAllColorThemes()} onThemeClicked={theme => this.setColorThemeById(theme?.id, true)} onClose={this.hideThemePicker} />}
+                {this.state.themePickerOpen && <ThemePickerModal
+                    themes={this.themeManager.getAllColorThemes()}
+                    selectedThemeId={this.themePickerColorThemeId}
+                    onThemeChanged={this.previewColorTheme}
+                    onSave={this.saveEditorTheme}
+                    onSimulatorThemeClicked={pxt.appTarget.simulator?.themePresets?.length
+                        ? this.showSimulatorThemePicker
+                        : undefined}
+                    onClose={this.hideThemePicker} />}
+                {this.state.simulatorThemePickerOpen && <SimulatorThemePickerModal
+                    presets={pxt.appTarget.simulator.themePresets}
+                    layouts={pxt.appTarget.simulator.themeLayouts}
+                    initialPreference={this.themePickerSimulatorThemePreference}
+                    defaultTheme={getDefaultSimulatorThemePreference(
+                        pxt.appTarget.colorThemeMap?.[this.themePickerColorThemeId],
+                        pxt.appTarget.simulator.themePresets
+                    )?.theme}
+                    onThemeChanged={preference => this.themePickerSimulatorThemePreference = {
+                        presetId: preference.presetId,
+                        theme: { ...preference.theme },
+                    }}
+                    onEditorThemeClicked={this.showEditorThemePicker}
+                    onSave={this.saveSimulatorTheme}
+                    onClose={this.hideSimulatorThemePicker} />}
             </div>
         );
     }

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -17,12 +17,14 @@ const FIELD_USER_PREFERENCES = "preferences";
 const FIELD_HIGHCONTRAST = "high-contrast";
 const FIELD_SCREEN_READER_MODE = "screen-reader-mode";
 const FIELD_COLOR_THEME_IDS = "colorThemeIds";
+const FIELD_SIMULATOR_THEMES = "simulatorThemes";
 const FIELD_LANGUAGE = "language";
 const FIELD_READER = "reader";
 export const USER_PREFERENCES = `${USER_PREF_MODULE}:${FIELD_USER_PREFERENCES}`
 export const HIGHCONTRAST = `${USER_PREF_MODULE}:${FIELD_HIGHCONTRAST}`
 export const SCREEN_READER_MODE = `${USER_PREF_MODULE}:${FIELD_SCREEN_READER_MODE}`
 export const COLOR_THEME_IDS = `${USER_PREF_MODULE}:${FIELD_COLOR_THEME_IDS}`
+export const SIMULATOR_THEMES = `${USER_PREF_MODULE}:${FIELD_SIMULATOR_THEMES}`
 export const LANGUAGE = `${USER_PREF_MODULE}:${FIELD_LANGUAGE}`
 export const READER = `${USER_PREF_MODULE}:${FIELD_READER}`
 export const HAS_USED_CLOUD = "has-used-cloud"; // Key into local storage to see if this computer has logged in before
@@ -73,6 +75,7 @@ class AuthClient extends pxt.auth.AuthClient {
                 case "highContrast": data.invalidate(HIGHCONTRAST); break;
                 case "screenReaderMode": data.invalidate(SCREEN_READER_MODE); break;
                 case "colorThemeIds": data.invalidate(COLOR_THEME_IDS); break;
+                case "simulatorThemes": data.invalidate(SIMULATOR_THEMES); break;
                 case "reader": data.invalidate(READER); break;
             }
         }
@@ -125,6 +128,7 @@ class AuthClient extends pxt.auth.AuthClient {
                 case HIGHCONTRAST: return /^true$/i.test(pxt.storage.getLocal(HIGHCONTRAST));
                 case SCREEN_READER_MODE: return /^true$/i.test(pxt.storage.getLocal(SCREEN_READER_MODE));
                 case COLOR_THEME_IDS: return pxt.U.jsonTryParse(pxt.storage.getLocal(COLOR_THEME_IDS)) as pxt.auth.ColorThemeIdsState;
+                case SIMULATOR_THEMES: return pxt.U.jsonTryParse(pxt.storage.getLocal(pxt.auth.SIMULATOR_THEMES_LOCAL_STORAGE_KEY)) as pxt.auth.SimulatorThemesState;
                 case LANGUAGE: return pxt.storage.getLocal(LANGUAGE);
                 case READER: return pxt.storage.getLocal(READER);
             }
@@ -142,6 +146,7 @@ class AuthClient extends pxt.auth.AuthClient {
                 case FIELD_HIGHCONTRAST: return state.preferences?.highContrast ?? pxt.auth.DEFAULT_USER_PREFERENCES().highContrast;
                 case FIELD_SCREEN_READER_MODE: return state.preferences?.screenReaderMode ?? pxt.auth.DEFAULT_USER_PREFERENCES().screenReaderMode;
                 case FIELD_COLOR_THEME_IDS: return state.preferences?.colorThemeIds ?? pxt.auth.DEFAULT_USER_PREFERENCES().colorThemeIds;
+                case FIELD_SIMULATOR_THEMES: return state.preferences?.simulatorThemes ?? pxt.auth.DEFAULT_USER_PREFERENCES().simulatorThemes;
                 case FIELD_LANGUAGE: return state.preferences?.language ?? pxt.auth.DEFAULT_USER_PREFERENCES().language;
                 case FIELD_READER: return state.preferences?.reader ?? pxt.auth.DEFAULT_USER_PREFERENCES().reader;
             }
@@ -246,7 +251,7 @@ export async function setHighContrastPrefAsync(highContrast: boolean): Promise<v
             op: 'replace',
             path: ['highContrast'],
             value: highContrast
-        });
+        }, { immediate: true });
     } else {
         // Identity not available, save this setting locally
         pxt.storage.setLocal(HIGHCONTRAST, highContrast.toString());
@@ -283,7 +288,7 @@ export async function setThemePrefAsync(themeId: string): Promise<void> {
             op: 'replace',
             path: ['colorThemeIds'],
             value: newColorThemePref
-        });
+        }, { immediate: true });
     } else {
         // Identity not available, save this setting locally
         const currentPrefsStr = pxt.storage.getLocal(COLOR_THEME_IDS);
@@ -295,6 +300,31 @@ export async function setThemePrefAsync(themeId: string): Promise<void> {
         const serialized = JSON.stringify(newColorThemePref);
         pxt.storage.setLocal(COLOR_THEME_IDS, serialized);
         data.invalidate(COLOR_THEME_IDS);
+    }
+}
+
+export async function setSimulatorThemePrefAsync(preference: pxt.auth.SimulatorThemePreference | undefined): Promise<void> {
+    const cli = await clientAsync();
+    const targetId = pxt.appTarget.id;
+
+    if (cli) {
+        const currentPrefs = await cli.userPreferencesAsync();
+        const newSimulatorThemePrefs = { ...currentPrefs?.simulatorThemes };
+        if (preference) newSimulatorThemePrefs[targetId] = preference;
+        else delete newSimulatorThemePrefs[targetId];
+        await cli.patchUserPreferencesAsync({
+            op: 'replace',
+            path: ['simulatorThemes'],
+            value: newSimulatorThemePrefs
+        }, { immediate: true });
+    } else {
+        const currentPrefs = pxt.U.jsonTryParse(
+            pxt.storage.getLocal(pxt.auth.SIMULATOR_THEMES_LOCAL_STORAGE_KEY)
+        ) as pxt.auth.SimulatorThemesState ?? {};
+        if (preference) currentPrefs[targetId] = preference;
+        else delete currentPrefs[targetId];
+        pxt.storage.setLocal(pxt.auth.SIMULATOR_THEMES_LOCAL_STORAGE_KEY, JSON.stringify(currentPrefs));
+        data.invalidate(SIMULATOR_THEMES);
     }
 }
 

--- a/webapp/src/components/SimulatorThemePickerModal.tsx
+++ b/webapp/src/components/SimulatorThemePickerModal.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+
+import {
+    SimulatorThemePickerModal as SharedSimulatorThemePickerModal,
+    SimulatorThemePickerModalProps as SharedSimulatorThemePickerModalProps,
+} from "../../../react-common/components/theming/SimulatorThemePickerModal";
+import * as simulator from "../simulator";
+
+export type SimulatorThemePickerModalProps = Omit<SharedSimulatorThemePickerModalProps, "renderPreview">;
+
+export const SimulatorThemePickerModal = (props: SimulatorThemePickerModalProps) => {
+    return <SharedSimulatorThemePickerModal
+        {...props}
+        renderPreview={theme => <WebappSimulatorThemePreview theme={theme} />} />;
+};
+
+interface WebappSimulatorThemePreviewProps {
+    theme: pxt.SimulatorTheme;
+}
+
+const WebappSimulatorThemePreview = (props: WebappSimulatorThemePreviewProps) => {
+    const { theme } = props;
+    const previewContainer = React.useRef<HTMLDivElement>();
+    const currentTheme = React.useRef(theme);
+
+    React.useEffect(() => {
+        currentTheme.current = theme;
+        simulator.setPreviewSimulatorTheme(theme);
+    }, [theme]);
+
+    React.useEffect(() => {
+        const loanedSimulator = simulator.driver?.loanSimulator();
+        const container = previewContainer.current;
+        if (!loanedSimulator || !container) return undefined;
+
+        container.appendChild(loanedSimulator);
+        const frame = loanedSimulator.querySelector("iframe");
+        const onLoad = () => simulator.setPreviewSimulatorTheme(currentTheme.current);
+        const onMessage = (event: MessageEvent) => {
+            if (event.source === frame?.contentWindow
+                && event.data?.type === "status"
+                && event.data?.state === "running") {
+                simulator.setPreviewSimulatorTheme(currentTheme.current);
+            }
+        };
+        frame?.addEventListener("load", onLoad);
+        window.addEventListener("message", onMessage);
+        simulator.setPreviewSimulatorTheme(currentTheme.current);
+
+        return () => {
+            frame?.removeEventListener("load", onLoad);
+            window.removeEventListener("message", onMessage);
+            simulator.driver?.unloanSimulator();
+            simulator.clearPreviewSimulatorTheme();
+        };
+    }, []);
+
+    return <div className="simulator-theme-preview" role="group" aria-label={lf("Simulator theme preview")}>
+        <div ref={previewContainer} />
+    </div>;
+};

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import * as pkg from "./package";
 import * as srceditor from "./srceditor"
 import * as core from "./core";
+import * as simulatorTheme from "./simulatorTheme";
+import * as simulatorThemePreference from "./simulatorThemePreference";
 
 import Util = pxt.Util;
 
@@ -10,11 +12,13 @@ import { Checkbox } from "../../react-common/components/controls/Checkbox";
 import { Button } from "../../react-common/components/controls/Button";
 import { Input } from "../../react-common/components/controls/Input";
 import { Textarea } from "../../react-common/components/controls/Textarea";
+import { SimulatorThemePickerModal } from "./components/SimulatorThemePickerModal";
 
 export class Editor extends srceditor.Editor {
     config: pxt.PackageConfig = {} as any;
     isSaving: boolean;
     changeMade: boolean = false;
+    private simulatorThemePickerOpen = false;
 
     constructor(public parent: IProjectView) {
         super(parent);
@@ -145,6 +149,33 @@ export class Editor extends srceditor.Editor {
         }
     }
 
+    private showSimulatorThemePicker = () => {
+        if (!pxt.appTarget.simulator?.themePresets?.length) return;
+        pxt.tickEvent("pxtjson.simulatortheme.open", undefined, { interactiveConsent: true });
+        this.simulatorThemePickerOpen = true;
+        this.parent.forceUpdate();
+    }
+
+    private closeSimulatorThemePicker = () => {
+        this.simulatorThemePickerOpen = false;
+        this.parent.forceUpdate();
+    }
+
+    private saveSimulatorTheme = async (preference: pxt.auth.SimulatorThemePreference) => {
+        this.config.theme = simulatorTheme.serializeProjectSimulatorThemePreference(
+            preference,
+            pxt.appTarget.simulator.themePresets
+        );
+        await this.save(true);
+        this.closeSimulatorThemePicker();
+    }
+
+    private useAccountSimulatorTheme = async () => {
+        delete this.config.theme;
+        await this.save(true);
+        this.closeSimulatorThemePicker();
+    }
+
     private showEditSettingsDialogAsync = async () => {
         pxt.tickEvent("pxtjson.editsettingsdialog", undefined, { interactiveConsent: true });
 
@@ -181,9 +212,24 @@ export class Editor extends srceditor.Editor {
             .forEach(dep => userConfigs = userConfigs.concat(dep.config.yotta.userConfigs));
 
         const pxtJsonOptions = pxt.appTarget.appTheme?.pxtJsonOptions || [];
+        const simulatorThemePresets = pxt.appTarget.simulator?.themePresets || [];
+        const simulatorThemesEnabled = !!simulatorThemePresets.length;
+        const accountSimulatorTheme = simulatorThemesEnabled
+            ? simulatorThemePreference.getEffectiveSimulatorThemePreference()?.theme
+            : undefined;
+        const projectSimulatorThemePreference = accountSimulatorTheme
+            ? simulatorTheme.getProjectSimulatorThemePreference(c.theme, simulatorThemePresets, accountSimulatorTheme)
+            : undefined;
+        const simulatorThemePresetId = projectSimulatorThemePreference?.presetId;
+        const hasCustomSimulatorTheme = simulatorThemePresetId === "custom";
+        const selectedSimulatorThemeName = !c.theme
+            ? lf("Use account theme")
+            : hasCustomSimulatorTheme
+                ? lf("Custom")
+                : pxt.Util.rlf(`{id:simulator-theme-name}${simulatorThemePresets.find(preset => preset.id === simulatorThemePresetId)?.name}`);
 
         return (
-            <div className="ui content">
+            <><div className="ui content">
                 <div className="ui small header">
                     <div className="content">
                         <Button
@@ -216,6 +262,17 @@ export class Editor extends srceditor.Editor {
                             resize="vertical"
                         />
                     }
+                    {simulatorThemesEnabled && <div className="pxt-json-simulator-theme">
+                        <label htmlFor="projectSimulatorTheme">{lf("Simulator theme")}</label>
+                        <Button
+                            id="projectSimulatorTheme"
+                            className="primary"
+                            title={lf("Choose simulator theme")}
+                            label={selectedSimulatorThemeName}
+                            ariaHasPopup="dialog"
+                            ariaExpanded={this.simulatorThemePickerOpen}
+                            onClick={this.showSimulatorThemePicker} />
+                    </div>}
                     {userConfigs.map(uc =>
                         <UserConfigCheckbox
                             key={`userconfig-${uc.description}`}
@@ -243,6 +300,15 @@ export class Editor extends srceditor.Editor {
                     </div>
                 </div>
             </div>
+            {simulatorThemesEnabled && this.simulatorThemePickerOpen && !!accountSimulatorTheme && <SimulatorThemePickerModal
+                presets={simulatorThemePresets}
+                layouts={pxt.appTarget.simulator?.themeLayouts}
+                initialPreference={projectSimulatorThemePreference}
+                accountTheme={accountSimulatorTheme}
+                onUseAccountTheme={this.useAccountSimulatorTheme}
+                onSave={this.saveSimulatorTheme}
+                onClose={this.closeSimulatorThemePicker} />}
+            </>
         )
     }
 

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as auth from "./auth";
 import * as screenshot from "./screenshot";
 import * as pkg from "./package";
+import * as simulatorThemePreference from "./simulatorThemePreference";
 
 import { Modal } from "../../react-common/components/controls/Modal";
 import { Share } from "../../react-common/components/share/Share";
@@ -193,9 +194,12 @@ export class ShareEditor extends auth.Component<ShareEditorProps, ShareEditorSta
         const thumbnails = simScreenshot || simGif;
 
         const hasProjectBeenPersistentShared = parent.hasHeaderBeenPersistentShared();
+        const simulatorTheme = pxt.appTarget.simulator?.themePresets?.length
+            ? simulatorThemePreference.getEffectiveSimulatorThemePreference()
+            : undefined;
 
-        const publishAsync = async (name: string, description?: string, screenshotUri?: string, forceAnonymous?: boolean) =>
-            parent.publishAsync(name, description, screenshotUri, forceAnonymous)
+        const publishAsync = async (name: string, description?: string, screenshotUri?: string, forceAnonymous?: boolean, sharedSimulatorTheme?: pxt.SimulatorTheme) =>
+            parent.publishAsync(name, description, screenshotUri, forceAnonymous, sharedSimulatorTheme)
 
         const setSharePreference = (anonymousByDefault: boolean) => parent.saveSharePreferenceForHeaderAsync(anonymousByDefault)
 
@@ -216,6 +220,7 @@ export class ShareEditor extends auth.Component<ShareEditorProps, ShareEditorSta
                     anonymousShareByDefault={parent.getSharePreferenceForHeader()}
                     setAnonymousSharePreference={setSharePreference}
                     isMultiplayerGame={this.props.parent.state.isMultiplayerGame}
+                    simulatorTheme={simulatorTheme?.presetId === "default" ? undefined : simulatorTheme?.theme}
                     kind={this.state.kind}
                     onClose={this.hide}
                 />

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -7,6 +7,8 @@ import * as data from "./data";
 import U = pxt.U
 import { postHostMessageAsync, shouldPostHostMessages } from "../../pxteditor";
 import { Milestones } from "./constants";
+import * as simulatorTheme from "./simulatorTheme";
+import * as simulatorThemePreference from "./simulatorThemePreference";
 
 
 
@@ -29,6 +31,7 @@ export const SLOW_TRACE_INTERVAL = 500;
 export let driver: pxsim.SimulatorDriver;
 let config: SimulatorConfig;
 let lastCompileResult: pxtc.CompileResult;
+let previewSimulatorTheme: pxt.SimulatorTheme | undefined;
 let displayedModals: pxt.Map<boolean> = {};
 export let simTranslations: pxt.Map<string>;
 
@@ -210,6 +213,7 @@ export async function initAsync(cfg: SimulatorConfig) {
                 postSimEditorEvent("stopped");
             } else if (state === pxsim.SimulatorState.Running) {
                 this.onDebuggerResume();
+                postPreviewSimulatorTheme();
             }
             cfg.onStateChanged(state);
         },
@@ -344,7 +348,15 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
         }
     }
 
-    const theme = pkg.config.theme || (pxt.appTarget.appTheme.matchWebUSBDeviceInSim && pxt.packetio.isConnected() && pxt.packetio.deviceVariant());
+    const deviceTheme = pxt.appTarget.appTheme.matchWebUSBDeviceInSim && pxt.packetio.isConnected()
+        ? pxt.packetio.deviceVariant()
+        : undefined;
+    const theme = previewSimulatorTheme || simulatorTheme.resolveSimulatorTheme(
+            pkg.config.theme,
+            deviceTheme,
+            simulatorThemePreference.getEffectiveSimulatorThemePreference()?.theme,
+            !!playerNumber
+        );
 
     const opts: pxsim.SimulatorRunOptions = {
         boardDefinition: boardDefinition,
@@ -411,6 +423,24 @@ export function setTraceInterval(intervalMs: number) {
 export function proxy(message: pxsim.SimulatorCustomMessage) {
     if (!driver) return;
     driver.postMessage(message);
+}
+
+export function setPreviewSimulatorTheme(theme: pxt.SimulatorTheme) {
+    previewSimulatorTheme = theme;
+    postPreviewSimulatorTheme();
+}
+
+function postPreviewSimulatorTheme() {
+    if (!previewSimulatorTheme || !driver) return;
+    const message: pxsim.SetSimulatorThemeMessage = {
+        type: "setsimtheme",
+        theme: previewSimulatorTheme,
+    };
+    driver.postMessage(message);
+}
+
+export function clearPreviewSimulatorTheme() {
+    previewSimulatorTheme = undefined;
 }
 
 export function dbgPauseResume() {

--- a/webapp/src/simulatorTheme.ts
+++ b/webapp/src/simulatorTheme.ts
@@ -1,0 +1,88 @@
+export function getSimulatorThemePresetId(
+    theme: string | pxt.Map<string> | undefined,
+    presets: pxt.SimulatorThemePreset[]
+): string | undefined {
+    if (!theme) return undefined;
+    if (typeof theme === "string") {
+        return presets.find(preset => preset.id.toLowerCase() === theme.toLowerCase())?.id;
+    }
+    return presets.find(preset => pxt.auth.simulatorThemeColorsEqual(preset.theme, theme))?.id;
+}
+
+export function getProjectSimulatorThemePreference(
+    projectTheme: string | pxt.Map<string> | undefined,
+    presets: pxt.SimulatorThemePreset[],
+    accountTheme: pxt.SimulatorTheme
+): pxt.auth.SimulatorThemePreference | undefined {
+    if (!projectTheme) return undefined;
+
+    if (typeof projectTheme === "string") {
+        const preset = presets.find(candidate => candidate.id.toLowerCase() === projectTheme.toLowerCase());
+        return preset
+            ? { presetId: preset.id, theme: { ...preset.theme } }
+            : { presetId: "custom", theme: { ...accountTheme, layout: projectTheme } };
+    }
+
+    const theme = { ...accountTheme, ...projectTheme } as pxt.SimulatorTheme;
+    if (!pxt.auth.isValidSimulatorTheme(theme)) return undefined;
+    return {
+        presetId: getSimulatorThemePresetId(theme, presets) || "custom",
+        theme,
+    };
+}
+
+export function serializeProjectSimulatorThemePreference(
+    preference: pxt.auth.SimulatorThemePreference,
+    presets: pxt.SimulatorThemePreset[]
+): string | pxt.SimulatorTheme {
+    const preset = presets.find(candidate => candidate.id === preference.presetId);
+    return preset
+        && preset.theme.layout === preference.theme.layout
+        && pxt.auth.simulatorThemeColorsEqual(preset.theme, preference.theme)
+        ? preset.id
+        : { ...preference.theme };
+}
+
+export function removeSimulatorThemeFromFiles(files: pxt.workspace.ScriptText): pxt.workspace.ScriptText {
+    if (!files?.[pxt.CONFIG_NAME]) return files;
+
+    try {
+        const config = JSON.parse(files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
+        if (config.theme === undefined) return files;
+        delete config.theme;
+        return {
+            ...files,
+            [pxt.CONFIG_NAME]: pxt.Package.stringifyConfig(config),
+        };
+    } catch {
+        return files;
+    }
+}
+
+export function addSimulatorThemeToFiles(
+    files: pxt.workspace.ScriptText,
+    theme: pxt.SimulatorTheme
+): pxt.workspace.ScriptText {
+    if (!theme || !files?.[pxt.CONFIG_NAME]) return files;
+
+    try {
+        const config = JSON.parse(files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
+        config.theme = theme;
+        return {
+            ...files,
+            [pxt.CONFIG_NAME]: pxt.Package.stringifyConfig(config),
+        };
+    } catch {
+        return files;
+    }
+}
+
+export function resolveSimulatorTheme(
+    projectTheme: string | pxt.Map<string> | undefined,
+    deviceTheme: string | undefined,
+    userTheme: pxt.SimulatorTheme | undefined,
+    multiplayer: boolean
+): string | pxt.Map<string> | undefined {
+    if (multiplayer) return undefined;
+    return projectTheme || deviceTheme || userTheme;
+}

--- a/webapp/src/simulatorThemePreference.ts
+++ b/webapp/src/simulatorThemePreference.ts
@@ -1,0 +1,42 @@
+import * as auth from "./auth";
+import * as data from "./data";
+import {
+    getDefaultSimulatorThemePreference,
+    isImplicitSimulatorThemePreference,
+} from "../../react-common/components/theming/simulatorThemeDefaults";
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
+
+// Embedded hosts can update the active simulator without writing the account preference.
+let sessionSimulatorThemePreference: pxt.auth.SimulatorThemePreference;
+
+export function getSimulatorThemePreference(): pxt.auth.SimulatorThemePreference | undefined {
+    if (sessionSimulatorThemePreference) return sessionSimulatorThemePreference;
+    const preferences = data.getData<pxt.auth.SimulatorThemesState>(auth.SIMULATOR_THEMES);
+    const preference = preferences?.[pxt.appTarget.id];
+    return pxt.auth.isValidSimulatorThemePreference(preference) ? preference : undefined;
+}
+
+export function getEffectiveSimulatorThemePreference(): pxt.auth.SimulatorThemePreference | undefined {
+    return getSimulatorThemePreference() || getDefaultSimulatorThemePreference(
+        ThemeManager.getInstance(document).getCurrentColorTheme(),
+        pxt.appTarget.simulator?.themePresets
+    );
+}
+
+export async function setSimulatorThemePreference(preference: pxt.auth.SimulatorThemePreference | undefined): Promise<void> {
+    if (preference && !pxt.auth.isValidSimulatorThemePreference(preference)) return;
+    const persistedPreference = preference && !isImplicitSimulatorThemePreference(
+        preference,
+        pxt.appTarget.simulator?.themePresets
+    ) ? preference : undefined;
+    const previousSessionPreference = sessionSimulatorThemePreference;
+    await auth.setSimulatorThemePrefAsync(persistedPreference);
+    if (sessionSimulatorThemePreference === previousSessionPreference) {
+        sessionSimulatorThemePreference = undefined;
+    }
+}
+
+export function setSessionSimulatorThemePreference(preference: pxt.auth.SimulatorThemePreference): void {
+    if (!pxt.auth.isValidSimulatorThemePreference(preference)) return;
+    sessionSimulatorThemePreference = preference;
+}

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -12,6 +12,7 @@ import * as indexedDBWorkspace from "./idbworkspace";
 import * as compiler from "./compiler"
 import * as auth from "./auth"
 import * as cloud from "./cloud"
+import * as simulatorTheme from "./simulatorTheme"
 
 import * as pxteditor from "../../pxteditor";
 
@@ -420,7 +421,11 @@ function getScriptRequest(h: Header, text: ScriptText, meta: ScriptMeta, screens
 }
 
 // https://github.com/Microsoft/pxt-backend/blob/master/docs/sharing.md#anonymous-publishing
-export async function anonymousPublishAsync(h: Header, text: ScriptText, meta: ScriptMeta, screenshotUri?: string) {
+export interface PublishOptions {
+    projectFilesMatchPublishedFiles?: boolean;
+}
+
+export async function anonymousPublishAsync(h: Header, text: ScriptText, meta: ScriptMeta, screenshotUri?: string, options?: PublishOptions) {
     checkHeaderSession(h);
 
     const saveId = {}
@@ -433,7 +438,7 @@ export async function anonymousPublishAsync(h: Header, text: ScriptText, meta: S
     h.pubVersions.push({ id: inf.id, type: "snapshot" });
     if (inf.shortid) inf.id = inf.shortid;
     h.pubId = inf.shortid
-    h.pubCurrent = h.saveId === saveId
+    h.pubCurrent = options?.projectFilesMatchPublishedFiles !== false && h.saveId === saveId
     h.meta = inf.meta;
     pxt.debug(`published; id /${h.pubId}`)
 
@@ -442,7 +447,7 @@ export async function anonymousPublishAsync(h: Header, text: ScriptText, meta: S
     return inf;
 }
 
-export async function persistentPublishAsync(h: Header, text: ScriptText, meta: ScriptMeta, screenshotUri?: string) {
+export async function persistentPublishAsync(h: Header, text: ScriptText, meta: ScriptMeta, screenshotUri?: string, options?: PublishOptions) {
     checkHeaderSession(h);
 
     const saveId = {}
@@ -454,7 +459,7 @@ export async function persistentPublishAsync(h: Header, text: ScriptText, meta: 
     if (!h.pubVersions) h.pubVersions = [];
     h.pubVersions.push({ id: script.id, type: "permalink" });
     h.pubId = shareID
-    h.pubCurrent = h.saveId === saveId
+    h.pubCurrent = options?.projectFilesMatchPublishedFiles !== false && h.saveId === saveId
     h.pubPermalink = shareID;
     h.meta = script.meta;
     pxt.debug(`published; id /${h.pubId}`)
@@ -1723,16 +1728,18 @@ export function installByIdAsync(id: string) {
     return Cloud.privateGetAsync(id, /* forceLiveEndpoint */ true)
         .then((scr: Cloud.JsonScript) =>
             getPublishedScriptAsync(scr.id)
-                .then(files => installAsync(
-                    {
+                .then(files => {
+                    const editableFiles = simulatorTheme.removeSimulatorThemeFromFiles(files);
+                    return installAsync({
                         name: scr.name,
                         pubId: id,
-                        pubCurrent: true,
+                        pubCurrent: editableFiles === files,
                         meta: scr.meta,
                         editor: scr.editor,
                         target: scr.target,
                         targetVersion: scr.targetVersion || (scr.meta && scr.meta.versions && scr.meta.versions.target)
-                    }, files)))
+                    }, editableFiles);
+                }))
 }
 
 // this promise is set while a sync is in progress


### PR DESCRIPTION
* sim theming editor

* more 'fixes' (still reading them but addressing known issues)

* more fixes

* modal button

* unsigned arduino feedback

* further requests from jacqueline + ability to set default sim theme

* fix lifecycle bug, where it didn't update sim in theme editor fast enough / required an edit to rerender

* dropdown for skin choice as well

* knob, skin -> layout

* first pass cleanup

* allow layouts to override which colors are valid

* save -> apply

* make sure sim theming won't leak into editors that do not have it enabled; only change for microbit should be 'apply' button

* fixes for persistence & apply not save for theme as well