### PR TITLE
fix offline app toast when clicking share on forum game

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1458,7 +1458,8 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
     private async ensureForumShareLink() {
         const { cardType, url } = this.props;
         if (cardType !== "forumUrl") return;
-        if (this.state.resolvedForumShareUrl || this.state.resolvingForumShare) return;
+        if (this.getForumEditorShareLink() || this.state.resolvingForumShare) return;
+        if (pxt.BrowserUtils.isPxtElectron()) return;
 
         this.setState({ resolvingForumShare: true });
         try {
@@ -1471,7 +1472,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                 }
             }
         } catch (e) {
-            core.handleNetworkError(e);
+            pxt.debug("Unable to resolve optional forum share link");
         }
         this.setState({ resolvingForumShare: false });
     }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/7744

same thing as 'open in editor' in offline app, discourse does not like the cors request and rejects it. It still produces the shareable link to the forum, this surpresses the error from it failing to generate a second link to share the game directly