### PR TITLE
Spelling fixes for markdown pages in the './docs' tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ svgo svgicons/myicon.svg
 
 When adding a CSS color or other style element that will be shared across editor targets (e.g. micro:bit, Arcade) and sub-applications (a.k.a. "CRAs", like skillmap, teachertool, etc.). Declare a CSS variable for it in `theme/themepacks.less`:
 
-1. Add the new variable to the `:root` pseudo-class. Choose a reasonable default value according to the guidlines in the file.
+1. Add the new variable to the `:root` pseudo-class. Choose a reasonable default value according to the guidelines in the file.
 2. Add the new variable to all theme classes defined in that file. At the time of this writing, only `theme-highcontrast` is defined. Choose a value that works well for the given theme.
 3. Add the new variable to the theme overrides for each target. This will be done in the target repo's `theme/themepacks.less` file (e.g. pxt-microbit, pxt-arcade).
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -18,7 +18,7 @@ interface and by adding additional blocks and functions specific to their hardwa
 
 ## MakeCode essentials
 
-All of the parts of the MakeCode programming experience, when put toghether, create what's typically called an "editor". Even though MakeCode incorporates much more than just editors,
+All of the parts of the MakeCode programming experience, when put together, create what's typically called an "editor". Even though MakeCode incorporates much more than just editors,
 this concrete term is used more often, rather than referring to the MakeCode target as a "programming experience".
 
 To describe the essentials of a MakeCode editor, it is combination of: a blocks editor, a language editor, a target simulator, and a target code generator.
@@ -30,7 +30,7 @@ The Blocks editor is where the user can interactively create a program by "pulli
 available in the Blocks Toolbox aligning next to the workspace.
 
 Blocks represent coding actions and programming structures that would traditionally be
-written in text. Coding elements such as loops, conditonal statements, and events are
+written in text. Coding elements such as loops, conditional statements, and events are
 containing blocks with other blocks fitting inside. Functions and assignments are "flat"
 blocks that fit into others. Variables, values, and properties are mini-blocks that fit into 
 slots of functions, assignments, or evaluators.

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -369,7 +369,7 @@ Ringing in the New Year with a New Release! The MakeCode team is very happy and 
 
 December 19th, 2019 by [Pelikhan](https://github.com/pelikhan)
 
-The latest episode of our GitHub intergration - streamlining the hosting of code
+The latest episode of our GitHub integration - streamlining the hosting of code
 in GitHub inside of MakeCode!
 **[Continue reading this blog post](/blog/makecode-with-github)**
 

--- a/docs/blog/alava/bdale-tminus1.md
+++ b/docs/blog/alava/bdale-tminus1.md
@@ -19,7 +19,7 @@ where we talked about [Microsoft MakeCode](https://www.makecode.com) and [MakeCo
 
 ### Unracing to the Finish Line in the Basement of the Holiday Inn
 
-Well, so far I've been showing you glamourous photos from the library where we work with the designers.  The reality is that we spend a lot of our time in a rented room in the basement of the Holiday Inn (Downtown Brooklyn), squashing bugs, writing device drivers, and fabricating (soldering) the required 
+Well, so far I've been showing you glamorous photos from the library where we work with the designers.  The reality is that we spend a lot of our time in a rented room in the basement of the Holiday Inn (Downtown Brooklyn), squashing bugs, writing device drivers, and fabricating (soldering) the required 
 tech for each of the 20 designers.  It's nice and quiet down here - we are close to the pool and the exercise room (both unused by us) and everyone once in a while we hear the rumble of a subway going by. 
 
 The most exciting part of my time down here is the terror of watching James Devine find another race in the JACDAC physical layer protocol [C++ implementation](https://github.com/lancaster-university/codal-core/tree/jacdac-v0/source/JACDAC) - he eventually squashes the race and sets up more stress testing, which reveals... another race! Here are the commits of the fixes James has made in the last few days:

--- a/docs/blog/arcade/in.md
+++ b/docs/blog/arcade/in.md
@@ -10,7 +10,7 @@ Over the past year we've been working hard to bring you the ability to sign into
 
 Have you ever been working on a MakeCode project at school and wanted to take it home? In the past, users have found creative ways to move projects from device to device and browser to browser, and these methods will still work! But Cloud Sync makes this a seamless experience: when you sign into MakeCode, your cloud-saved projects are downloaded to your browser automatically.
 
-Perhaps you've had the experience of returning to a lab computer only to realize the machine had been reset overnight, erasing your projects with it. Losing all your work can be devastating. Cloud Sync guards against this by continouously saving your work to the cloud as you edit your project.
+Perhaps you've had the experience of returning to a lab computer only to realize the machine had been reset overnight, erasing your projects with it. Losing all your work can be devastating. Cloud Sync guards against this by continuously saving your work to the cloud as you edit your project.
 
 ## Nice! How do I enable it?
 
@@ -24,7 +24,7 @@ On the home screen, you can tell a project is saved to cloud if it has a visible
 
 ## The Future
 
-The addition of identity to MakeCode represents a new foundation upon which a wide range of user-aware features can be built. We're excited by all the possiblities! But we're going to build on this new foundation carefully and thoughtfully, with your privacy and safety always our first priority.
+The addition of identity to MakeCode represents a new foundation upon which a wide range of user-aware features can be built. We're excited by all the possibilities! But we're going to build on this new foundation carefully and thoughtfully, with your privacy and safety always our first priority.
 
 ## Feedback?
 

--- a/docs/blog/arcade/intro-cloud-sync.md
+++ b/docs/blog/arcade/intro-cloud-sync.md
@@ -10,7 +10,7 @@ Over the past year we've been working hard to bring you the ability to sign into
 
 Have you ever been working on a MakeCode project at school and wanted to take it home? In the past, users have found creative ways to move projects from device to device and browser to browser, and these methods will still work! But Cloud Sync makes this a seamless experience: when you sign into MakeCode, your cloud-saved projects are downloaded to your browser automatically.
 
-Perhaps you've had the experience of returning to a lab computer only to realize the machine had been reset overnight, erasing your projects with it. Losing all your work can be devastating. Cloud Sync guards against this by continouously saving your work to the cloud as you edit your project.
+Perhaps you've had the experience of returning to a lab computer only to realize the machine had been reset overnight, erasing your projects with it. Losing all your work can be devastating. Cloud Sync guards against this by continuously saving your work to the cloud as you edit your project.
 
 ## Nice! How do I enable it?
 
@@ -24,7 +24,7 @@ On the home screen, you can tell a project is saved to cloud if it has a visible
 
 ## The Future
 
-The addition of identity to MakeCode represents a new foundation upon which a wide range of user-aware features can be built. We're excited by all the possiblities!
+The addition of identity to MakeCode represents a new foundation upon which a wide range of user-aware features can be built. We're excited by all the possibilities!
 But we're going to build on this new foundation carefully and thoughtfully, with your privacy and safety always our first priority.
 
 ## Feedback?

--- a/docs/blog/arcade/tutorial-update.md
+++ b/docs/blog/arcade/tutorial-update.md
@@ -12,7 +12,7 @@ Over the past summer, we conducted several user studies to get feedback on tutor
 
 ![Small screen tutorial view](/static/blog/arcade/tutorial-update/small-screen.jpg)
 
-To fix this, we’ve moved the tutorial instructions to the left side of the screen as a tab, sharing space with the game screen. This gives people a lot more room to code using the Toolbox and the Workpace on the right. We also added a mini game screen in the bottom right corner, so you can always see your game. You can expand the mini game screen to the full view on the left pane.
+To fix this, we’ve moved the tutorial instructions to the left side of the screen as a tab, sharing space with the game screen. This gives people a lot more room to code using the Toolbox and the Workspace on the right. We also added a mini game screen in the bottom right corner, so you can always see your game. You can expand the mini game screen to the full view on the left pane.
 
 ![Change locations of tutorial elements](/static/blog/arcade/tutorial-update/tutorial.gif)
 

--- a/docs/blog/github-extensions-episode-2.md
+++ b/docs/blog/github-extensions-episode-2.md
@@ -61,7 +61,7 @@ Once you have reviewed all the changes, you're ready to commit and push your cha
 
 ## Pulling changes
 
-If you've made changes on another computer, or you are working with other people on the same projects, chances are that you need to **pull** other changes from GitHub. MakeCode will detect that you need these changes and will try to merge the them into your project. If the merge fails, we might have to create a pull request or even fork the repository to accomodate the situation.
+If you've made changes on another computer, or you are working with other people on the same projects, chances are that you need to **pull** other changes from GitHub. MakeCode will detect that you need these changes and will try to merge the them into your project. If the merge fails, we might have to create a pull request or even fork the repository to accommodate the situation.
 
 ![Pull changes](/static/blog/github-extensions-reloaded/pullchanges.png)
 

--- a/docs/blog/makecode-with-github.md
+++ b/docs/blog/makecode-with-github.md
@@ -31,7 +31,7 @@ display automatically on the pull request timeline.
 
 If a commit modifies blocks, 
 MakeCode will automatically add the [rendered diff to the commit](https://github.com/pelikhan/pxt-ghdemo/commit/c2d19e4324c10eef74f207899121800ba25e7666#commitcomment-36469566). 
-This allows you to review code changes as blocks in addtion to just seeing them as text.
+This allows you to review code changes as blocks in addition to just seeing them as text.
 
 ![A rendered blocks diff attached to a commit](/static/blog/makecode-with-github/comment.png)
 

--- a/docs/blog/microbit/2019-beta.md
+++ b/docs/blog/microbit/2019-beta.md
@@ -20,7 +20,7 @@ We have a date! We plan to release this Beta live on **Friday June 14th**!
 
 Any bugs you find, please log them in GitHub: https://github.com/Microsoft/pxt-microbit/issues
 
-Also, the [micro:bit](https://microbit.org) Foudation is encouraging folks to join in their testing program. Go to the **[testing](https://microbit.org/testing)** page to sign up and help out.
+Also, the [micro:bit](https://microbit.org) Foundation is encouraging folks to join in their testing program. Go to the **[testing](https://microbit.org/testing)** page to sign up and help out.
 
 Any other comments, suggestions, and feedback, please participate in the micro:bit community on Slack: https://tech.microbit.org/get-involved/where-to-find/
 
@@ -30,7 +30,7 @@ In addition to general bug fixes, here’s a run-down of the new features for th
 
 * **Functions with parameters** – Hooray!!! This was one of the most requested features from educators. Now when you make a function, you have the option to add _Text_, _Boolean_ or _Number_ type parameters. Try out the **Edit Function** feature and let us know what you think!
 
-![Adding paramters to function blocks](/static/blog/microbit/2019-beta/functions.gif)
+![Adding parameters to function blocks](/static/blog/microbit/2019-beta/functions.gif)
 
 * **Green Screen** – For those of you who do screen recordings as part of your lessons, this is a cool new feature that will allow you to overlay your webcam onto the MakeCode workspace. Wow,  you can demonstrate code and hardware at the same time! You can access the **Green Screen** from the **Project Settings** menu.
 

--- a/docs/blog/microbit/2020-beta.md
+++ b/docs/blog/microbit/2020-beta.md
@@ -103,7 +103,7 @@ A last little feature we’ve added to help alleviate the hundreds of "Untitled"
 
 ### Multi-Edit
 
-So, you're creating radio programs for two micro:bits. One to send a message and another to receive a message. You have to make two projects seperately for both programs. Well, not anymore, now there's Multi-edit! Create, modify, and test out two programs at the same time. So awesome! Use the Multi-edit version of the editor at: https://makecode.com/multi.
+So, you're creating radio programs for two micro:bits. One to send a message and another to receive a message. You have to make two projects separately for both programs. Well, not anymore, now there's Multi-edit! Create, modify, and test out two programs at the same time. So awesome! Use the Multi-edit version of the editor at: https://makecode.com/multi.
 
 ![Multiple program editing](/static/blog/microbit/2020-beta/multi-edit.gif)
 

--- a/docs/blog/microbit/2020-release.md
+++ b/docs/blog/microbit/2020-release.md
@@ -84,7 +84,7 @@ A last little feature we’ve added to help alleviate the hundreds of "Untitled"
 
 ### Multi-Edit
 
-So, you're creating radio programs for two micro:bits. One to send a message and another to receive a message. You have to make two projects seperately for both programs. Well, not anymore, now there's Multi-edit! Create, modify, and test out two programs at the same time. So awesome! Use the Multi-edit version of the editor at: https://makecode.com/multi.
+So, you're creating radio programs for two micro:bits. One to send a message and another to receive a message. You have to make two projects separately for both programs. Well, not anymore, now there's Multi-edit! Create, modify, and test out two programs at the same time. So awesome! Use the Multi-edit version of the editor at: https://makecode.com/multi.
 
 ![Multiple program editing](/static/blog/microbit/2020-beta/multi-edit.gif)
 

--- a/docs/blog/microbit/2023-release.md
+++ b/docs/blog/microbit/2023-release.md
@@ -52,7 +52,7 @@ We are cautiously starting to add more validation rules and auto-assessment capa
 
 There is a new extension available in the extension gallery called "audio-recording" which will allow you to record short audio clips and play them back. This extension will only work on the micro:bit v2.
 
-![Audio extenstion card](/static/blog/microbit/2023-release/audio-ext.png)
+![Audio extension card](/static/blog/microbit/2023-release/audio-ext.png)
 
 ![New audio blocks](/static/blog/microbit/2023-release/audio-blocks.png)
 

--- a/docs/blog/microbit/csintro-educator.md
+++ b/docs/blog/microbit/csintro-educator.md
@@ -18,7 +18,7 @@ So, we decided to supplement the curriculum by providing some additional Educato
 
 ## New educator materials
 
-The new materials are designed to allow educators to deliver a Computer Science curriculum to students in a structured format that introduces them to new concepts with engaging activites and projects. In addtion to the individual lesson materials, there are course guides, overviews, and assessment guides help the teacher along in presenting the course.
+The new materials are designed to allow educators to deliver a Computer Science curriculum to students in a structured format that introduces them to new concepts with engaging activities and projects. In addition to the individual lesson materials, there are course guides, overviews, and assessment guides help the teacher along in presenting the course.
 
 These materials give the teacher who's new to the subject an already prepared lesson series which they can start to teach with right away. For educators that have wanted to introduce a Computer Science course into their classroom but have yet to develop the course material for one, use these materials and start teaching now!
 
@@ -30,13 +30,13 @@ Each lesson has classroom presentation slides that let you introduce students to
 
 ### Educator guides
 
-Every lesson has a complete guide to describe the lesson goals, activities, and indended outcomes.
+Every lesson has a complete guide to describe the lesson goals, activities, and intended outcomes.
 
 ![Example lesson page](/static/blog/microbit/csintro-educator/lesson-example.jpg)
 
 ### Student workbook
 
-The student workbook is for the student to follow. It sets the lesson goals and clearly describes the making and coding activites.
+The student workbook is for the student to follow. It sets the lesson goals and clearly describes the making and coding activities.
 
 ![Example student workbook page](/static/blog/microbit/csintro-educator/workbook-example.jpg)
 

--- a/docs/blog/microbit/microbit-V2.md
+++ b/docs/blog/microbit/microbit-V2.md
@@ -60,7 +60,7 @@ The following blocks support the microphone and the capacitive touch sensor on t
 
 * **On Logo Pressed** - this block detects when the capacitive touch sensor (the gold logo) is pressed.
 
-![on logo presed block](/static/blog/microbit/microbit-V2/on-logo-pressed.png)
+![on logo pressed block](/static/blog/microbit/microbit-V2/on-logo-pressed.png)
 
 * **Sound Level** - this block returns the current sound level that goes from 0 = silent, to 255 = very loud!
 

--- a/docs/blog/microbit/v0.9.77.md
+++ b/docs/blog/microbit/v0.9.77.md
@@ -12,7 +12,7 @@ https://youtu.be/Ah4fEbJtklU
 
 The [custom blocks feature](https://microbit.makecode.com/blocks/custom) allows to package JavaScript functions in a project 
 and surface them as blocks in the editor. A typical scenario is to bundled 
-some scafolding functions in a project and share it with students.
+some scaffolding functions in a project and share it with students.
 
 For example, the following JavaScript function
 

--- a/docs/blog/microbit/v1-beta.md
+++ b/docs/blog/microbit/v1-beta.md
@@ -43,7 +43,7 @@ If you want to bypass the home page, you can get to the editor directly at https
 
 ![If then else - block](/static/blog/microbit/v1-beta/if-then-else-block.png)
 
-* **Make a Variable** – based on feedback, we tried to make the process of creating variables much clearer. Now, you will explicitly click on the ``Make a Variable...`` button in the Toolbox to create a new variable with the name you want. The variable is then associated wtih the other blocks in the Variables drawer of the Toolbox.
+* **Make a Variable** – based on feedback, we tried to make the process of creating variables much clearer. Now, you will explicitly click on the ``Make a Variable...`` button in the Toolbox to create a new variable with the name you want. The variable is then associated with the other blocks in the Variables drawer of the Toolbox.
 
 ![Make a variable](/static/blog/microbit/v1-beta/make-variable.gif)
 

--- a/docs/blog/wonder-workshop/03-05-2018.md
+++ b/docs/blog/wonder-workshop/03-05-2018.md
@@ -57,7 +57,7 @@ As well as being our first robot, Cue was our first partner used primarily with 
 
 As with all MakeCode editors, you can toggle back and forth between editing your code in Blocks, or in JavaScript (and Wonder Workshop has added a super cool sound effect when you switch back and forth!). I was a bit worried about the coding experience on a tablet. However, with the JavaScript Toolbox code snippets that you can just touch to insert, and the on-screen keyboard improvements, it’s actually quite good.
 
-![Run blocks directy](/static/blog/wonder-workshop/03-05-2018/monaco-toolbox.jpg)
+![Run blocks directly](/static/blog/wonder-workshop/03-05-2018/monaco-toolbox.jpg)
 
 ## No Simulator – just Run!
 

--- a/docs/cli/checkdocs.md
+++ b/docs/cli/checkdocs.md
@@ -10,7 +10,7 @@ pxt checkdocs [--re foo]
 
 ## Description
 
-This commands scans the documentation and perfoms various validation steps:
+This commands scans the documentation and performs various validation steps:
 * checking for broken links,
 * compiling and decompiling code samples
 * ...

--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -8,7 +8,7 @@ Try out some blocks live in the **[Playground](https://makecode.com/playground)*
 
 ## ~
 
-Blocks are defined by annotations added to the beginning of an API element (export function, method, enum, etc.). Attributes are specified on annotation lines that begin with the comment form of `//%`. All of the `//%` annotations are found in TypeScript library files containg the code for the exposed APIs.
+Blocks are defined by annotations added to the beginning of an API element (export function, method, enum, etc.). Attributes are specified on annotation lines that begin with the comment form of `//%`. All of the `//%` annotations are found in TypeScript library files containing the code for the exposed APIs.
 They can optionally be [auto-generated](/simshim) from C++ library files or from TypeScript
 simulator files.
 
@@ -251,7 +251,7 @@ export function myFunction(myParam: Image[]): void {}
 
 ### Inline input
 
-Blocks with four or more parameters automatically switch to `External Inputs` mode, in which the parameters wrap instead of staying inline. To make a block with multiple parameters appear as a single line, use `inlineInputMode=inline`. The block will expand left to right instead of wrapping the parameter input across mulitple lines.
+Blocks with four or more parameters automatically switch to `External Inputs` mode, in which the parameters wrap instead of staying inline. To make a block with multiple parameters appear as a single line, use `inlineInputMode=inline`. The block will expand left to right instead of wrapping the parameter input across multiple lines.
 
 ```typescript-ignore
 //% block="map $value|from low $fromLow|high $fromHigh|to low $toLow|high $toHigh"
@@ -265,7 +265,7 @@ export function map(value: number,
 }
 ```
 
- To force external inputs, set `inlineInputMode=external`. In the block defintion, the `|` indicates where to start a new line if the block is in external inputs mode. New lines are also started after each parameter.
+ To force external inputs, set `inlineInputMode=external`. In the block definition, the `|` indicates where to start a new line if the block is in external inputs mode. New lines are also started after each parameter.
 
 ```typescript-ignore
 //% block="magnitude of 3d vector | at x $x and y $y and z $z"
@@ -457,7 +457,7 @@ parameter like so:
 
 ### Creating enumerations with blocks
 
-You can have blocks themselves define an enumeration dynamically. The block will specify some inital members but additional ones are added by selecting the "Add a new &lt;enum_name&gt;..." option in the parameter dropdown.
+You can have blocks themselves define an enumeration dynamically. The block will specify some initial members but additional ones are added by selecting the "Add a new &lt;enum_name&gt;..." option in the parameter dropdown.
 
 You first create a shadow block that defines the enumeration and has the initial members.
 
@@ -716,7 +716,7 @@ namespace Widgets {
     }
 
     /**
-     * Create a Gizmo widget and automtically set it to a variable
+     * Create a Gizmo widget and automatically set it to a variable
      */
     //% block="create gizmo"
     //% blockSetVariable=gizmo
@@ -762,7 +762,7 @@ class Gizmo {
 namespace Widgets {
 
     /**
-     * Create a Gizmo widget and automtically set it to a variable
+     * Create a Gizmo widget and automatically set it to a variable
      */
     //% block="create gizmo"
     //% blockSetVariable=gizmo

--- a/docs/develop/accessibility/accessibility-keyboard.md
+++ b/docs/develop/accessibility/accessibility-keyboard.md
@@ -4,7 +4,7 @@ Keyboard accessibility allows navigation to each element of interaction in the v
 
 ## Tab Index
 
-A ``Tab Index`` is a position in the tabbing navigation order of a document. In an enviroment where we read left-to-right, it should be possible to **navigate from left to right, from top to bottom** with the ``Tab`` key, and in the opposite direction using ``Shift + Tab``.
+A ``Tab Index`` is a position in the tabbing navigation order of a document. In an environment where we read left-to-right, it should be possible to **navigate from left to right, from top to bottom** with the ``Tab`` key, and in the opposite direction using ``Shift + Tab``.
 
 Here's an example of an HTML element with a tab index:
 
@@ -16,13 +16,13 @@ There are 3 ways to set the tab index attribute:
 
 * With a negative value (usually ``-1``). This means that the element isn't reachable by keyboard navigation. The element can still receive focus with the mouse.
 * Use a zero (``tabindex="0"``). This means that the element is reached by keyboard navigation in DOM order.
-* A positive value (greather than 0). This means that the element is reached in the order of 0 to the greatest N value. In other words, ``tabindex="0"`` is reached before ``tabindex="1"`` which is reached reach before ``tabindex="2"``, and so on.
+* A positive value (greater than 0). This means that the element is reached in the order of 0 to the greatest N value. In other words, ``tabindex="0"`` is reached before ``tabindex="1"`` which is reached reach before ``tabindex="2"``, and so on.
 
 The tab index is defined in HTML or JavaScript depending the page initialization scenario. We recommend using an HTML implementation when practical.
 
 ## Keyboard interaction
 
-Many elements respond to a mouse click. This is usually defined with the ``onClick`` attribute. If no additonal interaction is needed with a component, it is required that pressing the ``Enter`` or ``Space`` key has the same behavior to the ``onClick``.
+Many elements respond to a mouse click. This is usually defined with the ``onClick`` attribute. If no additional interaction is needed with a component, it is required that pressing the ``Enter`` or ``Space`` key has the same behavior to the ``onClick``.
 
 There are a helper methods to automate this action. Feel free to use them. In **React**, for example, the method is ``util.fireClickOnEnter``.
 You will also have to decide on which keyboard event to use: ``KeyDown``, ``KeyUp`` or ``KeyPress``. When possible, always use the ``KeyDown`` event as ``KeyPress`` has compatibility problems with Internet Explorer.

--- a/docs/develop/accessibility/accessibility-testing.md
+++ b/docs/develop/accessibility/accessibility-testing.md
@@ -52,7 +52,7 @@ The tree views use standard navigation. The user must be able to use the ``Right
 
 ### Drop down menu
 
-Dropdown menues are located at the top right hand-corner of the view. A menu must be opened when the focus is given to it's parent button and must be close if the user press ``Tab``, ``Shift + Tab`` or ``Escape``. When the menu is open, navigation through the options of the dropdown menu are with the ``Up`` and ``Down`` arrow keys. The navigation must not loop.
+Dropdown menus are located at the top right hand-corner of the view. A menu must be opened when the focus is given to it's parent button and must be close if the user press ``Tab``, ``Shift + Tab`` or ``Escape``. When the menu is open, navigation through the options of the dropdown menu are with the ``Up`` and ``Down`` arrow keys. The navigation must not loop.
 
 ![](/static/images/accessibility/accessibility-dropdown.gif)
 
@@ -96,7 +96,7 @@ Every interactive component must be announced during navigation:
 * Input (also, mentions the current value)
 * Search result (at least tells the total number of results)
 
-The way components are described is different from a one screen reader to another. Verify that all of them provide enough information to understand the purpose of the interactive component, its content, and its state (especially when disabled). Although it is assumend that the user already knows how to interact with a slider, a dropdown menu, or other component, verify that any additional usage information is provided by the screen reader.
+The way components are described is different from a one screen reader to another. Verify that all of them provide enough information to understand the purpose of the interactive component, its content, and its state (especially when disabled). Although it is assumed that the user already knows how to interact with a slider, a dropdown menu, or other component, verify that any additional usage information is provided by the screen reader.
 
 ## Testing high contrast
 

--- a/docs/extensions/asset-packs.md
+++ b/docs/extensions/asset-packs.md
@@ -1,6 +1,6 @@
 # Asset packs
 
-Certain editors (such as [MakeCode Arcade](https://arcade.makecode.com)) can include resource files inside of projects. The resources, or _assets_, might contain byte respresentations of images, animations, sounds, tilemaps, etc.
+Certain editors (such as [MakeCode Arcade](https://arcade.makecode.com)) can include resource files inside of projects. The resources, or _assets_, might contain byte representations of images, animations, sounds, tilemaps, etc.
 
 An extension containing assets may use them to support the code provided in the extension (custom buttons, animations, etc.). However, you can mark an extension to import only its assets and not include any of the code exported in the extension. This is useful as a way to package reusable assets and publish them for others to use in their projects.
 

--- a/docs/extensions/extensions.md
+++ b/docs/extensions/extensions.md
@@ -46,7 +46,7 @@ configuration section under ``packages.approvedEditorExtensions``.
 The editor and the editor extension &lt;iframe&gt; communicate using a protocol of IFrame messages. 
 
 * Messages have a unique ``id`` to correlate responses to requests.
-* A ``response`` message can be requested. The ``id`` identifer can be used to correlate a receive response to the original query.
+* A ``response`` message can be requested. The ``id`` identifier can be used to correlate a receive response to the original query.
 * All messages sent by the editor extension must contain the extension id, ``extId``. This identifier is passed when loading the &lt;iframe&gt; (see [Initialization](#initialization)).
 
 ```typescript-ignore
@@ -149,7 +149,7 @@ function receivedResponse(resp) {
 
 ### Read user code
 
-The ``extusercode`` message requests to read the entire set of files in the project. If successfull, the response contains a ``resp`` field with a map of the file names to file contents.
+The ``extusercode`` message requests to read the entire set of files in the project. If successful, the response contains a ``resp`` field with a map of the file names to file contents.
 
 ```typescript-ignore
 export interface UserCodeResponse extends ExtensionResponse {

--- a/docs/extensions/getting-started/objects-instances.md
+++ b/docs/extensions/getting-started/objects-instances.md
@@ -14,7 +14,7 @@ Now, it would be nice if the **pick** function was general enough to pick a frui
  */
 enum TropicalFruit {
     Banana = 0,
-    Pinapple = 1,
+    Pineapple = 1,
     Coconut = 2
 }
 
@@ -177,7 +177,7 @@ namespace tropic {
 
 ## Step 3: Defining blocks for banana methods
 
-In the blocks model, class methods aren't available, or don't show up, in the Toolbox until there's an actual object instance related to it. The [block definitions](/defining-blocks#objects-and-instance-methods) for the methods must "tag" them to an instance. Let's take the **peel** method as an example. We've inserted the ``%fruit`` parameter at the beginning of the `block` attribute. This is not a parameter for the method, but an association of the block to an instance variable initially called `fruit`. This will cause the **peel** block to be valid in the workspace as a method of `fruit` even if the value of `fruit` is stil `null` or `undefined`. You can think of it as a placeholder or a default instance name, but without it, the **peel** method has no context.
+In the blocks model, class methods aren't available, or don't show up, in the Toolbox until there's an actual object instance related to it. The [block definitions](/defining-blocks#objects-and-instance-methods) for the methods must "tag" them to an instance. Let's take the **peel** method as an example. We've inserted the ``%fruit`` parameter at the beginning of the `block` attribute. This is not a parameter for the method, but an association of the block to an instance variable initially called `fruit`. This will cause the **peel** block to be valid in the workspace as a method of `fruit` even if the value of `fruit` is still `null` or `undefined`. You can think of it as a placeholder or a default instance name, but without it, the **peel** method has no context.
 
 ```typescript-ignore
 /*
@@ -234,7 +234,7 @@ export class banana {
 
 So now, when a **ripen** block is placed onto the workspace, an instance is created by calling the `tropic.pickBanana()` function as an object factory for `fruit`.
 
-Add the `autoCreate` attribute as shown and restart the target. Delete any blocks in the workspace and pull out **ripen** as you did before. After swithing to JavaScript, you'll see that `fruit` is now set to an instance of `banana` rather than being just a variable declaration with a `null` value.
+Add the `autoCreate` attribute as shown and restart the target. Delete any blocks in the workspace and pull out **ripen** as you did before. After switching to JavaScript, you'll see that `fruit` is now set to an instance of `banana` rather than being just a variable declaration with a `null` value.
 
 ```typescript-ignore
 let fruit = tropic.pickBanana()

--- a/docs/extensions/getting-started/simple-extension.md
+++ b/docs/extensions/getting-started/simple-extension.md
@@ -21,7 +21,7 @@ Let's expand the `tropic` namespace and add some functions. If you're running a 
  */
 enum TropicalFruit {
     Banana = 0,
-    Pinapple = 1,
+    Pineapple = 1,
     Coconut = 2
 }
 
@@ -89,7 +89,7 @@ Make or copy a small picture and save it as an icon file in the `/docs/static/li
 
 ## Step 3: Include the block descriptions
 
-The namespace shows up as a toolbox category in the MakeCode editor. MakeCode uses metadata from the JsDoc in the namespace as attributes to determine the order in the toolbox where the category is placed, the catergory icon, and the category color. The metadata is added using `//%` with the `weight`, `icon`, and `color` attributes. Let's add these for `tropic`:
+The namespace shows up as a toolbox category in the MakeCode editor. MakeCode uses metadata from the JsDoc in the namespace as attributes to determine the order in the toolbox where the category is placed, the category icon, and the category color. The metadata is added using `//%` with the `weight`, `icon`, and `color` attributes. Let's add these for `tropic`:
 
 ```typescript-ignore
 /**
@@ -104,7 +104,7 @@ The attributes we've defined for our namespace mean:
 
 * **weight**: the relative order in which the category is placed in the Toolbox list (higher numbers movve the category up).
 * **icon**: a Unicode identifier for an icon from the [Font Awesome](http://fontawesome.io/icons) icon set.
-* **color**: the RGB color for the catergory item and blocks rendered from the namespace.
+* **color**: the RGB color for the category item and blocks rendered from the namespace.
 
 For the functions, we add the `blockId` and `block` attributes. This will make the block compiler create actual blocks for the functions. The functions will now show up as blocks under the `tropic` category in the toolbox too.
 
@@ -141,7 +141,7 @@ enum TropicalFruit {
     //% block=banana
     Banana = 0,
     //% block=pineapple
-    Pinapple = 1,
+    Pineapple = 1,
     //% block=coconut
     Coconut = 2
 }

--- a/docs/extensions/getting-started/sources.md
+++ b/docs/extensions/getting-started/sources.md
@@ -28,7 +28,7 @@ enum TropicalFruit {
     //% block=banana
     Banana = 0,
     //% block=pineapple
-    Pinapple = 1,
+    Pineapple = 1,
     //% block=coconut
     Coconut = 2
 }
@@ -164,7 +164,7 @@ The methods to pick, peel, and eat tropical fruit.
 
 ```cards
 tropic.pick(TropicalFruit.Coconut);
-tropic.peel(TropicalFruit.Cocount);
+tropic.peel(TropicalFruit.Coconut);
 ```
 
 ```package

--- a/docs/extensions/getting-started/vscode.md
+++ b/docs/extensions/getting-started/vscode.md
@@ -60,7 +60,7 @@ For a quick introduction on creating extensions, try the [simple extension](/ext
 
 ## Step 5: Testing
 
-In order to test your extension, you need to create a new project, and manually add a reference back to the extensin you've been developing.
+In order to test your extension, you need to create a new project, and manually add a reference back to the extension you've been developing.
 
 * Open the local editor and create a new project. For example, you might call it *Just Look At It*.
 * Open the project settings by clicking the gear (Gear -> ``Project Settings``)
@@ -90,7 +90,7 @@ git commit -a -m "Amazing flying bananas"
 pxt bump
 ```
 
-The `pxt bump` will make sure there are no uncommited changes, bump the version number,
+The `pxt bump` will make sure there are no uncommitted changes, bump the version number,
 create a git tag, and push everything to github.
 
 In the editor, paste the full URL to your repo after selecting `Settings -> Extensions`. Your extension should show up.

--- a/docs/extensions/github-docs.md
+++ b/docs/extensions/github-docs.md
@@ -231,7 +231,7 @@ The `my-extension-name` in the above snippet should match the name listed in the
 
 ## Step 5: Commit your changes and test
 
-Once you've commited your changes to master, you can test before pushing a release by creating a MakeCode project that points to a commit with your changes.
+Once you've committed your changes to master, you can test before pushing a release by creating a MakeCode project that points to a commit with your changes.
 
 1. In your github repo, copy the SHA hash for the commit that you want to test
 2. In MakeCode, create a new project
@@ -278,7 +278,7 @@ would become:
 }
 ```
 
-Once you've made these changes, switch back to `main.ts` and reload the page. Your project should now have the version of your extension from that commmit.
+Once you've made these changes, switch back to `main.ts` and reload the page. Your project should now have the version of your extension from that commit.
 
 ## Step 6: Create a release to push your changes
 
@@ -288,7 +288,7 @@ If you are working using the [makecode CLI](https://github.com/microsoft/pxt-mkc
 
 If you are working from within MakeCode, use the **Create Release** button that appears in the GitHub settings for your extension.
 
-Otherwise you can push a version manually by changing the version in `pxt.json` and pushin a new tag in your repo of the format `v0.0.0` (where `0.0.0` is replaced with the new version in `pxt.json`).
+Otherwise you can push a version manually by changing the version in `pxt.json` and push in a new tag in your repo of the format `v0.0.0` (where `0.0.0` is replaced with the new version in `pxt.json`).
 
 ## Localization
 

--- a/docs/extensions/naming-conventions.md
+++ b/docs/extensions/naming-conventions.md
@@ -1,6 +1,6 @@
 # Naming Conventions
 
-Naming conventions provide a consistant and expected style of usage across all namespaces used by MakeCode. This allows the coding user to make general assumptions about name forms used for functions, methods, properties, and enumerations. While writing code, a user can assume a certain order of name case and style for the names exposed by your extension. This eases the composition of code and saves the user from errors when they try to use a name as they might expect to.
+Naming conventions provide a consistent and expected style of usage across all namespaces used by MakeCode. This allows the coding user to make general assumptions about name forms used for functions, methods, properties, and enumerations. While writing code, a user can assume a certain order of name case and style for the names exposed by your extension. This eases the composition of code and saves the user from errors when they try to use a name as they might expect to.
 
 Although not enforced, these naming conventions help keep the blocks and functions in the MakeCode editor consistent. 
 As much as possible, please try to follow these conventions and consider exceptions only when absolutely necessary. Thank you for creating MakeCode extensions!

--- a/docs/extensions/versioning.md
+++ b/docs/extensions/versioning.md
@@ -38,11 +38,11 @@ git push --tags
 
 ## Resolving incompatible versions
 
-If an extension version used by a project isn't current, errors might occur when the editor trys to load the project. Extension versions used by the project may be incompatible with the current editor. If errors occur in an extension when the editor trys to load a project, the user is prompted to have the edtior attempt an action to try and resolve them. These actions are:
+If an extension version used by a project isn't current, errors might occur when the editor tries to load the project. Extension versions used by the project may be incompatible with the current editor. If errors occur in an extension when the editor tries to load a project, the user is prompted to have the editor attempt an action to try and resolve them. These actions are:
 
-1. **Try to fix**: The extentions used by the project are upgraded to their current versions and the editor attempts to reload the project. If any errors are found again, the user is prompted to try a load action again but can only choose from options **2** or **3**.
+1. **Try to fix**: The extensions used by the project are upgraded to their current versions and the editor attempts to reload the project. If any errors are found again, the user is prompted to try a load action again but can only choose from options **2** or **3**.
 
-2. **Ignore errors and load**: The project and its extensions are loaded anyway. The user must resolve any incompatibilty problems with the project and extensions.
+2. **Ignore errors and load**: The project and its extensions are loaded anyway. The user must resolve any incompatibility problems with the project and extensions.
 
 3. **Go to the old editor**: This option only appears if the project was created in a previous version of the editor and if the editor is in a web browser. With this action, the project is loaded with an older editor version that matches the project version. This will restore the conditions of the editor environment that existed when the project was last saved.
 

--- a/docs/github-teacher-verification.md
+++ b/docs/github-teacher-verification.md
@@ -19,9 +19,9 @@ Go to https://github.com/signup and use your educator email account.
 
 ### 1. Verify your account
 
-After creating your account, you will see a prompt to verify yourself as an Educator. Continue the verification and select “Apply for your GitHub teacher benefits”. 
+After creating your account, you will see a prompt to verify yourself as an Educator. Continue the verification and select "Apply for your GitHub teacher benefits". 
 
-Alternatively, you can verify your account and bypass the benifits selection at: https://education.github.com/discount_requests/teacher_application.
+Alternatively, you can verify your account and bypass the benefits selection at: https://education.github.com/discount_requests/teacher_application.
 
 ![Apply for teacher benefits](/static/github-teacher/teacher-benefits-signup.png)
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,6 +1,6 @@
 # Python in MakeCode
 
-Our Python support is called **MakeCode Python**. As with TypeScript, the Python implementation is a subset of the full Python languange.
+Our Python support is called **MakeCode Python**. As with TypeScript, the Python implementation is a subset of the full Python language.
 
 The TypeScript implementation in MakeCode is called Static TypeScript (STS) and similarly, MakeCode Python is often referred to as Static Python (SPY).
 
@@ -33,7 +33,7 @@ Some of the common value types for variables are numeric, boolean, and string.
 ```python
 cards = 52
 finished = False
-month = "Febraury"
+month = "February"
 ```
 
 Expressions are formed using values of these types along with associated operators:
@@ -105,7 +105,7 @@ showArea(32)
 
 ### Code translation
 
-Python support in MakeCode works by converting SPY source code into Static Typscript (STS) and vice versa.
+Python support in MakeCode works by converting SPY source code into Static Typescript (STS) and vice versa.
 The translation is mostly 1:1 (that is for every statement of STS you usually get
 one statement of SPY and vice versa).
 The code generated in both directions is meant to be human readable.

--- a/docs/static/playground/samples/README.md
+++ b/docs/static/playground/samples/README.md
@@ -15,7 +15,7 @@ The samples are held in the `PLAY_SAMPLES[]` array. You set the name, category, 
 The entry attributes for the sample are:
 
 * **chapter**: the category for the sample
-* **name**: the sample's name which shows in the the selction dropdown list
+* **name**: the sample's name which shows in the the selection dropdown list
 * **id**: selection id (`<option value/>`) for the sample dropdown list
 * **path**: the path to the sample - `sample` or `category/sample`
 

--- a/docs/streamer/docs.md
+++ b/docs/streamer/docs.md
@@ -10,7 +10,7 @@ https://youtu.be/P59Q0i6Zkrg
 
 ## Why Streamer?
 
-"Streaming" is a very popular activity these days where gamers "stream" their gameplay on Twitch.tv and Mixer. Popular streams may have tens of thousands (or more) viewers watching them play. However, they are not just broadcasting; they are also interacting with their audience in various ways. The interaction between the live audience and the artist is one of the reasons streaming is so successul.
+"Streaming" is a very popular activity these days where gamers "stream" their gameplay on Twitch.tv and Mixer. Popular streams may have tens of thousands (or more) viewers watching them play. However, they are not just broadcasting; they are also interacting with their audience in various ways. The interaction between the live audience and the artist is one of the reasons streaming is so successful.
 
 Talented streamers have a sophisticated live production environment to remix their webcams, game streams, sounds and live chat. Viewers can triggers events by making donation, vote for outcome of the game, etc...
 
@@ -54,7 +54,7 @@ As part of a returning an assignment, a student could record video "walking" thr
 
 ### Live streaming on Twitch or Mixer
 
-Streamer simplifies the setup of scenes in your streaming software, you only have one scene :) You can definitely integrate Streamer in your exisiting OBS/StreamLabs/...
+Streamer simplifies the setup of scenes in your streaming software, you only have one scene :) You can definitely integrate Streamer in your existing OBS/StreamLabs/...
 
 ## How to use Streamer?
 
@@ -76,7 +76,7 @@ The camera feed maybe be rotated backwards, this is quite common when using a do
 
 ### Green screen
 
-A green screen is a way to minimize the oclusion of your webcam over the code editor. Any green screen drapped placed behind you will work, make sure it is well lighted.
+A green screen is a way to minimize the occlusion of your webcam over the code editor. Any green screen draped placed behind you will work, make sure it is well lighted.
 
 ### Paint tools
 
@@ -109,7 +109,7 @@ Then measure the time between the clap sound and the video. That's your offset!
 
 ### File format
 
-Streamer will save your recording as a ".webm" file with the "h264" codec. .webm files can be uploaded to YouTube or viewed in Chrome or Edge but some popular video editting tools don't support this, like iMovie. One way to get around this is to convert it into a more standard format like .mp4. To do this, we recommend using a popular command line tool called "ffmpeg". 
+Streamer will save your recording as a ".webm" file with the "h264" codec. .webm files can be uploaded to YouTube or viewed in Chrome or Edge but some popular video editing tools don't support this, like iMovie. One way to get around this is to convert it into a more standard format like .mp4. To do this, we recommend using a popular command line tool called "ffmpeg". 
 
 #### Installing ffmpeg
 
@@ -144,5 +144,5 @@ You can specify the title, subtitle, video subtitles and various other places. Y
 
 The introduction video will automatically run once when transitioning from the countdown scene to any other view. This is typically a branding video.
 
-The ending video will automatically run when transition from the any sence to the countdown scene. This is the time to wrap up your demo and eventually
+The ending video will automatically run when transitioning from the any sense to the countdown scene. This is the time to wrap up your demo and eventually
 stop the recording.

--- a/docs/targets/pxtarget.md
+++ b/docs/targets/pxtarget.md
@@ -286,7 +286,7 @@ PXT expects to find the C/C++ sources on github.
 
 ### ``uploadDocs`` and ``uploadApiStringsBranchRx``
 
-The ``uploadDocs`` flag determins if the API strings and docs have to be uploaded
+The ``uploadDocs`` flag determines if the API strings and docs have to be uploaded
 to crowdin when a build occurs on master or release branches.
 
 The ``uploadApiStringsBranchRx`` flag provide a custom regex

--- a/docs/td2mkcd.md
+++ b/docs/td2mkcd.md
@@ -17,7 +17,7 @@ to store and retrieve your scripts:
 - use the **Share** link on the upper left of the MakeCode editor to obtain
   an anonymized URL that you can use to later retrieve your encrypted script
   from the cloud; do not lose this URL, as it is the only way to retrieve
-  your (unecrypted) script text
+  your (unencrypted) script text
 
 ## Editors and Languages
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -87,7 +87,7 @@ Block | blocks used, search, collapse, expand, delete, format, screenshot,help, 
 Editor tools| Rename, download, save, undo, zoomIn, zoomOut, startStopSimulator, restart, trace, toggleCollapse
 Menu | Javascript tab, Blocks tab, open, add package, reset, report abuse, gettingstarted, about, high contrast etc
 Typescript | keep text, discard text, toolbox click, item click, item drag
-Projects | new porject, rename, import, import url, tutorials
+Projects | new project, rename, import, import url, tutorials
 Simulator | Start, stop, restart, fullscreen, screen, mute, make, screenshot
 Hex files | import success\failure,
 Share | publish, facebook, twitter

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -15,7 +15,7 @@ Create a checklist of rules to evaluate student projects. Use AI prompts to get 
 
 ![A screenshot of the GitHub Explorer page](/static/tools/github-explorer.png)
 
-Browse all your GitHub projects accross all MakeCode editors in a single place.
+Browse all your GitHub projects across all MakeCode editors in a single place.
 
 ## [Playground](/playground)
 

--- a/docs/translate.md
+++ b/docs/translate.md
@@ -16,7 +16,7 @@ If you want to help with translating the MakeCode project, please sign in to Cro
 
 #### Sign up to translate
 
-For a quick explaination of how to sign up and join a MakeCode translation team, watch this
+For a quick explanation of how to sign up and join a MakeCode translation team, watch this
 short video:
 
 https://youtu.be/4PqWq50e8C4

--- a/docs/translate/files.md
+++ b/docs/translate/files.md
@@ -47,9 +47,9 @@ The block strings can include syntax characters and tokens as well as the text t
 
 All of the documentation pages are translated. These pages are written in [markdown](https://daringfireball.net/projects/markdown/) and are copied up to Crowdin verbatim, no processing or text extraction. So, in the file folder tree you will see files with names that end with ``.md`` meaning that they are markdown files. The markdown pages support documentation for how-to pages, maker projects, lessons, coding courses, and code block reference...just to name a few.
 
-In MakeCode, there are a few extensions to "standard" markdown to provide addtional style information for page rendering on the document server. These are for adding hint boxes, inserting code blocs directly into pages, highlighting block names, embedding simulation blocks, macros, and other features. These are described in the [writing docs](/writing-docs) section.
+In MakeCode, there are a few extensions to "standard" markdown to provide additional style information for page rendering on the document server. These are for adding hint boxes, inserting code blocs directly into pages, highlighting block names, embedding simulation blocks, macros, and other features. These are described in the [writing docs](/writing-docs) section.
 
-You can freely translate the content in these files as appropriate for the language context. However, be aware of any MakeCode style and block extensions to the common markdown and avoid incorrecly translating those.
+You can freely translate the content in these files as appropriate for the language context. However, be aware of any MakeCode style and block extensions to the common markdown and avoid incorrectly translating those.
 
 In this example, a reference page for the **show animation** block is translated. Notice that the code blocks, code parameter names, and hint style specifiers are left untranslated. Only the descriptive content for the page is translated.
 

--- a/docs/translate/in-context.md
+++ b/docs/translate/in-context.md
@@ -44,5 +44,5 @@ You will be prompted with a dialog that contains the block translatable string.
 
 ## Documentation page translation
 
-When on any documention page, click on the **Language** button
+When on any documentation page, click on the **Language** button
 in the footer and then select **Translate this page** in the dialog.

--- a/docs/translate/markdown.md
+++ b/docs/translate/markdown.md
@@ -28,7 +28,7 @@ Code highlights help to ephasize text that represents a block in the editor Tool
 <0>||basic:show number||</0>
 ```
 
-The `<0>` and `<0/>` are mardown escape codes and you leave them as is, at the same place in the string. The `||` are delimiters for this highlight extension and those are left alone too. The portion of it to the left of the `:`, which is `basic`, is the blocks category and it stays untranslated. The rest of it, `show number` relates to the block text and it does get translated. Typically, this will translate to the same text as the blocks in the `jsdoc` files.
+The `<0>` and `<0/>` are markdown escape codes and you leave them as is, at the same place in the string. The `||` are delimiters for this highlight extension and those are left alone too. The portion of it to the left of the `:`, which is `basic`, is the blocks category and it stays untranslated. The rest of it, `show number` relates to the block text and it does get translated. Typically, this will translate to the same text as the blocks in the `jsdoc` files.
 
 ### Avatar sections
 

--- a/docs/writing-docs/skillmaps.md
+++ b/docs/writing-docs/skillmaps.md
@@ -1,6 +1,6 @@
 # Skillmaps
 
-A skillmap is is one or more guided pathways with focused learning objectives along the way. The goal of a skillmap is to have students progrerssively aquire a set of design and coding skills until they reach an achievement goal.
+A skillmap is is one or more guided pathways with focused learning objectives along the way. The goal of a skillmap is to have students progressively acquire a set of design and coding skills until they reach an achievement goal.
 
 ### ~ reminder
 

--- a/docs/writing-docs/snippets.md
+++ b/docs/writing-docs/snippets.md
@@ -63,7 +63,7 @@ basic.showString("HELLO!")
 
 ### highlight
 
-When used in snippets, the renderer will higlight the next line of code or block following a comment containing
+When used in snippets, the renderer will highlight the next line of code or block following a comment containing
 **@highlight**. Use `// @highlight` in blocks and TypeScript, and `# @highlight`
 in Python.
 
@@ -232,7 +232,7 @@ run the snippet in the same page.
 
 ### ghost (tutorials only)
 
-The **ghost** snippet will have addtional blocks to appear in the Toolbox during
+The **ghost** snippet will have additional blocks to appear in the Toolbox during
 a tutorial step. This is used to provide additional block choices other than
 those exactly matching the code snippet in a **blocks** section. The **ghost** blocks
 don't render any code but serve to identify other blocks to add into the Toolbox choices.
@@ -278,7 +278,7 @@ the code in the snippet. This let's you use a snippet for descriptive purposes b
 have it excluded from any validation checks.
 
     ```typescript-ignore
-    // You can include illegal TS in here, e.g. to showcase concepts/psuedocode
+    // You can include illegal TS in here, e.g. to showcase concepts/pseudocode
     for (initialization; check; update) {
         ...
     }
@@ -361,7 +361,7 @@ page for more.
 
 ### ~ hint
 
-#### jres resoures
+#### jres resources
 
 The older `jres` format was previously used to include tile resources. Although older files with `jres` snippets will
 still render, the `assetjson` is the preferred resource format.

--- a/docs/writing-docs/tutorials/activities.md
+++ b/docs/writing-docs/tutorials/activities.md
@@ -2,9 +2,9 @@
 
 Rather than have multiple tutorials for related activities, a tutorial can use the _activity_ format to progress to further activities in the same tutorial. Activities each have their own set of steps to complete.
 
-## Enable activites
+## Enable activities
 
-To have the tutorial engine interpert the sections in the tutorial as activities with steps, use the **@activities** metadata option at the top of the page.
+To have the tutorial engine interpret the sections in the tutorial as activities with steps, use the **@activities** metadata option at the top of the page.
 
 ```
 ### @activities 1
@@ -59,7 +59,7 @@ The activity tutorial structure uses a two-level layout - activity and steps, ne
 
 ### Title
 
-In an activity style tutorial, the title can appear in a psuedo-activity that serves as an introduction. The title is also displayed in the tutorial control bar.
+In an activity style tutorial, the title can appear in a pseudo-activity that serves as an introduction. The title is also displayed in the tutorial control bar.
 
 ```markdown
 ### @activities true

--- a/docs/writing-docs/tutorials/multi-lang.md
+++ b/docs/writing-docs/tutorials/multi-lang.md
@@ -1,6 +1,6 @@
 # Multiple languages
 
-In addtion to Block-based tutorials, MakeCode supports tutorials for JavaScript and Python.
+In addition to Block-based tutorials, MakeCode supports tutorials for JavaScript and Python.
 
 ## Using JavaScript
 

--- a/docs/writing-docs/tutorials/resources.md
+++ b/docs/writing-docs/tutorials/resources.md
@@ -20,7 +20,7 @@ Resource sections use the ```` ```jres```` markdown tag and the objects are cont
 
 ### Tiles and tilemaps
 
-The most common use of ```` ```jres```` resourses is for tiles, tilemaps, or maybe some built-in images for game programs. These can be created in the MakeCode editor and then copied directly from the ``.jres`` project files.
+The most common use of ```` ```jres```` resources is for tiles, tilemaps, or maybe some built-in images for game programs. These can be created in the MakeCode editor and then copied directly from the ``.jres`` project files.
 
 Here's an example tilemap extracted from a [MakeCode Arcade](https://arcade.makecode.com) ``.jres`` file:
 

--- a/docs/writing-docs/user-tutorials.md
+++ b/docs/writing-docs/user-tutorials.md
@@ -44,7 +44,7 @@ The dependencies for a shared tutorial project are used when the tutorial starts
 
 MakeCode uses a local caching policy for tutorials to reduce interaction with website services. On first use, tutorial content is retrieved from a MakeCode website and then reused from the local cache when a tutorial is run another time. A requested tutorial will refresh from the website when its cache retention period expires.
 
-This caching policy can present a problem if you're developing a tutorial and want to review the recent changes. When you run the tutorial to check your changes, they might not appear and you only see content you viewed the first time. In order to see and test new changes you've published for your tutorial, it's recommended that you view them in a **new anonyomous / incognito** browser window.
+This caching policy can present a problem if you're developing a tutorial and want to review the recent changes. When you run the tutorial to check your changes, they might not appear and you only see content you viewed the first time. In order to see and test new changes you've published for your tutorial, it's recommended that you view them in a **new anonymous / incognito** browser window.
 
 ### ~
 
@@ -91,7 +91,7 @@ Click on the ``lab`` icon in the **Explorer** view to open any markdown file (``
 
 #### Cloud caching
 
-To increase performance, the MakeCode websites may "cloud cache" the release version of a previously used extension and tutorials hosted in a user GitHub repository. This means that if you commit changes to a tutorial you have in a repostory, those updates might not appear when you try to test the tutorial in MakeCode. The MakeCode cloud cache will not reflect your changes until you **create a new release version** for your repository. Making a new release will force the cache to clear the prior version and refresh to the new version the next time it's requested. See [GitHub releases](https://arcade.makecode.com/github/release) for more about creating a versioned release.
+To increase performance, the MakeCode websites may "cloud cache" the release version of a previously used extension and tutorials hosted in a user GitHub repository. This means that if you commit changes to a tutorial you have in a repository, those updates might not appear when you try to test the tutorial in MakeCode. The MakeCode cloud cache will not reflect your changes until you **create a new release version** for your repository. Making a new release will force the cache to clear the prior version and refresh to the new version the next time it's requested. See [GitHub releases](https://arcade.makecode.com/github/release) for more about creating a versioned release.
 
 Again, to be clear, you need to make the release through the [Github integration](https://makecode.com/extensions/github-authoring) on the MakeCode website. Making a release directly on github.com does _not_ force the cache to clear.
 


### PR DESCRIPTION
Inspired by previous shaming contributions. Ran a spell check on the `./docs` markdown files to reveal spelling errors. Here's a set of "de-shamed" files.