### PR TITLE
fix monaco editor scrolling when 8 million extensions

### DIFF
--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -19,6 +19,8 @@
 
 .monacoToolboxDiv {
     height: 100%;
+    /* Prevent large category lists from expanding the page scroll bounds. */
+    contain: paint;
 }
 
 .monacoEditorRightArea {


### PR DESCRIPTION
fix 
<img width="1919" height="904" alt="image" src="https://github.com/user-attachments/assets/b9387bab-6a9e-44c3-ad2a-3d71dff080cc" />

repro, just add a ton of extensions (like 30 or so good start) then see editor window expand.

build https://arcade.makecode.com/app/2ade25db765faff2d9d539aa0b3966ea9af3d7a2-aba2cb9c3f

context (i didn't specifically ask if i can share game publicly as repro so don't out it) https://forum.makecode.com/t/bug-js-editor-goes-off-screen-new-update-version/45634/11