### PR TITLE
fix styling of disconnect github button and remove comma

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -952,6 +952,19 @@ Avatar
     width: 0;
 }
 
+.common-menu-dropdown-pane li.common-menu-dropdown-item.common-button.github-menuitem {
+    padding: 8px 18px;
+
+    .avatar img {
+        position: relative;
+        left: -0.25em;
+        width: 1.5em;
+        height: 1.5em;
+        border-radius: 1.5em;
+        margin-right: 0.45em;
+    }
+}
+
 /* Json editor */
 #pxtJsonEditor .ui.content {
     padding: 1rem;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -538,13 +538,13 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             items.push({ role: "separator" });
             items.push({
                 role: "menuitem",
-                className: "ui item",
+                className: "github-menuitem",
                 title: lf("Unlink {0} from GitHub", githubUser.name),
                 onClick: this.signOutGithub,
                 children: <>
                     <div className="avatar" role="presentation">
-                        <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />
-                    </div>,
+                        <img src={githubUser.photo} alt={lf("User picture")} />
+                    </div>
                     {lf("Disconnect GitHub")}
                 </>
             });

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -707,13 +707,13 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
             items.push({ role: "separator" });
             items.push({
                 role: "menuitem",
-                className: "ui item",
+                className: "github-menuitem",
                 title: lf("Unlink {0} from GitHub", githubUser.name),
                 onClick: this.signOutGithub,
                 children: <>
                     <div className="avatar" role="presentation">
-                        <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />
-                    </div>,
+                        <img src={githubUser.photo} alt={lf("User picture")} />
+                    </div>
                     {lf("Disconnect GitHub")}
                 </>
             });
@@ -758,13 +758,15 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
             });
         }
 
-        return <MenuDropdown
-            id="settings-menuitem"
-            className="settings-menuitem"
-            title={lf("Settings")}
-            icon="icon setting large"
-            items={items}
-        />
+        return (
+            <MenuDropdown
+                id="settings-menuitem"
+                className="settings-menuitem"
+                title={lf("Settings")}
+                icon="icon setting large"
+                items={items}
+            />
+        );
     }
 }
 


### PR DESCRIPTION
noticed that the disconnect github button is very broken in minecraft:

<img width="724" height="549" alt="disconnect-button" src="https://github.com/user-attachments/assets/bd5fc94b-c437-4372-9ecd-1bb06b3fe20e" />

the cause was some semantic ui styling overflowing onto the menu dropdown.

here it is fixed:

<img width="380" height="520" alt="image" src="https://github.com/user-attachments/assets/b2adb8dc-9d3b-456d-9917-5eb2201e2374" />


this does *not* need to be cherry picked to microbit and arcade, because they use the version in the identity dropdown which does not have the same issue. only affects minecraft because we don't have identity there.