### PR TITLE
piano roll responsiveness and other fixes

### DIFF
--- a/react-common/components/controls/DropdownModal.tsx
+++ b/react-common/components/controls/DropdownModal.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import { classList, ControlProps } from "../util";
+import { Button, ButtonViewProps } from "./Button";
+import { DropdownProps } from "./Dropdown";
+import { FocusList } from "./FocusList";
+import { Modal } from "./Modal";
+
+interface DropdownModalProps extends DropdownProps {
+    onClose: () => void;
+}
+
+export const DropdownModal = (props: DropdownModalProps) => {
+    const {
+        className,
+        ariaLabel,
+        items,
+        selectedId,
+        onItemSelected,
+        onClose
+    } = props;
+
+    const focusableItems = React.useRef<{[k: string]: HTMLButtonElement}>({});
+
+    React.useEffect(() => {
+        if (Object.keys(focusableItems.current).length) {
+            focusableItems.current[selectedId ?? 0].focus();
+        }
+    }, [selectedId]);
+
+
+    return (
+        <Modal
+            className={classList("common-dropdown-modal", className)}
+            title={ariaLabel}
+            hideTitle={true}
+            onClose={onClose}
+            hideDismissButton={true}
+        >
+            <FocusList
+                role="listbox"
+                className="common-menu-dropdown-pane common-dropdown-shadow"
+                childTabStopId={selectedId}
+                useUpAndDownArrowKeys={true}
+                onClose={onClose}
+            >
+                    <ul role="presentation">
+                        { items.map(item =>
+                            <li key={item.id} role="presentation">
+                                <Button
+                                    {...item}
+                                    buttonRef={ref => focusableItems.current[item.id] = (ref as HTMLButtonElement)}
+                                    className={classList("common-dropdown-item", item.className)}
+                                    onClick={() => {
+                                        onItemSelected(item.id);
+                                        onClose();
+                                    }}
+                                    ariaSelected={item.id === selectedId}
+                                    leftIcon={classList("fas fa-check", selectedId !== item.id && "transparent")}
+                                    role="option"/>
+                            </li>
+                        )}
+                    </ul>
+            </FocusList>
+        </Modal>
+    )
+}

--- a/react-common/components/controls/Input.tsx
+++ b/react-common/components/controls/Input.tsx
@@ -8,7 +8,7 @@ export interface InputProps extends ControlProps {
     inputClassName?: string;
     groupClassName?: string;
     initialValue?: string;
-    label?: string;
+    label?: string | JSX.Element;
     title?: string;
     placeholder?: string;
     icon?: string;

--- a/react-common/styles/controls/DropdownModal.less
+++ b/react-common/styles/controls/DropdownModal.less
@@ -1,0 +1,17 @@
+.common-dropdown-modal .common-modal {
+    .common-modal-header {
+        display: none;
+    }
+    .common-modal-body {
+        background: none;
+    }
+
+    .common-menu-dropdown-pane {
+        position: relative;
+        right: unset;
+    }
+
+    .common-dropdown-item .fas.fa-check.transparent {
+        opacity: 0;
+    }
+}

--- a/react-common/styles/react-common.less
+++ b/react-common/styles/react-common.less
@@ -11,6 +11,7 @@
 @import "controls/Checkbox.less";
 @import "controls/DraggableGraph.less";
 @import "controls/Dropdown.less";
+@import "controls/DropdownModal.less";
 @import "controls/EditorToggle.less";
 @import "controls/Icon.less";
 @import "controls/Input.less";

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -12,7 +12,6 @@
     --note-event-text-color-hover: #ffffff;
     --note-event-border-hover: 2px solid #ffffff;
 
-    --header-text-color: black;
 
     --white-key-color: white;
     --black-key-color: black;
@@ -28,7 +27,9 @@
 
     --velocity-slider-color: var(--note-event-color);
 
-    --header-background: #f0f0f0;
+    --header-background: var(--pxt-neutral-background1);
+    --header-text-color: var(--pxt-neutral-foreground1);
+
     --piano-roll-border-color: var(--workspace-grid-line-color);
 }
 
@@ -134,6 +135,10 @@
 
     &>.common-dropdown #snap-select {
         min-width: 4.75rem;
+    }
+
+    .common-button.menu-button {
+        color: var(--header-text-color);
     }
 }
 
@@ -347,6 +352,16 @@
     background-color: var(--playhead-color);
 }
 
+.piano-roll .header .velocity-editor-toggle {
+    overflow-x: hidden;
+
+    label {
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+    }
+}
+
 .velocity-editor {
     position: relative;
     display: flex;
@@ -427,5 +442,11 @@
     /* Hide the done button */
     .music-editor-edit-controls .common-button.green {
         display: none;
+    }
+}
+
+@media @tabletAndBelow {
+    .common-dropdown > .common-button {
+        min-width: 8rem;
     }
 }

--- a/theme/piano-roll/piano-roll.less
+++ b/theme/piano-roll/piano-roll.less
@@ -64,6 +64,13 @@
 .piano-roll .header-container {
     height: var(--header-height);
     flex-shrink: 0;
+
+    .header > .common-dropdown .common-menu-dropdown-pane {
+        max-height: 15rem;
+        overflow-y: auto;
+        overflow-x: hidden;
+        z-index: 2;
+    }
 }
 
 .piano-roll .header,

--- a/webapp/src/components/musicEditor/EditControls.tsx
+++ b/webapp/src/components/musicEditor/EditControls.tsx
@@ -46,25 +46,28 @@ export const EditControls = (props: EditControlsProps) => {
 
     const showAssetName = !!pxt.appTarget?.appTheme.assetEditor;
 
-    return <div className="music-editor-edit-controls">
-        {nameError &&
-            <div className="music-editor-name-error">
-                {nameError}
-            </div>
-        }
-        {showAssetName &&
-            <Input
-                placeholder={lf("Asset Name")}
-                initialValue={assetName || editName}
-                onBlur={handleNameEdit}
-                onEnterKey={handleNameEdit} />
-        }
-        {!hideDoneButton &&
-            <Button
-                className="green"
-                title={lf("Done")}
-                label={lf("Done")}
-                onClick={onDoneClicked} />
-        }
-    </div>
+    return (
+        <div className="music-editor-edit-controls">
+            {nameError &&
+                <div className="music-editor-name-error">
+                    {nameError}
+                </div>
+            }
+            {showAssetName &&
+                <Input
+                    className="mobile-hidden"
+                    placeholder={lf("Asset Name")}
+                    initialValue={assetName || editName}
+                    onBlur={handleNameEdit}
+                    onEnterKey={handleNameEdit} />
+            }
+            {!hideDoneButton &&
+                <Button
+                    className="green"
+                    title={lf("Done")}
+                    label={lf("Done")}
+                    onClick={onDoneClicked} />
+            }
+        </div>
+    );
 }

--- a/webapp/src/components/musicEditor/PlaybackControls.tsx
+++ b/webapp/src/components/musicEditor/PlaybackControls.tsx
@@ -136,7 +136,11 @@ export const PlaybackControls = (props: PlaybackControlsProps) => {
         </div>
         <Input
             id="music-playback-tempo-input music-editor-label"
-            label={lf("Tempo:")}
+            label={
+                <span className="mobile-hidden tablet-hidden">
+                    {lf("Tempo:")}
+                </span>
+            }
             initialValue={beatsPerMinute.toString()}
             onBlur={handleTempoChange}
             onEnterKey={handleTempoChange}
@@ -165,7 +169,7 @@ export const PlaybackControls = (props: PlaybackControlsProps) => {
                 onClick={onRedoClick} />
         </div>
         <div className="music-playback-measures">
-            <div className="music-editor-label">
+            <div className="music-editor-label mobile-hidden tablet-hidden">
                 {lf("Measures:")}
             </div>
             <Button

--- a/webapp/src/components/pianoRoll/AssetNameModal.tsx
+++ b/webapp/src/components/pianoRoll/AssetNameModal.tsx
@@ -1,0 +1,92 @@
+import { Input } from "../../../../react-common/components/controls/Input";
+import { Modal, ModalAction } from "../../../../react-common/components/controls/Modal";
+import { useState } from "react";
+import { isNameTaken } from "../../assets";
+
+interface AssetNameModalProps {
+    assetName: string;
+    onAssetNameChanged: (newAssetName: string) => void;
+    onClose: () => void;
+}
+
+export const AssetNameModal = (props: AssetNameModalProps) => {
+    const {
+        assetName,
+        onAssetNameChanged,
+        onClose
+    } = props;
+
+    const [editName, setEditName] = useState(assetName);
+    const [nameError, setNameError] = useState<string>();
+
+    const handleNameEdit = (newValue: string) => {
+        let errorMessage = null;
+
+        const trimmedName = newValue.trim(); // validate using the trimmed name
+
+        if (!trimmedName) {
+            setEditName("");
+            setNameError(undefined);
+            return;
+        }
+
+        if (!pxt.validateAssetName(trimmedName)) {
+            errorMessage = lf("Names may only contain letters, numbers, '-', '_', and space");
+        }
+        else if (isNameTaken(trimmedName) && trimmedName !== assetName) {
+            errorMessage = lf("This name is already used elsewhere in your project");
+        }
+
+        if (errorMessage) {
+            setNameError(errorMessage);
+        }
+        else {
+            setNameError(undefined);
+        }
+        setEditName(trimmedName);
+    }
+
+    const onSaveClick = () => {
+        if (!nameError) {
+            onAssetNameChanged(editName);
+            onClose();
+        }
+    }
+
+    const actions: ModalAction[] = [
+        {
+            label: lf("Cancel"),
+            onClick: onClose
+        },
+        {
+            label: lf("Save"),
+            onClick: onSaveClick,
+            disabled: !!nameError
+        }
+    ];
+
+    return (
+        <Modal
+            className="piano-roll-asset-name-modal"
+            title={lf("Change Asset Name")}
+            onClose={onClose}
+            actions={actions}
+        >
+            <div className="piano-roll-asset-name-modal-content">
+                <label htmlFor="asset-name-input">{lf("Asset Name")}</label>
+                <Input
+                    id="asset-name-input"
+                    initialValue={editName}
+                    onBlur={handleNameEdit}
+                    onEnterKey={handleNameEdit}
+                    onChange={handleNameEdit}
+                />
+                {nameError &&
+                    <div className="piano-roll-asset-name-error">
+                        {nameError}
+                    </div>
+                }
+            </div>
+        </Modal>
+    )
+}

--- a/webapp/src/components/pianoRoll/Header.tsx
+++ b/webapp/src/components/pianoRoll/Header.tsx
@@ -139,6 +139,16 @@ export const Header = (props: Props) => {
 
     const overflowMenuItems: MenuItem[] = [];
 
+    overflowMenuItems.push(
+        {
+            role: "menuitemcheckbox",
+            label: lf("Velocity Editor"),
+            isChecked: velocityEditorVisible,
+            onChange: () => onVelocityEditorToggle(),
+            id: "show-velocity-editor"
+        }
+    );
+
     if (!isDrum) {
         overflowMenuItems.push(
             {
@@ -150,16 +160,6 @@ export const Header = (props: Props) => {
             }
         );
     }
-
-    overflowMenuItems.push(
-        {
-            role: "menuitemcheckbox",
-            label: lf("Velocity Editor"),
-            isChecked: velocityEditorVisible,
-            onChange: () => onVelocityEditorToggle(),
-            id: "show-velocity-editor"
-        }
-    );
 
     if (showSnapControls) {
         overflowMenuItems.push(

--- a/webapp/src/components/pianoRoll/Header.tsx
+++ b/webapp/src/components/pianoRoll/Header.tsx
@@ -1,6 +1,10 @@
+import { useState } from "react";
 import { Checkbox } from "../../../../react-common/components/controls/Checkbox";
 import { Dropdown, DropdownItem } from "../../../../react-common/components/controls/Dropdown";
-import { Song, lf, isDrumInstrument, NOTE_RANGES, SNAP_OPTIONS } from "./types";
+import { DropdownModal } from "../../../../react-common/components/controls/DropdownModal";
+import { MenuDropdown, MenuItem } from "../../../../react-common/components/controls/MenuDropdown";
+import { AssetNameModal } from "./AssetNameModal";
+import { Song, lf, isDrumInstrument, NOTE_RANGES, SNAP_OPTIONS, TIME_SIGNATURES } from "./types";
 
 interface Props {
     song: Song;
@@ -8,6 +12,10 @@ interface Props {
     velocityEditorVisible: boolean;
     snapTicks: number;
     showSnapControls: boolean;
+    showTimeSignature: boolean;
+    selectedTimeSignature: string;
+    showAssetName: boolean;
+    assetName?: string;
 
     onTrackSelected(trackId: number): void;
     onTrackCreated(): void;
@@ -16,6 +24,8 @@ interface Props {
     onOctavesChanged(minOctave: number, maxOctave: number): void;
     onVelocityEditorToggle(): void;
     onSnapChanged(snapTicks: number): void;
+    onTimeSignatureChanged: (newTimeSignature: string) => void;
+    onAssetNameChanged: (newAssetName: string) => void;
 }
 
 export const Header = (props: Props) => {
@@ -25,14 +35,32 @@ export const Header = (props: Props) => {
         velocityEditorVisible,
         snapTicks,
         showSnapControls,
+        showTimeSignature,
+        selectedTimeSignature,
+        showAssetName,
+        assetName,
+        onAssetNameChanged,
         onVelocityEditorToggle,
         onTrackSelected,
         onInstrumentSelected,
         onTrackCreated,
         onTrackDeleted,
         onOctavesChanged,
-        onSnapChanged
+        onSnapChanged,
+        onTimeSignatureChanged
     } = props;
+
+    const [modal, setModal] = useState<
+        "change-octave-range" |
+        "change-snap" |
+        "change-time-signature" |
+        "change-asset-name" |
+        undefined
+    >();
+
+    const closeModal = () => {
+        setModal(undefined);
+    };
 
     const onTrackDropdownChange = (id: string) => {
         if (id === "new-track") {
@@ -109,9 +137,108 @@ export const Header = (props: Props) => {
         id: option.id
     }));
 
+    const overflowMenuItems: MenuItem[] = [];
+
+    if (!isDrum) {
+        overflowMenuItems.push(
+            {
+                role: "menuitem",
+                title: lf("Octave Range…"),
+                label: lf("Octave Range…"),
+                id: "change-octave-range",
+                onClick: () => setModal("change-octave-range")
+            }
+        );
+    }
+
+    overflowMenuItems.push(
+        {
+            role: "menuitemcheckbox",
+            label: lf("Velocity Editor"),
+            isChecked: velocityEditorVisible,
+            onChange: () => onVelocityEditorToggle(),
+            id: "show-velocity-editor"
+        }
+    );
+
+    if (showSnapControls) {
+        overflowMenuItems.push(
+            {
+                role: "menuitem",
+                label: lf("Snap…"),
+                title: lf("Snap…"),
+                id: "change-snap",
+                onClick: () => setModal("change-snap")
+            }
+        );
+    }
+
+    if (showTimeSignature) {
+        overflowMenuItems.push(
+            {
+                role: "menuitem",
+                label: lf("Time Signature…"),
+                title: lf("Time Signature…"),
+                id: "change-time-signature",
+                onClick: () => setModal("change-time-signature")
+            }
+        );
+    }
+
+    if (showAssetName) {
+        overflowMenuItems.push(
+            {
+                role: "menuitem",
+                label: lf("Asset Name…"),
+                title: lf("Asset Name…"),
+                id: "change-asset-name",
+                onClick: () => setModal("change-asset-name")
+            }
+        );
+    }
+
+    const timeSignatures: DropdownItem[] = TIME_SIGNATURES.map(ts => ({
+        label: ts.name,
+        title: ts.name,
+        id: ts.id
+    }));
 
     return (
         <div className="header">
+            { modal === "change-octave-range" &&
+                <DropdownModal
+                    id="change-octave-range"
+                    items={rangeOptions}
+                    selectedId={selectedRangeId}
+                    onItemSelected={handleRangeDropdownChange}
+                    onClose={closeModal}
+                />
+            }
+            { modal === "change-snap" &&
+                <DropdownModal
+                    id="change-snap"
+                    items={snapOptions}
+                    selectedId={snapTicksToId(snapTicks)}
+                    onItemSelected={(id) => onSnapChanged(snapIdToTicks(id))}
+                    onClose={closeModal}
+                />
+            }
+            { modal === "change-time-signature" &&
+                <DropdownModal
+                    id="change-time-signature"
+                    items={timeSignatures}
+                    selectedId={selectedTimeSignature}
+                    onItemSelected={onTimeSignatureChanged}
+                    onClose={closeModal}
+                />
+            }
+            { modal === "change-asset-name" &&
+                <AssetNameModal
+                    assetName={assetName}
+                    onAssetNameChanged={onAssetNameChanged}
+                    onClose={closeModal}
+                />
+            }
             <Dropdown
                 id="track-select"
                 items={trackDropdownOptions}
@@ -131,8 +258,8 @@ export const Header = (props: Props) => {
                 onItemSelected={onInstrumentDropdownChange}
             />
             {!isDrum &&
-                <div className="octave-controls">
-                    <div className="music-editor-label">
+                <div className="octave-controls mobile-hidden">
+                    <div className="music-editor-label tablet-hidden">
                         {lf("Range:")}
                     </div>
                     <Dropdown
@@ -144,6 +271,7 @@ export const Header = (props: Props) => {
                 </div>
             }
             <Checkbox
+                className="mobile-hidden velocity-editor-toggle"
                 id="velocity-editor-toggle"
                 label={lf("Show Velocity Editor")}
                 isChecked={velocityEditorVisible}
@@ -152,17 +280,26 @@ export const Header = (props: Props) => {
             <div className="spacer" />
             {showSnapControls &&
                 <>
-                    <div className="music-editor-label">
+                    <div className="music-editor-label mobile-hidden">
                         {lf("Snap:")}
                     </div>
                     <Dropdown
                         id="snap-select"
+                        className="mobile-hidden"
                         items={snapOptions}
                         selectedId={snapTicksToId(snapTicks)}
                         onItemSelected={(id) => onSnapChanged(snapIdToTicks(id))}
                     />
                 </>
             }
+
+            <MenuDropdown
+                className="mobile-only"
+                id="overflow-menu"
+                items={overflowMenuItems}
+                icon="fas fa-ellipsis-v"
+                title={lf("More Options")}
+            />
         </div>
     );
 }

--- a/webapp/src/components/pianoRoll/PianoRoll.tsx
+++ b/webapp/src/components/pianoRoll/PianoRoll.tsx
@@ -61,6 +61,7 @@ interface StateSnapshot {
 
 interface ExtraState {
     velocityEditorVisible: boolean;
+    snapTicks: number;
 }
 
 
@@ -75,7 +76,8 @@ export class PianoRollModel extends AssetModel<StateSnapshot, ExtraState> {
 
     protected cloneExtraState(value: ExtraState): ExtraState {
         return {
-            velocityEditorVisible: value?.velocityEditorVisible
+            velocityEditorVisible: value?.velocityEditorVisible,
+            snapTicks: value?.snapTicks || 4
         };
     }
 }
@@ -92,11 +94,9 @@ const PianoRollInternal = (props: PianoRollProps) => {
     const { value, hasUndo, hasRedo, extraState } = useModelValue(model);
 
     const { song, selectedTrackIndex, assetName } = value;
-    const { velocityEditorVisible } = extraState;
+    const { velocityEditorVisible, snapTicks } = extraState;
 
     const [modal, setModal] = useState<{ type: modalType, trackId?: number, instrumentId?: number } | null>(null);
-
-    const [snapTicks, setSnapTicks] = useState(4);
 
     const workspaceContainerRef = useRef<HTMLDivElement>(null);
 
@@ -417,7 +417,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
     }
 
     const onVelocityEditorToggle = () => {
-        model.updateExtraState({ velocityEditorVisible: !extraState.velocityEditorVisible });
+        model.updateExtraState({ velocityEditorVisible: !extraState.velocityEditorVisible, snapTicks });
     }
 
     const onSelectionChange = useCallback((selection: WorkspaceSelection | undefined) => {
@@ -541,6 +541,10 @@ const PianoRollInternal = (props: PianoRollProps) => {
         }
     }, [song, updateSong]);
 
+    const setSnapTicks = (newSnapTicks: number) => {
+        model.updateExtraState({ velocityEditorVisible, snapTicks: newSnapTicks });
+    }
+
     const showHeader = !fieldEditorParams?.hideHeader;
 
     return (
@@ -571,6 +575,8 @@ const PianoRollInternal = (props: PianoRollProps) => {
                         velocityEditorVisible={velocityEditorVisible}
                         snapTicks={snapTicks}
                         showSnapControls={fieldEditorParams?.showSnapControls}
+                        showTimeSignature={!!fieldEditorParams?.showTimeSignature}
+                        selectedTimeSignature={selectedTimeSignature?.id}
                         onVelocityEditorToggle={onVelocityEditorToggle}
                         onTrackSelected={onTrackSelected}
                         onInstrumentSelected={onInstrumentSelected}
@@ -578,6 +584,10 @@ const PianoRollInternal = (props: PianoRollProps) => {
                         onTrackDeleted={onTrackDeleted}
                         onOctavesChanged={onOctavesChanged}
                         onSnapChanged={setSnapTicks}
+                        onTimeSignatureChanged={onTimeSignatureChanged}
+                        showAssetName={true}
+                        assetName={assetName}
+                        onAssetNameChanged={onNameChange}
                     />
                 </div>
             }
@@ -636,6 +646,7 @@ const PianoRollInternal = (props: PianoRollProps) => {
                 />
                 {fieldEditorParams?.showTimeSignature &&
                     <Dropdown
+                        className="mobile-hidden"
                         id="time-signature-dropdown"
                         items={timeSignatures}
                         selectedId={selectedTimeSignature?.id}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7702
fixes https://github.com/microsoft/pxt-arcade/issues/7701
fixes https://github.com/microsoft/pxt-arcade/issues/7692
fixes https://github.com/microsoft/pxt-arcade/issues/7691
fixes https://github.com/microsoft/pxt-arcade/issues/7690

fixes a few things:
* the piano roll now resizes nicely down to mobile phone width (controls that don't fit in the header/footer go into an overflow menu in the header)
* dropdowns now have a max height
* the snap ticks are saved in the field state
* fixed the header/footer colors so that they match the selected editor theme

<img width="1877" height="1318" alt="piano-roll-resize" src="https://github.com/user-attachments/assets/79e3a13e-b6e6-4d7c-b513-13642b7057ad" />


selecting an item in the overflow menu pops a full screen dropdown modal:

<img width="982" height="1317" alt="piano-dropdown-modal" src="https://github.com/user-attachments/assets/8f74f83b-b1be-4dbd-be0a-f16c1ced4062" />
