### PR TITLE
[stable13.1] reset theme button, fix builtin extensions still being preferred, sim editor sizing (#11593)

### DIFF
--- a/react-common/components/theming/SimulatorThemePickerModal.tsx
+++ b/react-common/components/theming/SimulatorThemePickerModal.tsx
@@ -4,6 +4,7 @@ import { Input } from "../controls/Input";
 import { Modal } from "../controls/Modal";
 import { copySimulatorTheme, getSimulatorThemeForLayout } from "./simulatorThemeDefaults";
 import { ThemePickerToggle } from "./ThemePickerModal";
+import { useThemeReset } from "./useThemeReset";
 
 export interface SimulatorThemePickerModalProps {
     presets: pxt.SimulatorThemePreset[];
@@ -16,6 +17,7 @@ export interface SimulatorThemePickerModalProps {
     onUseAccountTheme?: () => void | Promise<void>;
     onThemeChanged?: (preference: pxt.auth.SimulatorThemePreference) => void;
     onSave: (preference: pxt.auth.SimulatorThemePreference) => void | Promise<void>;
+    onReset?: () => Promise<void>;
     onClose: () => void;
 }
 
@@ -59,8 +61,17 @@ export const SimulatorThemePickerModal = (props: SimulatorThemePickerModalProps)
         onUseAccountTheme,
         onThemeChanged,
         onSave,
+        onReset,
         onClose,
     } = props;
+    const aspectRatio = pxt.appTarget.simulator?.aspectRatio || 1.22;
+    const previewStyle: React.CSSProperties & {
+        "--simulator-theme-aspect-ratio": number;
+        "--simulator-theme-padding-bottom": string;
+    } = {
+        "--simulator-theme-aspect-ratio": aspectRatio,
+        "--simulator-theme-padding-bottom": `${100 / aspectRatio}%`,
+    };
     const defaultColorFields = getDefaultColorFields(presets[0].theme);
     const getColorFields = (layoutId: string) => {
         const fields = layouts?.find(layout => layout.id === layoutId)?.colorFields;
@@ -93,6 +104,7 @@ export const SimulatorThemePickerModal = (props: SimulatorThemePickerModalProps)
     const layoutId = theme.layout;
     const layoutIsKnown = layoutId === pxt.auth.DEFAULT_SIMULATOR_LAYOUT || layouts?.some(layout => layout.id === layoutId);
     const colorFields = getColorFields(layoutId);
+    const { resetAction, confirmation } = useThemeReset("simulator-theme-picker-modal", onReset);
 
     const selectPreset = (id: string) => {
         if (id === ACCOUNT_PRESET_ID && onUseAccountTheme) {
@@ -133,6 +145,8 @@ export const SimulatorThemePickerModal = (props: SimulatorThemePickerModalProps)
         onThemeChanged?.({ presetId: CUSTOM_PRESET_ID, theme: nextTheme });
     };
 
+    if (confirmation) return confirmation;
+
     return <Modal
         id="simulator-theme-picker-modal"
         title={lf("Simulator Theme")}
@@ -143,6 +157,7 @@ export const SimulatorThemePickerModal = (props: SimulatorThemePickerModalProps)
             selected="simulator"
             onModeChanged={onEditorThemeClicked} />}
         actions={[
+            ...(resetAction ? [resetAction] : []),
             {
                 label: lf("Apply"),
                 className: "primary",
@@ -151,7 +166,7 @@ export const SimulatorThemePickerModal = (props: SimulatorThemePickerModalProps)
                     : onSave({ presetId, theme }),
             },
         ]}>
-        <div className="simulator-theme-picker">
+        <div className="simulator-theme-picker" style={previewStyle}>
             {renderPreview(theme)}
             <div className="simulator-theme-controls">
                 <div className="simulator-theme-select-field">

--- a/react-common/components/theming/ThemePickerModal.tsx
+++ b/react-common/components/theming/ThemePickerModal.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Modal } from "../controls/Modal";
 import { EditorToggle } from "../controls/EditorToggle";
 import { ThemeCard } from "./ThemeCard";
+import { useThemeReset } from "./useThemeReset";
 
 export type ThemePickerMode = "editor" | "simulator";
 
@@ -45,6 +46,7 @@ export interface ThemePickerModalProps {
     selectedThemeId?: string;
     onThemeChanged: (theme: pxt.ColorThemeInfo) => void;
     onSave: (theme: pxt.ColorThemeInfo) => void;
+    onReset?: () => Promise<void>;
     onSimulatorThemeClicked?: () => void;
     onClose(): void;
 }
@@ -53,6 +55,9 @@ export const ThemePickerModal = (props: ThemePickerModalProps) => {
         props.selectedThemeId || props.themes[0]?.id
     );
     const selectedTheme = props.themes.find(theme => theme.id === selectedThemeId);
+    const { resetAction, confirmation } = useThemeReset("theme-picker-modal", props.onReset);
+
+    if (confirmation) return confirmation;
 
     return (
         <Modal
@@ -64,7 +69,7 @@ export const ThemePickerModal = (props: ThemePickerModalProps) => {
             rightHeader={props.onSimulatorThemeClicked && <ThemePickerToggle
                 selected="editor"
                 onModeChanged={props.onSimulatorThemeClicked} />}
-            actions={[{
+            actions={[...(resetAction ? [resetAction] : []), {
                 label: lf("Apply"),
                 className: "primary",
                 disabled: !selectedTheme,

--- a/react-common/components/theming/themeReset.ts
+++ b/react-common/components/theming/themeReset.ts
@@ -1,0 +1,16 @@
+import { getDefaultSimulatorThemePreference } from "./simulatorThemeDefaults";
+
+/** Reset this editor's preferences only. */
+export async function resetEditorThemesAsync(
+    target: Pick<pxt.TargetBundle, "appTheme" | "colorThemeMap" | "simulator">,
+    saveColorTheme: (theme: pxt.ColorThemeInfo) => Promise<void>,
+    clearSimulatorTheme: () => Promise<void>
+): Promise<pxt.auth.SimulatorThemePreference | undefined> {
+    const defaultThemeId = target.appTheme?.defaultColorTheme;
+    const defaultTheme = defaultThemeId ? target.colorThemeMap?.[defaultThemeId] : undefined;
+    if (!defaultTheme) throw new Error("No default editor theme configured");
+
+    await saveColorTheme(defaultTheme);
+    await clearSimulatorTheme();
+    return getDefaultSimulatorThemePreference(defaultTheme, target.simulator?.themePresets);
+}

--- a/react-common/components/theming/useThemeReset.tsx
+++ b/react-common/components/theming/useThemeReset.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { Modal, ModalAction } from "../controls/Modal";
+
+/** Shared confirmation for editor-wide pickers, not project-specific theme settings. */
+export function useThemeReset(pickerId: string, onReset: (() => Promise<void>) | undefined) {
+    const [confirming, setConfirming] = React.useState(false);
+    const [resetting, setResetting] = React.useState(false);
+    const [failed, setFailed] = React.useState(false);
+    const inFlight = React.useRef(false);
+    const restoreFocus = React.useRef(false);
+
+    React.useEffect(() => {
+        if (!confirming && restoreFocus.current) {
+            document.getElementById(pickerId)?.querySelector<HTMLElement>(".theme-reset-button")?.focus();
+            restoreFocus.current = false;
+        }
+    }, [confirming, pickerId]);
+
+    const cancel = () => {
+        if (inFlight.current) return;
+        restoreFocus.current = true;
+        setConfirming(false);
+    };
+
+    const confirm = async () => {
+        if (!onReset || inFlight.current) return;
+        inFlight.current = true;
+        setResetting(true);
+        setFailed(false);
+        try {
+            await onReset();
+        } catch (error) {
+            pxt.reportException(error);
+            setFailed(true);
+        } finally {
+            inFlight.current = false;
+            setResetting(false);
+        }
+    };
+
+    const resetAction: ModalAction | undefined = onReset ? {
+        label: lf("Reset"),
+        className: "primary inverted theme-reset-button",
+        onClick: () => {
+            setFailed(false);
+            setConfirming(true);
+        },
+    } : undefined;
+
+    const confirmation = confirming && <Modal
+        key="theme-reset-confirmation"
+        title={lf("Reset all themes?")}
+        ariaDescribedBy="theme-reset-description"
+        onClose={cancel}
+        hideDismissButton={resetting}
+        actions={[
+            { label: lf("Cancel"), onClick: cancel, disabled: resetting },
+            { label: resetting ? lf("Resetting...") : lf("Reset"), className: "primary", onClick: confirm, disabled: resetting },
+        ]}>
+        <p id="theme-reset-description">
+            {lf("Are you sure you want to reset the editor and simulator themes to their defaults? This will remove your editor-wide theme customizations. Themes set directly on projects will not be changed. This action cannot be undone.")}
+        </p>
+        {failed && <p role="alert">{lf("Unable to reset themes. Please try again.")}</p>}
+    </Modal>;
+
+    return { resetAction, confirmation };
+}

--- a/react-common/styles/theming/ThemePickerModal.less
+++ b/react-common/styles/theming/ThemePickerModal.less
@@ -19,6 +19,10 @@
     .common-modal-footer {
         grid-template-columns: 1fr auto;
 
+        .theme-reset-button {
+            justify-self: start;
+        }
+
         button:only-child {
             justify-self: end;
             min-width: 8rem;
@@ -27,7 +31,7 @@
 }
 
 .theme-picker-modal>.common-modal,
-.simulator-theme-picker-modal:not(.standalone)>.common-modal {
+.simulator-theme-picker-modal>.common-modal {
     height: 90%;
     max-height: 48rem;
     display: flex;
@@ -70,22 +74,62 @@
     padding-left: 1.5rem;
 }
 
+.simulator-theme-picker-modal>.common-modal {
+    overflow: hidden;
+
+    .common-modal-body {
+        display: flex;
+        overflow: hidden;
+    }
+
+    .common-modal-footer {
+        flex-shrink: 0;
+    }
+}
+
 .simulator-theme-picker {
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
     display: grid;
-    grid-template-columns: minmax(18rem, 1fr) minmax(18rem, 1fr);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
     gap: 2rem;
-    align-items: center;
+    align-items: stretch;
 }
 
 .simulator-theme-preview {
+    position: relative;
     min-width: 0;
+    min-height: 0;
 
     .simframe {
         margin: 0;
     }
 
+    .simframe.ui.embed {
+        // Fresh homescreen/skillmap frames have no inline ratio from the simulator driver.
+        padding-bottom: var(--simulator-theme-padding-bottom);
+    }
+
     .simframe > .ui.loader {
         display: none;
+    }
+}
+
+@media only screen and (min-width: 50.001rem) {
+    .simulator-theme-preview .simframe.ui.embed {
+        // Cap the viewport at the target's default ratio, even in a short pane.
+        // If width is constrained further, the simulator centers itself within the taller viewport.
+        // Override the driver's inline padding ratio only while inside the desktop picker.
+        position: absolute;
+        inset: 0;
+        margin: auto;
+        width: auto;
+        max-width: 100%;
+        height: 100%;
+        aspect-ratio: var(--simulator-theme-aspect-ratio);
+        padding-bottom: 0 !important;
     }
 }
 
@@ -94,6 +138,14 @@
     flex-direction: column;
     gap: 0.75rem;
     min-width: 0;
+    min-height: 0;
+    overflow-y: auto;
+    // Leave room for focus outlines inside the independently scrolling controls.
+    padding: 0.25rem;
+    scrollbar-gutter: stable;
+    > * {
+        flex-shrink: 0;
+    }
 }
 
 .simulator-theme-select-field {
@@ -128,9 +180,13 @@
 
 .simulator-theme-color {
     display: grid;
-    grid-template-columns: minmax(7rem, 1fr) 3rem minmax(8rem, 1fr);
+    grid-template-columns: minmax(0, 1fr) 3rem minmax(0, 1fr);
     gap: 0.5rem;
     align-items: center;
+
+    > span {
+        overflow-wrap: anywhere;
+    }
 
     .common-input-wrapper {
         min-width: 0;
@@ -173,17 +229,26 @@
     }
 
     .simulator-theme-picker {
+        flex: none;
+        width: 100%;
         grid-template-columns: 1fr;
+        grid-template-rows: auto;
+    }
+
+    .simulator-theme-picker-modal>.common-modal .common-modal-body {
+        display: block;
+        overflow-y: auto;
+    }
+
+    .simulator-theme-controls {
+        overflow: visible;
+        scrollbar-gutter: auto;
     }
 
     .simulator-theme-preview {
-        max-width: 28rem;
         width: 100%;
+        max-width: 28rem;
         justify-self: center;
-    }
-
-    .simulator-theme-color {
-        grid-template-columns: minmax(5.5rem, 1fr) 3rem minmax(6.5rem, 1fr);
     }
 }
 

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -51,6 +51,7 @@ import { ThemePickerModal } from '../../react-common/components/theming/ThemePic
 import './App.css';
 
 import { ThemeManager } from 'react-common/components/theming/themeManager';
+import { resetEditorThemesAsync } from '../../react-common/components/theming/themeReset';
 import { FeedbackModal } from 'react-common/components/controls/Feedback/Feedback';
 import { SimulatorThemePickerModal } from './components/SimulatorThemePickerModal';
 import {
@@ -120,6 +121,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
         this.showEditorThemePicker = this.showEditorThemePicker.bind(this);
         this.closeThemePicker = this.closeThemePicker.bind(this);
         this.saveSimulatorTheme = this.saveSimulatorTheme.bind(this);
+        this.resetEditorThemes = this.resetEditorThemes.bind(this);
 
         this.state = {
             cloudSyncCheckHasFinished: false,
@@ -556,6 +558,25 @@ class AppImpl extends React.Component<AppProps, AppState> {
         this.closeThemePicker(false);
     }
 
+    async resetEditorThemes(): Promise<void> {
+        pxt.tickEvent("skillmap.theme.reset", undefined, { interactiveConsent: true });
+        const defaultSimulatorPreference = await resetEditorThemesAsync(
+            pxt.appTarget,
+            theme => this.persistColorTheme(theme),
+            () => authClient.setSimulatorThemePreferenceAsync(undefined)
+        );
+        if (defaultSimulatorPreference) {
+            const resources = await this.ready();
+            await resources.sendMessageAsync?.({
+                type: "pxteditor",
+                action: "setsimulatortheme",
+                preference: defaultSimulatorPreference,
+                savePreference: false,
+            } as pxt.editor.EditorMessageSetSimulatorThemeRequest);
+        }
+        this.closeThemePicker(false);
+    }
+
     private async persistColorTheme(theme: pxt.ColorThemeInfo) {
         pxt.tickEvent(`skillmap.menu.theme.changetheme`, { theme: theme.id });
         this.themeManager.switchColorTheme(theme.id);
@@ -618,6 +639,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
                     selectedThemeId={this.state.editorThemeId || this.themeManager.getCurrentColorTheme()?.id}
                     onThemeChanged={this.previewColorTheme}
                     onSave={this.changeTheme}
+                    onReset={this.resetEditorThemes}
                     onSimulatorThemeClicked={simulatorThemePresets.length
                         ? this.showSimulatorThemePicker
                         : undefined}
@@ -633,6 +655,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
                     onThemeChanged={simulatorThemePreference => this.setState({ simulatorThemePreference })}
                     onEditorThemeClicked={this.showEditorThemePicker}
                     onSave={this.saveSimulatorTheme}
+                    onReset={this.resetEditorThemes}
                     onClose={this.closeThemePicker} />}
                 { feedbackEnabled && this.props.showFeedback && <FeedbackModal kind="rating" onClose={this.props.dispatchCloseFeedback} />}
             </div>);

--- a/tests/pxt-editor-test/editorrunner.ts
+++ b/tests/pxt-editor-test/editorrunner.ts
@@ -20,6 +20,7 @@ import {
     getSimulatorThemePreferenceForColorThemeChange,
     isImplicitSimulatorThemePreference,
 } from "../../react-common/components/theming/simulatorThemeDefaults";
+import { resetEditorThemesAsync } from "../../react-common/components/theming/themeReset";
 
 pxt.appTarget = {
     versions: {
@@ -132,6 +133,83 @@ describe("simulator themes", () => {
 
     it("initializes an empty cloud-synced simulator theme map", () => {
         chai.expect(pxt.auth.DEFAULT_USER_PREFERENCES().simulatorThemes).deep.equals({});
+    });
+
+    describe("reset editor-wide themes", () => {
+        const target = {
+            appTheme: { defaultColorTheme: lightTheme.id },
+            colorThemeMap: { light: lightTheme, dark: darkTheme },
+            simulator: { themePresets: presets },
+        } as Pick<pxt.TargetBundle, "appTheme" | "colorThemeMap" | "simulator">;
+
+        it("saves the configured editor default then clears the simulator preference", async () => {
+            const calls: string[] = [];
+            const result = await resetEditorThemesAsync(target, async theme => {
+                chai.expect(theme).equals(lightTheme);
+                calls.push("editor");
+            }, async () => { calls.push("simulator"); });
+
+            chai.expect(calls).deep.equals(["editor", "simulator"]);
+            chai.expect(result).deep.equals({ presetId: "default", theme: defaultSimulatorTheme });
+        });
+
+        it("uses the default editor theme's simulator colors and layout", async () => {
+            const configuredTarget = {
+                ...target,
+                appTheme: { ...target.appTheme, defaultColorTheme: inlineSimulatorTheme.id },
+                colorThemeMap: { ...target.colorThemeMap, inline: inlineSimulatorTheme },
+            };
+            const result = await resetEditorThemesAsync(configuredTarget, async () => {}, async () => {});
+            chai.expect(result?.theme).deep.equals({
+                ...defaultSimulatorTheme,
+                "background-color": "#123456",
+                layout: "inline",
+            });
+        });
+
+        it("preserves project themes instead of replacing them with the editor default", async () => {
+            const projectTheme = Object.freeze({ ...retroSimulatorTheme });
+            const projectConfig = Object.freeze({ name: "themed project", theme: projectTheme });
+            const before = JSON.stringify(projectConfig);
+            const result = await resetEditorThemesAsync(target, async () => {}, async () => {});
+
+            chai.expect(JSON.stringify(projectConfig)).equals(before);
+            chai.expect(resolveSimulatorTheme(projectConfig.theme, undefined, result?.theme, false))
+                .equals(projectTheme);
+        });
+
+        it("resets editor preferences even on targets without simulator themes", async () => {
+            let simulatorCleared = false;
+            const result = await resetEditorThemesAsync({ ...target, simulator: undefined }, async theme => {
+                chai.expect(theme).equals(lightTheme);
+            }, async () => { simulatorCleared = true; });
+            chai.expect(result).equals(undefined);
+            chai.expect(simulatorCleared).equals(true);
+        });
+
+        it("does not change preferences if the default editor theme is unavailable", async () => {
+            let changed = false;
+            let failed = false;
+            try {
+                await resetEditorThemesAsync({ ...target, colorThemeMap: {} },
+                    async () => { changed = true; }, async () => { changed = true; });
+            } catch {
+                failed = true;
+            }
+            chai.expect(failed).equals(true);
+            chai.expect(changed).equals(false);
+        });
+
+        it("propagates persistence errors so the confirmation can offer retry", async () => {
+            const error = new Error("Unable to save preferences");
+            let caught: unknown;
+            try {
+                await resetEditorThemesAsync(target, async () => {}, async () => { throw error; });
+            } catch (err) {
+                caught = err;
+            }
+            chai.expect(caught).equals(error);
+        });
     });
 
     it("uses the user theme only when project and device themes are absent", () => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -89,6 +89,7 @@ import { initGitHubDb } from "./idbworkspace";
 import { BlockDefinition, CategoryNameID } from "./toolbox";
 import { FeedbackModal } from "../../react-common/components/controls/Feedback/Feedback";
 import { ThemeManager } from "../../react-common/components/theming/themeManager";
+import { resetEditorThemesAsync } from "../../react-common/components/theming/themeReset";
 import {
     getDefaultSimulatorThemePreference,
     getSimulatorThemeForLayout,
@@ -257,6 +258,7 @@ export class ProjectView
         this.previewColorTheme = this.previewColorTheme.bind(this);
         this.saveEditorTheme = this.saveEditorTheme.bind(this);
         this.saveSimulatorTheme = this.saveSimulatorTheme.bind(this);
+        this.resetEditorThemes = this.resetEditorThemes.bind(this);
         this.onThemeChanged = this.onThemeChanged.bind(this);
         this.setColorThemeById = this.setColorThemeById.bind(this);
         this.showLoginDialog = this.showLoginDialog.bind(this);
@@ -4916,6 +4918,22 @@ export class ProjectView
         await this.saveThemePickerDrafts();
     }
 
+    async resetEditorThemes(): Promise<void> {
+        pxt.tickEvent("theme.reset", undefined, { interactiveConsent: true });
+        await resetEditorThemesAsync(
+            pxt.appTarget,
+            theme => this.setColorThemeById(theme.id, true, false),
+            () => simulatorThemePreference.setSimulatorThemePreference(undefined)
+        );
+        // Discard previews without restoring the pre-reset editor theme. Project themes stay intact.
+        if (pxt.appTarget.simulator?.themePresets?.length) {
+            this.closeSimulatorThemePicker(false, true, false);
+        } else {
+            this.resetThemePickerDrafts(false);
+            this.setState({ themePickerOpen: false });
+        }
+    }
+
     async setSimulatorThemePreference(preference: pxt.auth.SimulatorThemePreference, savePreference = true) {
         if (savePreference) await simulatorThemePreference.setSimulatorThemePreference(preference);
         else simulatorThemePreference.setSessionSimulatorThemePreference(preference);
@@ -5959,6 +5977,7 @@ export class ProjectView
                     selectedThemeId={this.themePickerColorThemeId}
                     onThemeChanged={this.previewColorTheme}
                     onSave={this.saveEditorTheme}
+                    onReset={this.resetEditorThemes}
                     onSimulatorThemeClicked={pxt.appTarget.simulator?.themePresets?.length
                         ? this.showSimulatorThemePicker
                         : undefined}
@@ -5977,6 +5996,7 @@ export class ProjectView
                     }}
                     onEditorThemeClicked={this.showEditorThemePicker}
                     onSave={this.saveSimulatorTheme}
+                    onReset={this.resetEditorThemes}
                     onClose={this.hideSimulatorThemePicker} />}
             </div>
         );

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -747,7 +747,13 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         let trgConfig = await data.getAsync<pxt.TargetConfig>("target-config:")
         const packagesConfig = await pxt.packagesConfigAsync();
         const repos = installedExtensions(packagesConfig);
-        bundled.forEach(e => repos.push(e));
+        const builtinExtensions = trgConfig?.packages?.builtinExtensionsLib;
+        bundled.forEach((extension, name) => {
+            const extensionConfig = builtinExtensions?.[name];
+            if (!extensionConfig || (extensionConfig.preferred && !extensionConfig.hidden)) {
+                repos.push(extension);
+            }
+        });
 
         const toBeFetched: string[] = [];
         if (trgConfig?.packages?.approvedRepoLib) {

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -3,10 +3,12 @@ import * as auth from "./auth";
 import * as screenshot from "./screenshot";
 import * as pkg from "./package";
 import * as simulatorThemePreference from "./simulatorThemePreference";
+import { getSimulatorThemeForSharing } from "./simulatorTheme";
 
 import { Modal } from "../../react-common/components/controls/Modal";
 import { Share } from "../../react-common/components/share/Share";
 import { SimRecorderImpl } from "./components/SimRecorder";
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -194,9 +196,11 @@ export class ShareEditor extends auth.Component<ShareEditorProps, ShareEditorSta
         const thumbnails = simScreenshot || simGif;
 
         const hasProjectBeenPersistentShared = parent.hasHeaderBeenPersistentShared();
-        const simulatorTheme = pxt.appTarget.simulator?.themePresets?.length
-            ? simulatorThemePreference.getEffectiveSimulatorThemePreference()
-            : undefined;
+        const simulatorTheme = getSimulatorThemeForSharing(
+            simulatorThemePreference.getSimulatorThemePreference(),
+            ThemeManager.getInstance(document).getCurrentColorTheme(),
+            pxt.appTarget.simulator?.themePresets
+        );
 
         const publishAsync = async (name: string, description?: string, screenshotUri?: string, forceAnonymous?: boolean, sharedSimulatorTheme?: pxt.SimulatorTheme) =>
             parent.publishAsync(name, description, screenshotUri, forceAnonymous, sharedSimulatorTheme)
@@ -220,7 +224,7 @@ export class ShareEditor extends auth.Component<ShareEditorProps, ShareEditorSta
                     anonymousShareByDefault={parent.getSharePreferenceForHeader()}
                     setAnonymousSharePreference={setSharePreference}
                     isMultiplayerGame={this.props.parent.state.isMultiplayerGame}
-                    simulatorTheme={simulatorTheme?.presetId === "default" ? undefined : simulatorTheme?.theme}
+                    simulatorTheme={simulatorTheme}
                     kind={this.state.kind}
                     onClose={this.hide}
                 />

--- a/webapp/src/simulatorTheme.ts
+++ b/webapp/src/simulatorTheme.ts
@@ -1,3 +1,19 @@
+import { copySimulatorTheme, getDefaultSimulatorThemePreference } from "../../react-common/components/theming/simulatorThemeDefaults";
+
+/** Snapshot Default's current colors for sharing, without changing saved preferences. */
+export function getSimulatorThemeForSharing(
+    preference: pxt.auth.SimulatorThemePreference | undefined,
+    colorTheme: pxt.ColorThemeInfo | undefined,
+    presets: pxt.SimulatorThemePreset[] | undefined
+): pxt.SimulatorTheme | undefined {
+    if (!presets?.length) return undefined;
+    const defaultPreference = getDefaultSimulatorThemePreference(colorTheme, presets);
+    const theme = !preference || preference.presetId === defaultPreference?.presetId
+        ? defaultPreference?.theme
+        : preference.theme;
+    return theme && copySimulatorTheme(theme);
+}
+
 export function getSimulatorThemePresetId(
     theme: string | pxt.Map<string> | undefined,
     presets: pxt.SimulatorThemePreset[]


### PR DESCRIPTION


* always have share sim toggle

* updatePreferredExtensions had a line messing up having built ins not as preferred

* reset theme button

* adjust sizing issues on homescreen

* when sharing on default theme, resolve instead of default which will be diff per user

* Apply suggestion from @jwunderl