### PR TITLE
correct default values for dynamic dispatch

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -38,6 +38,8 @@ out to your editor soon!
 
 * variable declarations with `let`, `const`
 * functions with lexical scoping and recursion
+* default parameter initializers, evaluated in the called TypeScript function
+  when an argument is omitted or `undefined`, including on virtual/interface calls
 * top-level code in the file; hello world really is `console.log("Hello world")`
 * `if ... else if ... else` statements
 * `while` and `do ... while` loops
@@ -283,8 +285,6 @@ There are following differences currently, which should be fixed soon.
 They are mostly missing bridges between static, nominally typed classes,
 and dynamic maps.
 
-* default parameters are resolved at call site; they should be resolved in the
-  called method so eg. virtual methods can have different defaults
 * `x.foo`, where `x` is class and `foo` is method cannot be currently used as a value;
   we could make it equivalent to JavaScript's `x.foo.bind(x)`
 * `Object.keys()` is currently not implemented for classes; when it will be

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -2364,10 +2364,14 @@ ${lbl}: .short 0xffff
                             }
                             args.push(irToNode(expr))
                         } else {
-                            if (!opts.unfetteredInitializers && !isNumericLiteral(prm.initializer)) {
-                                userError(9212, lf("only numbers, null, true and false supported as default arguments"))
+                            // Emitted functions apply their own defaults, including on
+                            // virtual/interface calls where the implementation may differ.
+                            // Shims and helpers may have no emitted parameter prologue.
+                            const needsCallerDefault = attrs.helper || attrs.shim;
+                            if (needsCallerDefault && !opts.unfetteredInitializers && !isNumericLiteral(prm.initializer)) {
+                                userError(9212, lf("only numbers, null, true and false supported as default arguments for shims and helpers"))
                             }
-                            args.push(prm.initializer)
+                            args.push(needsCallerDefault ? prm.initializer : irToNode(emitLit(undefined)))
                         }
                     } else {
                         userError(9213, lf("unsupported default argument (shouldn't happen)"))
@@ -3155,13 +3159,9 @@ ${lbl}: .short 0xffff
                 }
             }
 
-            const destructuredParameters: ParameterDeclaration[] = []
             const fieldAssignmentParameters: ParameterDeclaration[] = []
 
             proc.args = getParameters(node).map((p, i) => {
-                if (p.name.kind === SK.ObjectBindingPattern) {
-                    destructuredParameters.push(p)
-                }
                 if (node.kind == SK.Constructor && isCtorField(p)) {
                     fieldAssignmentParameters.push(p)
                 }
@@ -3181,7 +3181,25 @@ ${lbl}: .short 0xffff
                 }
             })
 
-            destructuredParameters.forEach(dp => emitVariableDeclaration(dp))
+            // Arity wrappers pad omitted arguments with undefined. Keep defaults in
+            // the shared body so direct, virtual, interface and action calls all run
+            // them, including native entries which can skip the arity wrapper.
+            const attrs = parseComments(node);
+            proc.args.forEach(l => {
+                const parameter = l.def as ParameterDeclaration;
+                // Simulator shim dummies must match the native caller-side behavior.
+                if (parameter.initializer && !attrs.shim && !attrs.helper) {
+                    const supplied = proc.mkLabel("defaultarg");
+                    proc.emitJmpZ(supplied, ir.rtcall("pxt::eqq_bool", [l.load(), emitLit(undefined)]));
+                    proc.emitExpr(l.storeByRef(emitEscapedExpression(parameter.initializer, "initializer")));
+                    proc.emitLbl(supplied);
+                    proc.stackEmpty();
+                }
+                if (parameter.name.kind === SK.ObjectBindingPattern) {
+                    // Destructure the resolved argument, not the initializer again.
+                    emitVarOrParam(parameter, l.load(), typeOf(parameter));
+                }
+            })
 
             // for constructor(public foo:number) generate this.foo = foo;
             for (let p of fieldAssignmentParameters) {

--- a/tests/compile-test/lang-test0/56ifacedispatch.ts
+++ b/tests/compile-test/lang-test0/56ifacedispatch.ts
@@ -117,12 +117,8 @@ namespace IfaceDispatch {
 
     // --- optional and defaulted parameters through an interface ----------
     //
-    // The emitter fills in a defaulted argument at the call site from the
-    // statically known signature. Through an interface- or any-typed
-    // reference there is no such signature, so an omitted argument arrives as
-    // undefined and the callee's own default does not apply. What must hold
-    // is that the interface and any paths agree with each other, and that a
-    // callee written to test for undefined works on every path.
+    // Defaults are applied in the runtime callee, so omitted arguments work
+    // through concrete, interface and any-typed references alike (#11562).
 
     interface QzOptIface {
         qzOpt(a: number, b?: number): number
@@ -146,7 +142,7 @@ namespace IfaceDispatch {
         const iface: QzOptIface = impl
         const dyn: any = impl
 
-        // a concrete call gets the default filled in at the call site
+        // a concrete call still applies the default
         assert(impl.qzOpt(1) == 6, "opt:concrete")
 
         // explicit arguments behave the same on every path
@@ -154,8 +150,8 @@ namespace IfaceDispatch {
         assert(iface.qzOpt(1, 2) == 3, "opt:iface2")
         assert(dyn.qzOpt(1, 2) == 3, "opt:any2")
 
-        // omitting the argument yields the same result on both dynamic paths
-        assert(("" + iface.qzOpt(1)) == ("" + dyn.qzOpt(1)), "opt:dynagree")
+        assert(iface.qzOpt(1) == 6, "opt:iface-default")
+        assert(dyn.qzOpt(1) == 6, "opt:any-default")
 
         // a callee that defaults explicitly works everywhere
         assert(impl.qzOptSafe(1) == 6, "opt:safe1")

--- a/tests/compile-test/lang-test0/57defaultparamdispatch.ts
+++ b/tests/compile-test/lang-test0/57defaultparamdispatch.ts
@@ -1,21 +1,6 @@
-// Reproduces a known defect: default parameter values are not applied when a
-// method is invoked through dynamic (interface or any-typed) dispatch.
-//
-// Mechanism: a statically resolved call site fills omitted arguments with the
-// declared defaults, because the compiler can see the declaration. A dynamic
-// call site pushes only the arguments written at the call, and the arity
-// wrapper on the callee fills the missing slots with `undefined` -- the
-// parameter initializer (`b = 5` below) never runs. The method then computes
-// 1 + undefined = NaN.
-//
-// The assertions that fail today are commented out (block marked REPRO) so
-// the suite stays green. To reproduce: uncomment that block and run
-// `gulp testlang` -- qzdp:iface and qzdp:any fail with the calls yielding
-// NaN instead of 6. A fix for the defect makes the REPRO block pass; it can
-// then be uncommented permanently and the qzdp:agree assertion below retired.
-//
-// 56ifacedispatch.ts documents the same constraint where it affects the
-// dispatch corpus; this file is the minimal standalone repro.
+// Regression for #11562. Default initializers belong to the runtime callee,
+// not the statically known call signature. Both omitted and explicit undefined
+// arguments trigger defaults; other falsy values must survive unchanged.
 
 interface DfShape {
     dfOpt(a: number, b?: number): number;
@@ -35,7 +20,7 @@ function testDefaultParamDispatch() {
     const viaIface: DfShape = direct;
     const viaAny: any = direct;
 
-    // Statically resolved call: the compiler applies the default. Passes.
+    // Statically resolved calls still apply the default.
     assert(direct.dfOpt(1) == 6, "qzdp:direct");
 
     // Passing the argument explicitly works on every path.
@@ -43,15 +28,110 @@ function testDefaultParamDispatch() {
     assert(viaIface.dfOpt(1, 2) == 3, "qzdp:iface2");
     assert(viaAny.dfOpt(1, 2) == 3, "qzdp:any2");
 
-    // REPRO -- uncomment these two lines to surface the defect:
-    // assert(viaIface.dfOpt(1) == 6, "qzdp:iface");
-    // assert(viaAny.dfOpt(1) == 6, "qzdp:any");
+    // Regression for #11562: dynamic calls must apply the implementation's default.
+    assert(viaIface.dfOpt(1) == 6, "qzdp:iface");
+    assert(viaAny.dfOpt(1) == 6, "qzdp:any");
 
-    // Kept active so any CHANGE in the current behavior is noticed: the two
-    // dynamic paths must at least agree with each other. Compared as strings
-    // so this holds both before a fix (NaN == NaN fails as numbers) and
-    // after one.
-    assert("" + viaIface.dfOpt(1) == "" + viaAny.dfOpt(1), "qzdp:agree");
+    assert(direct.dfOpt(1, undefined) === 6, "qzdp:direct-undefined");
+    assert(viaIface.dfOpt(1, undefined) === 6, "qzdp:iface-undefined");
+    assert(viaAny.dfOpt(1, undefined) === 6, "qzdp:any-undefined");
+    assert(viaIface.dfOpt(1, 0) === 1, "qzdp:zero");
+    assert(viaIface.dfOpt(1, null) === 1, "qzdp:null");
+}
+
+namespace DefaultDispatch {
+    class Base implements DfShape {
+        dfOpt(a: number, b = 5): number { return a + b; }
+    }
+    class Derived extends Base {
+        dfOpt(a: number, b = 9): number { return a + b; }
+        fromSuper(): number { return super.dfOpt(1); }
+    }
+    class ParameterProperty {
+        constructor(public value = 13) { }
+    }
+    class DerivedConstructor extends ParameterProperty {
+        constructor(value = 17) { super(value); }
+    }
+    interface OptionalValues {
+        value(n?: any): any;
+        pair(a?: number, b?: number): number;
+        capture(n?: number): () => number;
+    }
+    class Values implements OptionalValues {
+        value(n: any = 11): any { return n; }
+        pair(a = 2, b = 3): number { return a * 10 + b; }
+        capture(n = 7): () => number { return () => ++n; }
+    }
+    function free(n = 19): number { return n; }
+    function bool(n = true): boolean { return n; }
+    function ref(n: number[] = null): number[] { return n; }
+    function missing(n?: number): number { return n; }
+    function immutableCapture(n = 29): () => number { return () => n; }
+
+    // Native calls use TD_ID; simjs runs the TypeScript dummy body.
+    //% shim=TD_ID
+    function shimDefault(n = 31): number { return n; }
+    //% shim=TD_ID
+    //% n.defl=37 explicitDefaults="n"
+    function annotatedDefault(n?: number): number { return n; }
+
+    export function run() {
+        const derived = new Derived();
+        const base: Base = derived;
+        const iface: DfShape = derived;
+        const dynamic: any = derived;
+        assert(derived.dfOpt(1) === 10, "qzdp:derived");
+        assert(base.dfOpt(1) === 10, "qzdp:virtual-default");
+        assert(iface.dfOpt(1) === 10, "qzdp:override-iface");
+        assert(dynamic.dfOpt(1) === 10, "qzdp:override-any");
+        assert(base.dfOpt(1, undefined) === 10, "qzdp:virtual-undefined");
+        assert(base.dfOpt(1, 2) === 3, "qzdp:virtual-explicit");
+        assert(derived.fromSuper() === 6, "qzdp:super");
+
+        const action: (n?: number) => number = free;
+        const dynamicAction: any = free;
+        const arrow: (n?: number) => number = (n = 23) => n;
+        assert(free() === 19 && free(undefined) === 19, "qzdp:free");
+        assert(action() === 19 && action(undefined) === 19, "qzdp:action");
+        assert(dynamicAction() === 19, "qzdp:any-action");
+        assert(arrow() === 23 && arrow(0) === 0, "qzdp:arrow");
+        const literal: DfShape = { dfOpt: (a: number, b = 41) => a + b };
+        assert(literal.dfOpt(1) === 42, "qzdp:literal-action");
+
+        const values: OptionalValues = new Values();
+        const anyValues: any = values;
+        assert(values.value() === 11, "qzdp:value-default");
+        assert(values.value(undefined) === 11, "qzdp:value-undefined");
+        assert(values.value(null) === null, "qzdp:preserve-null");
+        assert(values.value(0) === 0, "qzdp:preserve-zero");
+        assert(values.value(false) === false, "qzdp:preserve-false");
+        assert(values.value("") === "", "qzdp:preserve-empty-string");
+        const nan = values.value(0 / 0);
+        assert(nan !== nan, "qzdp:preserve-nan");
+        assert(values.pair() === 23, "qzdp:multiple");
+        assert(anyValues.pair() === 23, "qzdp:arity-padding");
+        assert(values.pair(undefined, 8) === 28, "qzdp:argument-hole");
+        assert(values.pair(4) === 43, "qzdp:trailing");
+        const counter = values.capture();
+        const explicitCounter = values.capture(10);
+        assert(counter() === 8 && counter() === 9, "qzdp:boxed-param");
+        assert(explicitCounter() === 11, "qzdp:boxed-explicit");
+        assert(immutableCapture()() === 29, "qzdp:immutable-capture");
+
+        assert(new ParameterProperty().value === 13, "qzdp:constructor-property");
+        assert(new ParameterProperty(undefined).value === 13, "qzdp:constructor-undefined");
+        assert(new DerivedConstructor().value === 17, "qzdp:derived-constructor");
+        assert(new DerivedConstructor(0).value === 0, "qzdp:constructor-zero");
+        assert(bool() && !bool(false), "qzdp:boolean");
+        const array = [1, 2];
+        assert(ref() === null && ref(array) === array, "qzdp:reference");
+        assert(missing() === undefined, "qzdp:no-default");
+        assert(shimDefault() === 31 && shimDefault(0) === 0, "qzdp:shim-default");
+        assert(shimDefault(undefined) === undefined, "qzdp:shim-undefined-unchanged");
+        assert(annotatedDefault() === 37, "qzdp:annotated-default");
+    }
 }
 
 testDefaultParamDispatch();
+DefaultDispatch.run();

--- a/tests/compile-test/lang-test0/58defaultinitializers.ts
+++ b/tests/compile-test/lang-test0/58defaultinitializers.ts
@@ -1,0 +1,63 @@
+// Defaults run once, in the callee's lexical scope and parameter order, after
+// every explicit call argument is evaluated. No unfetteredInitializers needed.
+namespace DefaultInitializers {
+    let trace = "";
+    let calls = 0;
+    function next(): number { trace += "d"; return ++calls; }
+    function supplied(): number { trace += "a"; return 10; }
+    function absent(): number { calls++; return undefined; }
+
+    interface Factory {
+        make(n?: number, other?: number): number;
+        empty(n?: number): number;
+        array(value?: number[]): number[];
+        text(value?: string): string;
+    }
+    class Maker implements Factory {
+        offset = 100;
+        constructor() { }
+        make(n = next(), other = n + this.offset): number { return n + other; }
+        empty(n = absent()): number { return n; }
+        array(value = [next()]): number[] { return value; }
+        text(value = "hello"): string { return value; }
+    }
+    function destructured({ x } = { x: next() }, n = x + 1): number { return x + n; }
+    function captured(n = next()): () => number { return () => ++n; }
+    function defaults(text = "world", negative = -1, missing: number = undefined): string {
+        return text + ":" + negative + ":" + missing;
+    }
+    function scope() {
+        let outer = 40;
+        const f: (n?: number) => number = (n = ++outer) => n;
+        assert(f() === 41 && f(undefined) === 42, "qzdpi:lexical");
+        assert(f(0) === 0 && outer === 42, "qzdpi:lexical-explicit");
+    }
+    export function run() {
+        const direct = new Maker();
+        const iface: Factory = direct;
+        const dynamic: any = direct;
+        assert(iface.make() === 102 && calls === 1, "qzdpi:iface-order-this");
+        assert(dynamic.make() === 104 && calls === 2, "qzdpi:any-order-this");
+        trace = "";
+        assert(direct.make(undefined, supplied()) === 13, "qzdpi:direct");
+        assert(trace === "ad" && calls === 3, "qzdpi:argument-evaluation-order");
+        assert(iface.make(7, 8) === 15 && calls === 3, "qzdpi:skip-supplied");
+        assert(direct.empty() === undefined && calls === 4, "qzdpi:undefined-default-once");
+        assert(dynamic.empty() === undefined && calls === 5, "qzdpi:any-undefined-once");
+        const a = iface.array();
+        const b = iface.array();
+        a[0] = 99;
+        assert(a !== b && b[0] === 7, "qzdpi:fresh-reference");
+        assert(iface.array(a) === a && calls === 7, "qzdpi:reference-supplied");
+        assert(destructured() === 17 && calls === 8, "qzdpi:destructured-once");
+        assert(destructured({ x: 20 }) === 41 && calls === 8, "qzdpi:destructured-explicit");
+        const action: (n?: number) => () => number = captured;
+        const counter = action();
+        assert(counter() === 10 && counter() === 11 && calls === 9, "qzdpi:boxed-default");
+        assert(iface.text() === "hello" && dynamic.text(undefined) === "hello", "qzdpi:string-default");
+        assert(direct.text("") === "", "qzdpi:string-explicit");
+        assert(defaults() === "world:-1:undefined", "qzdpi:other-initializers");
+        scope();
+    }
+}
+DefaultInitializers.run();

--- a/tests/compile-test/lang-test0/README-codegen.md
+++ b/tests/compile-test/lang-test0/README-codegen.md
@@ -13,7 +13,7 @@ before structurally cannot:
 The coverage matrix below is the index: failure mode -> covering test -> layer
 -> what the failure looks like when it fires.
 
-The corpus is sized for two optimization families:
+The corpus covers:
 
 - **Boolean condition lowering.** Conditions lower to short-circuit jumps that
   yield a raw 0/1 rather than a tagged value materialized and then narrowed,
@@ -23,6 +23,10 @@ The corpus is sized for two optimization families:
   helpers, shared interface-call thunks, object-literal store specialization,
   vtable wrapper-skip for calls whose arity already matches, and a typed
   index-signature store fast path.
+- **Default parameters (#11562).** TypeScript implementations initialize omitted
+  or `undefined` arguments in their common entry code, including dynamic and
+  virtual dispatch. Shim/helper fallbacks and explicit-default annotations retain
+  their caller-side handling.
 
 ## Coverage matrix
 
@@ -40,7 +44,10 @@ The corpus is sized for two optimization families:
 | Threshold miscounting in a count-gated specialization -- members just below and just above the gate behaving differently | `56ifacedispatch.ts` `testThresholds` (`qzLo` 2 sites vs `qzHi` 5+, `qzFew` 4 reads vs `qzMany` 6+) and `testStores` (`qzRare` 2 stores vs `qzHot` 4) | testlang, hw-ab | `th:lo1`, `th:hi1`..`th:hi5`, `th:few*`, `th:many*`, `th:agree`, `st:rare`, `st:hot` |
 | The same miscounting for the checked-field-load gate, which counts per class field rather than per interface member and so is not reachable from the semantic layer | `tests/thumb-test/cases/fieldbaseline.ts`, one class whose `qzTally` is read above the gate and `qzSpare` below it, with `asmchecks.ts` counting the inline checked-load sequences by field offset | testthumb | `expected at least 6 inline checked loads of qzTally, found N`, or `listing unexpectedly contains N checked-field-load thunks (ldfldchk_)` |
 | Arity holes in wrapper-skip -- one member name declared at two arities by two unrelated interfaces | `56ifacedispatch.ts` `testArityCollision`, with the two dispatches interleaved in a loop so neither can be hoisted | testlang, hw-ab | `ar:one1`, `ar:two1`, `ar:mixed` |
-| A missing trailing argument on a dynamic call (the documented default-parameter constraint) | `56ifacedispatch.ts` `testDefaults` | testlang, hw-ab | `opt:concrete`, `opt:dynagree`, `opt:safe1`..`opt:safe4`, `opt:iface2`, `opt:any2` |
+| Missing defaults on dynamic calls, or using a base method's default for an override | `56ifacedispatch.ts` `testDefaults`, `57defaultparamdispatch.ts` | testlang, testthumb (assembly), hw-ab | `opt:iface-default`, `opt:any-default`, `qzdp:iface`, `qzdp:any`, `qzdp:virtual-default` |
+| Replacing supplied falsy values, missing argument holes, or defaulting after constructor-property/closure creation | `57defaultparamdispatch.ts` | testlang, testthumb (assembly), hw-ab | `qzdp:preserve-*`, `qzdp:argument-hole`, `qzdp:boxed-param`, `qzdp:constructor-property` |
+| Default expressions evaluated twice, in the caller's scope, or before explicit arguments | `58defaultinitializers.ts` | testlang, testthumb (assembly), hw-ab | `qzdpi:argument-evaluation-order`, `qzdpi:undefined-default-once`, `qzdpi:lexical`, `qzdpi:fresh-reference`, `qzdpi:destructured-once` |
+| Native wrapper bypass also bypasses default initialization, or guards added to functions without defaults | `tests/thumb-test/cases/defaultparameters.ts` with normal, `noIfaceSpec` and `slowMethods` switches | testthumb | Guard-placement, wrapper routing, boxed-parameter or constructor-store assertion fails |
 | Get and call sharing a dispatch bucket -- one member name that is a field on one type and a method on another | `56ifacedispatch.ts` `testGetCallCollision`, through both interface-typed and `any`-typed references | testlang, hw-ab | `gc:get1`, `gc:call1`, `gc:agree`, `gc:get2`, `gc:call2`, `gc:type` |
 | `toString` fixed-slot violation -- an override not reached through concatenation, templates, direct call, interface or `any` | `56ifacedispatch.ts` `testToString`; also present in `tests/thumb-test/cases/ifacebaseline.ts` | testlang, testthumb (shape), hw-ab | `ts:concat`, `ts:template`, `ts:iface`, `ts:any`, `ts:anyconcat` |
 | Polymorphic call site confused between class instances and object literals (maps) | `56ifacedispatch.ts` `testPolymorphic` -- one call site `useQzVal` fed both, plus a mixed array iterated twice | testlang, hw-ab | `poly:class`, `poly:literal`, `poly:elem0`..`poly:elem3`, `poly:total` |
@@ -106,19 +113,31 @@ single call site fed both class instances and object literals; a `toString`
 override reached five different ways; stores through property signatures,
 accessors, inherited fields, `super`, a run-time-keyed map and a typed index
 signature over both a literal and a class instance; and dynamic gets by dot, by
-string literal and by computed key. One constraint is documented in the file
-rather than asserted away: the emitter fills a defaulted argument in at the
-call site from the statically known signature, so through an interface- or
-`any`-typed reference there is no signature and the callee's own default does
-not apply. `testDefaults` therefore asserts that the interface and `any` paths
-agree with each other, and that a callee written to test for `undefined` works
-on every path.
+string literal and by computed key. `testDefaults` asserts that concrete,
+interface and `any` calls apply the callee's default, just as an explicit
+`undefined` check in the method body does.
 
-`57defaultparamdispatch.ts` is the minimal standalone repro of that defect: a
-two-line block marked REPRO is commented out so the suite stays green, and
-uncommenting it makes `gulp testlang` fail with `qzdp:iface` -- a ready-made
-red test for whoever picks the fix up. The file's active assertions pin the
-parts that must hold either way.
+### `57defaultparamdispatch.ts` and `58defaultinitializers.ts`
+
+The formerly disabled #11562 repro is active. The dispatch corpus covers
+direct, virtual, interface, `any`, action and object-literal calls; different
+base/derived defaults; `super`; constructors and parameter properties; explicit
+`undefined`, argument holes, and supplied falsy values; mutable and immutable
+parameter captures; native shims and comment-annotated defaults.
+
+The initializer corpus runs in normal compiler mode, without
+`unfetteredInitializers`. Strings, negative numbers, `undefined`, arrays, object
+destructuring, calls, earlier parameters, `this`, and lexical captures are
+evaluated as ordinary expressions. Assertions pin evaluation order and exactly
+one evaluation, including when the default expression itself returns undefined.
+
+Both files execute in simjs, compile and assemble in the native suite, and are
+registered as `defaultparamdispatch` and `defaultinitializers` device payloads.
+The focused native probe checks a strict undefined guard after `_nochk`, so
+both `_args` padding and optimized `_iface` entries reach it. It also checks
+box initialization before capture, constructor defaults before property stores,
+and absence of guards in a plain function. Assembly checks do not execute ARM
+instructions or validate the physical collector; that requires the device run.
 
 ### `tests/thumb-test/cases/boolbaseline.ts`
 

--- a/tests/hw-ab/gen-project.js
+++ b/tests/hw-ab/gen-project.js
@@ -60,7 +60,9 @@ const PASS_REPEATS = Math.round(PASS_WINDOW_MS / PASS_INTERVAL_MS);
 const CASES = {
     "conditiontruthiness": "54conditiontruthiness.ts",
     "conditionlowering": "55conditionlowering.ts",
-    "ifacedispatch": "56ifacedispatch.ts"
+    "ifacedispatch": "56ifacedispatch.ts",
+    "defaultparamdispatch": "57defaultparamdispatch.ts",
+    "defaultinitializers": "58defaultinitializers.ts"
 };
 
 // Exact text of the host prelude's assert. Matching it exactly rather than by

--- a/tests/thumb-test/asmchecks.ts
+++ b/tests/thumb-test/asmchecks.ts
@@ -113,6 +113,13 @@ function escapeRegExp(s: string): string {
 
 export const asmChecks: pxt.Map<AsmCheck> = {
 
+    "defaultparameters.ts": (asm, res) => {
+        chai.assert(hexSize(res) > 0, "empty default parameter hex output");
+        checkDefaultParameters(asm);
+        chai.assert(/DpProbe_exact__P\d+_iface:\s+b DpProbe_exact__P\d+_nochk/.test(asm),
+            "exact interface entry must reach the common default prologue");
+    },
+
     "boolbaseline.ts": (asm) => {
         // Boolean condition lowering emits thumb fast paths for the boolean
         // conversion runtime calls.
@@ -221,6 +228,29 @@ export const asmChecks: pxt.Map<AsmCheck> = {
 
 // --- switch variants -----------------------------------------------------
 
+function checkDefaultParameters(asm: string) {
+    const code = userCode(asm);
+    const procedure = (name: string): string => {
+        const match = new RegExp("^" + name + "__P\\d+_pre:([\\s\\S]*?); endfun", "m").exec(code);
+        chai.assert(!!match, "missing procedure " + name);
+        return match[1];
+    };
+    for (const name of ["DpProbe_padded", "DpProbe_exact", "DpProbe_capture", "DpCtor_constructor"]) {
+        const body = procedure(name);
+        chai.assert.equal(countMatches(body, /bl pxt::eqq_bool/g), 1, name + " strict undefined guard");
+        chai.assert(/_nochk:[\s\S]*?movs r1, #0\s+mov r7, sp\s+str r7, \[r6, #4\]\s+bl pxt::eqq_bool\s+cmp r0, #0\s+beq \.defaultarg_/.test(body),
+            name + " must check undefined (not truthiness) in the shared body");
+    }
+    chai.assert(/_args:[\s\S]*?bl _expand_args_2_\d+[\s\S]*?bl DpProbe_padded__P\d+_nochk/.test(procedure("DpProbe_padded")),
+        "short dynamic calls must pad arguments then reach the default prologue");
+    chai.assert(/bl pxtrt::mklocRef[\s\S]*?bl pxtrt::ldlocRef[\s\S]*?bl pxt::eqq_bool[\s\S]*?movs r1, #23[\s\S]*?bl pxtrt::stlocRef[\s\S]*?bl pxt::mkAction/.test(procedure("DpProbe_capture")),
+        "default must update the rooted parameter box before creating its closure");
+    chai.assert(/bl pxt::eqq_bool[\s\S]*?movs r0, #27[\s\S]*?str r0, \[sp, args@1\][\s\S]*?str r1, \[r0, #4\]/.test(procedure("DpCtor_constructor")),
+        "constructor default must precede the parameter-property store");
+    assertNoMatch(procedure("dpPlain"), /defaultarg|bl pxt::eqq_bool/g, "default guards in a plain function");
+    assertNoMatch(code, /^dpShim__P\d+:/gm, "emitted TypeScript body for a native shim");
+}
+
 /**
  * A case compiled a second time with extra compile switches and checked
  * against different expectations -- the opt-out half of the differential
@@ -237,6 +267,23 @@ export interface VariantCheck {
 }
 
 export const variantChecks: VariantCheck[] = [
+
+    {
+        caseFile: "defaultparameters.ts",
+        switches: { noIfaceSpec: true },
+        label: "noIfaceSpec",
+        check: (asm) => {
+            checkDefaultParameters(asm);
+            assertNoMatch(asm, /^DpProbe_exact__P\d+_iface:/gm, "exact interface entry without specialization");
+        },
+    },
+
+    {
+        caseFile: "defaultparameters.ts",
+        switches: { slowMethods: true },
+        label: "slowMethods",
+        check: checkDefaultParameters,
+    },
 
     {
         caseFile: "ifacebaseline.ts",
@@ -316,6 +363,11 @@ export const variantChecks: VariantCheck[] = [
  * emitter produced real code for them.
  */
 export const externalCases: pxt.Map<AsmCheck> = {
+
+    "tests/compile-test/lang-test0/58defaultinitializers.ts": (asm, res) => {
+        chai.assert(codeSize(asm) > 0, "no default initializer code generated");
+        chai.assert(hexSize(res) > 0, "no default initializer hex generated");
+    },
 
     "tests/compile-test/lang-test0/54conditiontruthiness.ts": (asm) => {
         chai.assert(codeSize(asm) > 0, "no code generated");

--- a/tests/thumb-test/cases/defaultparameters.ts
+++ b/tests/thumb-test/cases/defaultparameters.ts
@@ -1,0 +1,26 @@
+interface DpExact {
+    exact(n: number): number;
+}
+class DpProbe implements DpExact {
+    padded(n = 5): number { return n; }
+    exact(n = 7): number { return n; }
+    capture(n = 11): () => number { return () => ++n; }
+}
+class DpCtor {
+    constructor(public value = 13) { }
+}
+function dpPlain(n: number): number { return n + 1; }
+//% shim=TD_ID
+function dpShim(n = 17): number { return n; }
+
+const dpProbe = new DpProbe();
+const dpDynamic: any = dpProbe;
+const dpExact: DpExact = dpProbe;
+const dpAction: () => number = dpDynamic.capture();
+let dpTotal = dpDynamic.padded();
+dpTotal += dpExact.exact(undefined);
+dpTotal += dpExact.exact(0);
+dpTotal += dpAction();
+dpTotal += new DpCtor(undefined).value;
+dpTotal += dpPlain(2) + dpShim();
+console.log(dpTotal);


### PR DESCRIPTION
fix https://github.com/microsoft/pxt/issues/11562
build and test https://arcade.makecode.com/app/42de182450c50f8d694f1eab5591cfb1fc05cb86-a44715369a#pub:S79673-77916-59274-53267 (same on live prints 10 NaN as expected)