### PR TITLE
fix a few places where master branch is hard coded

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -250,8 +250,27 @@ namespace pxt.github {
 
         async loadConfigAsync(repopath: string, tag: string): Promise<pxt.PackageConfig> {
             if (!tag) {
-                pxt.debug(`dep: default to master branch`)
-                tag = "master";
+                pxt.debug(`dep: no tag specified, try master and main`);
+                let res: pxt.PackageConfig;
+                let error: any;
+                try {
+                    res = await this.loadConfigAsync(repopath, "master");
+                }
+                catch (e) {
+                    error = e;
+                    pxt.log(`Error loading default master config for ${repopath}: ${e.message}`);
+                }
+                if (res) return res;
+
+                try {
+                    res = await this.loadConfigAsync(repopath, "main");
+                }
+                catch (e) {
+                    error = e;
+                    pxt.log(`Error loading default main config for ${repopath}: ${e.message}`);
+                }
+                if (res) return res;
+                else throw error;
             }
 
             // cache lookup
@@ -288,8 +307,28 @@ namespace pxt.github {
 
         async loadPackageAsync(repopath: string, tag: string, fallbackPackageFiles?: pxt.Map<string>): Promise<CachedPackage> {
             if (!tag) {
-                pxt.debug(`load pkg: default to master branch`)
-                tag = "master";
+                pxt.debug(`load pkg: no tag specified, try master and main`);
+
+                let res: CachedPackage;
+                let error: any;
+                try {
+                    res = await this.loadPackageAsync(repopath, "master", fallbackPackageFiles);
+                }
+                catch (e) {
+                    error = e;
+                    pxt.log(`Error loading default master package for ${repopath}: ${e.message}`);
+                }
+                if (res) return res;
+
+                try {
+                    res = await this.loadPackageAsync(repopath, "main", fallbackPackageFiles);
+                }
+                catch (e) {
+                    error = e;
+                    pxt.log(`Error loading default main package for ${repopath}: ${e.message}`);
+                }
+                if (res) return res;
+                else throw error;
             }
 
             // try using github proxy first
@@ -626,14 +665,28 @@ namespace pxt.github {
         })
     }
 
-    export function getRefAsync(repopath: string, branch: string) {
-        branch = branch || "master";
-        return ghGetJsonAsync("https://api.github.com/repos/" + repopath + "/git/refs/heads/" + branch)
-            .then(resolveRefAsync)
-            .catch(err => {
-                if (err.statusCode == 404) return undefined;
-                else Promise.reject(err);
-            })
+    export async function getRefAsync(repopath: string, branch: string): Promise<string | undefined> {
+        if (!branch) {
+            // try master and main
+            let res = await getRefAsync(repopath, "master");
+            if (!res)
+                res = await getRefAsync(repopath, "main");
+            return res;
+        }
+
+        try {
+            const ref = await ghGetJsonAsync("https://api.github.com/repos/" + repopath + "/git/refs/heads/" + branch);
+            return resolveRefAsync(ref);
+        }
+        catch (e) {
+            pxt.debug(`Error fetching ref for ${repopath} branch ${branch}: ${e.message}`);
+            if (e.statusCode === 404) {
+                return undefined;
+            }
+            else {
+                throw e;
+            }
+        }
     }
 
     function generateNextRefName(res: RefsResult, pref: string): string {

--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -501,7 +501,7 @@ export function initGitHubDb() {
         async loadConfigAsync(repopath: string, tag: string): Promise<pxt.PackageConfig> {
             repopath = repopath.toLowerCase()
             // don't cache master
-            if (tag == "master")
+            if (tag === "master" || tag === "main")
                 return this.mem.loadConfigAsync(repopath, tag);
 
             const id =  this.configCacheKey(repopath, tag);
@@ -523,13 +523,34 @@ export function initGitHubDb() {
         }
 
         async loadPackageAsync(repopath: string, tag: string, fallbackPackageFiles?: pxt.Map<string>): Promise<pxt.github.CachedPackage> {
-            repopath = repopath.toLowerCase()
             if (!tag) {
-              pxt.debug(`dep: default to master`)
-              tag = "master"
+                pxt.debug(`dep: no tag specified, try master and main`)
+                let res: pxt.github.CachedPackage;
+                let error: any;
+
+                try {
+                    res = await this.loadPackageFromMemoryAsync(repopath, "master", fallbackPackageFiles);
+                }
+                catch (e) {
+                    error = e;
+                }
+
+                if (res) return res;
+
+                try {
+                    res = await this.loadPackageFromMemoryAsync(repopath, "main", fallbackPackageFiles);
+                }
+                catch (e) {
+                    error = e;
+                }
+
+                if (res) return res;
+                throw error;
             }
+            repopath = repopath.toLowerCase()
+
             // don't cache master
-            if (tag == "master")
+            if (tag === "master" || tag === "main")
                 return this.loadPackageFromMemoryAsync(repopath, tag, fallbackPackageFiles);
 
             const id = this.packageCacheKey(repopath, tag);

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -965,7 +965,7 @@ data.mountVirtualApi("pkg-git-pr", {
         const ghid = f.getPkgId() == "this" && header && header.githubId;
         if (!ghid) return Promise.resolve(missing);
         const parsed = pxt.github.parseRepoId(ghid);
-        if (!parsed || !parsed.tag || parsed.tag == "master") return Promise.resolve(missing);
+        if (!parsed || !parsed.tag || parsed.tag == "master" || parsed.tag == "main") return Promise.resolve(missing);
         return pxt.github.findPRNumberforBranchAsync(parsed.fullName, parsed.tag)
             .catch(e => missing);
     },

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1113,7 +1113,7 @@ export async function commitAsync(hd: Header, options: CommitOptions = {}) {
     // add compiled javascript to be run in github pages
     if (pxt.appTarget.appTheme.githubCompiledJs
         && options.binaryJs
-        && (!parsed.tag || parsed.tag == "master")) {
+        && (!parsed.tag || parsed.tag == "master" || parsed.tag == "main")) {
         const v = cfg.version || "0.0.0";
         const opts: compiler.CompileOptions = {
             jsMetaVersion: v
@@ -1658,6 +1658,7 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
 
 export async function importGithubAsync(id: string): Promise<Header> {
     // if tag is not specified, asssume master
+    // FIXME: should handle the case where default branch is main
     const repoid = pxt.github.normalizeRepoId(id, "master").replace(/^github:/, "")
     const parsed = pxt.github.parseRepoId(repoid)
 


### PR DESCRIPTION
trying to fix the minecraft build, which is failing because the roller coaster extension doesn't have a master branch (it uses main).

i did a ctrl-shift-f for "master" in our codebase and tried to fix all the places where it's referenced so that we also support main. one place i didn't fix was importing a github repo, as that seemed to be working fine for me and it was an annoying refactor to do.