### PR TITLE
Spelling fixes for markdown pages in the './common-docs' tree

### DIFF
--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -90,7 +90,7 @@ export interface RenderBlocksRequestMessage extends SimulatorMessage {
 }
 ```
 
-* ``id``: The identifer of the snippet element. This is used to match the document element of the snippet with the rendered blocks returned later.
+* ``id``: The identifier of the snippet element. This is used to match the document element of the snippet with the rendered blocks returned later.
 * ``code``: The text of the code snippet to send, compile, and render. The snippet may be JavaScript or the Blockly XML payload.
 * ``packageId``: the identifier of a project shared in the editor (without the ``https://makecode.com/`` prefix)
 
@@ -113,7 +113,7 @@ export interface RenderBlocksResponseMessage extends SimulatorMessage {
 }
 ```
 
-* ``id``: The identifer of the snippet element. This is used to replace the document element of the snippet with the rendered blocks or to associate the rendered blocks if the snippet is to be retained in the document.
+* ``id``: The identifier of the snippet element. This is used to replace the document element of the snippet with the rendered blocks or to associate the rendered blocks if the snippet is to be retained in the document.
 * ``svg``: The SVG image element.
 * ``uri``: The data source of the blocks image.
 * ``width``: The width of the SVG blocks image.

--- a/common-docs/github/commit.md
+++ b/common-docs/github/commit.md
@@ -12,7 +12,7 @@ If the changes look correct, click on **commit & push changes** to create a **co
 
 ## Review & revert
 
-It's good practice to **review** your **local** changes before commiting; just like you review your answer sheet before turning in a test. If you find some changes that are incorrect, you can decide to fix them right away, **revert** the entire file, or even just **commit** them so you can make any fixes later.
+It's good practice to **review** your **local** changes before committing; just like you review your answer sheet before turning in a test. If you find some changes that are incorrect, you can decide to fix them right away, **revert** the entire file, or even just **commit** them so you can make any fixes later.
 
 ## See Also
 

--- a/common-docs/github/private-assignments.md
+++ b/common-docs/github/private-assignments.md
@@ -12,7 +12,7 @@ This collaboration method is quite similar to the way professional developers us
 #### Public repositories
 
 Using **public** repositories simplifies a lot the configuration phase for the assignments.
-If it is acceptable for the code to be publically available on [GitHub](https://github.com), 
+If it is acceptable for the code to be publicly available on [GitHub](https://github.com), 
 we recommend using the [public assignments](/github/public-assignments).
 
 ### ~

--- a/common-docs/github/test-extension.md
+++ b/common-docs/github/test-extension.md
@@ -1,6 +1,6 @@
 # Testing an Extension
 
-Both the extension and a test project are open in separate editor tabs in the browser. You can work on both simultanously as you add and modify your extension code. As you switch between them, each will reload automatically.
+Both the extension and a test project are open in separate editor tabs in the browser. You can work on both simultaneously as you add and modify your extension code. As you switch between them, each will reload automatically.
 
 ## API Tests
 

--- a/common-docs/online-learning.md
+++ b/common-docs/online-learning.md
@@ -16,7 +16,7 @@ https://youtu.be/oBarPukXXXQ
 
 ## [Google Classroom](https://classroom.google.com) #googleclassroom
 
-You can use shared urls or download files from the MakeCode editor to create assigments in Google Classroom. See the tutorial video below.
+You can use shared urls or download files from the MakeCode editor to create assignments in Google Classroom. See the tutorial video below.
 
 ### #youtubegoogleclassroom
 
@@ -24,7 +24,7 @@ https://youtu.be/vDISKdJ3ynA
 
 ## [Canvas](https://www.canvas.net/) #canvas
 
-You can use shared urls or download files from the MakeCode editor to create assigments in Canvas. See the tutorial video below.
+You can use shared urls or download files from the MakeCode editor to create assignments in Canvas. See the tutorial video below.
 
 ### #youtubecanvas
 

--- a/common-docs/reference/arrays/pick-random.md
+++ b/common-docs/reference/arrays/pick-random.md
@@ -23,7 +23,7 @@ let item = list[Math.randomRange(0, list.length - 1)]
 
 ## Returns
 
-* An item from the array that is ramdomly selected.
+* An item from the array that is randomly selected.
 
 ## Example #example
 

--- a/common-docs/reference/text/char-code-at.md
+++ b/common-docs/reference/text/char-code-at.md
@@ -6,7 +6,7 @@ Get the code for a character (letter, number, or symbol) from a place in a text 
 "".charCodeAt(0)
 ```
 
-Like the position of a character in the an alphabet, or the traditional order of characters in a language, characters are assigned a code in a character set when used with computers. If a character set used only the 5 characters of "ABCDE", then 'A', as the first character, would have a character code of `0` and 'D' would have a charcter code of `3`.
+Like the position of a character in the an alphabet, or the traditional order of characters in a language, characters are assigned a code in a character set when used with computers. If a character set used only the 5 characters of "ABCDE", then 'A', as the first character, would have a character code of `0` and 'D' would have a character code of `3`.
 
 You can find the code of a character in a text string by selecting it from it's position in a string.
 

--- a/common-docs/share.md
+++ b/common-docs/share.md
@@ -14,7 +14,7 @@ Give your project a Title and optionally, you can create a thumbnail image or an
 
 Clicking "Share Project" will create a link to your project.
 
-![Share project anonomously](/static/share/anon-share-link.png)
+![Share project anonymously](/static/share/anon-share-link.png)
 
 This link is not published anywhere else and it is not tied to a specific user (it’s an "anonymous link"). If you lose the link, then there’s no way to get it back - you will have to share your project again to create a new link. These links are snapshots in time of a project, so if you make any subsequent changes to your project, you will have to Share your project again to create a new link with the changes. There is also no way to remove or "unpublish" an anonymous share link, except through the "Report Abuse" function (see below for more information).
 
@@ -58,7 +58,7 @@ By default, all shared projects in MakeCode can be copied and edited. There is n
 
 ## Asset Packs #asset-packs
 
-Certain editors (such as [MakeCode Arcade](https://arcade.makecode.com)) can include resource files inside of projects. The resources, or _assets_, might contain byte respresentations of images, animations, sounds, tilemaps, etc. An **Asset Pack** is a resource only project where just the assets are shared and no code is loaded from the shared project.
+Certain editors (such as [MakeCode Arcade](https://arcade.makecode.com)) can include resource files inside of projects. The resources, or _assets_, might contain byte representations of images, animations, sounds, tilemaps, etc. An **Asset Pack** is a resource only project where just the assets are shared and no code is loaded from the shared project.
 
 If this feature is supported by your editor, you can set a project as an asset pack by going to the **Settings** (⚙️) menu and selecting 'Project Settings'. Enable the 'Import as asset pack' setting. Watch this video to see how it's done:
 

--- a/common-docs/types/function/define.md
+++ b/common-docs/types/function/define.md
@@ -80,7 +80,7 @@ function addStrings(stringA: string, stringB: string, first: boolean) {
 
 #### Pull down the parameter
 
-In blocks, you can pull a parmeter from the function block and drag it down and place it as a variable in the code inside the function.
+In blocks, you can pull a parameter from the function block and drag it down and place it as a variable in the code inside the function.
 
 Pull the ``||variables:message||`` parameter from the **repeat** function.
 


### PR DESCRIPTION
Inspired by previous shaming contributions. Ran a spell check on the `./common-docs` markdown files to reveal spelling errors. Here's a set of "de-shamed" files.

RE: #11572